### PR TITLE
move storage description functionality to singledispatch methods

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -38,6 +38,7 @@ subiquity/common/filesystem/labels.py
 subiquity/common/filesystem/manipulator.py
 subiquity/common/filesystem/tests/__init__.py
 subiquity/common/filesystem/tests/test_actions.py
+subiquity/common/filesystem/tests/test_labels.py
 subiquity/common/filesystem/tests/test_manipulator.py
 subiquity/common/__init__.py
 subiquity/common/serialize.py

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -34,6 +34,7 @@ subiquity/common/api/tests/test_server.py
 subiquity/common/errorreport.py
 subiquity/common/filesystem/actions.py
 subiquity/common/filesystem/__init__.py
+subiquity/common/filesystem/labels.py
 subiquity/common/filesystem/manipulator.py
 subiquity/common/filesystem/tests/__init__.py
 subiquity/common/filesystem/tests/test_actions.py

--- a/subiquity/common/filesystem/actions.py
+++ b/subiquity/common/filesystem/actions.py
@@ -151,7 +151,7 @@ def _can_edit_generic(device):
         "Cannot edit {selflabel} as it is part of the {cdtype} "
         "{cdname}.").format(
             selflabel=labels.label(device),
-            cdtype=cd.desc(),
+            cdtype=labels.desc(cd),
             cdname=labels.label(cd))
 
 
@@ -247,7 +247,7 @@ def _can_remove_device(device):
         return _("Cannot remove {selflabel} from pre-existing {cdtype} "
                  "{cdlabel}.").format(
                     selflabel=labels.label(device),
-                    cdtype=cd.desc(),
+                    cdtype=labels.desc(cd),
                     cdlabel=labels.label(cd))
     if isinstance(cd, Raid):
         if device in cd.spare_devices:
@@ -258,7 +258,7 @@ def _can_remove_device(device):
                 "Removing {selflabel} would leave the {cdtype} {cdlabel} with "
                 "less than {min_devices} devices.").format(
                     selflabel=labels.label(device),
-                    cdtype=cd.desc(),
+                    cdtype=labels.desc(cd),
                     cdlabel=labels.label(cd),
                     min_devices=min_devices)
     elif isinstance(cd, LVM_VolGroup):
@@ -267,7 +267,7 @@ def _can_remove_device(device):
                 "Removing {selflabel} would leave the {cdtype} {cdlabel} with "
                 "no devices.").format(
                     selflabel=labels.label(device),
-                    cdtype=cd.desc(),
+                    cdtype=labels.desc(cd),
                     cdlabel=labels.label(cd))
     return True
 
@@ -283,7 +283,7 @@ def _can_delete_generic(device):
         "Cannot delete {selflabel} as it is part of the {cdtype} "
         "{cdname}.").format(
             selflabel=labels.label(device),
-            cdtype=cd.desc(),
+            cdtype=labels.desc(cd),
             cdname=labels.label(cd))
 
 
@@ -311,7 +311,7 @@ def _can_delete_raid_vg(device):
                 "of the {cdtype} {cdname}.").format(
                     devicelabel=labels.label(device),
                     partnum=p._number,
-                    cdtype=cd.desc(),
+                    cdtype=labels.desc(cd),
                     cdname=labels.label(cd),
                     )
     if mounted_partitions > 1:

--- a/subiquity/common/filesystem/actions.py
+++ b/subiquity/common/filesystem/actions.py
@@ -18,6 +18,7 @@ import functools
 
 from subiquitycore.gettext38 import pgettext
 
+from subiquity.common.filesystem import labels
 from subiquity.models.filesystem import (
     Bootloader,
     Disk,
@@ -149,9 +150,9 @@ def _can_edit_generic(device):
     return _(
         "Cannot edit {selflabel} as it is part of the {cdtype} "
         "{cdname}.").format(
-            selflabel=device.label,
+            selflabel=labels.label(device),
             cdtype=cd.desc(),
-            cdname=cd.label)
+            cdname=labels.label(cd))
 
 
 _can_edit.register(Partition, _can_edit_generic)
@@ -165,7 +166,7 @@ def _can_edit_raid(raid):
     elif len(raid._partitions) > 0:
         return _(
             "Cannot edit {raidlabel} because it has partitions.").format(
-                raidlabel=raid.label)
+                raidlabel=labels.label(raid))
     else:
         return _can_edit_generic(raid)
 
@@ -178,7 +179,7 @@ def _can_edit_vg(vg):
         return _(
             "Cannot edit {vglabel} because it has logical "
             "volumes.").format(
-                vglabel=vg.label)
+                vglabel=labels.label(vg))
     else:
         return _can_edit_generic(vg)
 
@@ -245,9 +246,9 @@ def _can_remove_device(device):
     if cd.preserve:
         return _("Cannot remove {selflabel} from pre-existing {cdtype} "
                  "{cdlabel}.").format(
-                    selflabel=device.label,
+                    selflabel=labels.label(device),
                     cdtype=cd.desc(),
-                    cdlabel=cd.label)
+                    cdlabel=labels.label(cd))
     if isinstance(cd, Raid):
         if device in cd.spare_devices:
             return True
