### PR TITLE
Fix div by zero in blockdev available check

### DIFF
--- a/subiquity/models/blockdev.py
+++ b/subiquity/models/blockdev.py
@@ -242,6 +242,9 @@ class Blockdev():
     @property
     def percent_free(self):
         ''' return the device free percentage of the whole device'''
+        if self.size == 0:
+            return 0
+
         percent = (int((1.0 - (self.usedspace / self.size)) * 100))
         return percent
 


### PR DESCRIPTION
Some blockdevices make report a size of zero; don't
explode when calculating percent free.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
