### PR TITLE
redo how install variant determines which models to wait for

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -345,7 +345,10 @@ The server code proceeds in stages:
     commands.
  2. Then it waits for all the model objects that feed into the curtin
     config to be configured.
- 3. It waits for confirmation.
+ 3. It waits for confirmation. This can in theory be interrupted by a
+    change in the model objects which are considered 'interesting',
+    see below, so it is possible to transition from here to the
+    previous state.
  4. It runs "curtin install" and waits for that to finish.
  5. It waits for the model objects that feed into the cloud-init config to be
     configured.
@@ -360,6 +363,14 @@ Each of these states gets a different value of the `ApplicationState`
 enum, so the client gets notified via long-polling `meta.status.GET()`
 of progress. In addition, `ApplicationState.ERROR` indicates something
 has gone wrong.
+
+Originally subiquity was just the server installer and so the set of
+models that have to be configured for each step was just static. But
+subiquity can also install desktop systems and maybe one day Ubuntu
+core, and different information is needed to fully configure each
+different variant. This information is handled by the
+`subiquity.models.subiquity.SubiquityModel.set_source_variant` method
+and surrounding code.
 
 ### Error handling
 

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -165,10 +165,9 @@ class SubiquityModel:
     async def wait_confirmation(self):
         await self._confirmation.wait()
 
-    def needs_configuration(self, model_name):
-        if model_name is None:
-            return False
-        return model_name not in self._configured_names
+    def is_postinstall_only(self, model_name):
+        return model_name in self._cur_postinstall_model_names and \
+               model_name not in self._cur_install_model_names
 
     def confirm(self):
         self._confirmation.set()

--- a/subiquity/server/controller.py
+++ b/subiquity/server/controller.py
@@ -35,7 +35,6 @@ class SubiquityController(BaseController):
     autoinstall_schema = None
     autoinstall_default = None
     endpoint = None
-    relevant_variants = ('desktop', 'server')
 
     def __init__(self, app):
         super().__init__(app)

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -199,17 +199,19 @@ class InstallController(SubiquityController):
     async def install(self, *, context):
         context.set('is-install-context', True)
         try:
-            self.app.update_state(ApplicationState.WAITING)
+            while True:
+                self.app.update_state(ApplicationState.WAITING)
 
-            await self.model.wait_install()
+                await self.model.wait_install()
 
-            if not self.app.interactive:
-                if 'autoinstall' in self.app.kernel_cmdline:
-                    self.model.confirm()
+                if not self.app.interactive:
+                    if 'autoinstall' in self.app.kernel_cmdline:
+                        self.model.confirm()
 
-            self.app.update_state(ApplicationState.NEEDS_CONFIRMATION)
+                self.app.update_state(ApplicationState.NEEDS_CONFIRMATION)
 
-            await self.model.wait_confirmation()
+                if await self.model.wait_confirmation():
+                    break
 
             self.app.update_state(ApplicationState.RUNNING)
 

--- a/subiquity/server/controllers/timezone.py
+++ b/subiquity/server/controllers/timezone.py
@@ -79,7 +79,6 @@ class TimeZoneController(SubiquityController):
         }
 
     autoinstall_default = ''
-    relevant_variants = ('desktop', )
 
     def load_autoinstall_data(self, data):
         self.deserialize(data)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -61,7 +61,10 @@ from subiquity.common.types import (
     LiveSessionSSHInfo,
     PasswordKind,
     )
-from subiquity.models.subiquity import SubiquityModel
+from subiquity.models.subiquity import (
+    ModelNames,
+    SubiquityModel,
+    )
 from subiquity.server.controller import SubiquityController
 from subiquity.server.geoip import GeoIP
 from subiquity.server.errors import ErrorController
@@ -111,9 +114,7 @@ class MetaController:
     async def client_variant_POST(self, variant: str) -> None:
         if variant not in ('desktop', 'server'):
             raise ValueError(f'unrecognized client variant {variant}')
-        for controller in self.app.controllers.instances:
-            if variant not in controller.relevant_variants:
-                controller.configured()
+        self.app.base_model.set_source_variant(variant)
 
     async def ssh_info_GET(self) -> Optional[LiveSessionSSHInfo]:
         ips = []
@@ -156,6 +157,27 @@ def get_installer_password_from_cloudinit_log():
                 return line[len("installer:"):].strip()
 
     return None
+
+
+INSTALL_MODEL_NAMES = ModelNames({
+    "debconf_selections",
+    "filesystem",
+    "kernel",
+    "keyboard",
+    "mirror",
+    "network",
+    "proxy",
+    })
+
+POSTINSTALL_MODEL_NAMES = ModelNames({
+    "identity",
+    "locale",
+    "packages",
+    "snaplist",
+    "ssh",
+    "userdata",
+    },
+    desktop={"timezone"})
 
 
 class SubiquityServer(Application):
@@ -207,7 +229,8 @@ class SubiquityServer(Application):
         root = '/'
         if self.opts.dry_run:
             root = os.path.abspath('.subiquity')
-        return SubiquityModel(root)
+        return SubiquityModel(
+            root, INSTALL_MODEL_NAMES, POSTINSTALL_MODEL_NAMES)
 
     def __init__(self, opts, block_log_dir):
         super().__init__(opts)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -376,7 +376,7 @@ class SubiquityServer(Application):
             if not controller.interactive():
                 override_status = 'skip'
             elif self.state == ApplicationState.NEEDS_CONFIRMATION:
-                if self.base_model.needs_configuration(controller.model_name):
+                if self.base_model.is_postinstall_only(controller.model_name):
                     override_status = 'confirm'
         if override_status is not None:
             resp = web.Response(headers={'x-status': override_status})


### PR DESCRIPTION
This is probably a bit overkill, but the thrust here is to allow the source variant (i.e. desktop or server) to change more than once. This isn't going to happen for a long time obviously but I wanted to clean this up sooner rather than later. There are ways this could be made still more general of course, but well. I think this is OK.