### PR TITLE
Add client_variant

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -435,6 +435,7 @@ class SubiquityClient(TuiApplication):
                 endpoint_names.append(c.endpoint_name)
         if endpoint_names:
             await self.client.meta.mark_configured.POST(endpoint_names)
+        await self.client.meta.client_variant.POST('server')
         self.controllers.index = index - 1
         self.next_screen()
 

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -65,6 +65,10 @@ class API:
             def POST(endpoint_names: List[str]) -> None:
                 """Mark the controllers for endpoint_names as configured."""
 
+        class client_variant:
+            def POST(variant: str) -> None:
+                """Choose the install variant - desktop/server"""
+
         class confirm:
             def POST(tty: str) -> None:
                 """Confirm that the installation should proceed."""

--- a/subiquity/server/controller.py
+++ b/subiquity/server/controller.py
@@ -35,6 +35,7 @@ class SubiquityController(BaseController):
     autoinstall_schema = None
     autoinstall_default = None
     endpoint = None
+    relevant_variants = ('desktop', 'server')
 
     def __init__(self, app):
         super().__init__(app)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -107,6 +107,13 @@ class MetaController:
             if controller.endpoint in endpoints:
                 controller.configured()
 
+    async def client_variant_POST(self, variant: str) -> None:
+        if variant not in ('desktop', 'server'):
+            raise ValueError(f'unrecognized client variant {variant}')
+        for controller in self.app.controllers.instances:
+            if variant not in controller.relevant_variants:
+                controller.configured()
+
     async def ssh_info_GET(self) -> Optional[LiveSessionSSHInfo]:
         ips = []
         for dev in self.app.base_model.network.get_all_netdevs():


### PR DESCRIPTION
We need to know which controllers to block on, and which are optional.
The mechanism, for now, is this client_variant functionality, which adds
a mandatory early API call that the client shall use.  This allows
controllers to say that they are only required to be configured for
certain install clients, such as is necessary for timezone (which is
needed on desktop, and optional on server).