### PR TITLE
Add new schema comparison, robust to timezone changes

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -71,15 +71,5 @@ timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoi
 validate
 grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' .subiquity/subiquity-server-debug.log
 
-case "$(lsb_release -sr)" in
-    # Limit schema check to Focal+ - the timezone list on bionic is different
-    # And Impish adds more ...
-    # Temporarily disable on Impish until a better answer is available
-    "20.04"|"20.10"|"21.04")
-        python3 -m subiquity.cmd.schema > "$testschema"
-        diff -u "autoinstall-schema.json" "$testschema"
-        ;;
-esac
-
-# if (( $(echo "$(lsb_release -sr) >= 20.04" | bc -l) )); then
-# fi
+python3 -m subiquity.cmd.schema > "$testschema"
+scripts/schema-cmp.py "autoinstall-schema.json" "$testschema"

--- a/scripts/schema-cmp.py
+++ b/scripts/schema-cmp.py
@@ -9,8 +9,7 @@ import sys
 def load(filename):
     with open(filename, 'r') as f:
         data = json.load(f)
-    tz = data['properties']['timezone']['enum']
-    del data['properties']['timezone']['enum']
+    tz = data['properties']['timezone'].pop('enum')
     return data, tz
 
 expected, _ = load(sys.argv[1])

--- a/scripts/schema-cmp.py
+++ b/scripts/schema-cmp.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# usage: schema-cmp.py expected.json actual.json
+# schema comparison should match, except timezones which we just spot
+# check for a few expected values and expect that reality is a superset
+import json
+import sys
+
+def load(filename):
+    with open(filename, 'r') as f:
+        data = json.load(f)
+    tz = data['properties']['timezone']['enum']
+    del data['properties']['timezone']['enum']
+    return data, tz
+
+expected, _ = load(sys.argv[1])
+actual, actual_tz = load(sys.argv[2])
+
+if expected != actual:
+    print('schema mismatch')
+    print('expected:')
+    print(expected)
+    print('actual:')
+    print(actual)
+    sys.exit(1)
+
+expected_tz = [
+    '',
+    'geoip',
+    'UTC',
+    'America/New_York',
+]
+
+for tz in expected_tz:
+    assert tz in actual_tz, f'tz {tz} not found'


### PR DESCRIPTION
Improve the schema comparison - mostly I'm worried about the
non-timezone items, spot check the timezone list for a few that should
be there.