### PR TITLE
subiquitycore wlan fixes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -154,5 +154,5 @@ parts:
     build-packages: [python-setuptools, build-essential, libnl-3-dev, libnl-genl-3-dev, libnl-route-3-dev]
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: 844c957b7f61f78bbd814cceef87f0d8eb218675
+    source-commit: abf7c7c399bdc9909a14194f579f2e53c226cb8e
     requirements: [requirements.txt]

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -449,6 +449,7 @@ class BaseNetworkController(BaseController):
         device = self.model.get_netdev_by_name(dev_name)
         device.set_ssid_psk(wlan.ssid, wlan.psk)
         self.update_link(device)
+        self.apply_config()
 
     def start_scan(self, dev_name: str) -> None:
         device = self.model.get_netdev_by_name(dev_name)

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -447,6 +447,10 @@ class BaseNetworkController(BaseController):
 
     def set_wlan(self, dev_name: str, wlan: WLANConfig) -> None:
         device = self.model.get_netdev_by_name(dev_name)
+        if wlan.ssid and not device.configured_ssid:
+            # Turn DHCP4 on by default when specifying an SSID for
+            # the first time...
+            device.config['dhcp4'] = True
         device.set_ssid_psk(wlan.ssid, wlan.psk)
         self.update_link(device)
         self.apply_config()

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -453,7 +453,10 @@ class BaseNetworkController(BaseController):
 
     def start_scan(self, dev_name: str) -> None:
         device = self.model.get_netdev_by_name(dev_name)
-        self.observer.trigger_scan(device.ifindex)
+        try:
+            self.observer.trigger_scan(device.ifindex)
+        except RuntimeError as r:
+            device.info.wlan['scan_state'] = 'error %s' % (r,)
         self.update_link(device)
 
     @abc.abstractmethod

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -82,8 +82,8 @@ class VLANConfig:
 
 @attr.s(auto_attribs=True)
 class WLANConfig:
-    ssid: str
-    psk: str
+    ssid: Optional[str]
+    psk: Optional[str]
 
 
 @attr.s(auto_attribs=True)
@@ -133,7 +133,7 @@ class NetDevInfo:
 
     vlan: Optional[VLANConfig]
     bond: Optional[BondConfig]
-    wlan: Optional[WLANConfig]
+    wlan: Optional[WLANStatus]
 
     dhcp4: DHCPStatus
     dhcp6: DHCPStatus

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -421,11 +421,18 @@ class NetworkModel(object):
     def new_link(self, ifindex, link):
         log.debug("new_link %s %s %s", ifindex, link.name, link.type)
         if link.type in NETDEV_IGNORED_IFACE_TYPES:
+            log.debug('ignoring based on type')
             return
         if not self.support_wlan and link.type == "wlan":
+            log.debug('ignoring based on support_wlan')
             return
-        if link.is_virtual and (
-                link.type not in NETDEV_ALLOWED_VIRTUAL_IFACE_TYPES):
+        is_virtual = link.is_virtual
+        if link.type == "wlan":
+            # mac80211_hwsim nics show up as virtual but we pretend
+            # they are real for testing purposes.
+            is_virtual = False
+        if is_virtual and link.type not in NETDEV_ALLOWED_VIRTUAL_IFACE_TYPES:
+            log.debug('ignoring based on is_virtual')
             return
         dev = self.devices_by_name.get(link.name)
         if dev is not None:
@@ -438,9 +445,10 @@ class NetworkModel(object):
                 dev.info = link
         else:
             config = self.config.config_for_device(link)
-            if link.is_virtual and not config:
+            if is_virtual and not config:
                 # If we see a virtual device without there already
                 # being a config for it, we just ignore it.
+                log.debug('ignoring virtual device with no config')
                 return
             dev = NetworkDev(self, link.name, link.type)
             dev.info = link

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -105,7 +105,7 @@ class NetworkConfigureWLANStretchy(Stretchy):
             fp -= 1
         self.inputs.focus_position = fp
         try:
-            self.parent.controller.start_scan(self.dev_info)
+            self.parent.controller.start_scan(self.dev_info.name)
         except RuntimeError as r:
             log.exception("start_scan failed")
             self.error.set_text("%s" % (r,))
@@ -146,7 +146,7 @@ class NetworkConfigureWLANStretchy(Stretchy):
         if self.dev_info.wlan.config.ssid is None and self.form.ssid.value:
             # Turn DHCP4 on by default when specifying an SSID for
             # the first time...
-            self.parent.controller.enable_dhcp(self.dev_info, 4)
+            self.parent.controller.enable_dhcp(self.dev_info.name, 4)
         if self.form.ssid.value:
             ssid = self.form.ssid.value
         else:
@@ -157,7 +157,7 @@ class NetworkConfigureWLANStretchy(Stretchy):
             psk = None
         self.parent.controller.set_wlan(
             self.dev_info, WLANConfig(ssid=ssid, psk=psk))
-        self.parent.update_link(self.dev_info)
+        self.parent.update_link(self.dev_info.name)
         self.parent.remove_overlay()
 
     def cancel(self, sender=None):

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -138,6 +138,8 @@ class NetworkConfigureWLANStretchy(Stretchy):
         return col
 
     def update_link(self, dev_info):
+        if dev_info.name != self.dev_info.name:
+            return
         self.dev_info = dev_info
         self.inputs.contents = [(obj, ('pack', None))
                                 for obj in self._build_iface_inputs()]

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -146,10 +146,6 @@ class NetworkConfigureWLANStretchy(Stretchy):
                                 for obj in self._build_iface_inputs()]
 
     def done(self, sender):
-        if self.dev_info.wlan.config.ssid is None and self.form.ssid.value:
-            # Turn DHCP4 on by default when specifying an SSID for
-            # the first time...
-            self.parent.controller.enable_dhcp(self.dev_info.name, 4)
         if self.form.ssid.value:
             ssid = self.form.ssid.value
         else:


### PR DESCRIPTION
Trying to enable wlan support in subiquity revealed a bunch of mostly trivialish bugs, mostly introduced by the refactoring I did in aid of the client/server split -- several of these affect console-conf too.

It also adds some code to work with mac80211_hwsim emulated wlan NICs -- that needs https://github.com/canonical/probert/pull/105 too though.