### PR TITLE
create and use an API for guided disk usage

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -28,6 +28,8 @@ from subiquity.common.types import (
     ApplicationState,
     ApplicationStatus,
     ErrorReportRef,
+    GuidedChoice,
+    GuidedStorageResponse,
     KeyboardSetting,
     KeyboardSetup,
     IdentityData,
@@ -184,6 +186,14 @@ class API:
             def GET(dev_name: str) -> str: ...
 
     class storage:
+        class guided:
+            def GET(wait: bool = False) -> GuidedStorageResponse:
+                pass
+
+            def POST(choice: Optional[GuidedChoice]) \
+                    -> StorageResponse:
+                pass
+
         def GET(wait: bool = False) -> StorageResponse: ...
         def POST(config: Payload[list]): ...
 

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -223,6 +223,7 @@ class Disk:
     size: int
     usage_labels: List[str]
     partitions: List[Partition]
+    ok_for_guided: bool
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -209,10 +209,41 @@ class Bootloader(enum.Enum):
 
 
 @attr.s(auto_attribs=True)
+class Partition:
+    size: int
+    number: int
+    annotations: List[str]
+
+
+@attr.s(auto_attribs=True)
+class Disk:
+    id: str
+    label: str
+    type: str
+    size: int
+    usage_labels: List[str]
+    partitions: List[Partition]
+
+
+@attr.s(auto_attribs=True)
+class GuidedChoice:
+    disk_id: str
+    use_lvm: bool = False
+    password: Optional[str] = attr.ib(default=None, repr=False)
+
+
+@attr.s(auto_attribs=True)
+class GuidedStorageResponse:
+    status: ProbeStatus
+    error_report: Optional[ErrorReportRef] = None
+    disks: Optional[List[Disk]] = None
+
+
+@attr.s(auto_attribs=True)
 class StorageResponse:
     status: ProbeStatus
-    bootloader: Optional[Bootloader] = None
     error_report: Optional[ErrorReportRef] = None
+    bootloader: Optional[Bootloader] = None
     orig_config: Optional[list] = None
     config: Optional[list] = None
     blockdev: Optional[dict] = None

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -617,6 +617,10 @@ class _Formattable(ABC):
 # space for the GPT data.
 GPT_OVERHEAD = 2 * (1 << 20)
 
+# Disks larger than this are considered sensible targets for guided
+# installation.
+MIN_SIZE_GUIDED = 6 * (1 << 30)
+
 
 @attr.s(cmp=False)
 class _Device(_Formattable, ABC):
@@ -908,7 +912,8 @@ class Disk(_Device):
             type=self.desc(),
             size=self.size,
             usage_labels=self.usage_labels(),
-            partitions=[p.for_client() for p in self._partitions])
+            partitions=[p.for_client() for p in self._partitions],
+            ok_for_guided=self.size >= MIN_SIZE_GUIDED)
 
 
 @fsobj("partition")

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -900,6 +900,16 @@ class Disk(_Device):
 
     ok_for_lvm_vg = ok_for_raid
 
+    def for_client(self):
+        from subiquity.common.types import Disk
+        return Disk(
+            id=self.id,
+            label=self.label,
+            type=self.desc(),
+            size=self.size,
+            usage_labels=self.usage_labels(),
+            partitions=[p.for_client() for p in self._partitions])
+
 
 @fsobj("partition")
 class Partition(_Formattable):
@@ -1047,6 +1057,13 @@ class Partition(_Formattable):
         return True
 
     ok_for_lvm_vg = ok_for_raid
+
+    def for_client(self):
+        from subiquity.common.types import Partition
+        return Partition(
+            size=self.size,
+            number=self._number,
+            annotations=self.annotations + self.usage_labels())
 
 
 @fsobj("raid")

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -44,6 +44,10 @@ from subiquity.common.types import (
     ProbeStatus,
     StorageResponse,
     )
+from subiquity.models.filesystem import (
+    dehumanize_size,
+    DeviceAction,
+    )
 from subiquity.server.controller import (
     SubiquityController,
     )
@@ -108,6 +112,63 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             raise Exception(
                 "autoinstall config did not create needed bootloader "
                 "partition")
