### PR TITLE
Implement Filesystem Model Reset

### DIFF
--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -80,7 +80,6 @@ class Controller:
         self.signal.connect_signals(signals)
         log.debug(self.signal)
 
-
 # EventLoop -------------------------------------------------------------------
     def redraw_screen(self):
         if hasattr(self, 'loop'):
@@ -142,9 +141,7 @@ class Controller:
         self.ui.set_footer(message)
         self.redraw_screen()
 
-
 # Modes ----------------------------------------------------------------------
-
     # Welcome -----------------------------------------------------------------
     def welcome(self, *args, **kwargs):
         title = "Wilkommen! Bienvenue! Welcome! Zdrastvutie! Welkom!"
@@ -211,7 +208,8 @@ class Controller:
     def filesystem(self, reset=False):
         # FIXME: Is this the best way to zero out this list for a reset?
         if reset:
-            self.models["filesystem"].devices = {}
+            log.info("Resetting Filesystem model")
+            self.models["filesystem"].reset()
 
         title = "Filesystem setup"
         footer = ("Select available disks to format and mount")

--- a/subiquity/filesystem/__init__.py
+++ b/subiquity/filesystem/__init__.py
@@ -110,6 +110,11 @@ class FilesystemModel(ModelPolicy):
         self.prober = prober.Prober(self.options)
         self.probe_storage()
 
+    def reset(self):
+        log.debug('FilesystemModel: resetting disks')
+        for disk in self.devices.values():
+            disk.reset()
+
     def get_signal_by_name(self, selection):
         for x, y, z in self.get_signals():
             if x == selection:
@@ -377,8 +382,8 @@ class DiskPartitionView(WidgetWrap):
         self.signal.emit_signal('filesystem:create-swap-entire-device')
 
     def done(self, result):
-        actions = self.disk_obj.get_actions()
-        self.signal.emit_signal('filesystem:finish', False, actions)
+        ''' Return to FilesystemView '''
+        self.signal.emit_signal('filesystem:show')
 
     def cancel(self, button):
         self.signal.emit_signal('filesystem:show')
@@ -436,7 +441,7 @@ class FilesystemView(ViewPolicy):
 
     def _build_buttons(self):
         buttons = [
-            Color.button_secondary(reset_btn(on_press=self.cancel),
+            Color.button_secondary(reset_btn(on_press=self.reset),
                                    focus_map='button_secondary focus'),
             Color.button_secondary(done_btn(on_press=self.done),
                                    focus_map='button_secondary focus'),
@@ -482,7 +487,7 @@ class FilesystemView(ViewPolicy):
         self.signal.emit_signal(self.model.get_previous_signal)
 
     def reset(self, button):
-        self.signal.emit_signal('filesystem:reset', True)
+        self.signal.emit_signal('filesystem:show', True)
 
     def done(self, button):
         actions = self.model.get_actions()

--- a/subiquity/filesystem/blockdev.py
+++ b/subiquity/filesystem/blockdev.py
@@ -73,6 +73,13 @@ class Blockdev():
         self.bcache = []
         self.lvm = []
 
+    def reset(self):
+        ''' Wipe out any actions queued for this disk '''
+        self.disk = parted.freshDisk(self.device, self.parttype)
+        self.mounts = {}
+        self.bcache = []
+        self.lvm = []
+
     def _get_largest_free_region(self):
         """Finds largest free region on the disk"""
         # There are better ways to do it, but let's be straightforward


### PR DESCRIPTION
- Reset button will clear out any changes made to the filesystem model.
- Fixed Reset button label and callback.
- Reverted change to DiskPartitionView which called filesystem:finish instead
  of returning back to FilesystemView.
- Fixed a few lint errors.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
