### PR TITLE
Workaround dryrun test actually setting timezone

### DIFF
--- a/examples/autoinstall.yaml
+++ b/examples/autoinstall.yaml
@@ -41,7 +41,7 @@ snaps:
   - name: etcd
     channel: 3.2/stable
 updates: all
-timezone: Pacific/Guam
+# timezone: Pacific/Guam
 storage:
   config:
   - {type: disk, ptable: gpt, path: /dev/vdb, wipe: superblock, preserve: false, grub_device: true, id: disk-1}

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -55,8 +55,8 @@ python3 scripts/check-yaml-fields.py .subiquity/subiquity-curtin-install.conf \
         storage.config[-1].options='"errors=remount-ro"'
 python3 scripts/check-yaml-fields.py <(python3 scripts/check-yaml-fields.py .subiquity/etc/cloud/cloud.cfg.d/99-installer.cfg datasource.None.userdata_raw) \
         locale='"en_GB.UTF-8"' \
-        timezone='"Pacific/Guam"' \
         'snap.commands=[snap install --channel=3.2/stable etcd]'
+        # timezone='"Pacific/Guam"'
 grep -q 'finish: subiquity/Install/install/postinstall/install_package1: SUCCESS: installing package1' \
      .subiquity/subiquity-server-debug.log
 grep -q 'finish: subiquity/Install/install/postinstall/install_package2: SUCCESS: installing package2' \


### PR DESCRIPTION
Until a proper fix can be finished, remove the set of timezone from the
integration tests.