### PR TITLE
make: fix install_deps order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,16 @@ endif
 
 all: dryrun
 
-install_deps: gitdeps
+aptdeps:
+	sudo apt update && \
 	sudo apt-get install -y python3-urwid python3-pyudev python3-nose python3-flake8 \
 		python3-yaml python3-coverage python3-dev pkg-config libnl-genl-3-dev \
 		libnl-route-3-dev python3-attr python3-distutils-extra python3-requests \
 		python3-requests-unixsocket python3-jsonschema python3-apport \
-		python3-bson xorriso isolinux python3-aiohttp probert cloud-init ssh-import-id \
+		python3-bson xorriso isolinux python3-aiohttp cloud-init ssh-import-id \
 		curl jq
+
+install_deps: aptdeps gitdeps
 
 i18n:
 	$(PYTHON) setup.py build_i18n

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ aptdeps:
 		libnl-route-3-dev python3-attr python3-distutils-extra python3-requests \
 		python3-requests-unixsocket python3-jsonschema python3-apport \
 		python3-bson xorriso isolinux python3-aiohttp cloud-init ssh-import-id \
-		curl jq
+		curl jq build-essential
 
 install_deps: aptdeps gitdeps
 

--- a/scripts/installdeps.sh
+++ b/scripts/installdeps.sh
@@ -11,7 +11,7 @@ ConditionPathExists=/dev/zfs
 EOF
 cp -r /etc/systemd/system/zfs-mount.service.d/ /etc/systemd/system/zfs-share.service.d/
 systemctl daemon-reload
-apt-get install -o APT::Get::Always-Include-Phased-Updates=true -y --no-install-recommends libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libsystemd-dev python3-distutils-extra pkg-config python3.5 python3-pip git lsb-release python3-setuptools gcc python3-dev python3-wheel pep8 python3-pyflakes python3-bson make curl jq
+apt-get install -o APT::Get::Always-Include-Phased-Updates=true -y --no-install-recommends libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libsystemd-dev python3-distutils-extra pkg-config python3.5 python3-pip git lsb-release python3-setuptools gcc python3-dev python3-wheel pep8 python3-pyflakes python3-bson make curl jq build-essential
 pip3 install -r requirements.txt
 
 make gitdeps


### PR DESCRIPTION
Getting the apt packages needs to be first, as processing probert is
more than a trivial git clone and needs some of those apt packages.
Drop probert as a requirement since it's redundant with the git
checkout.  Also +build-essential to the list.