### PR TITLE
unset GIT_DIR in update-part.py

### DIFF
--- a/scripts/update-part.py
+++ b/scripts/update-part.py
@@ -6,6 +6,10 @@ import yaml
 
 part = sys.argv[1]
 
+# unset GIT_DIR if set (because then the -C arguments we pass to git
+# do nothing)
+os.environ.pop('GIT_DIR', None)
+
 
 def r(*args, **kw):
     print('running', args)


### PR DESCRIPTION
Otherwise very confusing things happen (it turns out GIT_DIR is set when
running an exec command during rebase).