### PR TITLE
Add support for merging lists when merging user-data

### DIFF
--- a/subiquity/common/resources.py
+++ b/subiquity/common/resources.py
@@ -33,7 +33,8 @@ def get_users_and_groups(chroot_prefix=[]):
     users_and_groups_path = resource_path('users-and-groups')
     groups = ['admin']
     if os.path.exists(users_and_groups_path):
-        groups = open(users_and_groups_path).read().split()
+        with open(users_and_groups_path) as f:
+            groups = f.read().split()
     groups.append('sudo')
 
     command = chroot_prefix + ['getent', 'group']


### PR DESCRIPTION
The current `merge_config()` function from curtin does not merge lists in any way, but overwrites them. This is generally a good idea, and curtin depends on such behaviour, but in case of user-data we may want to merge lists instead.

One of the possible use cases is defining the main user in the `identity` section, and some extra users in the user-data `users` section.

Before this change, the user defined in the `identity` section overwrote any users defined in user-data. With this change, the user list can now be automatically merged, with user-data having lower priority than autoinstall configuration.

I have mentioned this earlier [on the forums](https://discourse.ubuntu.com/t/please-test-autoinstalls-for-20-04/15250/101?u=forst).

The bonus is that we now also avoid a deep copy here.

~~On an unrelated note, this pull request also contains a small change to one of the example YAML files, which had the `snaps` key incorrectly specified twice.~~

---

An example of a configuration that becomes possible with this change:

```yaml
#cloud-config
autoinstall:
  version: 1
  ...
  identity:
    hostname: testname
    realname: Real Name
    username: someuser
    password: "$6$..."
  user-data:
    users:
      - name: extrauser
        gecos: Extra User
        ssh_authorized_keys:
          - "ssh-ed25519 AAAA..."
        shell: /bin/bash
```