### PR TITLE
Verify that machine-config arg is a file

### DIFF
--- a/console_conf/cmd/tui.py
+++ b/console_conf/cmd/tui.py
@@ -44,6 +44,7 @@ def parse_options(argv):
                         help='Run the installer in ascii mode.')
     parser.add_argument('--machine-config', metavar='CONFIG',
                         dest='machine_config',
+                        type=argparse.FileType(),
                         help="Don't Probe. Use probe data file")
     parser.add_argument('--screens', action='append', dest='screens',
                         default=[])

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -36,6 +36,7 @@ def make_server_args_parser():
     parser.add_argument('--socket')
     parser.add_argument('--machine-config', metavar='CONFIG',
                         dest='machine_config',
+                        type=argparse.FileType(),
                         help="Don't Probe. Use probe data file")
     parser.add_argument('--bootloader',
                         choices=['none', 'bios', 'prep', 'uefi'],

--- a/subiquitycore/prober.py
+++ b/subiquitycore/prober.py
@@ -29,8 +29,7 @@ class Prober():
     def __init__(self, machine_config, debug_flags):
         self.saved_config = None
         if machine_config:
-            with open(machine_config) as mc:
-                self.saved_config = yaml.safe_load(mc)
+            self.saved_config = yaml.safe_load(machine_config)
         self.debug_flags = debug_flags
         log.debug('Prober() init finished, data:{}'.format(self.saved_config))
 


### PR DESCRIPTION
If machine-config is pointed to a non-existant file, dryrun can kind of
unhelpfully hang without much indication that anything is happening.