### PR TITLE
Logfile permissions

### DIFF
--- a/subiquity/log.py
+++ b/subiquity/log.py
@@ -18,8 +18,8 @@ import os
 import sys
 from logging.handlers import TimedRotatingFileHandler
 
-LOGDIR = "logs"
-LOGFILE = os.path.join(LOGDIR, "debug.log")
+LOGDIR = ".subiquity"
+LOGFILE = os.path.join(LOGDIR, "subiquity-debug.log")
 
 
 def setup_logger(name=__name__):


### PR DESCRIPTION
- Handle PermissionError on logfile open
- Rename logdir and logfile to be more meaninful to subiquity

Fixes #77 
