### PR TITLE
Fixed minimum number of component devices for RAID5 and RAID10

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -163,9 +163,9 @@ raidlevels = [
     RaidLevel(_("0 (striped)"),  "raid0",  2, False),
     # for translators: this is a description of a RAID level
     RaidLevel(_("1 (mirrored)"), "raid1",  2),
-    RaidLevel(_("5"),            "raid5",  3),
+    RaidLevel(_("5"),            "raid5",  2),
     RaidLevel(_("6"),            "raid6",  4),
-    RaidLevel(_("10"),           "raid10", 4),
+    RaidLevel(_("10"),           "raid10", 2),
     ]
 
 


### PR DESCRIPTION
This fix allows creation of RAID10 with two or three component devices (See also https://bugs.launchpad.net/subiquity/+bug/1880023). Additionally the minimum number of components for RAID5 is changed to two.

**Reasoning:**
In general, the numbers should reflect what is possible to do with mdadm on the command-line. Additionally there are some non-obvious reasons:
- RAID10 using two disks offers the advantage of roughly RAID0 read speed in a single stream scenario. In comparison, RAID1 will only deliver the speed of a single component. For multi-stream reads (number streams >= number components) the speed is comparable.
- While RAID5 with two component devices is only relevant for special purposes (e.g. growing to more components, different IO semantics), a three component RAID5 is probably not uncommon.

**References:**
Unfortunately, documentation is distributed on the raid mailinglist, but the mdadm sourcecode gives some hints:
- [RAID5](https://github.com/neilbrown/mdadm/blob/5f4184557a98bb641a7889e280265109c73e2f43/Create.c#L155)
- RAID10 is a little bit more complex. The layout default is: [0x102](https://github.com/neilbrown/mdadm/blob/5f4184557a98bb641a7889e280265109c73e2f43/Create.c#L58) and the [minimum requirement for RAID10](https://github.com/neilbrown/mdadm/blob/5f4184557a98bb641a7889e280265109c73e2f43/Create.c#L226) is 
 `(layout&255) * ((layout>>8)&255) == number of disks`