### PR TITLE
Fix is_root check on sudo

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -196,7 +196,9 @@ class FilesystemController(ControllerPolicy):
     def show_disk_information(self, device):
         """ Show disk information, requires sudo/root
         """
-        if not utils.is_root():
+        root = utils.is_root()
+        log.debug('show_disk_info is_root ? {}'.format(root))
+        if not root:
             result = "hdparm requires root permission."
         else:
             out = utils.run_command("hdparm -i {}".format(device))

--- a/subiquity/utils.py
+++ b/subiquity/utils.py
@@ -119,7 +119,10 @@ def is_root():
     """ Returns root or if sudo user exists
     """
     sudo_user = os.getenv('SUDO_USER', None)
+    euid = os.geteuid()
 
-    if os.geteuid() != 0 or not sudo_user:
+    log.debug('is_root: euid={} sudo_user={}'.format(
+        euid, sudo_user))
+    if euid != 0 or sudo_user is not None:
         return False
     return True


### PR DESCRIPTION
Add debugging and logging for is_root check.
Fix up logic so we check if sudo_user is non None
Now we can see disk info when running as root in the installer.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
