### PR TITLE
guided_GET: allow caller to specify min size

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -42,6 +42,10 @@ BIOS_GRUB_SIZE_BYTES = 1 * 1024 * 1024    # 1MiB
 PREP_GRUB_SIZE_BYTES = 8 * 1024 * 1024    # 8MiB
 UEFI_GRUB_SIZE_BYTES = 512 * 1024 * 1024  # 512MiB EFI partition
 
+# Disks larger than this are considered sensible targets for guided
+# installation.
+MIN_SIZE_GUIDED = 6 * (1 << 30)
+
 
 class FilesystemController(SubiquityTuiController, FilesystemManipulator):
 
@@ -55,7 +59,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         self.answers.setdefault('manual', [])
 
     async def make_ui(self):
-        status = await self.endpoint.guided.GET()
+        status = await self.endpoint.guided.GET(MIN_SIZE_GUIDED)
         if status.status == ProbeStatus.PROBING:
             self.app.aio_loop.create_task(self._wait_for_probing())
             return SlowProbing(self)
@@ -63,7 +67,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
             return self.make_guided_ui(status)
 
     async def _wait_for_probing(self):
-        status = await self.endpoint.guided.GET(wait=True)
+        status = await self.endpoint.guided.GET(MIN_SIZE_GUIDED, wait=True)
         if isinstance(self.ui.body, SlowProbing):
             self.ui.set_body(self.make_guided_ui(status))
 

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -188,7 +188,8 @@ class API:
 
     class storage:
         class guided:
-            def GET(wait: bool = False) -> GuidedStorageResponse:
+            def GET(min_size: int = None, wait: bool = False) \
+                    -> GuidedStorageResponse:
                 pass
 
             def POST(choice: Optional[GuidedChoice]) \

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -617,10 +617,6 @@ class _Formattable(ABC):
 # space for the GPT data.
 GPT_OVERHEAD = 2 * (1 << 20)
 
-# Disks larger than this are considered sensible targets for guided
-# installation.
-MIN_SIZE_GUIDED = 6 * (1 << 30)
-
 
 @attr.s(cmp=False)
 class _Device(_Formattable, ABC):
@@ -904,7 +900,7 @@ class Disk(_Device):
 
     ok_for_lvm_vg = ok_for_raid
 
-    def for_client(self):
+    def for_client(self, min_size):
         from subiquity.common.types import Disk
         return Disk(
             id=self.id,
@@ -913,7 +909,7 @@ class Disk(_Device):
             size=self.size,
             usage_labels=self.usage_labels(),
             partitions=[p.for_client() for p in self._partitions],
-            ok_for_guided=self.size >= MIN_SIZE_GUIDED)
+            ok_for_guided=self.size >= min_size)
 
 
 @fsobj("partition")


### PR DESCRIPTION
Caller to guided_GET can now specify a minimum size disk that is
acceptable for guided partitioning.  The unit is bytes.
The default value if this is unspecified is 6GiB.

Note that this default value is wholly inadequate for Desktop, which by
my measurements needs at least 8GiB to get the install completed if you
tell it to install everything, even though later it settles to a lower
installed size of 6.6GiB.