### PR TITLE
update curtin to get raid, zipl config, unmounting fixes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -38,7 +38,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: e0d29598c49cef7d3dc7e2b37c127256a6c3cdf8
+    source-commit: 3673687e867eeb88a3e7fd72587a75d5fc811f5a
     python-packages:
       - pyyaml==5.3.1
       - oauthlib

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -38,7 +38,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: 1f663e5104bbd3304c215a2b5f32a9f8103cba80
+    source-commit: e0d29598c49cef7d3dc7e2b37c127256a6c3cdf8
     python-packages:
       - pyyaml==5.3.1
       - oauthlib


### PR DESCRIPTION
I don't know if we want to wait for https://code.launchpad.net/~mwhudson/curtin/+git/curtin/+merge/406515 to land first.