### PR TITLE
Unbreak make and installer script with subiquity-tui rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,14 @@ dryrun: probert
 	$(MAKE) ui-view DRYRUN="--dry-run --uefi"
 
 ui-view:
-	(PYTHONPATH=$(PYTHONPATH) bin/$(PYTHONSRC) $(DRYRUN) $(MACHARGS))
+	(PYTHONPATH=$(PYTHONPATH) bin/$(PYTHONSRC)-tui $(DRYRUN) $(MACHARGS))
 
 ui-view-serial:
-	(TERM=att4424 PYTHONPATH=$(PYTHONPATH) bin/$(PYTHONSRC) $(DRYRUN) --serial)
+	(TERM=att4424 PYTHONPATH=$(PYTHONPATH) bin/$(PYTHONSRC)-tui $(DRYRUN) --serial)
 
 lint:
 	echo "Running flake8 lint tests..."
-	flake8 bin/$(PYTHONSRC) --ignore=F403
+	flake8 bin/$(PYTHONSRC)-tui --ignore=F403
 	flake8 --exclude $(PYTHONSRC)/tests/ $(PYTHONSRC) --ignore=F403
 
 unit:

--- a/installer/resources/overlay/subiquity/installer.sh
+++ b/installer/resources/overlay/subiquity/installer.sh
@@ -19,7 +19,7 @@ After=getty@tty1.service
 
 [Service]
 Environment=PYTHONPATH=/usr/local
-ExecStart=-/sbin/agetty -n --noclear -l /usr/local/bin/subiquity ${SERIAL} console vt100
+ExecStart=-/sbin/agetty -n --noclear -l /usr/local/bin/subiquity-tui ${SERIAL} console vt100
 TTYReset=yes
 TTYVHangup=yes
 TTYVTDisallocate=yes


### PR DESCRIPTION
After renaming bin/subiquity to bin/subiquity-tui we broke a
few things that invoked subiquity via bin/subiquity which is
now bin/subiquity-tui

Signed-off-by: Ryan Harper ryan.harper@canonical.com
