### PR TITLE
make sure freshly allocated action ids are really unique

### DIFF
--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -18,7 +18,6 @@ import unittest
 import attr
 
 from subiquity.models.filesystem import (
-    attributes,
     Bootloader,
     dehumanize_size,
     DeviceAction,
@@ -114,7 +113,7 @@ class TestDehumanizeSize(unittest.TestCase):
 class FakeDev:
 
     size = attr.ib()
-    id = attributes.idfield("fakedev")
+    id = attr.ib(default="id")
 
 
 class TestRoundRaidSize(unittest.TestCase):

--- a/subiquity/ui/views/filesystem/tests/test_filesystem.py
+++ b/subiquity/ui/views/filesystem/tests/test_filesystem.py
@@ -33,6 +33,7 @@ class FilesystemViewTests(unittest.TestCase):
         model = mock.create_autospec(spec=FilesystemModel)
         model._probe_data = {}
         model._actions = []
+        model._all_ids = set()
         disk = Disk(
             m=model, serial="DISK-SERIAL", path='/dev/thing',
             info=FakeStorageInfo(size=100*(2**20), free=50*(2**20)))


### PR DESCRIPTION
Because the server and any clients can create action objects now,
per-process global counters are not going to cut it.

For https://bugs.launchpad.net/subiquity/+bug/1925063.