### PR TITLE
Add initial bonding UX panels and model connections

### DIFF
--- a/subiquity/controllers/network.py
+++ b/subiquity/controllers/network.py
@@ -18,6 +18,7 @@ from subiquity.controller import ControllerPolicy
 from subiquity.models import NetworkModel
 from subiquity.ui.views import (NetworkView,
                                 NetworkSetDefaultRouteView,
+                                NetworkBondInterfacesView,
                                 NetworkConfigureInterfaceView,
                                 NetworkConfigureIPv4InterfaceView)
 from subiquity.ui.dummy import DummyView
@@ -58,6 +59,11 @@ class NetworkController(ControllerPolicy):
         self.ui.set_body(NetworkSetDefaultRouteView(self.model,
                                                     self.signal))
 
+    def bond_interfaces(self):
+        self.ui.set_header("Bond interfaces")
+        self.ui.set_body(NetworkBondInterfacesView(self.model,
+                                                   self.signal))
+
     def network_configure_interface(self, iface):
         self.ui.set_header("Network interface {}".format(iface))
         self.ui.set_body(NetworkConfigureInterfaceView(self.model,
@@ -78,9 +84,6 @@ class NetworkController(ControllerPolicy):
         self.model.prev_signal = ('Back to configure interface menu',
                                   'network:configure-interface-menu',
                                   'network_configure_interface')
-        self.ui.set_body(DummyView(self.signal))
-
-    def bond_interfaces(self):
         self.ui.set_body(DummyView(self.signal))
 
     def install_network_driver(self):

--- a/subiquity/prober.py
+++ b/subiquity/prober.py
@@ -79,3 +79,8 @@ class Prober():
     def get_storage_info(self, device):
         ''' Load a StorageInfo class for specified device '''
         return StorageInfo({device: self.get_storage().get(device)})
+
+
+def make_network_info(device, info):
+    ''' Create a NetworkInfo class for specified device from info'''
+    return NetworkInfo({device: info})

--- a/subiquity/ui/views/__init__.py
+++ b/subiquity/ui/views/__init__.py
@@ -25,6 +25,7 @@ from .network import NetworkView  # NOQA
 from .network_default_route import NetworkSetDefaultRouteView  # NOQA
 from .network_configure_interface import NetworkConfigureInterfaceView  # NOQA
 from .network_configure_ipv4_interface import NetworkConfigureIPv4InterfaceView  # NOQA
+from .network_bond_interfaces import NetworkBondInterfacesView  # NOQA
 from .installpath import InstallpathView  # NOQA
 from .installprogress import ProgressView  # NOQA
 from .welcome import WelcomeView  # NOQA

--- a/subiquity/ui/views/network.py
+++ b/subiquity/ui/views/network.py
@@ -81,7 +81,7 @@ class NetworkView(ViewPolicy):
             info = self.model.get_iface_info(iface)
             log.debug('iface info:{}'.format(info))
             template = ''
-            if info['bonded']:
+            if info['bond_slave']:
                 template += '(Bonded) '
             if info['speed']:
                 template += '{speed} '.format(**info)
@@ -140,6 +140,13 @@ class NetworkView(ViewPolicy):
                 if len(ifaces) < 2:
                     log.debug('Skipping default route menu option'
                               ' (only one nic)')
+                    continue
+            if ':bond-interfaces' in sig:
+                not_bonded = [iface for iface in ifaces
+                              if not self.model.iface_is_bonded(iface)]
+                if len(not_bonded) < 2:
+                    log.debug('Skipping bonding menu option'
+                              ' (not enough available nics)')
                     continue
             opts.append(
                 Color.menu_button(

--- a/subiquity/ui/views/network_bond_interfaces.py
+++ b/subiquity/ui/views/network_bond_interfaces.py
@@ -1,0 +1,135 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from urwid import Text, Columns, Pile, ListBox, CheckBox
+from subiquity.view import ViewPolicy
+from subiquity.ui.buttons import cancel_btn, done_btn
+from subiquity.ui.interactive import Selector
+from subiquity.ui.utils import Color, Padding
+import logging
+
+log = logging.getLogger('subiquity.ui.bond_interfaces')
+
+
+class NetworkBondInterfacesView(ViewPolicy):
+    def __init__(self, model, signal):
+        self.model = model
+        self.signal = signal
+        self.bond_iface = None
+        self.bond_mode = Selector(self.model.bonding_modes.values())
+        self.selected_ifaces = []
+        body = [
+            Padding.center_50(self._build_iface_selection()),
+            Padding.line_break(""),
+            Padding.center_50(self._build_bondmode_configuration()),
+            Padding.line_break(""),
+            Padding.center_20(self._build_buttons())
+        ]
+        super().__init__(ListBox(body))
+
+    def _build_iface_selection(self):
+        log.debug('bond: _build_iface_selection')
+        items = [
+            Text("INTERFACE SELECTION")
+        ]
+        all_iface_names = self.model.get_all_interface_names()
+        avail_ifnames = [iface for iface in all_iface_names
+                         if not self.model.iface_is_bonded(iface)]
+        log.debug('available for bonding: {}'.format(avail_ifnames))
+
+        if len(avail_ifnames) == 0:
+            log.debug('Nothing available...')
+            return Pile([Color.info_minor(Text("No available interfaces."))])
+
+        for ifname in avail_ifnames:
+            device = self.model.get_interface(ifname)
+            device_speed = self.model.iface_get_speed(ifname)
+            iface_string = "{}     {},     {}".format(device.ifname,
+                                                      device.ip,
+                                                      device_speed)
+            log.debug('bond: iface_string={}'.format(iface_string))
+            self.selected_ifaces.append(CheckBox(iface_string))
+
+        items += self.selected_ifaces
+        log.debug('iface_select: items: {}'.format(items))
+        return Pile(items)
+
+    def _build_bondmode_configuration(self):
+        log.debug('bond: _build_bondmode_configuration')
+        items = [
+            Text("BOND CONFIGURATION"),
+            Columns(
+                [
+                    ("weight", 0.2, Text("Bonding Mode", align="right")),
+                    ("weight", 0.3,
+                     Color.string_input(Pile(self.bond_mode.group),
+                                        focus_map="string_input focus"))
+                ],
+                dividechars=4
+            ),
+        ]
+        log.debug('bond_mode: items: {}'.format(items))
+        return Pile(items)
+
+    def _build_buttons(self):
+        log.debug('bond: _build_buttons')
+        cancel = cancel_btn(on_press=self.cancel)
+        done = done_btn(on_press=self.done)
+
+        items = [
+            Color.button(done, focus_map='button focus'),
+            Color.button(cancel, focus_map='button focus')
+        ]
+        log.debug('buttons: items: {}'.format(items))
+        return Pile(items)
+
+    def done(self, result):
+        selected_labels = [x.get_label() for x in self.selected_ifaces
+                           if x.state]
+        if len(selected_labels) < 2:
+            log.debug('Not enough interfaces for bonding')
+            # FIXME: raise error message?
+            return
+
+        # unpack label into iface name
+        bond_interfaces = []
+        for label in selected_labels:
+            bond_interfaces.append(label.split(' ')[0])
+
+        result = {
+            'bond-interfaces': bond_interfaces,
+            'bond-mode': self.bond_mode.value,
+        }
+        log.debug('bonding_done: result = {}'.format(result))
+
+        # generate bond name based on number of bonds created
+        existing_bonds = self.model.get_bond_masters()
+        bond_name = "bond{}".format(int(len(existing_bonds)))
+
+        try:
+            self.model.add_bond(ifname=bond_name,
+                                interfaces=result['bond-interfaces'],
+                                params={'bond-mode': result['bond-mode']},
+                                subnets=[])
+        except ValueError:
+            log.exception('Failed to add bond: {}'.format(result))
+            return
+
+        log.debug('bond: successful bond creation')
+        self.signal.prev_signal()
+
+    def cancel(self, button):
+        log.debug('bond: button_cancel')
+        self.signal.prev_signal()


### PR DESCRIPTION
We now have a bonding UX panel, modeled after the raid menu
where we have a list of interfaces and a radiobox for
selecting the bond mode.  This calls into the network
model to add the bond interface.
- Update the network view to only display the Bond option if we have
  more than one interface that is available (ie, not already part of
  a bond).
- Also update the bond info to include the bond interface composition
  in the hardware info such that it displays according to spec
- Add iface_is_bonded_slave to model
- Update network model info dict to include bond_{slave,master}.  This
  helps us display the (Bonded) attribute for slaves, but not the primary
  bond iface.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
