### PR TITLE
Make exiting installer easier

### DIFF
--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -104,6 +104,10 @@ class InstallProgressController(ControllerPolicy):
             self.kitt_pos += 1
 
     def reboot(self):
+        if self.opts.dry_run:
+            log.debug('dry-run enabled, skipping reboot, quiting instead')
+            self.signal.emit_signal('quit')
+
         curtin_reboot()
 
     @coroutine

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -32,7 +32,8 @@ class ProgressView(ViewPolicy):
         self.signal = signal
         self.text = Text("Wait for it ...", align="center")
         self.body = [
-            Padding.center_79(self.text)
+            Padding.center_79(self.text),
+            Padding.line_break(""),
         ]
         self.pile = Pile(self.body)
         super().__init__(Filler(self.pile, valign="middle"))
@@ -43,8 +44,17 @@ class ProgressView(ViewPolicy):
                                      on_press=self.reboot),
                          focus_map='button focus'))
 
+        z = Padding.center_20(
+            Color.button(confirm_btn(label="Quit Installer",
+                                     on_press=self.quit),
+                         focus_map='button focus'))
+
         self.pile.contents.append((w, self.pile.options()))
-        self.pile.focus_position = 1
+        self.pile.contents.append((z, self.pile.options()))
+        self.pile.focus_position = 2
 
     def reboot(self, btn):
         self.signal.emit_signal('installprogress:curtin-reboot')
+
+    def quit(self, btn):
+        self.signal.emit_signal('quit')


### PR DESCRIPTION
- Add a 'Quit Installer' button on the final install progress screen. This
  is useful for users who want to mess around with the system post-install.
- Redirect 'Reboot' to 'quit' if we're in dry-run mode.

Fixes #105 

Signed-off-by: Ryan Harper ryan.harper@canonical.com