@@ -256,18 +257,18 @@ def _can_remove_device(device):
             return _(
                 "Removing {selflabel} would leave the {cdtype} {cdlabel} with "
                 "less than {min_devices} devices.").format(
-                    selflabel=device.label,
+                    selflabel=labels.label(device),
                     cdtype=cd.desc(),
-                    cdlabel=cd.label,
+                    cdlabel=labels.label(cd),
                     min_devices=min_devices)
     elif isinstance(cd, LVM_VolGroup):
         if len(cd.devices) == 1:
             return _(
                 "Removing {selflabel} would leave the {cdtype} {cdlabel} with "
                 "no devices.").format(
-                    selflabel=device.label,
+                    selflabel=labels.label(device),
                     cdtype=cd.desc(),
-                    cdlabel=cd.label)
+                    cdlabel=labels.label(cd))
     return True
 
 
@@ -281,9 +282,9 @@ def _can_delete_generic(device):
     return _(
         "Cannot delete {selflabel} as it is part of the {cdtype} "
         "{cdname}.").format(
-            selflabel=device.label,
+            selflabel=labels.label(device),
             cdtype=cd.desc(),
-            cdname=cd.label)
+            cdname=labels.label(cd))
 
 
 @_can_delete.register(Partition)
@@ -308,21 +309,21 @@ def _can_delete_raid_vg(device):
             return _(
                 "Cannot delete {devicelabel} as partition {partnum} is part "
                 "of the {cdtype} {cdname}.").format(
-                    devicelabel=device.label,
+                    devicelabel=labels.label(device),
                     partnum=p._number,
                     cdtype=cd.desc(),
-                    cdname=cd.label,
+                    cdname=labels.label(cd),
                     )
     if mounted_partitions > 1:
         return _(
             "Cannot delete {devicelabel} because it has {count} mounted "
             "partitions.").format(
-                devicelabel=device.label,
+                devicelabel=labels.label(device),
                 count=mounted_partitions)
     elif mounted_partitions == 1:
         return _(
             "Cannot delete {devicelabel} because it has 1 mounted partition."
-            ).format(devicelabel=device.label)
+            ).format(devicelabel=labels.label(device))
     else:
         return _can_delete_generic(device)
 

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -124,12 +124,12 @@ def _desc_lv(lv):
 
 
 @functools.singledispatch
-def label(device):
+def label(device, *, short=False):
     raise NotImplementedError(repr(device))
 
 
 @label.register(Disk)
-def _label_disk(disk):
+def _label_disk(disk, *, short=False):
     if disk.multipath and disk.wwn:
         return disk.wwn
     if disk.serial:
@@ -140,29 +140,17 @@ def _label_disk(disk):
 @label.register(Raid)
 @label.register(LVM_VolGroup)
 @label.register(LVM_LogicalVolume)
-def _label_just_name(device):
+def _label_just_name(device, *, short=False):
     return device.name
 
 
 @label.register(Partition)
-def _label_partition(partition):
-    return _("partition {number} of {device}").format(
-        number=partition._number, device=label(partition.device))
-
-
-@functools.singledispatch
-def short_label(device):
-    raise NotImplementedError(repr(device))
-
-
-@short_label.register(Partition)
-def _short_label_partition(partition):
-    return _("partition {number}").format(number=partition._number)
-
-
-@short_label.register(LVM_LogicalVolume)
-def _short_label_lv(lv):
-    return lv.name
+def _label_partition(partition, *, short=False):
+    if short:
+        return _("partition {number}").format(number=partition._number)
+    else:
+        return _("partition {number} of {device}").format(
+            number=partition._number, device=label(partition.device))
 
 
 def _usage_labels_generic(device):

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -38,6 +38,12 @@ def _annotations_generic(device):
 
 @functools.singledispatch
 def annotations(device):
+    """annotations that should be displayed alongside `device`
+
+    The main example is whether this is a new or pre-existing device but
+    partitions, particularly bootloader partitions, can get a richer set
+    of annotations.
+    """
     return _annotations_generic(device)
 
 
@@ -93,6 +99,10 @@ def _annotations_vg(vg):
 
 @functools.singledispatch
 def desc(device):
+    """A description of the class of thing device is part of.
+
+    E.g. "partition of local disk" or "LVM volume group".
+    """
     raise NotImplementedError(repr(device))
 
 
@@ -125,6 +135,13 @@ def _desc_lv(lv):
 
 @functools.singledispatch
 def label(device, *, short=False):
+    """A label that identifies `device`
+
+    E.g. the serial number for a disk, or the name of a logical volume
+    or a string like "partition $n of $disk_serial". Passing short=True
+    returns just "partition $n" for a partition, for when what it is a
+    partition of is obvious.
+    """
     raise NotImplementedError(repr(device))
 
 
@@ -195,6 +212,11 @@ def _usage_labels_generic(device):
 
 @functools.singledispatch
 def usage_labels(device):
+    """A list of strings that describe how `device` is used.
+
+    E.g. ["component of software RAID 5 md0"] or ["to be reformatted as
+    xfs", "not mounted"].
+    """
     return _usage_labels_generic(device)
 
 

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -57,7 +57,7 @@ def _annotations_disk(disk):
 def _annotations_partition(partition):
     r = _annotations_generic(partition)
     if partition.flag == "prep":
-        r.append("PReP")
+        r.append(_("PReP"))
         if partition.preserve:
             if partition.grub_device:
                 # boot loader partition
@@ -78,7 +78,7 @@ def _annotations_partition(partition):
                 r.append(_("configured"))
             else:
                 r.append(_("unconfigured"))
