### PR TITLE
fix keyerror: updates

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -134,6 +134,8 @@ class SubiquityModel:
             }
 
     def configured(self, model_name):
+        if model_name not in ALL_MODEL_NAMES:
+            return
         self._events[model_name].set()
         if model_name in INSTALL_MODEL_NAMES:
             unconfigured = {


### PR DESCRIPTION
While playing with interactive-sections I found that I could trigger a keyerror exception where 'updates' was not found.
Here's a quick fix for now and I want to ponder adding a test case.
