### PR TITLE
Handle network devices with missing udev hardware data

### DIFF
--- a/subiquity/views/network.py
+++ b/subiquity/views/network.py
@@ -46,8 +46,10 @@ class NetworkView(WidgetWrap):
 
     def _build_model_inputs(self):
         sl = []
+        log.info("probing for network devices")
         self.model.probe_network()
         for iface in self.model.get_interfaces():
+            log.info("looking at {}".format(iface))
             sl.append(Color.button_primary(confirm_btn(label=iface,
                                                        on_press=self.confirm),
                                            focus_map='button_primary focus'))


### PR DESCRIPTION
We've encountered some usb nics which don't have an entry
in the udev database, subsequently the ID_XXX_FROM_DATABASE
isn't present in the output.  Address this by using some
fallback keys, ID_XXX, ID_XXX_ID and an Unknown value if
all fail.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