+
+    def guided_direct(self, disk):
+        self.reformat(disk)
+        result = {
+            "size": disk.free_for_partitions,
+            "fstype": "ext4",
+            "mount": "/",
+            }
+        self.partition_disk_handler(disk, None, result)
+
+    def guided_lvm(self, disk, lvm_options=None):
+        self.reformat(disk)
+        if DeviceAction.TOGGLE_BOOT in disk.supported_actions:
+            self.add_boot_disk(disk)
+        self.create_partition(
+            device=disk, spec=dict(
+                size=dehumanize_size('1G'),
+                fstype="ext4",
+                mount='/boot'
+                ))
+        part = self.create_partition(
+            device=disk, spec=dict(
+                size=disk.free_for_partitions,
+                fstype=None,
+                ))
+        vg_name = 'ubuntu-vg'
+        i = 0
+        while self.model._one(type='lvm_volgroup', name=vg_name) is not None:
+            i += 1
+            vg_name = 'ubuntu-vg-{}'.format(i)
+        spec = dict(name=vg_name, devices=set([part]))
+        if lvm_options and lvm_options['encrypt']:
+            spec['password'] = lvm_options['luks_options']['password']
+        vg = self.create_volgroup(spec)
+        # There's no point using LVM and unconditionally filling the
+        # VG with a single LV, but we should use more of a smaller
+        # disk to avoid the user running into out of space errors
+        # earlier than they probably expect to.
+        if vg.size < 10 * (2 << 30):
+            # Use all of a small (<10G) disk.
+            lv_size = vg.size
+        elif vg.size < 20 * (2 << 30):
+            # Use 10G of a smallish (<20G) disk.
+            lv_size = 10 * (2 << 30)
+        elif vg.size < 200 * (2 << 30):
+            # Use half of a larger (<200G) disk.
+            lv_size = vg.size // 2
+        else:
+            # Use at most 100G of a large disk.
+            lv_size = 100 * (2 << 30)
+        self.create_logical_volume(
+            vg=vg, spec=dict(
+                size=lv_size,
+                name="ubuntu-lv",
+                fstype="ext4",
+                mount="/",
+                ))
 
     async def _probe_response(self, wait, resp_cls):
         if self._probe_task.task is None or not self._probe_task.task.done():

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -119,7 +119,7 @@ class GuidedChoiceForm(SubForm):
                 table = TablePile([TableRow(cells)])
                 tables.append(table)
                 enabled = False
-                if obj is disk and disk.size > 6*(2**30):
+                if obj is disk and disk.ok_for_guided:
                     enabled = True
                     if initial < 0:
                         initial = len(options)
@@ -205,12 +205,7 @@ class GuidedDiskSelectionView(BaseView):
         self.controller = controller
 
         if disks:
-            found_ok_disk = False
-            for disk in disks:
-                if disk.size > 6*(2**30):
-                    found_ok_disk = True
-                    break
-            if found_ok_disk:
+            if any(disk.ok_for_guided for disk in disks):
                 self.form = GuidedForm(disks=disks)
 
                 connect_signal(self.form, 'submit', self.done)

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -38,12 +38,14 @@ from subiquitycore.ui.table import (
     TableRow,
     )
 from subiquitycore.ui.utils import (
+    Color,
     rewrap,
     screen,
     )
 from subiquitycore.view import BaseView
 
-from .helpers import summarize_device
+from subiquity.common.types import GuidedChoice
+from subiquity.models.filesystem import humanize_size
 
 
 log = logging.getLogger("subiquity.ui.views.filesystem.guided")
@@ -79,6 +81,28 @@ class LVMOptionsForm(SubForm):
     luks_options = SubFormField(LUKSOptionsForm, "", help=NO_HELP)
 
 
+def summarize_device(disk):
+    label = disk.label
+    rows = [(disk, [
+        (2, Text(label)),
+        Text(disk.type),
+        Text(humanize_size(disk.size), align="right"),
+        ])]
+    if disk.partitions:
+        for part in disk.partitions:
+            details = ", ".join(part.annotations)
+            rows.append((part, [
+                Text(_("partition {number}").format(number=part.number)),
+                (2, Text(details)),
+                Text(humanize_size(part.size), align="right"),
+                ]))
+    else:
+        rows.append((None, [
+            (4, Color.info_minor(Text(", ".join(disk.usage_labels))))
+            ]))
+    return rows
+
+
 class GuidedChoiceForm(SubForm):
 
     disk = ChoiceField(caption=NO_CAPTION, help=NO_HELP, choices=["x"])
@@ -90,7 +114,7 @@ class GuidedChoiceForm(SubForm):
         options = []
         tables = []
         initial = -1
-        for disk in parent.model.all_disks():
+        for disk in parent.disks:
             for obj, cells in summarize_device(disk):
                 table = TablePile([TableRow(cells)])
                 tables.append(table)
@@ -122,8 +146,8 @@ class GuidedForm(Form):
 
     cancel_label = _("Back")
 
