### PR TITLE
Change dpkg-build flags to sign source deb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ git-checkout-deb:
         rm -fr $(GITDEBDIR); \
     fi
 
-DPKGBUILDARGS = -us -uc -i'.git.*|.tox|.bzr.*|.editorconfig|.travis-yaml'
+DPKGBUILDARGS = -i'.git.*|.tox|.bzr.*|.editorconfig|.travis-yaml'
 deb-src: git-checkout-deb clean tarball
 	@dpkg-buildpackage -S -sa $(DPKGBUILDARGS)
 
@@ -88,7 +88,7 @@ deb-release: git-checkout-deb tarball
 	@dpkg-buildpackage -S -sd $(DPKGBUILDARGS)
 
 deb: git-checkout-deb
-	@dpkg-buildpackage -b $(DPKGBUILDARGS)
+	@dpkg-buildpackage -us -uc -b $(DPKGBUILDARGS)
 
 clean:
 	@if [ -d "$(DEBDIR)" ]; then \


### PR DESCRIPTION
Don't include -us -uc when creating deb source and dpkg will
actually sign the source package.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
