### PR TITLE
Don't display mounted disks except during dry-run

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -37,7 +37,7 @@ UEFI_GRUB_SIZE_BYTES = 512 * 1024 * 1024  # 512MiB EFI partition
 class FilesystemController(ControllerPolicy):
     def __init__(self, common):
         super().__init__(common)
-        self.model = FilesystemModel(self.prober)
+        self.model = FilesystemModel(self.prober, self.opts)
         self.iscsi_model = IscsiDiskModel()
         self.ceph_model = CephDiskModel()
         self.raid_model = RaidModel()

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -90,7 +90,8 @@ class FilesystemModel(ModelPolicy):
         'leave unformatted'
     ]
 
-    def __init__(self, prober):
+    def __init__(self, prober, opts):
+        self.opts = opts
         self.prober = prober
         self.info = {}
         self.devices = {}
@@ -140,6 +141,10 @@ class FilesystemModel(ModelPolicy):
                                           size=self.info[disk].size)
         return self.devices[disk]
 
+    def get_disks(self):
+        return [self.get_disk(d) for d in sorted(self.info.keys())
+                if len(d) > 0]
+
     def get_partitions(self):
         log.debug('probe_storage: get_partitions()')
         partitions = []
@@ -154,7 +159,8 @@ class FilesystemModel(ModelPolicy):
         return partitions
 
     def get_available_disks(self):
-        return sorted(self.info.keys())
+        return [dev.disk.devpath for dev in self.get_disks()
+                if self.opts.dry_run is True or dev.mounted is False]
 
     def get_used_disks(self):
         return [dev.disk.devpath for dev in self.devices.values()

--- a/subiquity/ui/views/filesystem.py
+++ b/subiquity/ui/views/filesystem.py
@@ -380,6 +380,7 @@ class FilesystemView(ViewPolicy):
         self.signal = signal
         self.items = []
         self.model.probe_storage()  # probe before we complete
+        self.installable = True
         self.body = [
             Padding.center_79(Text("FILE SYSTEM")),
             Padding.center_79(self._build_partition_list()),
@@ -437,12 +438,17 @@ class FilesystemView(ViewPolicy):
 
     def _build_buttons(self):
         log.debug('FileSystemView: building buttons')
-        buttons = [
-            Color.button(done_btn(on_press=self.done),
-                         focus_map='button focus'),
-            Color.button(reset_btn(on_press=self.reset),
-                         focus_map='button focus')
-        ]
+        buttons = []
+
+        # don't enable done botton if we can't install
+        if self.installable:
+            buttons.append(
+                Color.button(done_btn(on_press=self.done),
+                             focus_map='button focus'))
+
+        buttons.append(Color.button(reset_btn(on_press=self.reset),
+                                    focus_map='button focus'))
+
         return Pile(buttons)
 
     def _get_percent_free(self, device):
@@ -459,7 +465,12 @@ class FilesystemView(ViewPolicy):
         col_1 = []
         col_2 = []
 
-        for dname in self.model.get_available_disks():
+        avail_disks = self.model.get_available_disks()
+        if len(avail_disks) == 0:
+            self.installable = False
+            return Pile([Color.info_minor(Text("No available disks."))])
+
+        for dname in avail_disks:
             disk = self.model.get_disk_info(dname)
             device = self.model.get_disk(dname)
             btn = menu_btn(label=disk.name,


### PR DESCRIPTION
Enhance our mounted disk detection. Don't display these
devices unless we're in dry-run mode.  Add support for
the case where we don't have any disks and prevent
the installer from progressing.  Fixes #48 

Signed-off-by: Ryan Harper ryan.harper@canonical.com
