### PR TITLE
include the traceback in the response when a server method fails

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -400,6 +400,17 @@ All of these errors result in an error report (using the same format
 as apport) being generated, before the error-commands (if any) are
 run.
 
+Error reports are represented over the API by the `ErrorReportRef`
+type. This contains enough information to find the error report and
+know if it is complete yet (there is an API method `errors.wait.GET()`
+that will block until the error report has been completed).
+
+Immediate errors end up in the `error` field in the return value for
+`meta.status.GET()`.
+
+When an API error happens, the server puts a serialized
+`ErrorReportRef` in the `x-error-report` header of the response.
+
 Some things that could be considered "errors", like failing to contact
 the snap store are ignored and not presented to the user, instead the
 relevant screens are skipped.

--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import inspect
+import traceback
 
 from aiohttp import web
 
@@ -123,7 +124,9 @@ def _make_handler(controller, definition, implementation, serializer):
                     serializer.serialize(def_ret_ann, result),
                     headers={'x-status': 'ok'})
             except Exception as exc:
+                tb = traceback.TracebackException.from_exception(exc)
                 resp = web.Response(
+                    text="".join(tb.format()),
                     status=500,
                     headers={
                         'x-status': 'error',


### PR DESCRIPTION
example:

$ curl  --unix-socket .subiquity/socket a/dry_run/crash
Traceback (most recent call last):
  File "/home/mwhudson/src/subiquity/subiquity/common/api/server.py", line 122, in handler
    result = await implementation(**args)
  File "/home/mwhudson/src/subiquity/subiquity/server/dryrun.py", line 24, in crash_GET
    1/0
ZeroDivisionError: division by zero