### PR TITLE
refresh: default to updating the installer when available

### DIFF
--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -54,6 +54,7 @@ class RefreshController(SubiquityController):
             },
         'additionalProperties': False,
         }
+    autoinstall_default = {'update': True}
 
     signals = [
         ('snapd-network-change', 'snapd_network_changed'),
@@ -70,14 +71,13 @@ class RefreshController(SubiquityController):
         self.new_snap_version = ""
 
         self.offered_first_time = False
-        if 'update' in self.ai_data:
-            self.active = self.ai_data['update']
-        else:
-            self.active = self.interactive()
+        self.active = self.interactive()
 
     def load_autoinstall_data(self, data):
         if data is not None:
             self.ai_data = data
+        if 'update' in self.ai_data:
+            self.active = self.ai_data['update']
 
     def start(self):
         if not self.active:

--- a/subiquity/ui/views/refresh.py
+++ b/subiquity/ui/views/refresh.py
@@ -213,7 +213,7 @@ class RefreshView(BaseView):
             done_btn(_("Continue without updating"), on_press=self.done),
             other_btn(_("Back"), on_press=self.cancel),
             ])
-        buttons.base_widget.focus_position = 1
+        buttons.base_widget.focus_position = 0
 
         excerpt = _(self.available_excerpt).format(
             current=self.controller.current_snap_version,


### PR DESCRIPTION
Way too many good bugfixes are shipped in the new installer, thus
default to update the installer when a new one is available.

Also, it seems like self.active was always interactive, meaning
autoinstall refresh-installer doesn't do anything? Not sure if that
was intentional. Because self.active was only assigned in __init__,
which always has self.ai_data as an empty dict.