-        r.append("bios_grub")
+        r.append(_("bios_grub"))
     elif partition.flag == "extended":
         # extended partition
         r.append(_("extended"))

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -1,0 +1,89 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import functools
+
+from subiquity.models.filesystem import (
+    Disk,
+    LVM_VolGroup,
+    Partition,
+    )
+
+
+def _annotations_generic(device):
+    preserve = getattr(device, 'preserve', None)
+    if preserve is None:
+        return []
+    elif preserve:
+        # A pre-existing device such as a partition or RAID
+        return [_("existing")]
+    else:
+        # A newly created device such as a partition or RAID
+        return [_("new")]
+
+
+@functools.singledispatch
+def annotations(device):
+    return _annotations_generic(device)
+
+
+@annotations.register(Disk)
+def _annotations_disk(disk):
+    return []
+
+
+@annotations.register(Partition)
+def _annotations_partition(partition):
+    r = _annotations_generic(partition)
+    if partition.flag == "prep":
+        r.append("PReP")
+        if partition.preserve:
+            if partition.grub_device:
+                # boot loader partition
+                r.append(_("configured"))
+            else:
+                # boot loader partition
+                r.append(_("unconfigured"))
+    elif partition.is_esp:
+        if partition.fs() and partition.fs().mount():
+            r.append(_("primary ESP"))
+        elif partition.grub_device:
+            r.append(_("backup ESP"))
+        else:
+            r.append(_("unused ESP"))
+    elif partition.flag == "bios_grub":
+        if partition.preserve:
+            if partition.device.grub_device:
+                r.append(_("configured"))
+            else:
+                r.append(_("unconfigured"))
+        r.append("bios_grub")
+    elif partition.flag == "extended":
+        # extended partition
+        r.append(_("extended"))
+    elif partition.flag == "logical":
+        # logical partition
+        r.append(_("logical"))
+    return r
+
+
+@annotations.register(LVM_VolGroup)
+def _annotations_vg(vg):
+    r = _annotations_generic(vg)
+    member = next(iter(vg.devices))
+    if member.type == "dm_crypt":
+        # Flag for a LVM volume group
+        r.append(_("encrypted"))
+    return r

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -131,7 +131,7 @@ def _desc_vg(vg):
 
 @desc.register(LVM_LogicalVolume)
 def _desc_lv(lv):
-    return _("LVM logival volume")
+    return _("LVM logical volume")
 
 
 @functools.singledispatch

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -78,7 +78,7 @@ def _annotations_partition(partition):
                 r.append(_("configured"))
             else:
                 r.append(_("unconfigured"))
-        r.append(_("bios_grub"))
+        r.append(_("BIOS grub spacer"))
     elif partition.flag == "extended":
         # extended partition
         r.append(_("extended"))

--- a/subiquity/common/filesystem/tests/test_labels.py
+++ b/subiquity/common/filesystem/tests/test_labels.py
@@ -1,0 +1,125 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from subiquity.common.filesystem.labels import (
+    annotations,
+    usage_labels,
+    )
+from subiquity.models.tests.test_filesystem import (
+    make_model,
+    make_model_and_disk,
+    make_model_and_partition,
+    make_partition,
+    )
+
+
+class TestAnnotations(unittest.TestCase):
+
+    def test_disk_annotations(self):
+        # disks never have annotations
+        model, disk = make_model_and_disk()
+        self.assertEqual(annotations(disk), [])
+        disk.preserve = True
+        self.assertEqual(annotations(disk), [])
+
+    def test_partition_annotations(self):
+        model = make_model()
+        part = make_partition(model)
+        self.assertEqual(annotations(part), ['new'])
+        part.preserve = True
+        self.assertEqual(annotations(part), ['existing'])
+
+        model = make_model()
+        part = make_partition(model, flag="bios_grub")
+        self.assertEqual(
+            annotations(part), ['new', 'BIOS grub spacer'])
+        part.preserve = True
+        self.assertEqual(
+            annotations(part),
+            ['existing', 'unconfigured', 'BIOS grub spacer'])
+        part.device.grub_device = True
+        self.assertEqual(
+            annotations(part),
+            ['existing', 'configured', 'BIOS grub spacer'])
+
+        model = make_model()
+        part = make_partition(model, flag="boot", grub_device=True)
+        self.assertEqual(annotations(part), ['new', 'backup ESP'])
+        fs = model.add_filesystem(part, fstype="fat32")
+        model.add_mount(fs, "/boot/efi")
+        self.assertEqual(annotations(part), ['new', 'primary ESP'])
+
+        model = make_model()
+        part = make_partition(model, flag="boot", preserve=True)
+        self.assertEqual(annotations(part), ['existing', 'unused ESP'])
+        part.grub_device = True
+        self.assertEqual(annotations(part), ['existing', 'backup ESP'])
+        fs = model.add_filesystem(part, fstype="fat32")
+        model.add_mount(fs, "/boot/efi")
+        self.assertEqual(annotations(part), ['existing', 'primary ESP'])
+
+        model = make_model()
+        part = make_partition(model, flag="prep", grub_device=True)
+        self.assertEqual(annotations(part), ['new', 'PReP'])
+
+        model = make_model()
+        part = make_partition(model, flag="prep", preserve=True)
+        self.assertEqual(
+            annotations(part), ['existing', 'PReP', 'unconfigured'])
+        part.grub_device = True
+        self.assertEqual(
+            annotations(part), ['existing', 'PReP', 'configured'])
+
+    def test_vg_default_annotations(self):
+        model, disk = make_model_and_disk()
+        vg = model.add_volgroup('vg-0', {disk})
+        self.assertEqual(annotations(vg), ['new'])
+        vg.preserve = True
+        self.assertEqual(annotations(vg), ['existing'])
+
+    def test_vg_encrypted_annotations(self):
+        model, disk = make_model_and_disk()
+        dm_crypt = model.add_dm_crypt(disk, key='passw0rd')
+        vg = model.add_volgroup('vg-0', {dm_crypt})
+        self.assertEqual(annotations(vg), ['new', 'encrypted'])
+
+
+class TestUsageLabels(unittest.TestCase):
+
+    def test_partition_usage_labels(self):
+        model, partition = make_model_and_partition()
+        self.assertEqual(usage_labels(partition), ["unused"])
+        fs = model.add_filesystem(partition, 'ext4')
+        self.assertEqual(
+            usage_labels(partition),
+            ["to be formatted as ext4", "not mounted"])
+        model._orig_config = model._render_actions()
+        fs.preserve = True
+        partition.preserve = True
+        self.assertEqual(
+            usage_labels(partition),
+            ["already formatted as ext4", "not mounted"])
+        model.remove_filesystem(fs)
+        fs2 = model.add_filesystem(partition, 'ext4')
+        self.assertEqual(
+            usage_labels(partition),
+            ["to be reformatted as ext4", "not mounted"])
+        model.add_mount(fs2, '/')
+        self.assertEqual(
+            usage_labels(partition),
+            ["to be reformatted as ext4", "mounted at /"])

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -745,14 +745,6 @@ class Partition(_Formattable):
 
     ok_for_lvm_vg = ok_for_raid
 
