### PR TITLE
set trusted=yes,check-date=no for cdrom pool during installation

### DIFF
--- a/bin/subiquity-configure-apt
+++ b/bin/subiquity-configure-apt
@@ -61,7 +61,7 @@ else
 fi
 
 cat > "$TARGET_MOUNT_POINT/etc/apt/sources.list" <<EOF
-deb file:///cdrom $(lsb_release -sc) main restricted
+deb [trusted=yes,check-date=no] file:///cdrom $(lsb_release -sc) main restricted
 EOF
 
 $PY -m curtin in-target -- apt-get update


### PR DESCRIPTION
The pool is loaded off the same media as the installer and the
filesystem being installed so there's no real loss of security doing
this and it makes it easier for people to master custom ISOs with extra
packages in the pool and systems with inaccurate clocks (that cannot
reach ntp.ubuntu.com).