### PR TITLE
decide whether to let curtin create a swapfile when rendering config

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -314,7 +314,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             meth(disk)
         elif 'config' in self.ai_data:
             self.model.apply_autoinstall_config(self.ai_data['config'])
-            self.model.grub = self.ai_data.get('grub', {})
+            self.model.grub = self.ai_data.get('grub')
             self.model.swap = self.ai_data.get('swap')
 
     def start(self):


### PR DESCRIPTION
https://bugs.launchpad.net/subiquity/+bug/1927103 reports a regression
where a subiquity-installed system has a swapfile even if a swap
partition has been explicitly configured.

The reason this broke is that previously subiquity tracked whether a
swap file should be allowed or not by keeping track of whether a swap
partition was mounted in add_mount / remove_mount. But since the
client/server split, those methods aren't called in the server process
any more.

Just get rid of all the cleverness and call _should_add_swapfile when
rendering the curtin config.