### PR TITLE
verify signatures on the cdrom pool again

### DIFF
--- a/bin/subiquity-configure-apt
+++ b/bin/subiquity-configure-apt
@@ -61,7 +61,7 @@ else
 fi
 
 cat > "$TARGET_MOUNT_POINT/etc/apt/sources.list" <<EOF
-deb [trusted=yes,check-date=no] file:///cdrom $(lsb_release -sc) main restricted
+deb [check-date=no] file:///cdrom $(lsb_release -sc) main restricted
 EOF
 
 $PY -m curtin in-target -- apt-get update


### PR DESCRIPTION
It's not safe in the netboot case.