### PR TITLE
Don't redundantly remove from the overlay list

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -400,7 +400,8 @@ class SubiquityClient(TuiApplication):
             self.ui.body.show_stretchy_overlay(overlay)
 
     def remove_global_overlay(self, overlay):
-        self.global_overlays.remove(overlay)
+        if overlay in self.global_overlays:
+            self.global_overlays.remove(overlay)
         if isinstance(self.ui.body, BaseView):
             self.ui.body.remove_overlay(overlay)
 

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -256,11 +256,10 @@ class InstallConfirmation(Stretchy):
     def ok(self, sender):
         if isinstance(self.app.ui.body, ProgressView):
             self.app.ui.body.hide_continue()
+        self.app.remove_global_overlay(self)
         if self.app.controllers.Progress.showing:
-            self.app.remove_global_overlay(self)
             self.app.aio_loop.create_task(self.app.confirm_install())
         else:
-            self.app.global_overlays.remove(self)
             self.app.next_screen(self.app.confirm_install())
 
     def cancel(self, sender):


### PR DESCRIPTION
There are two places that remove from this list, and the current arm64
crash is running into a scenario where we try to remove from the
overlays list only to find that it's not actually there.
So don't remove if it's already gone.

LP: #1925068