### PR TITLE
Run console-conf on all ttys

### DIFF
--- a/console_conf/ui/views/login.py
+++ b/console_conf/ui/views/login.py
@@ -19,9 +19,12 @@ Login provides user with language selection
 
 """
 import logging
+import os
+
 from urwid import (ListBox, Pile, Text)
+
 from subiquitycore.ui.buttons import finish_btn
-from subiquitycore.ui.utils import Padding, Color
+from subiquitycore.ui.utils import Color, Padding
 from subiquitycore.view import BaseView
 from subiquitycore import utils
 
@@ -87,10 +90,10 @@ class LoginView(BaseView):
 
     def done(self, button):
         if not self.opts.dry_run:
-            # mark ourselves complete
-            utils.mark_firstboot_complete()
-
-            # disable the UI service restoring getty service
-            utils.disable_first_boot_service()
+            os.unlink("/etc/systemd/getty@.service")
+            os.unlink("/etc/systemd/serial-getty@.service")
+            utils.run_command(["systemctl", "daemon-reload"])
+            # This will kill the running process.
+            utils.run_command(["systemctl", "try-restart", "getty@*.service", "serial-getty@*.service"])
 
         self.signal.emit_signal('quit')

--- a/debian/console-conf.getty@.service
+++ b/debian/console-conf.getty@.service
@@ -1,21 +1,14 @@
 [Unit]
 Description=Ubuntu Core Firstboot Configuration %I
 After=systemd-user-sessions.service plymouth-quit-wait.service
-ExecPreStart=systemctl stop getty@%I
 After=rc-local.service
-ExecStop=systemctl start getty@%I
 Before=getty.target
 IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
-ConditionPathExists=!/writable/firstboot-complete
 
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
-ExecStartPre=/bin/systemctl stop getty@%I
 ExecStart=-/sbin/agetty -n --noclear -l /usr/bin/console-conf %I $TERM
-ExecStop=/bin/systemctl start getty@%I
-#ExecStopPost=/bin/echo "Post stop, starting getty@%I"
-#ExecStopPost=/bin/systemctl start getty@%I
 Type=idle
 Restart=always
 RestartSec=0
@@ -27,12 +20,6 @@ TTYVTDisallocate=yes
 KillMode=process
 IgnoreSIGPIPE=no
 SendsSIGHUP=yes
-
-#KillMode=process
-#Restart=always
-#StandardInput=tty-force
-#StandardOutput=tty
-#StandardError=tty
 
 [Install]
 WantedBy=getty.target

--- a/debian/console-conf.postinst
+++ b/debian/console-conf.postinst
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-#DEBHELPER#
-
-systemctl enable console-conf@tty1.service
-systemctl enable serial-console-conf@ttyS1.service

--- a/debian/console-conf.serial-getty@.service
+++ b/debian/console-conf.serial-getty@.service
@@ -1,16 +1,12 @@
 [Unit]
 Description=Ubuntu Core Firstboot Configuration %I
 BindsTo=dev-%i.device
-#After=getty@tty.service
 After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service
 After=rc-local.service
-ConditionPathExists=!/writable/firstboot-complete
 
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
-ExecStartPre=/sbin/systemctl stop serial-getty@%I
 ExecStart=-/sbin/agetty -n --noclear -l /usr/bin/console-conf %I $TERM
-ExecStop=/sbin/systemctl start serial-getty@%I
 Type=idle
 Restart=always
 UtmpIdentifier=%I
@@ -20,13 +16,6 @@ TTYVHangup=yes
 KillMode=process
 IgnoreSIGPIPE=no
 SendsSIGHUP=yes
-
-#TTYVTDisallocate=yes
-#KillMode=process
-#Restart=always
-#StandardInput=tty-force
-#StandardOutput=tty
-#StandardError=tty
 
 [Install]
 WantedBy=getty.target

--- a/debian/rules
+++ b/debian/rules
@@ -17,15 +17,16 @@ override_dh_auto_clean:
 	dh_auto_clean
 
 override_dh_install:
+	mkdir -p $(CURDIR)/debian/console-conf/etc/systemd/system
+	install -m 0644 $(CURDIR)/debian/console-conf.serial-getty@.service $(CURDIR)/debian/console-conf/etc/systemd/system/serial-getty@.service
+	install -m 0644 $(CURDIR)/debian/console-conf.getty@.service $(CURDIR)/debian/console-conf/etc/systemd/system/getty@.service
+	ln -s getty@.service $(CURDIR)/debian/console-conf/etc/systemd/system/autovt@.service
+	ln -s getty@.service $(CURDIR)/debian/console-conf/etc/systemd/system/getty@tty1.service
 	rm -rf $(PYBUILD_DESTDIR)usr/share/subiquity/subiquity-0.0.5.egg-info
 	dh_install --fail-missing
 
 override_dh_python3:
 	dh_python3 --ignore-shebangs
-
-override_dh_installinit:
-	dh_installinit --no-start --name=console-conf@
-	dh_installinit --no-start --name=serial-console-conf@
 
 override_dh_auto_test:
 	@echo "No tests."


### PR DESCRIPTION
This is surprisingly awkward to achieve.

I haven't tested this fully because the snap I have doesn't dhcp and it's too
lake in my day to fight with live-build so I don't know if the deactivation
at the end of the process works.
