### PR TITLE
Fix swap support

### DIFF
--- a/subiquity/filesystem/actions.py
+++ b/subiquity/filesystem/actions.py
@@ -93,6 +93,9 @@ class FormatAction(DiskAction):
         # fat filesystem require an id of <= 11 chars
         if fstype.startswith('fat'):
             self._action_id = self._action_id[:11]
+        # curtin detects fstype as 'swap'
+        elif fstype.startswith('linux-swap'):
+            self._fstype = 'swap'
 
     @property
     def fstype(self):


### PR DESCRIPTION
pyparted uses 'linux-swap(v1)' as the filesystem name to indicate swap files.
Curtin currently recognizes 'swap'.  Update the FormatAction class to emit
'swap' to match curtin.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
