### PR TITLE
Fix psuedo-random hangs on make run

### DIFF
--- a/installer/resources/grub/grub.cfg
+++ b/installer/resources/grub/grub.cfg
@@ -44,11 +44,11 @@ done
 
 # Create menuentry for installer
 menuentry "Boot Installer - Graphical Console" {
-    linux /vmlinuz ip=dhcp ro root=LABEL=cloudimg-rootfs overlayroot=tmpfs console=ttyS0 console=tty0 quiet splash
+    linux /vmlinuz ip=dhcp ro root=LABEL=cloudimg-rootfs overlayroot=tmpfs net.ifnames=0 console=ttyS0 console=tty0 quiet splash
     initrd /initrd.img
 }
 menuentry "Boot Installer - Serial Console" {
-    linux /vmlinuz ip=dhcp ro root=LABEL=cloudimg-rootfs overlayroot=tmpfs console=tty0 console=ttyS0
+    linux /vmlinuz ip=dhcp ro root=LABEL=cloudimg-rootfs overlayroot=tmpfs net.ifnames=0 console=tty0 console=ttyS0
     initrd /initrd.img
 }
 


### PR DESCRIPTION
Non-virtio nics get persistent names which require a 2 minute timeout
which slows the installer down.  Use net.ifnames=0 in grub config to
handle non virtio nics getting persistent names until a fix arrives.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
