### PR TITLE
Introduce safer loading of machine configs

### DIFF
--- a/bin/subiquity-tui
+++ b/bin/subiquity-tui
@@ -21,6 +21,7 @@ import signal
 from subiquity.log import setup_logger, LOGFILE
 from subiquity import __version__ as VERSION
 from subiquity.core import Controller as Subiquity
+from subiquity.core import CoreControllerError
 from subiquity.ui.frame import SubiquityUI
 from subiquity.utils import environment_check
 
@@ -63,7 +64,13 @@ def main():
 
     ui = SubiquityUI()
 
-    subiquity_interface = Subiquity(ui, opts)
+    try:
+        subiquity_interface = Subiquity(ui, opts)
+    except CoreControllerError as e:
+        logger.exception('Failed to load Subiquity interface')
+        print(e)
+        return 1
+
     subiquity_interface.run()
 
 if __name__ == '__main__':

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -19,7 +19,7 @@ from tornado.ioloop import IOLoop
 from tornado.util import import_object
 from subiquity.signals import Signal
 from subiquity.palette import STYLES, STYLES_MONO
-from subiquity.prober import Prober
+from subiquity.prober import Prober, ProberException
 
 log = logging.getLogger('subiquity.core')
 
@@ -31,11 +31,18 @@ class CoreControllerError(Exception):
 
 class Controller:
     def __init__(self, ui, opts):
+        try:
+            prober = Prober(opts)
+        except ProberException as e:
+            err = "Prober init failed: {}".format(e)
+            log.exception(err)
+            raise CoreControllerError(err)
+
         self.common = {
             "ui": ui,
             "opts": opts,
             "signal": Signal(),
-            "prober": Prober(opts),
+            "prober": prober,
             "loop": None
         }
         self.controllers = {

--- a/subiquity/tests/fakes.py
+++ b/subiquity/tests/fakes.py
@@ -1,7 +1,8 @@
 import os
-import json
+import yaml
 
 TOP_DIR = os.path.join('/'.join(__file__.split('/')[:-3]))
 TEST_DATA = os.path.join(TOP_DIR, 'subiquity', 'tests', 'data')
 FAKE_MACHINE_JSON = os.path.join(TEST_DATA, 'fake_machine.json')
-FAKE_MACHINE_STORAGE_DATA = json.load(open(FAKE_MACHINE_JSON)).get('storage')
+FAKE_MACHINE_JSON_DATA = yaml.safe_load(open(FAKE_MACHINE_JSON))
+FAKE_MACHINE_STORAGE_DATA = FAKE_MACHINE_JSON_DATA.get('storage')

--- a/subiquity/tests/test_models_filesystems.py
+++ b/subiquity/tests/test_models_filesystems.py
@@ -24,9 +24,11 @@ class TestFilesystemModel(testtools.TestCase):
         self.make_fsm()
 
     # mocking the reading of the fake data saves on IO
+    @patch.object(Prober, '_load_machine_config')
     @patch.object(Prober, 'get_storage')
-    def make_fsm(self, _get_storage):
+    def make_fsm(self, _get_storage, _load_machine_config):
         _get_storage.return_value = fakes.FAKE_MACHINE_STORAGE_DATA
+        _load_machine_config.return_value = fakes.FAKE_MACHINE_JSON_DATA
         self.opts = argparse.Namespace()
         self.opts.machine_config = fakes.FAKE_MACHINE_JSON
         self.opts.dry_run = True


### PR DESCRIPTION
- Switch to yaml.safe_load() which throws errors when fed /dev/zero.
- Add a new ProberExecption and bubble that up to the main program
- Update unit tests to mock out repeated calls to safe_load which slowed
  down the unittest run.

Fixes issue #74 

Signed-off-by: Ryan Harper ryan.harper@canonical.com
