### PR TITLE
Fix serial mode

### DIFF
--- a/installer/resources/user-data/installer-user-data
+++ b/installer/resources/user-data/installer-user-data
@@ -21,7 +21,7 @@ write_files:
         LASTCON=$(cat /proc/cmdline | fmt -w 1 | grep ^console= | tail -n 1)
         case $LASTCON in
             console=ttyS[0-9])
-                SERIAL="--serial"
+                SERIAL="-o --serial"
                 systemctl stop serial-getty@ttyS0.service
                 ;;
             console=tty[0-9])
@@ -30,22 +30,25 @@ write_files:
                 systemctl stop getty@tty1.service;
                 ;;
         esac
+        # generate service file
         cat <<EOF >/lib/systemd/system/subiquity.service
         [Unit]
         Description=Ubuntu Servier Installer Service
         After=getty@tty1.service
 
         [Service]
-        Type=oneshot
-        Environment="PYTHONPATH=/usr/local"
-        ExecStart=/usr/local/bin/subiquity ${SERIAL}
+        Environment=PYTHONPATH=/usr/local
+        ExecStart=-/sbin/agetty -n --noclear -l /usr/local/bin/subiquity ${SERIAL} console vt100
+        TTYReset=yes
+        TTYVHangup=yes
+        TTYVTDisallocate=yes
+        KillMode=process
+        Type=idle
+        Restart=always
         StandardInput=tty-force
         StandardOutput=tty
         StandardError=tty
         TTYPath=/dev/console
-        TTYReset=yes
-        TTYVHangup=yes
-        TTYVTDisallocate=yes
 
         [Install]
         WantedBy=default.target

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -15,7 +15,6 @@
 
 import logging
 import urwid
-import urwid.curses_display
 from tornado.ioloop import IOLoop
 from tornado.util import import_object
 from subiquity.signals import Signal
@@ -96,7 +95,6 @@ class Controller:
             }
             if self.common['opts'].run_on_serial:
                 palette = STYLES_MONO
-                additional_opts['screen'] = urwid.curses_display.Screen()
             else:
                 additional_opts['screen'].set_terminal_properties(colors=256)
                 additional_opts['screen'].reset_default_terminal_palette()


### PR DESCRIPTION
We can't use curses_display with an external event loop (tornado).  The good
news is that we don't have to.  Instead we switch to using agetty to bypass
login, specify the installer and options to execute.  This also handles
respawning the installer if it exits and works both on serial and without.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