-    def for_client(self):
-        from subiquity.common.filesystem import labels
-        from subiquity.common.types import Partition
-        return Partition(
-            size=self.size,
-            number=self._number,
-            annotations=labels.annotations(self) + labels.usage_labels(self))
-
 
 @fsobj("raid")
 class Raid(_Device):

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -612,11 +612,6 @@ class Disk(_Device):
     def size(self):
         return align_down(self._info.size)
 
-    def desc(self):
-        if self.multipath:
-            return _("multipath device")
-        return _("local disk")
-
     def dasd(self):
         return self._m._one(type='dasd', device_id=self.device_id)
 
@@ -664,7 +659,7 @@ class Disk(_Device):
         return Disk(
             id=self.id,
             label=labels.label(self),
-            type=self.desc(),
+            type=labels.desc(self),
             size=self.size,
             usage_labels=labels.usage_labels(self),
             partitions=[p.for_client() for p in self._partitions],
@@ -683,13 +678,6 @@ class Partition(_Formattable):
     grub_device = attr.ib(default=False)
     name = attr.ib(default=None)
     multipath = attr.ib(default=None)
-
-    def desc(self):
-        return _("partition of {device}").format(device=self.device.desc())
-
-    @property
-    def short_label(self):
-        return _("partition {number}").format(number=self._number)
 
     def available(self):
         if self.flag in ['bios_grub', 'prep'] or self.grub_device:
@@ -797,9 +785,6 @@ class Raid(_Device):
         # partitions)
         return self.size - 2*GPT_OVERHEAD
 
-    def desc(self):
-        return _("software RAID {level}").format(level=self.raidlevel[4:])
-
     @property
     def ok_for_raid(self):
         if self._fs is not None:
@@ -834,9 +819,6 @@ class LVM_VolGroup(_Device):
     def available_for_partitions(self):
         return self.size
 
-    def desc(self):
-        return _("LVM volume group")
-
     ok_for_raid = False
     ok_for_lvm_vg = False
 
@@ -870,13 +852,6 @@ class LVM_LogicalVolume(_Formattable):
     @property
     def is_esp(self):
         return False  # another hack!
-
-    def desc(self):
-        return _("LVM logical volume")
-
-    @property
-    def short_label(self):
-        return self.name
 
     ok_for_raid = False
     ok_for_lvm_vg = False

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -19,6 +19,7 @@ import attr
 
 from subiquity.common.filesystem.labels import (
     annotations,
+    usage_labels,
     )
 from subiquity.models.filesystem import (
     Bootloader,
@@ -356,25 +357,25 @@ class TestFilesystemModel(unittest.TestCase):
 
     def test_partition_usage_labels(self):
         model, partition = make_model_and_partition()
-        self.assertEqual(partition.usage_labels(), ["unused"])
+        self.assertEqual(usage_labels(partition), ["unused"])
         fs = model.add_filesystem(partition, 'ext4')
         self.assertEqual(
-            partition.usage_labels(),
+            usage_labels(partition),
             ["to be formatted as ext4", "not mounted"])
         model._orig_config = model._render_actions()
         fs.preserve = True
         partition.preserve = True
         self.assertEqual(
-            partition.usage_labels(),
+            usage_labels(partition),
             ["already formatted as ext4", "not mounted"])
         model.remove_filesystem(fs)
         fs2 = model.add_filesystem(partition, 'ext4')
         self.assertEqual(
-            partition.usage_labels(),
+            usage_labels(partition),
             ["to be reformatted as ext4", "not mounted"])
         model.add_mount(fs2, '/')
         self.assertEqual(
-            partition.usage_labels(),
+            usage_labels(partition),
             ["to be reformatted as ext4", "mounted at /"])
 
     def test_is_esp(self):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -17,6 +17,9 @@ import unittest
 
 import attr
 
+from subiquity.common.filesystem.labels import (
+    annotations,
+    )
 from subiquity.models.filesystem import (
     Bootloader,
     dehumanize_size,
@@ -216,68 +219,68 @@ class TestFilesystemModel(unittest.TestCase):
     def test_disk_annotations(self):
         # disks never have annotations
         model, disk = make_model_and_disk()
-        self.assertEqual(disk.annotations, [])
+        self.assertEqual(annotations(disk), [])
         disk.preserve = True
-        self.assertEqual(disk.annotations, [])
+        self.assertEqual(annotations(disk), [])
 
     def test_partition_annotations(self):
         model = make_model()
         part = make_partition(model)
-        self.assertEqual(part.annotations, ['new'])
+        self.assertEqual(annotations(part), ['new'])
         part.preserve = True
-        self.assertEqual(part.annotations, ['existing'])
+        self.assertEqual(annotations(part), ['existing'])
 
         model = make_model()
         part = make_partition(model, flag="bios_grub")
         self.assertEqual(
-            part.annotations, ['new', 'bios_grub'])
+            annotations(part), ['new', 'bios_grub'])
         part.preserve = True
         self.assertEqual(
-            part.annotations, ['existing', 'unconfigured', 'bios_grub'])
+            annotations(part), ['existing', 'unconfigured', 'bios_grub'])
         part.device.grub_device = True
         self.assertEqual(
-            part.annotations, ['existing', 'configured', 'bios_grub'])
+            annotations(part), ['existing', 'configured', 'bios_grub'])
 
         model = make_model()
         part = make_partition(model, flag="boot", grub_device=True)
