### PR TITLE
Unhardcode path to subiquity-loadkeys

### DIFF
--- a/subiquity/server/controllers/keyboard.py
+++ b/subiquity/server/controllers/keyboard.py
@@ -199,7 +199,7 @@ class KeyboardController(SubiquityController):
             fp.write(self.model.render_config_file())
         cmds = [
             ['setupcon', '--save', '--force', '--keyboard-only'],
-            ['/snap/bin/subiquity.subiquity-loadkeys'],
+            ['subiquity-loadkeys'],
             ]
         if self.opts.dry_run:
             scale = os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "1")


### PR DESCRIPTION
With multiple users of subiquity in different ways, this may not be
always available at this specific location.