### PR TITLE
Drop python3-parted use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ $(NAME)_$(VERSION).orig.tar.gz: clean
 tarball: $(NAME)_$(VERSION).orig.tar.gz
 
 install_deps:
-	sudo apt-get install python3-urwid python3-pyudev python3-netifaces python3-nose python3-flake8 python3-parted python3-yaml git bzr ubuntu-cloudimage-keyring python3-jinja2 python3-coverage
+	sudo apt-get install python3-urwid python3-pyudev python3-netifaces python3-nose python3-flake8 python3-yaml git bzr ubuntu-cloudimage-keyring python3-jinja2 python3-coverage
 
 dryrun:
 	$(MAKE) ui-view DRYRUN="--dry-run"

--- a/installer/geninstaller
+++ b/installer/geninstaller
@@ -35,7 +35,6 @@ SRC_DEPS=(
 )
 INSTALLER_DEPS=(
   "petname"
-  "python3-parted"
   "python3-urwid"
   "python3-pyudev"
   "python3-netifaces"

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -106,6 +106,7 @@ class FilesystemController(ControllerPolicy):
                 # adjust downward the partition size to accommodate
                 # the bios/grub partition
                 spec['bytes'] -= BIOS_GRUB_SIZE_BYTES
+                spec['partnum'] = 2
 
             if spec["fstype"] in ["swap"]:
                 current_disk.add_partition(partnum=spec["partnum"],

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -134,13 +134,15 @@ class FilesystemModel(ModelPolicy):
 
     def get_disk(self, disk):
         if disk not in self.devices:
-            self.devices[disk] = Blockdev(disk, self.info[disk].serial)
+            self.devices[disk] = Blockdev(disk, self.info[disk].serial,
+                                          self.info[disk].model)
         return self.devices[disk]
 
     def get_partitions(self):
         partitions = []
         for dev in self.devices.values():
-            partnames = [part.path for part in dev.disk.partitions]
+            partnames = [part.path for (num, part) in
+                         dev.disk.partitions.items()]
             partitions += partnames
 
         sorted(partitions)


### PR DESCRIPTION
Using parted required root privileges since it opened the underlying device.
Instead create our own Disk model and use sysfs interface for extracting
size information.
This also clears the way for providing device data via probert input.  This
means we can feed subiquity a probert dump and have it present that to
the installer UI even if we're running on a different system.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