-        self.assertEqual(part.annotations, ['new', 'backup ESP'])
+        self.assertEqual(annotations(part), ['new', 'backup ESP'])
         fs = model.add_filesystem(part, fstype="fat32")
         model.add_mount(fs, "/boot/efi")
-        self.assertEqual(part.annotations, ['new', 'primary ESP'])
+        self.assertEqual(annotations(part), ['new', 'primary ESP'])
 
         model = make_model()
         part = make_partition(model, flag="boot", preserve=True)
-        self.assertEqual(part.annotations, ['existing', 'unused ESP'])
+        self.assertEqual(annotations(part), ['existing', 'unused ESP'])
         part.grub_device = True
-        self.assertEqual(part.annotations, ['existing', 'backup ESP'])
+        self.assertEqual(annotations(part), ['existing', 'backup ESP'])
         fs = model.add_filesystem(part, fstype="fat32")
         model.add_mount(fs, "/boot/efi")
-        self.assertEqual(part.annotations, ['existing', 'primary ESP'])
+        self.assertEqual(annotations(part), ['existing', 'primary ESP'])
 
         model = make_model()
         part = make_partition(model, flag="prep", grub_device=True)
-        self.assertEqual(part.annotations, ['new', 'PReP'])
+        self.assertEqual(annotations(part), ['new', 'PReP'])
 
         model = make_model()
         part = make_partition(model, flag="prep", preserve=True)
         self.assertEqual(
-            part.annotations, ['existing', 'PReP', 'unconfigured'])
+            annotations(part), ['existing', 'PReP', 'unconfigured'])
         part.grub_device = True
         self.assertEqual(
-            part.annotations, ['existing', 'PReP', 'configured'])
+            annotations(part), ['existing', 'PReP', 'configured'])
 
     def test_vg_default_annotations(self):
         model, disk = make_model_and_disk()
         vg = model.add_volgroup('vg-0', {disk})
-        self.assertEqual(vg.annotations, ['new'])
+        self.assertEqual(annotations(vg), ['new'])
         vg.preserve = True
-        self.assertEqual(vg.annotations, ['existing'])
+        self.assertEqual(annotations(vg), ['existing'])
 
     def test_vg_encrypted_annotations(self):
         model, disk = make_model_and_disk()
         dm_crypt = model.add_dm_crypt(disk, key='passw0rd')
         vg = model.add_volgroup('vg-0', {dm_crypt})
-        self.assertEqual(vg.annotations, ['new', 'encrypted'])
+        self.assertEqual(annotations(vg), ['new', 'encrypted'])
 
     def _test_ok_for_xxx(self, model, make_new_device, attr,
                          test_partitions=True):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -234,13 +234,15 @@ class TestFilesystemModel(unittest.TestCase):
         model = make_model()
         part = make_partition(model, flag="bios_grub")
         self.assertEqual(
-            annotations(part), ['new', 'bios_grub'])
+            annotations(part), ['new', 'BIOS grub spacer'])
         part.preserve = True
         self.assertEqual(
-            annotations(part), ['existing', 'unconfigured', 'bios_grub'])
+            annotations(part),
+            ['existing', 'unconfigured', 'BIOS grub spacer'])
         part.device.grub_device = True
         self.assertEqual(
-            annotations(part), ['existing', 'configured', 'bios_grub'])
+            annotations(part),
+            ['existing', 'configured', 'BIOS grub spacer'])
 
         model = make_model()
         part = make_partition(model, flag="boot", grub_device=True)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -40,6 +40,7 @@ from subiquity.common.errorreport import ErrorReportKind
 from subiquity.common.filesystem.actions import (
     DeviceAction,
     )
+from subiquity.common.filesystem import labels
 from subiquity.common.filesystem.manipulator import FilesystemManipulator
 from subiquity.common.types import (
     Bootloader,
@@ -225,7 +226,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             status=ProbeStatus.DONE,
             error_report=self.full_probe_error(),
             disks=[
-                d.for_client(min_size) for d in self.model._all(type='disk')
+                labels.for_client(d, min_size=min_size)
+                for d in self.model._all(type='disk')
             ])
 
     async def guided_POST(self, choice: Optional[GuidedChoice]) \

--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -133,7 +133,8 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
             else:
                 text += _(", not mounted")
         else:
