### PR TITLE
Leverage code from Ubiquity to get rst presence

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -206,7 +206,6 @@ class API:
             def GET() -> RstResponse:
                 pass
 
-
     class snaplist:
         def GET(wait: bool = False) -> SnapListResponse: ...
         def POST(data: Payload[List[SnapSelection]]): ...

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -34,6 +34,7 @@ from subiquity.common.types import (
     KeyboardSetup,
     IdentityData,
     RefreshStatus,
+    RstResponse,
     SnapInfo,
     SnapListResponse,
     SnapSelection,
@@ -200,6 +201,11 @@ class API:
 
         class reset:
             def POST() -> StorageResponse: ...
+
+        class has_rst:
+            def GET() -> RstResponse:
+                pass
+
 
     class snaplist:
         def GET(wait: bool = False) -> SnapListResponse: ...

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -34,7 +34,6 @@ from subiquity.common.types import (
     KeyboardSetup,
     IdentityData,
     RefreshStatus,
-    RstResponse,
     SnapInfo,
     SnapListResponse,
     SnapSelection,
@@ -203,7 +202,7 @@ class API:
             def POST() -> StorageResponse: ...
 
         class has_rst:
-            def GET() -> RstResponse:
+            def GET() -> bool:
                 pass
 
     class snaplist:

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -241,11 +241,6 @@ class GuidedStorageResponse:
 
 
 @attr.s(auto_attribs=True)
-class RstResponse:
-    has_rst: bool = False
-
-
-@attr.s(auto_attribs=True)
 class StorageResponse:
     status: ProbeStatus
     error_report: Optional[ErrorReportRef] = None

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -241,6 +241,11 @@ class GuidedStorageResponse:
 
 
 @attr.s(auto_attribs=True)
+class RstResponse:
+    has_rst: bool = False
+
+
+@attr.s(auto_attribs=True)
 class StorageResponse:
     status: ProbeStatus
     error_report: Optional[ErrorReportRef] = None

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -43,7 +43,6 @@ from subiquity.common.types import (
     GuidedChoice,
     GuidedStorageResponse,
     ProbeStatus,
-    RstResponse,
     StorageResponse,
     )
 from subiquity.models.filesystem import (
@@ -241,13 +240,13 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.model.reset()
         return await self.GET(context)
 
-    async def has_rst_GET(self) -> RstResponse:
+    async def has_rst_GET(self) -> bool:
         search = '/sys/module/ahci/drivers/pci:ahci/*/remapped_nvme'
         for remapped_nvme in glob.glob(search):
             with open(remapped_nvme, 'r') as f:
                 if int(f.read()) > 0:
-                    return RstResponse(has_rst=True)
-        return RstResponse(has_rst=False)
+                    return True
+        return False
 
     @with_context(name='probe_once', description='restricted={restricted}')
     async def _probe_once(self, *, context, restricted):


### PR DESCRIPTION
Example:
curl --silent --unix-socket .subiquity/socket a/storage/has_rst ->
false

Origin commit:
https://git.launchpad.net/ubiquity/commit/?id=e5c7a06d97f017296bedf593c5966e931e9a8aec

Note that ubiquity believed this detection to be incomplete, so we
should explore the possibility that there is more to do here.

But then again, the comment predates the actual commit, so maybe it's ok?