### PR TITLE
Open the permissions on the socket

### DIFF
--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import inspect
+import os
 import traceback
 
 from aiohttp import web
@@ -174,4 +175,6 @@ async def make_server_at_path(socket_path, endpoint, controller):
     await runner.setup()
     site = web.UnixSite(runner, socket_path)
     await site.start()
+    # It is intended that a non-root client can connect.
+    os.chmod(socket_path, 0o666)
     return site

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -405,6 +405,8 @@ class SubiquityServer(Application):
         await runner.setup()
         site = web.UnixSite(runner, self.opts.socket)
         await site.start()
+        # It is intended that a non-root client can connect.
+        os.chmod(self.opts.socket, 0o666)
 
     async def wait_for_cloudinit(self):
         if self.opts.dry_run:


### PR DESCRIPTION
Installer clients can be non-root.
Installer clients run in an environment where root is just a
password-less sudo away.