### PR TITLE
prevent escape from leaving the finish screen

### DIFF
--- a/console_conf/ui/views/login.py
+++ b/console_conf/ui/views/login.py
@@ -127,3 +127,10 @@ class LoginView(BaseView):
             utils.disable_first_boot_service()
 
         self.signal.emit_signal('quit')
+
+    def keypress(self, size, key):
+        if key == 'esc':
+            # You can't press escape to get out of this screen!
+            return None
+
+        return super().keypress(size, key)


### PR DESCRIPTION
See https://bugs.launchpad.net/snappy/+bug/1621339
