### PR TITLE
handle pers="auto" in lszdev output

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -162,6 +162,8 @@ class ZdevInfo:
                 row[k] = True
             if v == "no":
                 row[k] = False
+            if k == "pers" and v == "auto":
+                row[k] = True
         return ZdevInfo(**row)
 
     @property

--- a/subiquity/server/controllers/zdev.py
+++ b/subiquity/server/controllers/zdev.py
@@ -34,7 +34,7 @@ lszdev_cmd = ['lszdev', '--pairs', '--columns',
               'id,type,on,exists,pers,auto,failed,names']
 
 lszdev_stock = '''id="0.0.1500" type="dasd-eckd" on="no" exists="yes" pers="no" auto="no" failed="no" names=""
-id="0.0.1501" type="dasd-eckd" on="no" exists="yes" pers="no" auto="no" failed="no" names=""
+id="0.0.1501" type="dasd-eckd" on="yes" exists="yes" pers="auto" auto="yes" failed="no" names=""
 id="0.0.1502" type="dasd-eckd" on="no" exists="yes" pers="no" auto="no" failed="no" names=""
 id="0.0.1503" type="dasd-eckd" on="no" exists="yes" pers="no" auto="no" failed="no" names=""
 id="0.0.1504" type="dasd-eckd" on="no" exists="yes" pers="no" auto="no" failed="no" names=""


### PR DESCRIPTION
I checked the lszdev source and for all the other fields that we are
assume are boolean, it can only output "yes" or "no". Today, at least --
not sure how to make sure this is not broken by future changes. Still
this is a help.

for https://bugs.launchpad.net/subiquity/+bug/1919420