### PR TITLE
Split unit / integration tests a bit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: run
-      run: sudo ./scripts/test-in-lxd.sh ${{ matrix.image }} ./scripts/runtests.sh
+      run: sudo ./scripts/test-in-lxd.sh ${{ matrix.image }} "make check"
   lint:
     runs-on: ubuntu-20.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,13 @@ flake8:
 	$(PYTHON) -m flake8 $(CHECK_DIRS) --exclude gettext38.py,contextlib38.py
 
 unit:
-	echo "Running unit tests..."
+	python3 -m unittest discover
+
+integration:
+	echo "Running integration tests..."
 	./scripts/runtests.sh
 
-check: unit
+check: unit integration
 
 probert:
 	@if [ ! -d "$(PROBERTDIR)" ]; then \

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eux
-python3 -m unittest discover
 
 testschema=.subiquity/test-autoinstall-schema.json
 


### PR DESCRIPTION
Unit tests should be quick and run frequently.
Integration tests can be longer and run less often.
Split them up.