-    def __init__(self, model):
-        self.model = model
+    def __init__(self, disks):
+        self.disks = disks
         super().__init__()
         connect_signal(self.guided.widget, 'change', self._toggle_guided)
 
@@ -173,34 +197,33 @@ installation will not be possible.
 """)
 
 
-class GuidedDiskSelectionView (BaseView):
+class GuidedDiskSelectionView(BaseView):
 
     title = _("Guided storage configuration")
 
-    def __init__(self, controller):
+    def __init__(self, controller, disks):
         self.controller = controller
 
-        found_disk = False
-        found_ok_disk = False
-        for disk in controller.model.all_disks():
-            found_disk = True
-            if disk.size > 6*(2**30):
-                found_ok_disk = True
-                break
+        if disks:
+            found_ok_disk = False
+            for disk in disks:
+                if disk.size > 6*(2**30):
+                    found_ok_disk = True
+                    break
+            if found_ok_disk:
+                self.form = GuidedForm(disks=disks)
 
-        if found_ok_disk:
-            self.form = GuidedForm(model=controller.model)
+                connect_signal(self.form, 'submit', self.done)
+                connect_signal(self.form, 'cancel', self.cancel)
 
-            connect_signal(self.form, 'submit', self.done)
-            connect_signal(self.form, 'cancel', self.cancel)
-
-            super().__init__(
-                self.form.as_screen(focus_buttons=False, excerpt=_(subtitle)))
-        elif found_disk:
-            super().__init__(
-                screen(
-                    [Text(rewrap(_(no_big_disks)))],
-                    [other_btn(_("OK"), on_press=self.manual)]))
+                super().__init__(
+                    self.form.as_screen(
+                        focus_buttons=False, excerpt=_(subtitle)))
+            else:
+                super().__init__(
+                    screen(
+                        [Text(rewrap(_(no_big_disks)))],
+                        [other_btn(_("OK"), on_press=self.manual)]))
         else:
             super().__init__(
                 screen(
@@ -212,17 +235,18 @@ class GuidedDiskSelectionView (BaseView):
 
     def done(self, sender):
         results = sender.as_data()
+        choice = None
         if results['guided']:
-            disk = results['guided_choice']['disk']
-            if results['guided_choice']['use_lvm']:
-                self.controller.guided_lvm(
-                    disk, results['guided_choice']['lvm_options'])
-            else:
-                self.controller.guided_direct(disk)
-        self.controller.manual()
+            choice = GuidedChoice(
+                disk_id=results['guided_choice']['disk'].id,
+                use_lvm=results['guided_choice']['use_lvm'])
+            opts = results['guided_choice'].get('lvm_options', {})
+            if opts.get('encrypt', False):
+                choice.password = opts['luks_options']['password']
+        self.controller.guided_choice(choice)
 
     def manual(self, sender):
-        self.controller.manual()
+        self.controller.guided_choice(None)
 
     def cancel(self, btn=None):
         self.controller.cancel()

--- a/subiquitycore/tui.py
+++ b/subiquitycore/tui.py
@@ -177,6 +177,9 @@ class TuiApplication(Application):
         return await self._wait_with_indication(
             awaitable, show_load, hide_load)
 
+    async def wait_with_progress(self, awaitable):
+        return await self._wait_with_indication(awaitable, self.show_progress)
+
     async def _move_screen(self, increment, coro):
         if coro is not None:
             await coro
@@ -206,8 +209,8 @@ class TuiApplication(Application):
                 return
 
     async def move_screen(self, increment, coro):
-        view = await self._wait_with_indication(
-            self._move_screen(increment, coro), self.show_progress)
+        view = await self.wait_with_progress(
+            self._move_screen(increment, coro))
         if view is not None:
             self.ui.set_body(view)
 


### PR DESCRIPTION
Not completely sure of the approach here. The types in the API in this PR expose pretty much exactly the information needed to implement subiquity's current UI for the guided storage config screen which is fine for a start I guess.

The part that makes me uncertain going on from this is how much to do server side vs client side. For example: when a RAID device is created, the disks or partitions that go into it should gain a label saying 'part of RAID mdX'. If we keep labels something the server decides, then there needs to be an API call to create the RAID device that then somehow indicates that the label of the partition should change. If we keep it client side, as currently implemented, there is more chance that the clients will diverge in behaviour, which is _probably_ bad?

Probably in general things should be done more server side, because I still want to implement the behaviour where you can plug a USB stick in while looking at the device screen and have it appear in the UI, and it wouldn't feel right for the client to be listening to udev events itself.

So I guess this means a RESTish API for manipulating storage configuration? That sounds quite fun to do but also like a lot of work!