### PR TITLE
mark the locale model as configured at start up

### DIFF
--- a/examples/answers-serial.yaml
+++ b/examples/answers-serial.yaml
@@ -1,0 +1,41 @@
+#serial
+Serial:
+  rich: false
+Welcome:
+  lang: en_US
+Refresh:
+  update: no
+Keyboard:
+  layout: us
+Zdev:
+  accept-default: yes
+Network:
+  accept-default: yes
+Proxy:
+  proxy: ""
+Mirror:
+  country-code: us
+Filesystem:
+  guided: yes
+  guided-index: 0
+Identity:
+  realname: Ubuntu
+  username: ubuntu
+  hostname: ubuntu-server
+  # ubuntu
+  password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+SSH:
+  install_server: true
+  pwauth: false
+  authorized_keys:
+    - |
+      ssh-rsa AAAAAAAAAAAAAAAAAAAAAAAAA # ssh-import-id lp:subiquity
+SnapList:
+  snaps:
+    hello:
+      channel: stable
+      is_classic: false
+InstallProgress:
+  reboot: yes
+
+

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -33,8 +33,13 @@ for answers in examples/answers*.yaml; do
     if [ -z "$config" ]; then
         config=examples/simple.json
     fi
+    serial=$(sed -n 's/^#serial/x/p' $answers || true)
+    opts=''
+    if [ -n "$serial" ]; then
+        opts='--serial'
+    fi
     # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
-    timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config $config" < $tty
+    timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config $config $opts" < $tty
     validate
     grep -q 'finish: subiquity/Install/install/run_unattended_upgrades: SUCCESS: downloading and installing security updates' .subiquity/subiquity-server-debug.log
 done

--- a/subiquity/client/controllers/serial.py
+++ b/subiquity/client/controllers/serial.py
@@ -29,6 +29,13 @@ class SerialController(SubiquityTuiController):
         ssh_info = await self.app.client.meta.ssh_info.GET()
         return SerialView(self, ssh_info)
 
+    def run_answers(self):
+        if 'rich' in self.answers:
+            if self.answers['rich']:
+                self.ui.body.rich_btn.base_widget._emit('click')
+            else:
+                self.ui.body.basic_btn.base_widget._emit('click')
+
     def done(self, rich):
         log.debug("SerialController.done rich %s next_screen", rich)
         self.app.set_rich(rich)

--- a/subiquity/server/controllers/locale.py
+++ b/subiquity/server/controllers/locale.py
@@ -36,6 +36,7 @@ class LocaleController(SubiquityController):
 
     def start(self):
         self.model.selected_language = os.environ.get("LANG")
+        self.configured()
 
     def serialize(self):
         return self.model.selected_language

--- a/subiquity/ui/views/serial.py
+++ b/subiquity/ui/views/serial.py
@@ -56,14 +56,13 @@ class SerialView(BaseView):
         super().__init__(self.make_serial())
 
     def make_serial(self):
-        btns = [
-            forward_btn(
+        self.rich_btn = forward_btn(
                 label="Continue in rich mode",
-                on_press=self.rich_mode),
-            forward_btn(
+                on_press=self.rich_mode)
+        self.basic_btn = forward_btn(
                 label="Continue in basic mode",
-                on_press=self.basic_mode),
-            ]
+                on_press=self.basic_mode)
+        btns = [self.rich_btn, self.basic_btn]
         widgets = [
             Text(""),
             Text(rewrap(SERIAL_TEXT)),


### PR DESCRIPTION
The subiquity client does not ask about language in non-rich mode on a
serial port, and that's OK. But we still need the install to complete :)

There are other ways to fix this I guess -- we could not wait on the
locale model to get configured, for example, or explicitly select a
C.UTF-8 locale when "Continue in basic mode" is selected, or probably
some other things. But this works and seems OK.