### PR TITLE
Fix runinstaller to work after installed

### DIFF
--- a/installer/runinstaller
+++ b/installer/runinstaller
@@ -19,35 +19,49 @@ MEM=${MEM-"1024"}
 INSTALLER=${INSTALLER-"installer.img"}
 UEFI=${UEFI-"1"}
 TARGET=${TARGET-"target.img"}
+GRAPHIC="-serial stdio"
 SPORT=2445
 
 QEMU=`which qemu-system-$ARCH`;
+case $ARCH in
+    i386|x86_64)
+        PKG=ovmf qemu-system-x86
+        if [ "${UEFI}" == "1" ]; then
+            UEFI=" -bios /usr/share/ovmf/OVMF.fd"
+        else
+            UEFI=""
+        fi
+    ;;
+    arm*) PKG=qemu-system-arm ;;
+    ppc*) PKG=qemu-system-ppc ;;
+    *)
+    echo "Unsupported arch: $ARCH";
+    exit 1;
+    ;;
+esac
 if [ -z $QEMU ]; then
-   case $ARCH in
-      i386|x86_64) PKG=qemu-system-x86 ;;
-      arm*) PKG=qemu-system-arm ;;
-      ppc*) PKG=qemu-system-ppc ;;
-      *)
-         echo "Unsupported arch: $ARCH";
-         exit 1;
-         ;;
-    esac
+    echo "Installing required packages: $PKG"
     sudo apt-get install $PKG || {
-       echo "Failed to install qemu-system package $PKG";
-       exit 1;
+        echo "Failed to install qemu-system package(s) $PKG";
+        if echo $PKG | grep -q ovmf; then
+            echo "ovmf package is only available in multiverse."
+            echo "You can enable multiverse and try again:"
+            echo "sudo add-apt-repository multiverse"
+        fi
+        exit 1;
     }
 fi
-
-if [ "${UEFI}" == "1" ]; then
-    UEFI=" -bios /usr/share/ovmf/OVMF.fd"
-else
-    UEFI=""
+# don't spawn sdl if we're headless
+if [ -z $DISPLAY ]; then
+    GRAPHIC="-nographic"
 fi
 
 # always recreate the target image
+echo "Creating dummy target image: ${TARGET}"
 qemu-img create -f raw ${TARGET} 10G
 
-# TODO, curses should work, but my xmonad setup blocks using it
+# TODO, curses should work, make serial|nographic optional
+echo "Launching Installer VM"
 sudo qemu-system-$ARCH -smp 2 -m $MEM -enable-kvm $UEFI\
                        -drive cache=unsafe,if=ide,file=$INSTALLER,serial=QM_INSTALL_01 \
                        -drive cache=unsafe,if=ide,file=$TARGET,serial=QM_TARGET_01 \
@@ -55,8 +69,7 @@ sudo qemu-system-$ARCH -smp 2 -m $MEM -enable-kvm $UEFI\
                        -net nic,model=e1000 \
                        -net nic,model=virtio \
                        -net nic,model=i82559er \
-                       -monitor telnet:127.0.0.1:2446,server,nowait -serial stdio
-#sudo qemu-system-$ARCH -m $MEM -enable-kvm -hda $INSTALLER -hdb $TARGET \
-#                       -monitor telnet:127.0.0.1:2446,server,nowait -curses
+                       -monitor telnet:127.0.0.1:2446,server,nowait \
+                       ${GRAPHIC}
 
 exit $?


### PR DESCRIPTION
Cleanup runinstaller to be usable after install via package.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
