### PR TITLE
Safe exit only on control-x

### DIFF
--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -82,8 +82,7 @@ class Controller:
         raise urwid.ExitMainLoop()
 
     def header_hotkeys(self, key):
-        if key in ['q', 'Q', 'ctrl c']:
-            self.exit()
+        return False
 
     def run(self):
         if not hasattr(self, 'loop'):

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -45,10 +45,5 @@ class ProgressView(ViewPolicy):
         self.pile.contents.append((w, self.pile.options()))
         self.pile.focus_position = 1
 
-    def keypress(self, size, key):
-        super().keypress(size, key)
-        if key in ['q', 'Q']:
-            self.signal.emit_signal('installprogress:curtin-reboot')
-
     def reboot(self, btn):
         self.signal.emit_signal('installprogress:curtin-reboot')

--- a/subiquity/view.py
+++ b/subiquity/view.py
@@ -20,12 +20,14 @@ Contains some default key navigations
 
 from urwid import WidgetWrap
 
-
 class ViewPolicy(WidgetWrap):
     def keypress(self, size, key):
         if key == 'esc':
             self.signal.emit_signal(self.model.get_previous_signal)
-        if key == 'Q' or key == 'q' or key == 'ctrl c':
+            return None
+        if key in ['ctrl x']:
             self.signal.register_signals('quit')
             self.signal.emit_signal('quit')
-        super().keypress(size, key)
+            return None
+
+        return super().keypress(size, key)


### PR DESCRIPTION
The single key 'Q' or 'q' was a bridge too far since we take
input at anytime and can surprise users.  Instead use a key
combination, control-x.  Clean up keypress handlers to match
urwid requirements (return None when handled, otherwise False,
or pass to super.

Closes #69 

Signed-off-by: Ryan Harper ryan.harper@canonical.com
