### PR TITLE
catch all errors getting application status

### DIFF
--- a/subiquity/client/controllers/progress.py
+++ b/subiquity/client/controllers/progress.py
@@ -77,7 +77,8 @@ class ProgressController(SubiquityTuiController):
             try:
                 app_status = await self.app.client.meta.status.GET(
                     cur=self.app_state)
-            except aiohttp.ClientError:
+            except Exception:
+                log.exception("getting status failed")
                 await asyncio.sleep(1)
                 continue
             self.app_state = app_status.state


### PR DESCRIPTION
When refreshing the snap, it is possible for the client to make a "get
current status" request to the new server before it gets restarted and
the new server can return values the client does not know about. Rather
than crashing the client when this happens, just ignore all errors when
getting application status.