### PR TITLE
Ensure install progress fails with missing curtin

### DIFF
--- a/subiquity/curtin.py
+++ b/subiquity/curtin.py
@@ -139,6 +139,9 @@ def curtin_find_curtin():
         if os.path.exists(curtin):
             log.debug('curtin found at: {}'.format(curtin))
             return curtin
+    # This ensures we fail when we attempt to run curtin
+    # but it's not present
+    return '/bin/false'
 
 
 def curtin_find_install_path():


### PR DESCRIPTION
If we fail to find curtin, we don't return a valid path
and this confuses the run async, so instead return
/bin/false which will return non-zero and trip the
async failure detection.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