-            text = prefix + _("unused {device}").format(device=device.desc())
+            text = prefix + _("unused {device}").format(
+                device=labels.desc(device))
         return TableRow([(2, Color.info_minor(Text(text)))])
 
     def set_bound_form_field(self, bff):
@@ -147,7 +148,7 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
                 ]))
                 self.no_selector_rows.append(self.all_rows[-1])
                 self.all_rows.append(TableRow([
-                    (2, Color.info_minor(Text("      " + device.desc())))
+                    (2, Color.info_minor(Text("      " + labels.desc(device))))
                 ]))
                 self.no_selector_rows.append(self.all_rows[-1])
             else:
@@ -155,7 +156,7 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
                     label = labels.label(device)
                     prefix = "    "
                 elif kind == PART:
-                    label = "  " + device.short_label
+                    label = "  " + labels.short_label(device)
                     prefix = "      "
                 else:
                     raise Exception("unexpected kind {}".format(kind))

--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -152,11 +152,11 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
                 ]))
                 self.no_selector_rows.append(self.all_rows[-1])
             else:
+                label = labels.label(device, short=True)
                 if kind == DEVICE:
-                    label = labels.label(device)
                     prefix = "    "
                 elif kind == PART:
-                    label = "  " + labels.short_label(device)
+                    label = "  " + label
                     prefix = "      "
                 else:
                     raise Exception("unexpected kind {}".format(kind))

--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -42,6 +42,7 @@ from subiquitycore.ui.utils import (
     Color,
     )
 
+from subiquity.common.filesystem import labels
 from subiquity.models.filesystem import (
     humanize_size,
     )
@@ -141,7 +142,7 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
         for kind, device in bff.form.possible_components:
             if kind == LABEL:
                 self.all_rows.append(TableRow([
-                    Text("    " + device.label),
+                    Text("    " + labels.label(device)),
                     Text(humanize_size(device.size), align='right')
                 ]))
                 self.no_selector_rows.append(self.all_rows[-1])
@@ -151,7 +152,7 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
                 self.no_selector_rows.append(self.all_rows[-1])
             else:
                 if kind == DEVICE:
-                    label = device.label
+                    label = labels.label(device)
                     prefix = "    "
                 elif kind == PART:
                     label = "  " + device.short_label

--- a/subiquity/ui/views/filesystem/delete.py
+++ b/subiquity/ui/views/filesystem/delete.py
@@ -25,6 +25,8 @@ from subiquitycore.ui.table import (
 from subiquitycore.ui.utils import button_pile
 from subiquitycore.ui.stretchy import Stretchy
 
+from subiquity.common.filesystem import labels
+
 from .helpers import summarize_device
 
 
@@ -39,7 +41,7 @@ class ConfirmDeleteStretchy(Stretchy):
 
         lines = [
             Text(_("Do you really want to delete the {desc} {label}?").format(
-                desc=obj.desc(), label=obj.label)),
+                desc=obj.desc(), label=labels.label(obj))),
             Text(""),
         ]
         stretchy_index = 0
@@ -113,7 +115,7 @@ class ConfirmReformatStretchy(Stretchy):
                 _(
                     "Do you really want to remove the existing filesystem "
                     "from {device}?"
-                    ).format(device=obj.label),
+                    ).format(device=labels.label(obj)),
                 "",
             ]
             m = fs.mount()
@@ -139,7 +141,7 @@ class ConfirmReformatStretchy(Stretchy):
                 _(
                     "Do you really want to remove all {things} from "
                     "{obj}?").format(
-                    things=things, obj=obj.label),
+                    things=things, obj=labels.label(obj)),
                 "",
             ]
             # XXX summarize partitions here?

--- a/subiquity/ui/views/filesystem/delete.py
+++ b/subiquity/ui/views/filesystem/delete.py
@@ -41,7 +41,7 @@ class ConfirmDeleteStretchy(Stretchy):
 
         lines = [
             Text(_("Do you really want to delete the {desc} {label}?").format(
-                desc=obj.desc(), label=labels.label(obj))),
+                desc=labels.desc(obj), label=labels.label(obj))),
             Text(""),
         ]
         stretchy_index = 0
