### PR TITLE
update curtin

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-tag: "21.2"
+    source-commit: 4339a49ee93fd99940f8e0b804227af409da82ae
     python-packages:
       - pyyaml==5.3.1
       - oauthlib

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1511,7 +1511,6 @@ class FilesystemModel(object):
         byid = {}
         objs = []
         exclusions = set()
-        seen_multipaths = set()
         for action in config:
             if is_probe_data and action['type'] == 'mount':
                 if not action['path'].startswith(self.target):
@@ -1549,12 +1548,6 @@ class FilesystemModel(object):
             if is_probe_data:
                 kw['preserve'] = True
             obj = byid[action['id']] = c(m=self, **kw)
-            multipath = kw.get('multipath')
-            if multipath:
-                if multipath in seen_multipaths:
-                    exclusions.add(obj)
-                else:
-                    seen_multipaths.add(multipath)
             objs.append(obj)
 
         while True:


### PR DESCRIPTION
This has a couple of changes relevant to subiquity: it only produces one disk action for multipath disks, which lets us remove some code that tries to remove all but one member disk and it fixes wiping disks that have very small partitions.