### PR TITLE
Use console-conf-wrapper on the serial line again.

### DIFF
--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -3,6 +3,11 @@ set -e
 
 trap true HUP INT QUIT TSTP
 
+# agetty only sets ICRNL if it has read the username and seen whether
+# it was terminated by CR or NL. We pass -n to agetty so that hasn't
+# happened and need to force it on. Yay UNIX!
+stty icrnl
+
 cat /usr/share/subiquity/console-conf-wait
 read REPLY
 exec console-conf "$@"

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -8,7 +8,7 @@ ConditionPathExists=!/var/lib/console-conf/complete
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStartPre=/bin/systemctl stop serial-getty@%I
-ExecStart=/sbin/agetty -n --keep-baud -f /usr/share/subiquity/console-conf-wait -w -l /usr/bin/console-conf --login-options "--serial" 115200,38400,9600 %I $TERM
+ExecStart=/sbin/agetty -n --keep-baud -l /usr/share/subiquity/console-conf-wrapper --login-options "--serial" 115200,38400,9600 %I $TERM
 ExecStopPost=/bin/systemctl start serial-getty@%I
 Type=idle
 Restart=always


### PR DESCRIPTION
This means that the "Please press enter to configure" message is actually shown
now. But it turns out we need some stty magic so that newline actually works to
enter console-conf.

Fixes https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1621142

I'm mostly creating this PR so you can all share my pain.
