### PR TITLE
Drop the confirm_ssh_keys call if UI not as expected

### DIFF
--- a/subiquity/client/controllers/ssh.py
+++ b/subiquity/client/controllers/ssh.py
@@ -116,7 +116,7 @@ class SSHController(SubiquityTuiController):
                         ssh_data, ssh_import_id, key_material, fingerprints)
                 else:
                     log.debug("ui.body of unexpected instance: %s",
-                            type(self.ui.body).__name__)
+                              type(self.ui.body).__name__)
 
     def fetch_ssh_keys(self, ssh_import_id, ssh_data):
         self._fetch_task = schedule_task(

--- a/subiquity/client/controllers/ssh.py
+++ b/subiquity/client/controllers/ssh.py
@@ -111,8 +111,12 @@ class SSHController(SubiquityTuiController):
                 ssh_data.authorized_keys = key_material.splitlines()
                 self.done(ssh_data)
             else:
-                self.ui.body.confirm_ssh_keys(
-                    ssh_data, ssh_import_id, key_material, fingerprints)
+                if isinstance(self.ui.body, SSHView):
+                    self.ui.body.confirm_ssh_keys(
+                        ssh_data, ssh_import_id, key_material, fingerprints)
+                else:
+                    log.debug("ui.body of unexpected instance: %s",
+                            type(self.ui.body).__name__)
 
     def fetch_ssh_keys(self, ssh_import_id, ssh_data):
         self._fetch_task = schedule_task(


### PR DESCRIPTION
There is a larger problem here of the UI body changing underneath of us,
but this is at least a baby step in the right direction.
Also this matches existing client/controllers/ssh.py behavior.
At least log the event when it happens.
LP: #1925048