### PR TITLE
add serialization support for unions of attr classes

### DIFF
--- a/subiquity/common/tests/test_serialization.py
+++ b/subiquity/common/tests/test_serialization.py
@@ -53,7 +53,7 @@ class CommonSerializerTests:
         (int, 1),
         (str, "v"),
         (list, [1]),
-        (dict, {2: 3}),
+        (dict, {"2": 3}),
         (type(None), None),
         ]
 
@@ -66,8 +66,9 @@ class CommonSerializerTests:
             self.serializer.deserialize(annotation, value), expected)
 
     def assertRoundtrips(self, annotation, value):
-        serialized = self.serializer.serialize(annotation, value)
-        self.assertDeserializesTo(annotation, serialized, value)
+        serialized = self.serializer.to_json(annotation, value)
+        self.assertEqual(
+            self.serializer.from_json(annotation, serialized), value)
 
     def assertSerialization(self, annotation, value, expected):
         self.assertSerializesTo(annotation, value, expected)
@@ -92,6 +93,10 @@ class CommonSerializerTests:
     def test_scalars(self):
         for typ, val in self.simple_examples:
             self.assertSerialization(typ, val, val)
+
+    def test_non_string_key_dict(self):
+        self.assertRaises(
+            Exception, self.serializer.serialize, dict, {1: 2})
 
 
 class TestSerializer(CommonSerializerTests, unittest.TestCase):

--- a/subiquity/common/tests/test_serialization.py
+++ b/subiquity/common/tests/test_serialization.py
@@ -112,6 +112,11 @@ class CommonSerializerTests:
     def test_serialize_dict_strkeys(self):
         self.assertSerialization(typing.Dict[str, str], {"a": "b"}, {"a": "b"})
 
+    def test_rountrip_union(self):
+        ann = typing.Union[Data, Container]
+        self.assertRoundtrips(ann, Data.make_random())
+        self.assertRoundtrips(ann, Container.make_random())
+
 
 class TestSerializer(CommonSerializerTests, unittest.TestCase):
 
@@ -134,6 +139,15 @@ class TestSerializer(CommonSerializerTests, unittest.TestCase):
             }
         self.assertSerialization(Container, container, expected)
 
+    def test_serialize_union(self):
+        data = Data.make_random()
+        expected = {
+            '$type': 'Data',
+            'field1': data.field1,
+            'field2': data.field2,
+            }
+        self.assertSerialization(typing.Union[Data, Container], data, expected)
+
 
 class TestCompactSerializer(CommonSerializerTests, unittest.TestCase):
 
@@ -153,3 +167,8 @@ class TestCompactSerializer(CommonSerializerTests, unittest.TestCase):
             [[data2.field1, data2.field2]],
             ]
         self.assertSerialization(Container, container, expected)
+
+    def test_serialize_union(self):
+        data = Data.make_random()
+        expected = ['Data', data.field1, data.field2]
+        self.assertSerialization(typing.Union[Data, Container], data, expected)

--- a/subiquity/common/tests/test_serialization.py
+++ b/subiquity/common/tests/test_serialization.py
@@ -98,6 +98,20 @@ class CommonSerializerTests:
         self.assertRaises(
             Exception, self.serializer.serialize, dict, {1: 2})
 
+    def test_roundtrip_dict(self):
+        ann = typing.Dict[int, str]
+        self.assertRoundtrips(ann, {1: "2"})
+
+    def test_roundtrip_dict_strkey(self):
+        ann = typing.Dict[str, int]
+        self.assertRoundtrips(ann, {"a": 2})
+
+    def test_serialize_dict(self):
+        self.assertSerialization(typing.Dict[int, str], {1: "a"}, [[1, "a"]])
+
+    def test_serialize_dict_strkeys(self):
+        self.assertSerialization(typing.Dict[str, str], {"a": "b"}, {"a": "b"})
+
 
 class TestSerializer(CommonSerializerTests, unittest.TestCase):
 


### PR DESCRIPTION
unions are serialized as a tagged union by adding a '$type' field
indicating which member of the set of types is present.

Depends on https://github.com/canonical/subiquity/pull/906