### PR TITLE
Simplify kitt spinner

### DIFF
--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-
 import logging
 from tornado.gen import coroutine
 import subiquity.utils as utils
@@ -31,21 +29,19 @@ log = logging.getLogger("subiquity.controller.installprogress")
 
 class InstallProgressController(ControllerPolicy):
     KITT = [
-        "\u2581",
-        "\u2582",
-        "\u2583",
-        "\u2584",
-        "\u2585",
-        "\u2586",
-        "\u2587",
-        "\u2588",
-        "\u2587",
-        "\u2586",
-        "\u2585",
-        "\u2584",
-        "\u2583",
-        "\u2582",
-    ]
+        "-......",
+        ".-.....",
+        "..-....",
+        "...-...",
+        "....-..",
+        ".....-.",
+        "......-",
+        ".....-.",
+        "....-..",
+        "...-...",
+        "..-....",
+        ".-.....",
+        "-......"]
 
     def __init__(self, common):
         super().__init__(common)
@@ -54,6 +50,7 @@ class InstallProgressController(ControllerPolicy):
         self.is_complete = False
         self.alarm = None
         self.kitt_pos = 0
+        self.kitt_len = len(self.KITT)
 
     @coroutine
     def curtin_install(self, postconfig):
@@ -93,13 +90,9 @@ class InstallProgressController(ControllerPolicy):
             self.progress_view.show_finished_button()
             self.loop.remove_alarm(self.alarm)
         else:
-            try:
-                cur_kitt = self.KITT[self.kitt_pos]
-            except IndexError:
-                self.kitt_pos = 0
-                cur_kitt = self.KITT[self.kitt_pos]
+            cur_kitt = self.KITT[self.kitt_pos % self.kitt_len]
             self.progress_view.text.set_text(
-                "Still installing, {}".format(
+                "Installing <{}>".format(
                     cur_kitt))
             self.alarm = self.loop.set_alarm_in(0.3, self.progress_indicator)
             self.kitt_pos += 1


### PR DESCRIPTION
Testing this out, I never saw any of the utf-8 output besides a ?
Instead use simple ascii ala kirby.  Also replace the
try:except with a modulo operation to index the list.
Drop the futures import.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
