### PR TITLE
add explicit dict serialization, improve implicit dict serialization

### DIFF
--- a/subiquity/common/tests/test_serialization.py
+++ b/subiquity/common/tests/test_serialization.py
@@ -53,7 +53,7 @@ class CommonSerializerTests:
         (int, 1),
         (str, "v"),
         (list, [1]),
-        (dict, {2: 3}),
+        (dict, {"2": 3}),
         (type(None), None),
         ]
 
@@ -66,8 +66,9 @@ class CommonSerializerTests:
             self.serializer.deserialize(annotation, value), expected)
 
     def assertRoundtrips(self, annotation, value):
-        serialized = self.serializer.serialize(annotation, value)
-        self.assertDeserializesTo(annotation, serialized, value)
+        serialized = self.serializer.to_json(annotation, value)
+        self.assertEqual(
+            self.serializer.from_json(annotation, serialized), value)
 
     def assertSerialization(self, annotation, value, expected):
         self.assertSerializesTo(annotation, value, expected)
@@ -92,6 +93,10 @@ class CommonSerializerTests:
     def test_scalars(self):
         for typ, val in self.simple_examples:
             self.assertSerialization(typ, val, val)
+
+    def test_non_string_key_dict(self):
+        self.assertRaises(
+            Exception, self.serializer.serialize, dict, {1: 2})
 
 
 class TestSerializer(CommonSerializerTests, unittest.TestCase):

--- a/subiquity/common/tests/test_serialization.py
+++ b/subiquity/common/tests/test_serialization.py
@@ -98,6 +98,20 @@ class CommonSerializerTests:
         self.assertRaises(
             Exception, self.serializer.serialize, dict, {1: 2})
 
+    def test_roundtrip_dict(self):
+        ann = typing.Dict[int, str]
+        self.assertRoundtrips(ann, {1: "2"})
+
+    def test_roundtrip_dict_strkey(self):
+        ann = typing.Dict[str, int]
+        self.assertRoundtrips(ann, {"a": 2})
+
+    def test_serialize_dict(self):
+        self.assertSerialization(typing.Dict[int, str], {1: "a"}, [[1, "a"]])
+
+    def test_serialize_dict_strkeys(self):
+        self.assertSerialization(typing.Dict[str, str], {"a": "b"}, {"a": "b"})
+
 
 class TestSerializer(CommonSerializerTests, unittest.TestCase):
 


### PR DESCRIPTION
I always forget that JSON dicts can only have string keys...

Depends on https://github.com/canonical/subiquity/pull/909, but mostly so the tests don't end up conflicting.