### PR TITLE
timezone: dryrun, GET with less side effects

### DIFF
--- a/examples/autoinstall.yaml
+++ b/examples/autoinstall.yaml
@@ -41,7 +41,7 @@ snaps:
   - name: etcd
     channel: 3.2/stable
 updates: all
-# timezone: Pacific/Guam
+timezone: Pacific/Guam
 storage:
   config:
   - {type: disk, ptable: gpt, path: /dev/vdb, wipe: superblock, preserve: false, grub_device: true, id: disk-1}

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -55,8 +55,8 @@ python3 scripts/check-yaml-fields.py .subiquity/subiquity-curtin-install.conf \
         storage.config[-1].options='"errors=remount-ro"'
 python3 scripts/check-yaml-fields.py <(python3 scripts/check-yaml-fields.py .subiquity/etc/cloud/cloud.cfg.d/99-installer.cfg datasource.None.userdata_raw) \
         locale='"en_GB.UTF-8"' \
+        timezone='"Pacific/Guam"' \
         'snap.commands=[snap install --channel=3.2/stable etcd]'
-        # timezone='"Pacific/Guam"'
 grep -q 'finish: subiquity/Install/install/postinstall/install_package1: SUCCESS: installing package1' \
      .subiquity/subiquity-server-debug.log
 grep -q 'finish: subiquity/Install/install/postinstall/install_package2: SUCCESS: installing package2' \

--- a/subiquity/server/controllers/timezone.py
+++ b/subiquity/server/controllers/timezone.py
@@ -31,8 +31,11 @@ def generate_possible_tzs():
     return special_keys + real_tzs
 
 
-def timedatectl_settz(tz):
+def timedatectl_settz(app, tz):
     tzcmd = ['timedatectl', 'set-timezone', tz]
+    if app.opts.dry_run:
+        tzcmd = ['sleep', str(1/app.scale_factor)]
+
     try:
         subprocess.run(tzcmd, universal_newlines=True)
     except subprocess.CalledProcessError as cpe:
@@ -59,7 +62,7 @@ def timedatectl_gettz():
         log.error('Failed to get live system timezone: %r', cpe)
     except IndexError:
         log.error('Failed to acquire system time zone')
-    log.debug('Failed to fine Time zone in timedatectl output')
+    log.debug('Failed to find Time zone in timedatectl output')
     return 'Etc/UTC'
 
 
@@ -102,7 +105,7 @@ class TimeZoneController(SubiquityController):
 
     def set_system_timezone(self):
         if self.model.should_set_tz:
-            timedatectl_settz(self.model.timezone)
+            timedatectl_settz(self.app, self.model.timezone)
 
     async def GET(self) -> TimeZoneInfo:
         if self.model.timezone:

--- a/subiquity/tests/test_timezonecontroller.py
+++ b/subiquity/tests/test_timezonecontroller.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import mock
-import subprocess
 
 from subiquity.common.types import TimeZoneInfo
 from subiquity.models.timezone import TimeZoneModel
@@ -102,3 +101,9 @@ class TestTimeZoneController(SubiTestCase):
         self.tzc.app.dry_run = True
         self.tzc.deserialize('geoip')
         self.assertEqual('sleep', subprocess_run.call_args.args[0][0])
+
+    @mock.patch('subiquity.server.controllers.timezone.timedatectl_settz')
+    def test_get_tz_should_not_set(self, tdc_settz):
+        run_coro(self.tzc.GET())
+        self.assertFalse(self.tzc.model.should_set_tz)
+        tdc_settz.assert_not_called()

--- a/subiquitycore/tests/mocks.py
+++ b/subiquitycore/tests/mocks.py
@@ -39,4 +39,7 @@ def make_app(model=None):
     app.next_screen = mock.Mock()
     app.prev_screen = mock.Mock()
     app.hub = MessageHub()
+    app.opts = mock.Mock()
+    app.opts.dry_run = True
+    app.scale_factor = 1000
     return app


### PR DESCRIPTION
* Remove the workaround for timezone set escaping dryrun
* Replace above workaround with a fix
* Reenable tests for above 
* Change behavior of GET /timezone, to no longer trigger timezone set to system
* Add tests for dryrun escape and GET not setting timezone

LP: #1936310