### PR TITLE
Fix issue with partition size inputs and units

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -21,7 +21,7 @@ import math
 from subiquity.model import ModelPolicy
 
 
-HUMAN_UNITS = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+HUMAN_UNITS = ['B', 'K', 'M', 'G', 'T', 'P']
 log = logging.getLogger('subiquity.models.filesystem')
 
 
@@ -182,7 +182,10 @@ def _dehumanize_size(size):
     if size.endswith("B"):
         size = size[:-1]
 
-    mpliers = {'B': 1, 'K': 2 ** 10, 'M': 2 ** 20, 'G': 2 ** 30, 'T': 2 ** 40}
+    # build mpliers based on HUMAN_UNITS
+    mpliers = {}
+    for (unit, exponent) in zip(HUMAN_UNITS, range(0, len(HUMAN_UNITS))):
+        mpliers.update({unit: 2 ** (exponent * 10)})
 
     num = size
     mplier = 'B'


### PR DESCRIPTION
There was a mismatch between what human size units we accepted
and what we matched for in the view validator.  Fix that by
ensuring all places use the HUMAN_BYTES variable, including building
the multiplier from the listed HUMAN_BYTES.

Also drop the use of mixed case for the units, now all size units
must be capital (B, K, M, G, T, P) etc.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
