### PR TITLE
have console-conf-write-login-details exit with code 2 when no IPs found

### DIFF
--- a/console_conf/cmd/write_login_details.py
+++ b/console_conf/cmd/write_login_details.py
@@ -14,14 +14,22 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import sys
-from console_conf.controllers.identity import write_login_details_standalone
+
 from subiquitycore.log import setup_logger
+from subiquitycore import __version__ as VERSION
+
+from console_conf.controllers.identity import write_login_details_standalone
 
 
 def main():
-    setup_logger(dir='/var/log/console-conf')
-    write_login_details_standalone()
+    logger = setup_logger(dir='/var/log/console-conf')
+    logger = logging.getLogger('console_conf')
+    logger.info(
+        "Starting console-conf-write-login-details v{}".format(VERSION))
+    logger.info("Arguments passed: {}".format(sys.argv))
+    return write_login_details_standalone()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also make the log files resulting from console-conf-write-login-details
execution a bit easier to spot.

I'd missed when fixing this on main that the text to display is never recalculated when console-conf-write-login-details exits with code 0.