### PR TITLE
add all documented fields to filesystem model classes

### DIFF
--- a/examples/autoinstall.yaml
+++ b/examples/autoinstall.yaml
@@ -51,5 +51,5 @@ storage:
   - {type: raid, name: md1, raidlevel: raid1, devices: [partition-system-1, partition-system-2], preserve: false, id: raid-system}
   - {type: format, fstype: ext4, volume: raid-boot, preserve: false, id: format-boot}
   - {type: format, fstype: ext4, volume: raid-system, preserve: false, id: format-system}
-  - {type: mount, device: format-boot, path: /boot, id: mount-boot}
   - {type: mount, device: format-system, path: /, id: mount-system}
+  - {type: mount, device: format-boot, path: /boot, id: mount-boot, options: 'errors=remount-ro'}

--- a/scripts/check-yaml-fields.py
+++ b/scripts/check-yaml-fields.py
@@ -17,7 +17,14 @@ def main():
             k, expected = arg, None
         v = config
         for part in k.split('.'):
+            if '[' in part:
+                part, index = part.split('[')
+                index = int(index[:-1])
+            else:
+                index = None
             v = v[part]
+            if index is not None:
+                v = v[index]
         if expected is None:
             print(v)
         else:

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -45,6 +45,8 @@ timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoi
 validate
 python3 scripts/check-yaml-fields.py .subiquity/subiquity-curtin-install.conf \
         debconf_selections.subiquity='"eek"'
+python3 scripts/check-yaml-fields.py .subiquity/subiquity-curtin-install.conf \
+        storage.config[-1].options='"errors=remount-ro"'
 python3 scripts/check-yaml-fields.py <(python3 scripts/check-yaml-fields.py .subiquity/etc/cloud/cloud.cfg.d/99-installer.cfg datasource.None.userdata_raw) \
         locale='"en_GB.UTF-8"'
 grep -q 'finish: subiquity/Install/install/postinstall/install_package1: SUCCESS: installing package1' \

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -926,6 +926,8 @@ class Partition(_Formattable):
     number = attr.ib(default=None)
     preserve = attr.ib(default=False)
     grub_device = attr.ib(default=False)
+    name = attr.ib(default=None)
+    multipath = attr.ib(default=None)
 
     @property
     def annotations(self):
@@ -1087,7 +1089,9 @@ class Raid(_Device):
         backlink="_constructed_device", default=attr.Factory(set))
 
     preserve = attr.ib(default=False)
+    wipe = attr.ib(default=None)
     ptable = attributes.ptable()
+    metadata = attr.ib(default=None)
 
     @property
     def size(self):
@@ -1217,6 +1221,7 @@ class LVM_LogicalVolume(_Formattable):
     name = attr.ib()
     volgroup = attributes.ref(backlink="_partitions")  # LVM_VolGroup
     size = attributes.size()
+    wipe = attr.ib(default=None)
 
     preserve = attr.ib(default=False)
 
@@ -1305,6 +1310,7 @@ class Filesystem:
     label = attr.ib(default=None)
     uuid = attr.ib(default=None)
     preserve = attr.ib(default=False)
+    extra_options = attr.ib(default=None)
 
     _mount = attributes.backlink()
 
@@ -1326,6 +1332,9 @@ class Filesystem:
 class Mount:
     device = attributes.ref(backlink="_mount")  # Filesystem
     path = attr.ib()
+    fstype = attr.ib(default=None)
+    options = attr.ib(default=None)
+    spec = attr.ib(default=None)
 
     def can_delete(self):
         # Can't delete mount of /boot/efi or swap, anything else is fine.


### PR DESCRIPTION
This lets autoinstall configs set them, even though nothing in subiquity
can set them yet.

Trying again now we've removed the multipath coalescing code that caused this to break the world last time.