### PR TITLE
Use storage path if disks don't have valid serial numbers

### DIFF
--- a/subiquity/models/actions.py
+++ b/subiquity/models/actions.py
@@ -115,6 +115,12 @@ class DiskAction():
         }
         if self._wipe:
             action.update({'wipe': self._wipe})
+        # if we don't have a valid serial, then we must use
+        # device path, which is stored in action_id
+        if self._serial in ['Unknown Serial']:
+            del action['serial']
+            action.update({'path': '/dev/{}'.format(self.action_id)})
+
         return action
 
     def dump(self):


### PR DESCRIPTION
Some disk devices (virtio) don't have serial numbers by default.
This breaks curtin which requires a serial or a path to uniquely
find the target disks.  Add a fallback to device path if the
current device includes the eye catcher 'Unknown Serial' which
is set by probert for devices that do not have a serial number.

Fixes: #63 

Signed-off-by: Ryan Harper ryan.harper@canonical.com
