### PR TITLE
Use subiquity inside the install image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# subiquity installer images
+installer/*.img

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ INSTALLIMG=ubuntu-server-${STREAM}-${RELEASE}-${ARCH}-installer.img
 .PHONY: installer run clean
 
 ui-view:
-	PYTHONPATH=$(shell pwd):$(PYTHONPATH) bin/subiquity
+	(PYTHONPATH=$(shell pwd) bin/subiquity)
 
 installer:
 	[ -e "installer/$(INSTALLIMG)" ] || \
-	(cd installer && ./geninstaller -r $(RELEASE) -a $(ARCH) -s $(STREAM))
+	(cd installer && ./geninstaller -v -r $(RELEASE) -a $(ARCH) -s $(STREAM))
 
 run: installer
 	(cd installer && INSTALLER=$(INSTALLIMG) ./runinstaller)

--- a/installer/geninstaller
+++ b/installer/geninstaller
@@ -68,10 +68,24 @@ userdata_write_file() {
     local path=${1}; shift;
     local owner=${1}; shift;
     local permissions=${1}; shift;
-    echo "-   content: |"
-    for x in "$@"; do
-        sed 's,^,        ,' "$x" || return
-    done
+    local encoding=${1}; shift;
+    case $encoding in 
+        none)
+            echo "-   content: |"
+            for x in "$@"; do
+                sed 's,^,        ,' "$x" || return
+            done
+            ;;
+        b64)
+            echo "-   encoding: $encoding"
+            echo "    content: |"
+            base64 "$@" | sed 's,^,        ,'
+            ;;
+        *)
+            log "ERROR: unsupported encoding $encoding"
+            return 1;
+            ;;
+    esac
     echo "    path: $path"
     echo "    owner: $owner"
     echo "    permissions: '$permissions'"
@@ -283,15 +297,29 @@ generate_seed() {
         log "Failed to write meta-data into $seed";
         return 1;
     }
-    log "Writing seed user-data"
+    log "Writing seed user-data (curtin)"
     # remove the old seed; copy in the base template and
     # append the curtin-cmd file
     rm -f ${seed}/user-data &&
     cp $installer_user_data $seed/user-data &&
     userdata_write_file "/usr/local/bin/curtin" \
-                         "root:root" "0755" \
+                         "root:root" "0755" "none" \
                          "$curtin_cmd" >> $seed/user-data || {
-        log "Failed to write user-data into $seed";
+        log "Failed to embed curtin into $seed";
+        return 1;
+    }
+
+    log "Writing seed user-data (subiquity)"
+    local subiquity_tar=$dldir/subiquity.tar
+    (cd ${TOPDIR}/.. &&
+     tar -cpf $subiquity_tar bin subiquity) || {
+        log "ERROR: Failed to package subiquity installer";
+        return 1;
+    }
+    userdata_write_file "/tmp/subiquity.tar" \
+                        "root:root" "0644" "b64" \
+                        "$subiquity_tar" >> $seed/user-data || {
+        log "Failed to subiquity into $seed";
         return 1;
     }
 

--- a/installer/resources/menu/extlinux-menu.conf
+++ b/installer/resources/menu/extlinux-menu.conf
@@ -9,4 +9,4 @@ label installer
    menu label ^Ubuntu Server Installer
    menu default
    linux /vmlinuz
-   append initrd=/initrd.img ip=::::myhostname:BOOTIF ro root=LABEL=cloudimg-rootfs overlayroot=tmpfs BOOTIF_DEFAULT=eth0 console=tty0 console=ttyS0 splash
+   append initrd=/initrd.img ip=::::myhostname:BOOTIF ro root=LABEL=cloudimg-rootfs overlayroot=tmpfs BOOTIF_DEFAULT=eth0 console=ttyS0 console=tty0 splash

--- a/installer/resources/user-data/installer-user-data
+++ b/installer/resources/user-data/installer-user-data
@@ -6,17 +6,24 @@ output: {all: '| tee -a /var/log/cloud-init-output.log'}
 packages:
  - python-urwid
  - python3-urwid
+power_state:
+ mode: poweroff
+ message: Bye Bye
+ timeout: 30
 runcmd:
     - cp /usr/share/doc/python-urwid/examples/input_test.py /tmp/installer.py
-    - chmod +x /tmp/installer.py
+    - tar -C /usr/local -xf /tmp/subiquity.tar
+    - chmod +x /tmp/installer.py /usr/local/bin/subiquity
     - systemctl enable subiquity.service
-    - systemctl stop serial-getty@ttyS0.service
+    - systemctl stop getty@tty1.service
+#    - systemctl stop serial-getty@ttyS0.service
     - /tmp/installer.sh
+    - telinit 0
 write_files:
 -   content: |
         #!/bin/bash
 
-        #chvt 2
+        chvt 2
         systemctl start subiquity
         # restart getty service after exiting "installer"
         # systemctl stop serial-getty@ttyS0.service
@@ -26,11 +33,12 @@ write_files:
 -   content: |
         [Unit]
         Description=Ubuntu Servier Installer Service
-        After=getty@tty2.service
+        After=getty@tty1.service
 
         [Service]
         Type=oneshot
-        ExecStart=/tmp/installer.py
+        Environment="PYTHONPATH=/usr/local"
+        ExecStart=/usr/local/bin/subiquity
         StandardInput=tty-force
         StandardOutput=tty
         StandardError=tty


### PR DESCRIPTION
- Tar up the subiquity code and inject that into the user-data
- Add support for encoding when adding binary files
- Until we have a way to detect serial presence, run installer on tty1
- Add power_state hook to shut machine off after subiquity exits
- git status ignore image file in installer dir

Signed-off-by: Ryan Harper ryan.harper@canonical.com
