### PR TITLE
fix rebooting after a partially interactive install

### DIFF
--- a/subiquity/server/controllers/reboot.py
+++ b/subiquity/server/controllers/reboot.py
@@ -43,6 +43,9 @@ class RebootController(SubiquityController):
         self.user_reboot_event.set()
         await self.rebooting_event.wait()
 
+    def interactive(self):
+        return self.app.interactive
+
     def start(self):
         self.app.aio_loop.create_task(self._run())
 


### PR DESCRIPTION
If the install is part-interactive, the client still runs and still
POSTs to the /reboot endpoint, so do not reject all requests to its
methods