### PR TITLE
avoid situation where overlays can be shown twice

### DIFF
--- a/subiquity/ui/frame.py
+++ b/subiquity/ui/frame.py
@@ -36,6 +36,8 @@ class SubiquityUI(SubiquityCoreUI):
             return super().keypress(size, key)
 
     def set_body(self, widget):
+        if widget is self.body:
+            return
         super().set_body(widget)
         if isinstance(widget, BaseView):
             for overlay in self.app.global_overlays:


### PR DESCRIPTION
https://bugs.launchpad.net/subiquity/+bug/1925068 reports a crash that
fails with the "self.global_overlays.remove(overlay)" in
remove_global_overlay failing because the overlay is not in the list. I
don't know how it happened but staring at the code I did guess one way
this could happen: if you have two non-interactive screens in a row
where the requests both take long enough to trip the 0.1s threshold to
show the progress screen, app.ui.set_body will get called twice with the
same view. Each call will layer all global overlays over the view, so
doing it twice will show the views twice.

This all makes me thing that the way global overlays are shown is a bit
wrong -- they should be "outside" the controller-supplied view! -- but,
well, it's easy enough to make sure that calling set_body twice with the
same view doesn't cause this particular problem.