### PR TITLE
Abstract resource file lookup relative to SNAP

### DIFF
--- a/bin/subiquity-service
+++ b/bin/subiquity-service
@@ -5,7 +5,7 @@ if [ -n "$1" ]; then
 fi
 /bin/dmesg -n 1
 if [ "$port" = "tty1" ]; then
-	$SNAP/usr/bin/subiquity-loadkeys
+	$SNAP/bin/subiquity-loadkeys
 	setfont $SNAP/subiquity.psf
 	exec /sbin/agetty -n --noclear -l $SNAP/usr/bin/python3 -o $SNAP/usr/bin/subiquity $port $TERM
 else

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -97,10 +97,8 @@ parts:
     organize:
       'bin/console-conf-tui': usr/bin/console-conf
       'bin/subiquity-tui': usr/bin/subiquity
-      'bin/subiquity-loadkeys': usr/bin/subiquity-loadkeys
       'bin/subiquity-service': usr/bin/subiquity-service
       'bin/subiquity-server': usr/bin/subiquity-server
-      'bin/subiquity-configure-apt': usr/bin/subiquity-configure-apt
   users-and-groups:
     plugin: nil
     build-packages:

--- a/subiquity/common/resources.py
+++ b/subiquity/common/resources.py
@@ -1,0 +1,26 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# importlib-resources is a backport lib for importlib.resources
+# With python 3.9 we can switch over to the built-in one.
+
+import logging
+import os
+
+log = logging.getLogger('subiquity.common.resources')
+
+
+def resource_path(relative_path):
+    return os.path.join(os.environ.get("SNAP", "."), relative_path)

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -28,6 +28,8 @@ from curtin.config import merge_config
 from subiquitycore.file_util import write_file
 from subiquitycore.utils import run_command
 
+from subiquity.common.resources import resource_path
+
 from .filesystem import FilesystemModel
 from .identity import IdentityModel
 from .kernel import KernelModel
@@ -188,9 +190,7 @@ class SubiquityModel:
             config['preserve_hostname'] = True
         user = self.identity.user
         if user:
-            users_and_groups_path = (
-                os.path.join(os.environ.get("SNAP", "."),
-                             "users-and-groups"))
+            users_and_groups_path = resource_path('users-and-groups')
             if os.path.exists(users_and_groups_path):
                 groups = open(users_and_groups_path).read().split()
             else:

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -283,7 +283,7 @@ class SubiquityModel:
 
             'curthooks_commands': {
                 '001-configure-apt': [
-                    'subiquity-configure-apt',
+                    resource_path('bin/subiquity-configure-apt'),
                     sys.executable, str(self.network.has_network).lower(),
                     ],
                 },

--- a/subiquity/server/controllers/keyboard.py
+++ b/subiquity/server/controllers/keyboard.py
@@ -23,6 +23,7 @@ from subiquitycore.context import with_context
 from subiquitycore.utils import arun_command
 
 from subiquity.common.apidef import API
+from subiquity.common.resources import resource_path
 from subiquity.common.serialize import Serializer
 from subiquity.common.types import (
     AnyStep,
@@ -117,7 +118,7 @@ def for_ui(setting):
 class KeyboardList:
 
     def __init__(self):
-        self._kbnames_dir = os.path.join(os.environ.get("SNAP", '.'), 'kbds')
+        self._kbnames_dir = resource_path('kbds')
         self.serializer = Serializer(compact=True)
         self._clear()
 
@@ -169,7 +170,7 @@ class KeyboardController(SubiquityController):
         }
 
     def __init__(self, app):
-        self._kbds_dir = os.path.join(os.environ.get("SNAP", '.'), 'kbds')
+        self._kbds_dir = resource_path('kbds')
         self.serializer = Serializer(compact=True)
         self.pc105_steps = None
         self.needs_set_keyboard = False
@@ -199,7 +200,7 @@ class KeyboardController(SubiquityController):
             fp.write(self.model.render_config_file())
         cmds = [
             ['setupcon', '--save', '--force', '--keyboard-only'],
-            ['subiquity-loadkeys'],
+            [resource_path('usr/bin/subiquity-loadkeys')],
             ]
         if self.opts.dry_run:
             scale = os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "1")

--- a/subiquity/server/controllers/keyboard.py
+++ b/subiquity/server/controllers/keyboard.py
@@ -200,7 +200,7 @@ class KeyboardController(SubiquityController):
             fp.write(self.model.render_config_file())
         cmds = [
             ['setupcon', '--save', '--force', '--keyboard-only'],
-            [resource_path('usr/bin/subiquity-loadkeys')],
+            [resource_path('bin/subiquity-loadkeys')],
             ]
         if self.opts.dry_run:
             scale = os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "1")

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -34,6 +34,7 @@ from subiquitycore.ui.utils import screen
 from subiquitycore.utils import crypt_password
 from subiquitycore.view import BaseView
 
+from subiquity.common.resources import resource_path
 from subiquity.common.types import IdentityData
 
 
@@ -163,8 +164,7 @@ class IdentityView(BaseView):
     def __init__(self, controller, identity_data):
         self.controller = controller
 
-        reserved_usernames_path = (
-            os.path.join(os.environ.get("SNAP", "."), "reserved-usernames"))
+        reserved_usernames_path = resource_path('reserved-usernames')
         reserved_usernames = set()
         if os.path.exists(reserved_usernames_path):
             with open(reserved_usernames_path) as fp:

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -19,7 +19,6 @@ Welcome provides user with language selection
 """
 
 import logging
-import os
 
 from urwid import Text
 
@@ -29,6 +28,8 @@ from subiquitycore.ui.stretchy import Stretchy
 from subiquitycore.ui.utils import button_pile, rewrap, screen
 from subiquitycore.screen import is_linux_tty
 from subiquitycore.view import BaseView
+
+from subiquity.common.resources import resource_path
 
 log = logging.getLogger("subiquity.views.welcome")
 
@@ -47,8 +48,7 @@ attach the contents of /var/log, it would be most appreciated.
 
 
 def get_languages():
-    base = os.environ.get("SNAP", ".")
-    lang_path = os.path.join(base, "languagelist")
+    lang_path = resource_path('languagelist')
 
     languages = []
     with open(lang_path) as lang_file:


### PR DESCRIPTION
Using SNAP to find the resource files is a bit of an odd requirement for
non-subiquity clients.  Start abstracting that away so it's easier to
change later.

Also move loadkeys to lookup from this, since the previous solution is
still a problem for ubuntu-desktop-installer.