@@ -110,7 +110,7 @@ class ConfirmReformatStretchy(Stretchy):
         if fs is not None:
             title = _(
                 "Remove filesystem from {device}"
-                ).format(device=obj.desc())
+                ).format(device=labels.desc(obj))
             lines = [
                 _(
                     "Do you really want to remove the existing filesystem "
@@ -136,7 +136,7 @@ class ConfirmReformatStretchy(Stretchy):
                 things = _("partitions")
             # things is either "logical volumes" or "partitions"
             title = _("Remove all {things} from {obj}").format(
-                things=things, obj=obj.desc())
+                things=things, obj=labels.desc(obj))
             lines = [
                 _(
                     "Do you really want to remove all {things} from "

--- a/subiquity/ui/views/filesystem/disk_info.py
+++ b/subiquity/ui/views/filesystem/disk_info.py
@@ -21,6 +21,8 @@ from subiquitycore.ui.utils import button_pile
 from subiquitycore.ui.stretchy import Stretchy
 from subiquitycore.ui.table import ColSpec, TablePile, TableRow
 
+from subiquity.common.filesystem import labels
+
 
 log = logging.getLogger('subiquity.ui.filesystem.disk_info')
 
@@ -52,7 +54,7 @@ class DiskInfoStretchy(Stretchy):
             Text(""),
             button_pile([done_btn(_("Close"), on_press=self.close)]),
             ]
-        title = _("Info for {device}").format(device=disk.label)
+        title = _("Info for {device}").format(device=labels.label(disk))
         super().__init__(title, widgets, 0, 2)
 
     def close(self, button=None):

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -63,9 +63,7 @@ from subiquitycore.view import BaseView
 from subiquity.common.filesystem.actions import (
     DeviceAction,
     )
-from subiquity.common.filesystem.labels import (
-    annotations,
-    )
+from subiquity.common.filesystem import labels
 from subiquity.models.filesystem import (
     humanize_size,
     )
@@ -107,8 +105,8 @@ class MountInfo:
 
     @property
     def desc(self):
-        anns = annotations(self.mount.device.volume)
-        desc = self.mount.device.volume.desc()
+        anns = labels.annotations(self.mount.device.volume)
+        desc = labels.desc(self.mount.device.volume)
         if anns:
             desc = anns[0] + " " + desc
         return desc
@@ -226,7 +224,7 @@ class WhyNotStretchy(Stretchy):
 
         title = "Cannot {action} {type}".format(
             action=_(action.value).lower(),
-            type=obj.desc())
+            type=labels.desc(obj))
         widgets = [
             Text(whynot),
             Text(""),
@@ -322,7 +320,7 @@ class DeviceList(WidgetWrap):
     def _label_REMOVE(self, action, device):
         cd = device.constructed_device()
         if cd:
-            return _("Remove from {device}").format(device=cd.desc())
+            return _("Remove from {device}").format(device=labels.desc(cd))
         else:
             return action.str()
 

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -63,6 +63,9 @@ from subiquitycore.view import BaseView
 from subiquity.common.filesystem.actions import (
     DeviceAction,
     )
+from subiquity.common.filesystem.labels import (
+    annotations,
+    )
 from subiquity.models.filesystem import (
     humanize_size,
     )
@@ -104,10 +107,10 @@ class MountInfo:
 
     @property
     def desc(self):
-        annotations = self.mount.device.volume.annotations
+        anns = annotations(self.mount.device.volume)
         desc = self.mount.device.volume.desc()
-        if annotations:
-            desc = annotations[0] + " " + desc
+        if anns:
+            desc = anns[0] + " " + desc
         return desc
 
     def startswith(self, other):

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -44,6 +44,9 @@ from subiquitycore.ui.utils import (
     )
 from subiquitycore.view import BaseView
 
+from subiquity.common.filesystem.labels import (
+    annotations,
+    )
 from subiquity.common.types import GuidedChoice
 from subiquity.models.filesystem import humanize_size
 
@@ -90,7 +93,7 @@ def summarize_device(disk):
         ])]
     if disk.partitions:
         for part in disk.partitions:
-            details = ", ".join(part.annotations)
+            details = ", ".join(annotations(part))
             rows.append((part, [
                 Text(_("partition {number}").format(number=part.number)),
                 (2, Text(details)),

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -44,9 +44,6 @@ from subiquitycore.ui.utils import (
     )
 from subiquitycore.view import BaseView
 
-from subiquity.common.filesystem.labels import (
-    annotations,
-    )
 from subiquity.common.types import GuidedChoice
 from subiquity.models.filesystem import humanize_size
 
@@ -93,7 +90,7 @@ def summarize_device(disk):
         ])]
     if disk.partitions:
         for part in disk.partitions:
