### PR TITLE
Add fixed_X attribute to Padding class and apply to all buttons

### DIFF
--- a/subiquity/ui/utils.py
+++ b/subiquity/ui/utils.py
@@ -43,6 +43,9 @@ def apply_padders(cls):
     for i in range(1, padding_count):
         setattr(cls, 'push_{}'.format(i), partialmethod(_Padding, left=i))
         setattr(cls, 'pull_{}'.format(i), partialmethod(_Padding, right=i))
+        setattr(cls, 'fixed_{}'.format(i),
+                partialmethod(_Padding, align='center',
+                              width=i, min_width=i))
         setattr(cls, 'center_{}'.format(i),
                 partialmethod(_Padding, align='center',
                               width=('relative', i)))
@@ -76,6 +79,17 @@ class Padding:
        .. code::
 
           Padding.pull_20(Text("This will be right indented 20 columns")
+
+    .. py:meth:: fixed_X(:class:`urwid.Widget`)
+
+       This method supports padding the widget to a fixed size and
+       centering it.
+       from 1-99, for example:
+
+       .. code::
+
+          Padding.fixed_20(Text("This will be centered and fixed sized
+                                 of 20 columns"))
 
     .. py:meth:: center_X(:class:`urwid.Widget`)
 

--- a/subiquity/ui/views/bcache.py
+++ b/subiquity/ui/views/bcache.py
@@ -37,7 +37,7 @@ class BcacheView(ViewPolicy):
             Padding.line_break(""),
             Padding.center_50(self._build_disk_selection(section='BACKING')),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/ceph.py
+++ b/subiquity/ui/views/ceph.py
@@ -34,7 +34,7 @@ class CephDiskView(ViewPolicy):
         body = [
             Padding.center_50(self._build_model_inputs()),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/filesystem.py
+++ b/subiquity/ui/views/filesystem.py
@@ -56,7 +56,7 @@ class DiskInfoView(ViewPolicy):
         body = []
         for h in hdinfo:
             body.append(Text(h))
-        body.append(Padding.center_20(self._build_buttons()))
+        body.append(Padding.fixed_10(self._build_buttons()))
         super().__init__(Padding.center_79(SimpleList(body)))
 
     def _build_buttons(self):
@@ -102,7 +102,7 @@ class AddFormatView(ViewPolicy):
             Padding.line_break(""),
             self._container(),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         format_box = Padding.center_50(ListBox(body))
         super().__init__(format_box)
@@ -200,7 +200,7 @@ class AddPartitionView(ViewPolicy):
             Padding.line_break(""),
             self._container(),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         partition_box = Padding.center_50(ListBox(body))
         super().__init__(partition_box)
@@ -363,7 +363,7 @@ class DiskPartitionView(ViewPolicy):
             Padding.line_break(""),
             Padding.center_79(self._build_menu()),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons()),
+            Padding.fixed_10(self._build_buttons()),
         ]
         super().__init__(ListBox(self.body))
 
@@ -488,7 +488,7 @@ class FilesystemView(ViewPolicy):
             Padding.center_79(self._build_menu()),
             Padding.line_break(""),
             Padding.center_79(self._build_used_disks()),
-            Padding.center_15(self._build_buttons()),
+            Padding.fixed_10(self._build_buttons()),
         ]
         super().__init__(ListBox(self.body))
         log.debug('FileSystemView init complete()')

--- a/subiquity/ui/views/hostname.py
+++ b/subiquity/ui/views/hostname.py
@@ -37,7 +37,7 @@ class HostnameView(ViewPolicy):
         body = [
             Padding.center_50(self._build_model_inputs()),
             Padding.line_break(""),
-            Padding.center_15(self._build_buttons()),
+            Padding.fixed_10(self._build_buttons()),
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -51,7 +51,7 @@ class IdentityView(ViewPolicy):
             Padding.line_break(""),
             Padding.center_50(Color.info_error(self.error)),
             Padding.line_break(""),
-            Padding.center_15(self._build_buttons()),
+            Padding.fixed_10(self._build_buttons()),
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/installpath.py
+++ b/subiquity/ui/views/installpath.py
@@ -36,7 +36,7 @@ class InstallpathView(ViewPolicy):
         self.body = [
             Padding.center_79(self._build_model_inputs()),
             Padding.line_break(""),
-            Padding.center_15(self._build_buttons()),
+            Padding.fixed_10(self._build_buttons()),
         ]
         super().__init__(ListBox(self.body))
 

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -39,12 +39,12 @@ class ProgressView(ViewPolicy):
         super().__init__(Filler(self.pile, valign="middle"))
 
     def show_finished_button(self):
-        w = Padding.center_20(
+        w = Padding.fixed_15(
             Color.button(confirm_btn(label="Reboot now",
                                      on_press=self.reboot),
                          focus_map='button focus'))
 
-        z = Padding.center_20(
+        z = Padding.fixed_15(
             Color.button(confirm_btn(label="Quit Installer",
                                      on_press=self.quit),
                          focus_map='button focus'))

--- a/subiquity/ui/views/network.py
+++ b/subiquity/ui/views/network.py
@@ -43,7 +43,7 @@ class NetworkView(ViewPolicy):
             Padding.line_break(""),
             Padding.center_79(self._build_additional_options()),
             Padding.line_break(""),
-            Padding.center_15(self._build_buttons()),
+            Padding.fixed_10(self._build_buttons()),
         ]
         # FIXME determine which UX widget should have focus
         super().__init__(ListBox(self.body))

--- a/subiquity/ui/views/network_bond_interfaces.py
+++ b/subiquity/ui/views/network_bond_interfaces.py
@@ -35,7 +35,7 @@ class NetworkBondInterfacesView(ViewPolicy):
             Padding.line_break(""),
             Padding.center_50(self._build_bondmode_configuration()),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/network_configure_interface.py
+++ b/subiquity/ui/views/network_configure_interface.py
@@ -36,7 +36,7 @@ class NetworkConfigureInterfaceView(ViewPolicy):
             Padding.center_79(self._build_gateway_ipv6_info()),
             Padding.center_79(self._build_manual_ipv6_button()),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/network_configure_ipv4_interface.py
+++ b/subiquity/ui/views/network_configure_ipv4_interface.py
@@ -40,7 +40,7 @@ class NetworkConfigureIPv4InterfaceView(ViewPolicy):
             Padding.center_79(self._build_iface_inputs()),
             Padding.line_break(""),
             Padding.center_79(self._build_set_as_default_gw_button()),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/network_default_route.py
+++ b/subiquity/ui/views/network_default_route.py
@@ -33,7 +33,7 @@ class NetworkSetDefaultRouteView(ViewPolicy):
             Padding.line_break(""),
             Padding.center_79(self._build_default_routes()),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/raid.py
+++ b/subiquity/ui/views/raid.py
@@ -38,7 +38,7 @@ class RaidView(ViewPolicy):
             Padding.line_break(""),
             Padding.center_50(self._build_raid_configuration()),
             Padding.line_break(""),
-            Padding.center_20(self._build_buttons())
+            Padding.fixed_10(self._build_buttons())
         ]
         super().__init__(ListBox(body))
 

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -36,7 +36,7 @@ class WelcomeView(ViewPolicy):
         self.body = [
             Padding.center_50(self._build_model_inputs()),
             Padding.line_break(""),
-            Padding.center_15(self._build_buttons()),
+            Padding.fixed_10(self._build_buttons())
         ]
         super().__init__(ListBox(self.body))
 


### PR DESCRIPTION
The new fixed_X attribute will center and set a fixed size on the
widget wrapped.  This keeps the widget the same size no matter the
scale of the window.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
