### PR TITLE
Show source list from test containers

### DIFF
--- a/scripts/test-in-lxd.sh
+++ b/scripts/test-in-lxd.sh
@@ -39,6 +39,9 @@ then
     done
 fi
 
+# debugging a github issue where the source.list is possibly malformed
+lxc file pull tester/etc/apt/sources.list -
+
 lxc exec tester -- sh -ec "
     cd ~/subiquity
     ./scripts/installdeps.sh


### PR DESCRIPTION
Builds on github are randomly failing with an error that sounds like a
bad sources.list.  Start showing the contents of that file in the build
logs.