-            details = ", ".join(annotations(part))
+            details = ", ".join(part.annotations)
             rows.append((part, [
                 Text(_("partition {number}").format(number=part.number)),
                 (2, Text(details)),

--- a/subiquity/ui/views/filesystem/helpers.py
+++ b/subiquity/ui/views/filesystem/helpers.py
@@ -40,7 +40,7 @@ def summarize_device(device, part_filter=lambda p: True):
         label = "{} ({})".format(label, ", ".join(anns))
     rows = [(device, [
         (2, Text(label)),
-        Text(device.desc()),
+        Text(labels.desc(device)),
         Text(humanize_size(device.size), align="right"),
         ])]
     partitions = device.partitions()
@@ -51,7 +51,7 @@ def summarize_device(device, part_filter=lambda p: True):
             details = ", ".join(
                 labels.annotations(part) + labels.usage_labels(part))
             rows.append((part, [
-                Text(part.short_label),
+                Text(labels.short_label(part)),
                 (2, Text(details)),
                 Text(humanize_size(part.size), align="right"),
                 ]))

--- a/subiquity/ui/views/filesystem/helpers.py
+++ b/subiquity/ui/views/filesystem/helpers.py
@@ -21,6 +21,7 @@ from subiquitycore.ui.utils import (
 
 from subiquity.common.filesystem.labels import (
     annotations,
+    usage_labels,
     )
 from subiquity.models.filesystem import (
     humanize_size,
@@ -49,7 +50,7 @@ def summarize_device(device, part_filter=lambda p: True):
         for part in device.partitions():
             if not part_filter(part):
                 continue
-            details = ", ".join(annotations(part) + part.usage_labels())
+            details = ", ".join(annotations(part) + usage_labels(part))
             rows.append((part, [
                 Text(part.short_label),
                 (2, Text(details)),
@@ -57,6 +58,6 @@ def summarize_device(device, part_filter=lambda p: True):
                 ]))
     else:
         rows.append((None, [
-            (4, Color.info_minor(Text(", ".join(device.usage_labels()))))
+            (4, Color.info_minor(Text(", ".join(usage_labels(device)))))
             ]))
     return rows

--- a/subiquity/ui/views/filesystem/helpers.py
+++ b/subiquity/ui/views/filesystem/helpers.py
@@ -51,7 +51,7 @@ def summarize_device(device, part_filter=lambda p: True):
             details = ", ".join(
                 labels.annotations(part) + labels.usage_labels(part))
             rows.append((part, [
-                Text(labels.short_label(part)),
+                Text(labels.label(part, short=True)),
                 (2, Text(details)),
                 Text(humanize_size(part.size), align="right"),
                 ]))

--- a/subiquity/ui/views/filesystem/helpers.py
+++ b/subiquity/ui/views/filesystem/helpers.py
@@ -19,10 +19,7 @@ from subiquitycore.ui.utils import (
     Color,
     )
 
-from subiquity.common.filesystem.labels import (
-    annotations,
-    usage_labels,
-    )
+from subiquity.common.filesystem import labels
 from subiquity.models.filesystem import (
     humanize_size,
     )
@@ -37,9 +34,10 @@ def summarize_device(device, part_filter=lambda p: True):
     device. This sounds a bit strange but hopefully you can figure it
     out by looking at the uses of this function.
     """
-    label = device.label
-    if annotations(device):
-        label = "{} ({})".format(label, ", ".join(annotations(device)))
+    label = labels.label(device)
+    anns = labels.annotations(device)
+    if anns:
+        label = "{} ({})".format(label, ", ".join(anns))
     rows = [(device, [
         (2, Text(label)),
         Text(device.desc()),
@@ -50,7 +48,8 @@ def summarize_device(device, part_filter=lambda p: True):
         for part in device.partitions():
             if not part_filter(part):
                 continue
-            details = ", ".join(annotations(part) + usage_labels(part))
+            details = ", ".join(
+                labels.annotations(part) + labels.usage_labels(part))
             rows.append((part, [
                 Text(part.short_label),
                 (2, Text(details)),
@@ -58,6 +57,6 @@ def summarize_device(device, part_filter=lambda p: True):
                 ]))
     else:
         rows.append((None, [
-            (4, Color.info_minor(Text(", ".join(usage_labels(device)))))
+            (4, Color.info_minor(Text(", ".join(labels.usage_labels(device)))))
             ]))
     return rows

--- a/subiquity/ui/views/filesystem/helpers.py
+++ b/subiquity/ui/views/filesystem/helpers.py
@@ -19,6 +19,9 @@ from subiquitycore.ui.utils import (
     Color,
     )
 
+from subiquity.common.filesystem.labels import (
+    annotations,
+    )
 from subiquity.models.filesystem import (
     humanize_size,
     )
@@ -34,8 +37,8 @@ def summarize_device(device, part_filter=lambda p: True):
     out by looking at the uses of this function.
     """
     label = device.label
-    if device.annotations:
-        label = "{} ({})".format(label, ", ".join(device.annotations))
+    if annotations(device):
+        label = "{} ({})".format(label, ", ".join(annotations(device)))
     rows = [(device, [
         (2, Text(label)),
         Text(device.desc()),
@@ -46,7 +49,7 @@ def summarize_device(device, part_filter=lambda p: True):
         for part in device.partitions():
             if not part_filter(part):
                 continue
-            details = ", ".join(part.annotations + part.usage_labels())
+            details = ", ".join(annotations(part) + part.usage_labels())
             rows.append((part, [
                 Text(part.short_label),
                 (2, Text(details)),

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -37,6 +37,7 @@ from subiquitycore.ui.container import Pile
 from subiquitycore.ui.stretchy import Stretchy
 from subiquitycore.ui.utils import rewrap
 
+from subiquity.common.filesystem import labels
 from subiquity.models.filesystem import (
     align_up,
     Disk,
@@ -258,7 +259,7 @@ class PartitionForm(Form):
         dev = self.mountpoints.get(mount)
         if dev is not None:
             return _("{device} is already mounted at {path}.").format(
-                device=dev.label.title(), path=mount)
+                device=labels.label(dev).title(), path=mount)
         if self.existing_fs_type is not None:
             if self.fstype.value is None:
                 if mount in common_mountpoints:
@@ -510,22 +511,22 @@ class PartitionStretchy(Stretchy):
         if partition is None:
             if isinstance(disk, LVM_VolGroup):
                 title = _("Adding logical volume to {vgname}").format(
-                    vgname=disk.label)
+                    vgname=labels.label(disk))
             else:
                 title = _("Adding {ptype} partition to {device}").format(
                     ptype=disk.ptable_for_new_partition().upper(),
-                    device=disk.label)
+                    device=labels.label(disk))
         else:
             if isinstance(disk, LVM_VolGroup):
                 title = _(
                     "Editing logical volume {lvname} of {vgname}"
                     ).format(
                         lvname=partition.name,
-                        vgname=disk.label)
+                        vgname=labels.label(disk))
             else:
                 title = _("Editing partition {number} of {device}").format(
                     number=partition.number,
-                    device=disk.label)
+                    device=labels.label(disk))
 
         super().__init__(title, widgets, 0, focus_index)
 
@@ -588,7 +589,8 @@ class FormatEntireStretchy(Stretchy):
             self.form.buttons,
         ]
 
-        title = _("Format and/or mount {device}").format(device=device.label)
+        title = _("Format and/or mount {device}").format(
+            device=labels.label(device))
 
         super().__init__(title, widgets, 0, 0)
 


### PR DESCRIPTION
This has the nice side-effect that subiquity.models.filesystem now contains very few translatable strings, which seems appropriate somehow.