### PR TITLE
update translations from launchpad

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -1,23 +1,23 @@
-# Latvian translation for subiquity
-# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
+# Arabic translation for subiquity
+# Copyright (c) 2021 Rosetta Contributors and Canonical Ltd 2021
 # This file is distributed under the same license as the subiquity package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2021-06-04 13:18+1200\n"
-"PO-Revision-Date: 2017-09-17 14:15+0000\n"
-"Last-Translator: Dimitri John Ledkov <dimitri.ledkov+lp@canonical.com>\n"
-"Language-Team: Latvian <lv@li.org>\n"
+"PO-Revision-Date: 2021-02-24 14:04+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Arabic <ar@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2;\n"
-"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n % 100 >= "
+"3 && n % 100 <= 10 ? 3 : n % 100 >= 11 && n % 100 <= 99 ? 4 : 5;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
 "X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
-"Language: lv\n"
 
 #: ../subiquity/client/client.py:70
 msgid ""
@@ -424,7 +424,7 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/filesystem.py:494
 #: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
-msgstr "Gatavs"
+msgstr ""
 
 #: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
@@ -433,19 +433,19 @@ msgstr "Gatavs"
 #: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
 #: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
-msgstr "Atcelt"
+msgstr ""
 
 #: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
 #: ../subiquity/ui/views/ssh.py:185
 msgid "Yes"
-msgstr "Jā"
+msgstr ""
 
 #: ../subiquitycore/ui/interactive.py:109
 #: ../subiquity/ui/views/installprogress.py:247
 #: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
 #: ../subiquity/ui/views/ssh.py:186
 msgid "No"
-msgstr "Nē"
+msgstr ""
 
 #: ../subiquitycore/ui/utils.py:349
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
@@ -455,7 +455,7 @@ msgstr "Nē"
 #: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
 #: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
 msgid "Close"
-msgstr "Aizvērt"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
@@ -466,7 +466,7 @@ msgstr "Aizvērt"
 #: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
 msgid "Save"
-msgstr "Saglabāt"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:88
 msgid "Subnet:"
@@ -474,11 +474,11 @@ msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:89
 msgid "Address:"
-msgstr "Adrese:"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:90
 msgid "Gateway:"
-msgstr "Vārteja:"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:91
 msgid "Name servers:"
@@ -514,7 +514,7 @@ msgstr ""
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:145
 msgid "Manual"
-msgstr "Manuālā"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:147
@@ -671,7 +671,7 @@ msgstr ""
 #: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
 #: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
-msgstr "Atpakaļ"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
@@ -842,7 +842,7 @@ msgstr ""
 #: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
 #: ../subiquity/ui/views/zdev.py:162
 msgid "Continue"
-msgstr "Turpināt"
+msgstr ""
 
 #: ../subiquity/ui/views/error.py:160
 #: ../subiquity/ui/views/installprogress.py:282
@@ -1110,7 +1110,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:498
 msgid "Reset"
-msgstr "Atstatīt"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
@@ -1134,7 +1134,7 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/guided.py:67
 #: ../subiquity/ui/views/identity.py:141
 msgid "Passwords do not match"
-msgstr "Paroles nesakrīt"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
@@ -1781,7 +1781,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:89
 msgid "Your name:"
-msgstr "Jūsu vārds:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:91
 msgid "Your server's name:"
@@ -1789,19 +1789,19 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:92
 msgid "The name it uses when it talks to other computers."
-msgstr "Šo nosaukumu izmanto saziņā ar citiem datoriem."
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:93
 msgid "Pick a username:"
-msgstr "Izvēlieties lietotājvārdu:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:94
 msgid "Choose a password:"
-msgstr "Izvēlieties paroli:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:95
 msgid "Confirm your password:"
-msgstr "Apstipriniet paroli:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
@@ -1888,7 +1888,7 @@ msgstr ""
 #: ../subiquity/ui/views/installprogress.py:151
 #: ../subiquity/ui/views/installprogress.py:154
 msgid "Installing system"
-msgstr "Instalēju sistēmu"
+msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:157
 #: ../subiquity/ui/views/installprogress.py:165

--- a/po/ast.po
+++ b/po/ast.po
@@ -7,77 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2018-03-16 02:12+0000\n"
+"Last-Translator: enolp <enolp@softastur.org>\n"
 "Language-Team: Asturian <ast@li.org>\n"
-"Language: ast\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: ast\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Zarrar"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -92,30 +420,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Fecho"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Encaboxar"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Sí"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Non"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Zarrar"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Guardar"
 
@@ -177,1102 +526,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Conexones de rede"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Atrás"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Sí"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Non"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "¡Instalación completada!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "¡Instalación finada!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Instalando'l sistema"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Asocedió un fallu na instalación"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "El nome del sirvidor nun ha tar baleru"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "El to nome"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "El nome del sirvidor:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "El nome del sirvidor ye perllargu, ha ser de < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "El nome del sirvidor nun ha tar baleru"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "El nome del sirvidor ye perllargu, ha ser de < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Falta'l nome d'usuariu"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "El nome del sirvidor ye perllargu, ha ser de < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Ha afitase la contraseña"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Les contraseñes nun concasen"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Siguir"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "SUMARIU DEL SISTEMA DE FICHEROS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "PRESEOS DISPONIBLES"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Ha afitase la contraseña"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Les contraseñes nun concasen"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1306,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1314,134 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "SUMARIU DEL SISTEMA DE FICHEROS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "PRESEOS DISPONIBLES"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1465,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1615,576 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Usa les tecles ARRIBA, ABAXO ya INTRO pa esbillar la to llingua."
-
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "El to nome"
+
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "El nome del sirvidor:"
+
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "La ID de SSH ye pergrande, ha ser de < "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "El nome del sirvidor nun ha tar baleru"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Falta'l nome d'usuariu"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Siguir"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Reaniciar agora"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Instalando'l sistema"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Asocedió un fallu na instalación"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2195,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2207,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2217,8 +2120,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2235,192 +2138,331 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "La ID de SSH ye pergrande, ha ser de < "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Usa les tecles ARRIBA, ABAXO ya INTRO pa esbillar la to llingua."
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""
 
 #~ msgid "Filesystem setup"
@@ -2429,8 +2471,17 @@ msgstr ""
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Informa d'esti fallu en Launchpad"
 
+#~ msgid "Installation complete!"
+#~ msgstr "¡Instalación completada!"
+
+#~ msgid "Finished install!"
+#~ msgstr "¡Instalación finada!"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "¡Gracies por usar Ubuntu!"
 
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr "Esbilla una interfaz pa configurala o primi Done pa siguir"
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "El nome del sirvidor ye perllargu, ha ser de < "

--- a/po/be.po
+++ b/po/be.po
@@ -7,76 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
 "PO-Revision-Date: 2020-05-03 17:04+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Belarusian <be@li.org>\n"
-"Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: be\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
@@ -92,30 +421,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr ""
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr ""
 
@@ -177,1101 +527,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1305,7 +1187,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1313,134 +1195,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1464,100 +1500,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1614,576 +1593,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2194,11 +1921,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2206,9 +1933,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2216,8 +2121,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2234,190 +2139,329 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""

--- a/po/bo.po
+++ b/po/bo.po
@@ -7,76 +7,404 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
 "PO-Revision-Date: 2019-12-12 00:58+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Tibetan <bo@li.org>\n"
-"Language: bo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: bo\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
@@ -92,30 +420,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr ""
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr ""
 
@@ -177,1101 +526,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1305,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1313,134 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1464,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1614,576 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2194,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2206,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2216,8 +2120,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2234,190 +2138,329 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,83 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2019-10-03 00:20+0000\n"
+"Last-Translator: Steve Langasek <steve.langasek@canonical.com>\n"
 "Language-Team: Catalan <ca@li.org>\n"
-"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: ca\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "disc local"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "ha fallat la configuració automàtica"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "Informació"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Edita"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Edita"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Edita"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "Edita"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
+msgctxt "NetDevAction"
+msgid "Edit Wifi"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:45
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Suprimeix"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Tanca"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -94,34 +416,55 @@ msgid " or "
 msgstr " o "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Aquest camp ha de ser un URL de tipus %s"
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Cancel·la"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Sí"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "No"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Tanca"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Desa"
 
@@ -183,1114 +526,633 @@ msgstr "Inhabilitat"
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Crea"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "ID del VLAN:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s ja existeix"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Nom:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Dispositius: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "El nom no pot estar buit"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "estàtica"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Connexions de xarxa"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "Continua sense cap xarxa"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "S'estan aplicant els canvis"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "estàtica"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Sí"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "No"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "S'ha produït un error"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "S'ha completat la instal·lació!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "S'està instal·lant el sistema"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "S'ha completat la instal·lació!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "S'ha produït un error durant la instal·lació"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "El nom no pot estar buit"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Informació"
-
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Edita"
-
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Formata"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "partició"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "volum lògic"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Formata"
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Suprimeix"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "disc local"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "ha fallat la configuració automàtica"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "volum lògic"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "partició de {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "partició {} de {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "partició {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-#, fuzzy
-msgid "LVM volume group"
-msgstr "Crea un grup de volums LVM"
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "volum lògic"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "El vostre nom:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "El nom que utilitza quan es comunica amb altres ordinadors."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Trieu un nom d'usuari:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Trieu una contrasenya:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Confirmeu la contrasenya:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Falta el nom d'usuari"
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Les contrasenyes no coincideixen"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "contrasenyes"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Continua"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr "Nivell RAID:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Dispositius:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Mida:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Nom: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr "Utilitza com a espai d'intercanvi"
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "D'acord"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "volum lògic {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "partició {} de {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formata i/o munta {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "volum lògic"
-msgstr[1] "volum lògic"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr "volums lògics"
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "particions"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "Contrasenyes"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "Crea un volum encriptat"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr "Contrasenya:"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr "Confirmeu la contrasenya:"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr "Les contrasenyes no coincideixen"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "PUNT DE MUNTATGE"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr "Crea un grup de volums LVM"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "MIDA"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TIPUS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "TIPUS DE DISPOSITIU"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Desmunta"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "No hi ha cap dispositiu disponible"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "DISPOSITIU"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "espai lliure"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr "Crea un grup de volums (LVM)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "DISPOSITIUS DISPONIBLES"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr "Contrasenya:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr "Confirmeu la contrasenya:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Les contrasenyes no coincideixen"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1324,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1332,135 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "D'acord"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Dispositius:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Mida:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Crea un volum encriptat"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "PUNT DE MUNTATGE"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
+msgstr "Les contrasenyes no coincideixen"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "MIDA"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
+msgstr "Crea un grup de volums LVM"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TIPUS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "TIPUS DE DISPOSITIU"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "Desmunta"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr "No hi ha cap dispositiu disponible"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "partició"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "DISPOSITIU"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "espai lliure"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
-msgstr "Crea un grup de volums (LVM)"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "DISPOSITIUS DISPONIBLES"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Nom: "
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr "Utilitza com a espai d'intercanvi"
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "Continua sense cap xarxa"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1484,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr ""
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "Nivell RAID:"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Torna-ho a provar"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr "Adreça de la rèplica:"
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1634,577 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Control+Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "El vostre nom:"
+
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "El nom que utilitza quan es comunica amb altres ordinadors."
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Trieu un nom d'usuari:"
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Trieu una contrasenya:"
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Confirmeu la contrasenya:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "des de GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "des de Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "ara mateix"
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr "minut"
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr "minuts"
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr "hora"
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr "hores"
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr "dia"
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr "dies"
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Falta el nom d'usuari"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Continua"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "contrasenyes"
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Disposició"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr "Variant"
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Premeu una de les tecles següents:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "Teniu la tecla següent al vostre teclat?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Bloq majús"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Alt dreta (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Control dreta"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Maj dreta"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr "Tecla de logotip dreta"
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "Tecla de menú"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Maj"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Control+Maj"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr "Control+Alt"
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Bloq Maj"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "Control esquerra+Majúscules esquerra"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Alt esquerra"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Control esquerra"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Maj esquerra"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr "Tecla de logotip esquerra"
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "Tecla de fixació de desplaçament"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr "Sense commutació"
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr "Drecera de teclat: "
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "Disposició:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr "Variant:"
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Reinicia ara"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "S'està instal·lant el sistema"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "S'ha completat la instal·lació!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Reinicia"
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "S'ha produït un error durant la instal·lació"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2215,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2227,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Disposició"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr "Variant"
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Premeu una de les tecles següents:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Teniu la tecla següent al vostre teclat?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Bloq majús"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Alt dreta (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Control dreta"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Maj dreta"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr "Tecla de logotip dreta"
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Tecla de menú"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Maj"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Control+Maj"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Control+Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Bloq Maj"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Control esquerra+Majúscules esquerra"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Alt esquerra"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Control esquerra"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Maj esquerra"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr "Tecla de logotip esquerra"
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Tecla de fixació de desplaçament"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr "Sense commutació"
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr "Drecera de teclat: "
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Disposició:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr "Variant:"
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "Adreça de la rèplica:"
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2237,8 +2120,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2255,192 +2138,331 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Torna-ho a provar"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "ara mateix"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "minut"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "minuts"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "hora"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "hores"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "dia"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "dies"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "des de Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "des de Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""
 
 #~ msgid "Filesystem setup"
@@ -2449,8 +2471,59 @@ msgstr ""
 #~ msgid "Choose the installation target"
 #~ msgstr "Seleccioneu la destinació de la instal·lació"
 
+#~ msgid "An error has occurred"
+#~ msgstr "S'ha produït un error"
+
+#~ msgid "Installation complete!"
+#~ msgstr "S'ha completat la instal·lació!"
+
+#~ msgid "Info"
+#~ msgstr "Informació"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Aquest camp ha de ser un URL de tipus %s"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s ja existeix"
+
 #~ msgid "-"
 #~ msgstr "-"
 
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
+
+#~ msgid "Edit"
+#~ msgstr "Edita"
+
+#~ msgid "Format"
+#~ msgstr "Formata"
+
+#~ msgid "partition {} of {}"
+#~ msgstr "partició {} de {}"
+
+#~ msgid "partition {}"
+#~ msgstr "partició {}"
+
+#~ msgid "partition of {}"
+#~ msgstr "partició de {}"
+
+#~ msgid "logical volume"
+#~ msgstr "volum lògic"
+
+#~ msgid "partition"
+#~ msgstr "partició"
+
+#~ msgid "logical volume {}"
+#~ msgstr "volum lògic {}"
+
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formata i/o munta {}"
+
+#~ msgid "Reboot"
+#~ msgstr "Reinicia"
+
+#~ msgid "Passphrases"
+#~ msgstr "Contrasenyes"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,86 +7,422 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-05-04 17:47+0000\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2019-10-30 18:47+0000\n"
 "Last-Translator: Pavel Borecki <Unknown>\n"
 "Language-Team: Czech <cs@li.org>\n"
-"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: cs\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+"Aktivována relace příkazového řádku v instalátoru.\n"
+"\n"
+"Tato relace je spuštěná v rámci prostředí instalátoru. Při ukončení\n"
+"příkazového řádku se vrátíte do instalátoru, například po zadání Ctrl+D\n"
+"nebo „exit“.\n"
+"\n"
+"Mějte na paměti, že toto je pouze dočasné prostředí. Změny, které v něm\n"
+"případně provedete, po restartu zaniknou. Pokud byla zahájena instalace,\n"
+"instalovaný systém bude připojený pod /target."
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr "ano"
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr "ne"
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr "Pro pokračování je zapotřebí potvrzení"
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+"Abyste se tomuto vyhnuli, přidejte do řádku parametrů zavádění jádra "
+"parametr „autoinstall“"
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr "Pokračovat v automatické instalaci?"
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr "Import klíčů se nezdařil:"
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr "nástroji ssh-keygen se nepodařilo zobrazit otisk stažených klíčů:"
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+"{selflabel} není možné upravit, protože je součástí {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr "Není možné upravovat už existující RAID pole."
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr "Není možné upravovat už existující skupiny svazků."
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr "Není možné odebrat {selflabel} z už existujícího {cdtype} {cdlabel}."
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+"Odebrání {selflabel} by zanechalo {cdtype} {cdlabel} s méně než "
+"{min_devices} zařízeními."
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr "Odebrání {selflabel} by zanechalo {cdtype} {cdlabel} bez zařízení."
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+"{selflabel} není možné smazat, protože je součástí {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr "Není možné smazat jediný oddíl na zařízení, které už má oddíly."
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr "Není možné smazat nepostradatelný oddíl, obsahující zavadeč systému"
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+"Není možné smazat jediný logický svazek ze skupiny svazků, která už má "
+"logické svazky."
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr "existující"
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr "nové"
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr "nastaveno"
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr "nenastaveno"
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr "hlavní ESP"
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr "záložní ESP"
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr "nevyužitý ESP"
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr "rozšířený"
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr "logický"
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr "zašifrováno"
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr "multipath zařízení"
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "místní disk"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr "oddíl {device}"
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr "sofwarový RAID {level}"
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr "LVM skupina svazků"
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr "LVM logický svazek"
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr "oddíl {number}"
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr "oddíl {number} na {device}"
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr "{component_name} od {desc} {name}"
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr "už obsahuje souborový systém {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr "znovu vytvořit souborový systém {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr "bude vytvořen souborový systém {fstype}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr "připojeno v {path}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr "nepřipojeno"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "nepoužito"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "využito"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr "Zjišťování blokových zařízení se nezdařilo"
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr "Nezdar při zjišťování disku"
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr "Nezdar při instalaci"
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr "Instalátor zhavaroval"
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr "Chyba sítě"
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "Neznámá chyba"
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "automatické nastavení se nezdařilo"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "Informace"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Upravit Wi-Fi"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Upravit IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Upravit IPv6"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "Upravit spřažení (bond)"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
-#, fuzzy
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
-msgstr "Přidat VLAN štítek"
+msgid "Edit Wifi"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:45
-#, fuzzy
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Smazat"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr "Otisky klíče hostitele jsou:\n"
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-"Otisk {keytype} klíče hostitele je:\n"
-"    {fingerprint}\n"
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Zavřít"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -97,34 +433,55 @@ msgid " or "
 msgstr " nebo "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Je třeba, aby obsahem této kolonky byla URL adresa %s"
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Hotovo"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Storno"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Ano"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Ne"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Zavřít"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Uložit"
 
@@ -157,14 +514,14 @@ msgid "Domains, comma separated"
 msgstr "Domény, oddělované čárkou"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr "mělo by být v podobě CIDR ({})"
+msgstr "mělo by být v CIDR zápisu ({example})"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "„%s“ není obsaženo v „%s“"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -186,87 +543,133 @@ msgstr "Vypnuto"
 msgid "IPv{v} Method: "
 msgstr "IPv{v} metoda: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Vytvořit"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "Identif. VLAN:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr "Je třeba, aby identif. VLAN byl z rozmezí 1 až 4095"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s už existuje"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr "Přidat VLAN štítek"
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
+#, python-brace-format
 msgid "Info for {device}"
-msgstr "Informace pro {}"
+msgstr "informace pro {device}"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Název:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Zařízení: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr "Režim spřáhnutí:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr "Zásada XMIT otisku:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr "Četnost LACP:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
+#, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr "Už zde je síťové zařízení nazvané „{}“"
+msgstr "Už zde existuje síťové zařízení nazvané „{netdev}“"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "Název je třeba vyplnit"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr "Název nemůže být delší, než 16 znaků"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr "Vytvořit spřažení (bond)"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr "Upravit spřažení (bond)"
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr "Vybrat síť"
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr "Nastavení WiFi pro rozhraní {nic}"
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr "VLAN {id} na rozhraní {link}"
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr "řídící spřažení pro {interfaces}"
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "nepřipojeno"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr "podřízeno {device}"
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "překročen časový limit"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "statické"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "vypnuto"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Síťová připojení"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -276,650 +679,308 @@ msgstr ""
 "aktualizacím."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Zpět"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "Pokračovat bez sítě"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "Provádějí se změny"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr "nepřipojeno"
-
-#: ../subiquitycore/ui/views/network.py:188
-#, fuzzy, python-brace-format
-msgid "enslaved to {device}"
-msgstr "podřízeno {}"
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "překročen časový limit"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, fuzzy, python-brace-format
-msgid "unknown state {state}"
-msgstr "neznámý stav {}"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "statické"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr "vypnuto"
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr "VLAN {id} na rozhraní {link}"
-
-#: ../subiquitycore/ui/views/network.py:360
-#, fuzzy, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr "řídí spřažení pro {}"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "Vybrat disk pro zavádění systému"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Wi-Fi nastavení síťového rozhraní {}"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Ano"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Ne"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr "Import klíčů se nezdařil:"
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr "nástroji ssh-keygen se nepodařilo zobrazit otisk stažených klíčů:"
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Došlo k chybě"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Instalace dokončena!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Instalace dokončena!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Instaluje se systém"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Instalace dokončena!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "V průběhu instalace došlo k chybě"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr "Zjišťování blokových zařízení se nezdařilo"
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr "Nezdar při zjišťování disku"
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr "Nezdar při instalaci"
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr "Instalátor zhavaroval"
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr "Chyba sítě"
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr "Neznámá chyba"
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr "nezdařilo se"
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr "automaticky"
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr "online"
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr "0 (prostřídáváno)"
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr "1 (zrcadleno)"
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Název je třeba vyplnit"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} není platné zadání"
+msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Informace"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "Ostatní"
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Upravit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
+msgstr "Ponechat nepřipojené"
 
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Znovuvytvořit souborový systém"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "Přidat oddíl"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "Vytvořit logický svazek"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Vytvořit souborový systém"
-
-#: ../subiquity/models/filesystem.py:424
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr "Odebrat z RAID/LVM"
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Smazat"
-
-#: ../subiquity/models/filesystem.py:426
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr "Nastavit jako zařízení pro zavádění systému"
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "{selflabel} není možné upravit, protože je součástí {cdtype} {cdname}."
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr "Není možné odebrat {selflabel} z už existujícího {cdtype} {cdlabel}."
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-"Odebrání {selflabel} by zanechalo {cdtype} {cdlabel} s méně než "
-"{min_devices} zařízeními."
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr "Odebrání {selflabel} by zanechalo {cdtype} {cdlabel} bez zařízení."
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "{selflabel} není možné smazat, protože je součástí {cdtype} {cdname}."
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr "existující"
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr "nové"
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr "{component_name} od {desc} {name}"
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr "už obsahuje souborový systém {fstype}"
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr "znovu vytvořit souborový systém {fstype}"
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr "bude vytvořen souborový systém {fstype}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr "připojeno v {path}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr "nepřipojeno"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr "nepoužito"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr "využito"
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-"{selflabel} není možné smazat, protože oddíl {partnum} je součástí {cdtype} "
-"{cdname}."
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-"{selflabel} není možné smazat, protože je z něho připojeno (mount) {count} "
-"oddílů."
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-"{selflabel} není možné smazat, protože je z něho připojen (mount) oddíl."
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "místní disk"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Nastavit proxy"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "automatické nastavení se nezdařilo"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-#, fuzzy
-msgid "unused ESP"
-msgstr "nepoužito"
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "logický svazek"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "oddíl {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "oddíl {} na {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "oddíl {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr "Není možné smazat jediný oddíl na zařízení, které už má oddíly."
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr "Není možné smazat nepostradatelný oddíl, obsahující zavadeč systému"
-
-#: ../subiquity/models/filesystem.py:1049
-#, fuzzy, python-brace-format
-msgid "software RAID {level}"
-msgstr "softwarové RAID pole {}"
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr "Není možné upravovat už existující RAID pole."
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr "{selflabel} není možné upravit, protože obsahuje oddíly."
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-#, fuzzy
-msgid "LVM volume group"
-msgstr "Vytvořit LVM skupinu svazků"
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr "Není možné upravovat už existující skupiny svazků."
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr "{selflabel} není možné upravit, protože obsahuje logické svazky."
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "logický svazek"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-"Není možné smazat jediný logický svazek ze skupiny svazků, která už má "
-"logické svazky."
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
+"Sorry, there was a problem examining the storage devices on this system.\n"
+msgstr ""
 "\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
-msgstr ""
-"Aktivována relace příkazového řádku v instalátoru.\n"
-"\n"
-"Tato relace je spuštěná v rámci prostředí instalátoru. Při ukončení\n"
-"příkazového řádku se vrátíte do instalátoru, například po zadání Ctrl+D\n"
-"nebo „exit“.\n"
-"\n"
-"Mějte na paměti, že toto je pouze dočasné prostředí. Změny, které v něm\n"
-"případně provedete, po restartu zaniknou. Pokud byla zahájena instalace,\n"
-"instalovaný systém bude připojený pod /target."
+"Omlouváme se, došlo k problému při zkoumání úložných zařízení na tomto "
+"systému.\n"
 
-#: ../subiquity/core.py:224
-#, fuzzy, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr "instalátor spuštěný na {} provede automatickou instalaci"
-
-#: ../subiquity/core.py:237
-#, fuzzy, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr "čeká se na instalátor spuštěný na {} až spustí ranné příkazy"
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr "ano"
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr "ne"
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr "Pro pokračování je zapotřebí potvrzení"
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-"Abyste se tomuto vyhnuli, přidejte do řádku parametrů zavádění jádra "
-"parametr „autoinstall“"
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr "Pokračovat v automatické instalaci?"
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-"Znaky „:“ (dvojtečka), „,“ (čárka) a = (rovnítko) není v této kolonce možné "
-"použít"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-"Jedinými znaky, které je možné v této kolonce použít, jsou a-z (bez "
-"diakritiky), 0-9, _ (podtržítko) a - (mínus/spojovník)"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Vaše jméno:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Název pro váš server:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "Název se používá při komunikaci s ostatními počítači."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Vyberte uživatelské jméno:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Zvolte heslo:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Potvrďte své heslo:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Skutečné jméno je příliš dlouhé – je třeba, aby bylo kratší než "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Název serveru nemůže zůstat nevyplněný"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Název serveru je příliš dlouhý – je třeba, aby byl kratší než "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Je třeba, aby se název stroje odpovídal regulárnímu výrazu NAME_REGEX, tj. "
-"[a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Chybí uživatelské jméno"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Uživatelské jméno je příliš dlouhé – je třeba, aby bylo kratší než "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Je třeba, aby uživatelské jméno odpovídalo regulárnímu výrazu NAME_REGEX, "
-"tj. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr "Uživatelské jméno „{username}“ je vyhrazeno pro použití systémem."
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Je třeba nastavit heslo"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Zadání hesla se neshodují"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr "{desc} neodpovídá"
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Nastavení profilu"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
-"Zadejte uživatelské jméno a heslo které budete používat pro přihlašování se "
-"do systému. Na následující obrazovce můžete nastavit přístup přes SSH, ale "
-"heslo je pořád potřebné pro sudo."
+"\n"
+"Omlouváme se, došlo k problému s dokončováním instalace.\n"
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "hesla"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
+"\n"
+"Omlouváme se, došlo k problému s uplatněním nastavení sítě.\n"
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+"\n"
+"Omlouváme se, instalátor byl kvůli chybě restartován.\n"
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+"\n"
+"Omlouváme se, došlo k neznámé chybě.\n"
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+"\n"
+"Ze systému jsou shromažďovány informace, které vývojářům\n"
+"pomohou s diagnostikou hlášení.\n"
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+"\n"
+"Načítání hlášení…\n"
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+"\n"
+"Shromažďování informací ze systému se nezdařilo. Další informace\n"
+"viz soubory ve /var/log/installer\n"
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+"\n"
+"Načítání hlášení se nezdařilo. Viz soubory ve /var/log/installer\n"
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+"\n"
+"Můžete pokračovat a instalátor pouze představí disky, přítomné v systému\n"
+"a ne ostatní bloková zařízení, nebo můžete být schopní opravit\n"
+"tento problém přepnutím do příkazového řádku a ručním\n"
+"přenastavením systémových blokových zařízení.\n"
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+"\n"
+"Může být možné problém opravit přepnutím se do příkazového\n"
+"řádku a ručním přenastavením systémových blokových zařízení.\n"
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+"\n"
+"V instalaci je možné pokračovat, ale bude se předpokládat, že síť není\n"
+"funkční.\n"
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+"\n"
+"Chcete zkusit spustit instalaci znovu?\n"
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr "Pro opětovný pokus o instalaci vyberte Pokračovat."
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+"\n"
+"Pokud chcete pomoci ve zlepšení instalátoru, můžete nám poslat hlášení "
+"chyby.\n"
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr "Zrušit odesílání"
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr "Zavřít hlášení"
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Pokračovat"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr "Přepnout do příkazového řádku"
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr "Restartovat instalátor"
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr "Odeslat společnosti Canonical"
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr "Odesláno společnosti Canonical"
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr "Zobrazit celé hlášení"
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+"Hlášení chyby bylo uloženo do\n"
+"\n"
+"  {loc}\n"
+"\n"
+"na souborový systém se štítkem {label!r}."
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr "DATUM"
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr "DRUH"
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr "STAV"
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr "Vyberte hlášení chyby, které zobrazit:"
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr "ZOBRAZENO"
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr "NEZOBRAZENO"
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
+#, python-brace-format
 msgid "formatted as {fstype}"
-msgstr "bude vytvořen souborový systém {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:132
+#, python-brace-format
 msgid ", mounted at {path}"
-msgstr "připojeno v {path}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ", souborový systém nepřipojen"
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:136
+#, python-brace-format
 msgid "unused {device}"
-msgstr "nepoužito {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
@@ -927,459 +988,236 @@ msgstr ""
 "Pokud všechny disky přiřadíte do RAID polí nebo LVM skupin svazků, nebude "
 "kam umístit oddíl pro zavaděč systému."
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr "znak „/“ (dopředné lomítko) nelze použít v názvu RAID zařízení"
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr "V názvu RAID zařízení nemohou být prázdné znaky (mezera, atp.)"
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr "Stupeň RAID pole:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Zařízení:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Velikost:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, fuzzy, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr "Už zde je RAID pole nazvané „{}“"
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ". a .. nejsou platné názvy pro RAID zařízení"
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, fuzzy, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr "Úroveň RAID „{}“ vyžaduje alespoň {} aktivních zařízení"
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr "Vytvořit softwarové RAID („MD“) úložiště"
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, fuzzy, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr "Upravit softwarové RAID úložiště „{}“"
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr "Ponechat bez souborového systému"
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, fuzzy, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr "Ponechat se souborovým systémem jako {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, fuzzy, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr "Zastropována velikost oddílu na {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, fuzzy, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr "Velikost zaokrouhlena na {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"Jedinými povolenými znaky v názvu logického svazku jsou a-z, A-Z, 0-9, +, "
-"_, . a -"
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, fuzzy, python-brace-format
-msgid "Size (max {size}):"
-msgstr "Velikost (nejvýše {}):"
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Název: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "Formát:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr "Připojení:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr "Použít pro odkládání stránek paměti (swap)"
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-"Použít tento oddíl pro odkládání stránek paměti v instalovaném systému."
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr "Název logického svazku je třeba vyplnit"
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr "Název logického svazku nemůže začínat spojovníkem"
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, fuzzy, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr "Logický svazek nemůže být nazván {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, fuzzy, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr "Název logického svazku nemůže obsahovat „{}“"
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, fuzzy, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr "Už zde je logický svazek nazvaný {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Délka popisu umístění přesahuje PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, fuzzy, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr "{} už je připojeno do {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, fuzzy, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-"Připojování existujícího souborového systému do {} je obvykle špatný nápad, "
-"pokračujte pouze s obezřetností."
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Vyžadován oddíl pro zavaděč systému\n"
-"\n"
-"GRUB bude nainstalován do MBR cílového disku.\n"
-"\n"
-"Nicméně, na disku s GPT tabulkou oddílů, není dostatek prostoru za MBR pro "
-"uložení druhé fáze GRUB, core.img, takže je třeba malého, nezformátovaného "
-"oddílu na začátku disku. Nebude obsahovat souborový systém a nebude připojen "
-"a není možné ho zde upravit."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-"Vyžadován oddíl pro zavaděč systému\n"
-"\n"
-"Toto je ESP / „EFI system partition“ vyžadované UEFI firmwarem. Grub bude "
-"nainstalován na tento oddíl, na kterém je třeba, aby byl vytvořen souborový "
-"systém fat32."
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-"Vyžadován oddíl pro zavaděč systému\n"
-"\n"
-"Toto je ESP / „EFI system partition“ vyžadované UEFI firmwarem. Grub bude "
-"nainstalován na tento oddíl, na kterém je třeba, aby byl vytvořen souborový "
-"systém fat32."
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-#, fuzzy
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr " Jediné hledisko tohoto oddílu, který je možné měnit, je velikost."
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-#, fuzzy
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-" Je možné zvolit zda použít stávající souborový systém na tomto oddílu, nebo "
-"ho vytvořit znovu."
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-"Vyžadován oddíl pro zavaděč systému\n"
-"\n"
-"Toto je PReP oddíl, který je vyžadován na architektuře POWER. Grub bude "
-"nainstalován na tento oddíl."
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-"Vyžadován oddíl pro zavaděč systému\n"
-"\n"
-"Toto je PReP oddíl, který je vyžadován na architektuře POWER. Grub bude "
-"nainstalován na tento oddíl."
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "OK"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr "Použít stávající souborový systém fat32"
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr "Znovu vytvořit čistý souborový systém fat32"
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "logický svazek {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "oddíl {} na {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-"Vytvoření souborového systému a jeho připojení přímo na nerozděleném "
-"úložišti není obvyklé. Nejspíš namísto toho chcete přidat oddíl."
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formát a/nebo připojení {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr "Opravdu chcete smazat {desc} {label}?"
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr "Obsahuje souborový systém {fstype} a ten je připojen do {path}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr "Obsahuje souborový systém {fstype} a ten není nikam připojen."
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "logický svazek"
-msgstr[1] "logický svazek"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:70
+#, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
-msgstr[0] "Obsahuje {n} {things}:"
-msgstr[1] "Obsahuje {n} {things}:"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr "Neobsahuje souborový systém, ani není nikam připojeno."
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Smazat"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:112
+#, python-brace-format
 msgid "Remove filesystem from {device}"
-msgstr "Odebrat souborový systém z {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:116
+#, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
-msgstr "Opravdu chcete odebrat existující souborový systém z {}?"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr "logické svazky"
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "oddíly"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr "Odebrat všechny {things} z {obj}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr "Opravdu chcete odebrat všechny {things} z {obj}?"
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr "Znovuvytvořit souborový systém"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
+#, python-brace-format
+msgid "existing {fstype}"
+msgstr "stávající {fstype}"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
+#, python-brace-format
+msgid "new {fstype}"
+msgstr "nový {fstype}"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Nejsou připojené žádná úložiště nebo oddíly."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "PŘÍPOJNÝ BOD"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "VELIKOST"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TYP"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "TYP ZAŘÍZENÍ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Odpojit"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "Žádná zařízení k dispozici"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr "Žádná využitá zařízení"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
+#, python-brace-format
+msgid "Remove from {device}"
+msgstr "Odebrat ze {device}"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr "Přidat {ptype} oddíl"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr "Přestat používat jako zařízení pro zavádění systému"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr "Přidat jako další zařízení pro zavádění systému"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr "Použít jako zařízení pro zavádění systému"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "ZAŘÍZENÍ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "volné místo"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr "Nastavení úložiště"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr "Vytvořit softwarové RAID pole (md)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr "Vytvořit skupinu svazků (LVM)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "SOUHRN SOUBOROVÉHO SYSTÉMU"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "ZAŘÍZENÍ K DISPOZICI"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr "VYUŽITÁ ZAŘÍZENÍ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr "Připojit souborový systém do /"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr "Vybrat disk pro zavádění systému"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr "Pro pokračování bude zapotřebí:"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Reset"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
+msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
-"Jedinými znaky, povolenými v názvu skupiny svazků, jsou a-z, A-Z, 0-9, +, "
-"_, . a -"
+"Nastavit rozvržení úložiště vedeně, nebo vytvořit uživatelsky určené:"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "Heslové fráze"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "Vytvořit šifrovaný svazek"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
 msgid "Passphrase:"
 msgstr "Heslová fráze:"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
 msgid "Confirm passphrase:"
 msgstr "Zopakování heslové fráze:"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr "Vyberte alespoň jedno zařízení, aby se stalo součástí skupiny svazků."
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Je třeba nastavit heslo"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr "Název skupiny svazků je třeba vyplnit"
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Zadání hesla se neshodují"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr "Název skupiny svazků nemůže začínat spojovníkem"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
-#, fuzzy, python-brace-format
-msgid "{name} is not a valid name for a volume group"
-msgstr "{} není platný název pro skupinu svazků"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:116
-#, fuzzy, python-brace-format
-msgid "There is already a volume group named '{name}'"
-msgstr "Už zde je skupina svazků nazvaná „{}“"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
-msgstr "Je třeba, aby heslová fráze byla nastavena"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr "Zadaní heslové fráze nejsou stejná"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr "Vytvořit LVM skupinu svazků"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:150
-#, fuzzy, python-brace-format
-msgid "Edit volume group \"{name}\""
-msgstr "Upravit skupinu svazků „{}“"
-
-#: ../subiquity/ui/views/filesystem/guided.py:51
-msgid "Configure a guided storage layout, or create a custom one:"
-msgstr "Nastavit rozvržení úložiště vedeně, nebo vytvořit uživatelsky určené:"
-
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr "Šifrovat LVM skupinu pomocí LUKS"
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr "Nastavit tuto jednotku coby LVM skupinu"
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr "Použít celou jednotku"
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr "Uživatelsky určené rozvržení úložiště"
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1414,35 +1252,36 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Volba „Použít celý disk“ nainstaluje Ubuntu na označený disk,\n"
-"na kterém budou nahrazeny jakékoli oddíly a data na nich.\n"
+"Volba „Použít celý disk“ nainstaluje Ubuntu na vybraný disk,\n"
+"přičemž jakékoli oddíly a data budu přepsány.\n"
 "\n"
-"Pokud to hardwarová platforma vyžaduje, je vytvořen také oddíl pro zavaděč "
-"systému.\n"
+"Pokud to hardwarová platforma vyžaduje, bude na disku vytvořen oddíl\n"
+"pro zavaděč systému.\n"
 "\n"
-"Pokud zvolíte použití LVM, budou vytvořeny dva další oddíly,\n"
-"jeden pro /boot a a druhý pokrývající zbytek disku. Bude vytvořena\n"
-"skupina LVM svazků, obsahující tento velký oddíl. Pro kořenový soubor.\n"
-"systém bude vytvořen 4 gigabajtový logický svazek. Ten je případně\n"
-"možné zvětšit běžnými nástroji pro příkazový řádek pro práci s LVM.\n"
+"Pokud zvolíte použití LVM, budou vytvořeny dva další oddíly – jeden pro\n"
+"/boot a druhý pokrývající zbytek disku. Dále bude vytvořena LVM skupina\n"
+"svazků, zabírající velký oddíl. Bude vytvořen logický svazek pro kořenový\n"
+"souborový systém, s velikostí určenou pomocí jednoduché heuristiky. Je\n"
+"možné ho snadno zvětšit pomocí standardních LVM nástrojů pro příkazový\n"
+"řádek (nebo na následující obrazovce).\n"
 "\n"
-"LVM skupinu svazků je možné také šifrovat. Toto bude vyžadovat\n"
-"nastavení hesla, které pak bude vyžadováno při každém spouštění\n"
-"systému.\n"
+"Skupinu svazků je také možné zašifrovat LVM. To vyžaduje nastavení hesla,\n"
+"které bude třeba zadávat v rámci každého spouštění operačního systému.\n"
 "\n"
-"Pokud zvolíte nepoužívat LVM, bude vytvořen jediný oddíl, pokrývají\n"
-"zbytek disku, na něm vytvořen souborový systém ext4 a připojen do /.\n"
+"Pokud nezvolíte použití LVM, bude vytvořen jediný oddíl pokrývající zbytek "
+"disku\n"
+"a ten pak naformátován jako ext4 a připojen do /.\n"
 "\n"
-"V obou případech, budete moci zkontrolovat a upravit výsledky.\n"
+"V každém případě budete mít možnost zrevidovat a upravit výsledky.\n"
 "\n"
-"Pokud zvolíte uživatelsky určené uspořádání úložiště, nebudou udělány žádné "
-"změny na disku\n"
-"a bude třeba, abyste zvolili přinejmenším disk pro zavádění systému a "
-"připojení souborového\n"
-"systému do /.\n"
+"Pokud zvolíte uživatelsky určené rozvržení úložiště, nebudou provedeny "
+"žádné\n"
+"automatické změny na disku a bude třeba, abyste přinejmenším vybrali disk "
+"pro\n"
+"zavádění systému a připojili souborový systém jako /.\n"
 "\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1456,7 +1295,7 @@ msgstr ""
 "může\n"
 "být pořád možné.\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
@@ -1466,131 +1305,328 @@ msgstr ""
 "Zjišťování blokových zařízení neobjevilo žádné disky. Žel to znamená, že\n"
 "nelze provést instalaci.\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr "Vedené uspořádání úložiště"
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "OK"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr "Nápověda k vedenému uspořádání úložiště"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
-#, fuzzy, python-brace-format
-msgid "existing {fstype}"
-msgstr "existující"
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+"Jedinými znaky, povolenými v názvu skupiny svazků, jsou a-z, A-Z, 0-9, +, _, "
+". a -"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Zařízení:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Velikost:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Vytvořit šifrovaný svazek"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+"Vyberte alespoň jedno zařízení, aby se stalo součástí skupiny svazků."
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr "Název skupiny svazků je třeba vyplnit"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr "Název skupiny svazků nemůže začínat spojovníkem"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "new {fstype}"
+msgid "There is already a volume group named '{name}'"
+msgstr "Už zde existuje skupina svazků nazvaná „{name}“"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:119
+#, python-brace-format
+msgid "{name} is not a valid name for a volume group"
+msgstr "{name} není platný název pro skupinu svazků"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
+msgstr "Je třeba, aby heslová fráze byla nastavena"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
+msgstr "Zadaní heslové fráze nejsou stejná"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
+msgstr "Vytvořit LVM skupinu svazků"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:157
+#, python-brace-format
+msgid "Edit volume group \"{name}\""
+msgstr "Upravit skupinu svazku „{name}“"
+
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr "Ponechat bez souborového systému"
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
+msgstr "Ponechat se souborovým systémem {fstype}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
+msgstr "Velikost oddílu omezena na {size}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
+msgstr "Velikost oddílu zaokroulena na {size}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
+msgstr ""
+"Jedinými povolenými znaky v názvu logického svazku jsou a-z, A-Z, 0-9, +, _, "
+". a -"
+
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
+msgstr "Velikost (max {size}):"
+
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Název: "
+
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Formát:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
+msgstr "Připojení:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr "Použít pro odkládání stránek paměti (swap)"
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
+msgstr ""
+"Použít tento oddíl pro odkládání stránek paměti v instalovaném systému."
+
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr "Název logického svazku je třeba vyplnit"
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr "Název logického svazku nemůže začínat spojovníkem"
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Nejsou připojené žádná úložiště nebo oddíly."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "PŘÍPOJNÝ BOD"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "VELIKOST"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TYP"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "TYP ZAŘÍZENÍ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "Odpojit"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr "Žádná zařízení k dispozici"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr "Žádná využitá zařízení"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
-#, fuzzy, python-brace-format
-msgid "Remove from {device}"
-msgstr "Odebrat z {}"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "Přidat {} oddíl"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-#, fuzzy
-msgid "Add As Another Boot Device"
-msgstr "Nastavit jako zařízení pro zavádění systému"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-#, fuzzy
-msgid "Use As Boot Device"
-msgstr "Nastavit jako zařízení pro zavádění systému"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Délka popisu umístění přesahuje PATH_MAX"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "ZAŘÍZENÍ"
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr "{device} už je připojeno do {path}."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "volné místo"
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+"Připojování existujícího souborového systému do {mountpoint} obvykle není "
+"dobrý nápad, pokračujte pouze obezřetně."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
-msgstr "Nastavení úložiště"
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+"Oddíl pro zavaděč\n"
+"\n"
+"{middle}\n"
+"\n"
+"Nicméně, na disku s GPT tabulkou oddílů není dostatek místa za\n"
+"MBR záznamem, aby sem GRUB umístil svůj core.img pro druhou fázi,\n"
+"takže je zapotřebí malého nenaformátovaného oddílu na začátku disku.\n"
+"Ten nebude obsahovat souborový systém a nebude připojen (mount),\n"
+"a není ho možné zde upravovat.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
-msgstr "Vytvořit softwarové RAID pole (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+"Pokud je disk označen jako zařízení pro zavádění systému, bude do\n"
+"MBR záznamu cílového disku nainstalován zavaděč GRUB."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
-msgstr "Vytvořit skupinu svazků (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+"Protože tento disk byl vybrán jako zařízení pro zavádění systému,\n"
+"GRUB bude nainstalován do MBR oblasti cílového disku."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "SOUHRN SOUBOROVÉHO SYSTÉMU"
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+"Oddíl pro zavaděč\n"
+"\n"
+"Toto je ESP / „systémový oddíl EFI“, jak je vyžadováno UEFI. Pokud\n"
+"je disk označen jako zařízení pro zavádění systému, GRUB bude\n"
+"nainstalován na tento oddíl, na kterém musí být souborový systém fat32.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "ZAŘÍZENÍ K DISPOZICI"
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+"Oddíl pro zavaděč\n"
+"\n"
+"Toto je ESP / „systémový oddíl EFI“, jak je vyžadováno UEFI. Protože\n"
+"disk byl označen jako zařízení pro zavádění systému, GRUB bude\n"
+"nainstalován na tento oddíl, na kterém musí být souborový systém fat32.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
-msgstr "VYUŽITÁ ZAŘÍZENÍ"
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+"Jediným aspektem tohoto oddílu, který je možné upravovat, je velikost.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
-msgstr "Připojit souborový systém do /"
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+"Je možné zvolit, zda chcete použít stávající souborový systém\n"
+"na tomto oddílu, nebo ho naformátovat znovu.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
-msgstr "Vybrat disk pro zavádění systému"
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+"Vyžadován oddíl pro zavaděč\n"
+"\n"
+"Toto je PReP oddíl, který je vyžadován na platformě POWER. Pokud\n"
+"je tento disk označen jako zařízení pro zavádění systému, GRUB bude\n"
+"nainstalován  na tento oddíl.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "Pokračovat bez sítě"
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+"Vyžadován oddíl pro zavaděč\n"
+"\n"
+"Toto je PReP oddíl, který je vyžadován na platformě POWER. protože\n"
+"byl tento disk označen jako zařízení pro zavádění systému, GRUB bude\n"
+"nainstalován  na tento oddíl.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr "Použít stávající souborový systém fat32"
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr "Znovu vytvořit čistý souborový systém fat32"
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr "Přidává se logický svazek do {vgname}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr "Přidává se {ptype} oddíl do {device}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr "Upravuje se logický svazek {lvname} z {vgname}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr "Upravuje se oddíl {number} na {device}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+"Vytvoření souborového systému a jeho připojení přímo na nerozděleném "
+"úložišti není obvyklé. Nejspíš namísto toho chcete přidat oddíl."
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1617,111 +1653,45 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr "Průzkum zařízení pro instalaci se nezdařil"
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr "Zobrazit hlášení chyb"
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
-msgstr "Zjišťuje se aktualizace instalátoru…"
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
+msgstr "znak „/“ (dopředné lomítko) nelze použít v názvu RAID zařízení"
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
-msgstr ""
-"Kontaktuje se sklad snap balíčků aby se zjistilo, zda je k dispozici novější "
-"verze instalátoru."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
+msgstr "V názvu RAID zařízení nemohou být prázdné znaky (mezera, atp.)"
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr "Kontaktování skladu se snap balíčky se nezdařilo"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "Stupeň RAID pole:"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr "Kontaktování skladu se snap balíčky se nezdařilo:"
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "Je k dispozici aktualizace instalátoru"
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
-msgstr "Je k dispozici instalátor verze {new} (nyní je spuštěná {current})."
-
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "Stahování aktualizace…"
-
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
-msgstr ""
-"Vyčkejte na dokončení stažení aktualizovaného instalátoru. Instalátor se "
-"poté automaticky zrestartuje."
-
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
-msgstr "Aktualizace se nezdařila"
-
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr "Stahování a instalace aktualizace:"
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "Pokračovat bez aktualizace"
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Zkusit znovu"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
+msgstr ". a .. nejsou platné názvy pro RAID zařízení"
+
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
-"Pokud zvolíte aktualizovat, aktualizace bude stažená a instalace bude "
-"pokračovat odtud."
+"RAID úroveň „{level}“ vyžaduje alespoň {min_active} aktivních zařízení"
 
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr "Aktualizovat na nový instalátor"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
+msgstr "Vytvořit softwarové RAID („MD“) úložiště"
 
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "Zrušit aktualizaci"
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-"Je možné zadat zrcadlo archivu, které bude použito namísto toho výchozího."
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr "Adresa zrcadla:"
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr "Nastavit zrcadlo Ubuntu archivu"
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
-msgstr ""
-"Pokud používáte alternativní zrcadlo pro Ubuntu, zadejte podrobnosti o něm "
-"sem."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
+msgstr "Upravit disk „{name}“ v softwarovém RAID poli"
 
 #: ../subiquity/ui/views/help.py:70
 #, python-brace-format
@@ -1789,16 +1759,12 @@ msgstr ""
 "Toto je {snap_version} instalátoru.\n"
 
 #: ../subiquity/ui/views/help.py:102
-#, fuzzy
 msgid ""
 "\n"
 "It is possible to connect to the installer over the network, which\n"
 "might allow the use of a more capable terminal and can offer more languages\n"
 "than can be rendered in the Linux console."
 msgstr ""
-"\n"
-"Je možné připojit se k instalátoru přes síť, což umožňuje použít\n"
-"vybavenější terminál."
 
 #: ../subiquity/ui/views/help.py:107
 msgid ""
@@ -1812,21 +1778,44 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
-"\n"
-"Pro připojení, použijte SSH na installer@{ip}.\n"
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
-"\n"
-"Heslo, které byste měli použít, je „{password}“.\n"
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
@@ -1836,7 +1825,7 @@ msgstr ""
 "Žel se zdá, že tento systém v tuto chvíli nemá žádnou globálně dosažitelnou "
 "IP adresu.\n"
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
@@ -1845,603 +1834,280 @@ msgstr ""
 "\n"
 "Instalátor žel nebyl schopen zjistit heslo, které bylo nastaveno.\n"
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr "Následující klíče je možné využít kdykoli:"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr "ESC"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr "jít zpět"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr "F1"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr "otevřít nabídku nápovědy"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr "Control-Z, F2"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr "přepnout do příkazového řádku"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr "Ctrl-vlevo, F3"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr "znovu vykreslit obrazovku"
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr "Ctrl-T, F4"
 
-#: ../subiquity/ui/views/help.py:185
-#, fuzzy
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
-msgstr "vyp/zap. barvy"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr "Ctrl-X"
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
-msgstr ""
+msgstr "ukončit"
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr "Ctrl+E"
 
-#: ../subiquity/ui/views/help.py:190
-#, fuzzy
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
-msgstr "vytvořit zašumněné hlášení chyby (pouze při zkoušce naprázdno)"
+msgstr "vytvořit podprobnější hlášení chyby"
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr "Ctrl+R"
 
-#: ../subiquity/ui/views/help.py:191
-#, fuzzy
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
-msgstr "vytvořit tiché hlášení chyby (pouze při zkoušce naprázdno)"
+msgstr "vytvořit stručnější hlášení chyby"
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Ctrl-X"
+msgstr "CTRL+G"
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr "Aktualizovat na nový instalátor"
+msgstr "předstírat pro spuštění instalace"
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr "Ctrl+U"
 
-#: ../subiquity/ui/views/help.py:193
-#, fuzzy
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
-msgstr "zhavarovat uživatelské rozhraní (pouze při zkoušce naprázdno)"
+msgstr "zhavarovat uživatelské rozhraní"
 
-#: ../subiquity/ui/views/help.py:207
-#, fuzzy
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
-msgstr "ukončit (pouze při zkoušce naprázdno)"
+msgstr "(pouze průchod nanečisto)"
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr "Klávesové zkratky"
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr "O tomto instalátoru"
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr "Klávesové zkratky"
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr "Vstoupit do příkazového řádku"
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr "Nápověda k SSH přístupu"
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr "Nápověda k této obrazovce"
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr "Zobrazit hlášení chyb"
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr "Nápověda"
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr "O instalátoru"
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
-"\n"
-"Vyberte jazyk, který použít v instalátoru a nastavit pro instalovaný "
-"systém.\n"
+"Znaky „:“ (dvojtečka), „,“ (čárka) a = (rovnítko) není v této kolonce možné "
+"použít"
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Pomocí kláves šipka nahoru nebo dolů a Enter vyberte svůj jazyk."
-
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr "Pomozte zvolením jazyka"
-
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Uživatelské jméno importu:"
-
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "GitHub uživatelské jméno:"
-
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "GitHub uživatelské jméno:"
-
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
-"GitHub uživatelské jméno může obsahovat pouze písmena a číslice a jednotlivé "
-"spojovníky a nemůže začínat nebo končit na spojovník."
+"Jedinými znaky, které je možné v této kolonce použít, jsou a-z (bez "
+"diakritiky), 0-9, _ (podtržítko) a - (mínus/spojovník)"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Launchpad uživatelské jméno:"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Vaše jméno:"
 
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"GitHub uživatelské jméno může obsahovat pouze písmena a číslice a jednotlivé "
-"spojovníky a nemůže začínat nebo končit na spojovník."
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Název pro váš server:"
 
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr "Nainstalovat OpenSSH server"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Název se používá při komunikaci s ostatními počítači."
 
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Importovat SSH identitu:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Vyberte uživatelské jméno:"
 
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "z účtu na GitHub"
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Zvolte heslo:"
 
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "z účtu na Launchpad"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Potvrďte své heslo:"
 
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Můžete importovat své SSH klíče z portálů GitHub nebo Launchpad."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr "Umožnit ověřovat se pro SSH heslem"
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Tuto kolonku je třeba vyplnit."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "SSH identifikátor je příliš dlouhý – je třeba, aby byl kratší než "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-"Je třeba, aby uživatelské jméno z portálu Launchpad začínalo na písmeno nebo "
-"číslici. Dále je třeba, aby všechna písmena byla malá. Znaky +,- a . jsou "
-"povolené až někde za prvním znakem."
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"GitHub uživatelské jméno může obsahovat pouze písmena a číslice a jednotlivé "
-"spojovníky a nemůže začínat nebo končit na spojovník."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr "Stahování SSH klíčů…"
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr "Potvrďte SSH klíče"
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr "Byly staženy klíče s následujícími otisky. Chcete je použít?"
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr "Potvrďte SSH klíč"
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr "Byl stažen klíč s následujícím otiskem. Chcete ho použít?"
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr "Nastavení SSH"
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-"Je možné zvolit instalaci serverového balíčku OpenSSH a zapnout tak "
-"zabezpečený vzdálený přístup ke svému serveru."
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "právě teď"
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr "minutou"
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr "minutami"
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr "hodinou"
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr "hodinami"
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr "dnem"
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr "dny"
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
-msgstr "před {amount:2} {unit}"
-
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Název serveru nemůže zůstat nevyplněný"
+
+#: ../subiquity/ui/views/identity.py:109
+#, python-brace-format
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Chybí uživatelské jméno"
+
+#: ../subiquity/ui/views/identity.py:123
+#, python-brace-format
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
+msgstr "Uživatelské jméno „{username}“ je vyhrazeno pro použití systémem."
 
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr "{desc} neodpovídá"
 
-#: ../subiquity/ui/views/snaplist.py:256
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap}"
-msgstr "Stahování informací pro {}"
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Nastavení profilu"
 
-#: ../subiquity/ui/views/snaplist.py:282
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap} failed"
-msgstr "Stahování informací pro {} se nezdařilo"
-
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
-msgstr "Propagované serverové snap balíčky"
-
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Pokračovat"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
-msgstr "Načítání serverových snap balíčků ze skladu, čekejte…"
-
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr "Je nám líto, načítání snap balíčků ze skladu se nezdařilo."
-
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
-"Toto jsou oblíbené snap balíčky pro serverová prostředí. Vybírejte je (nebo "
-"výběr rušte) pomocí MEZERNÍKU. Podrobnosti o balíčku, vydavateli a verzích "
-"obdržíte stiskem ENTER."
+"Zadejte uživatelské jméno a heslo které budete používat pro přihlašování se "
+"do systému. Na následující obrazovce můžete nastavit přístup přes SSH, ale "
+"heslo je pořád potřebné pro sudo."
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr "Automatické zjištění rozvržení klávesnice"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "hesla"
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-"Spouští se zjištění rozvržení klávesnice. Bude vám položena série dotazů o "
-"vaší klávesnici. Stiskem klávesy Esc se kdykoli můžete vrátit na předchozí "
-"obrazovku."
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Automatické zjištění rozvržení klávesnice se nezdařilo, je nám líto"
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-"Automatické zjištění rozvržení klávesnice dokončeno.\n"
-"\n"
-"Vaše klávesnice rozpoznána jako:\n"
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-"\n"
-"Pokud je toto správně, vyberte na příští obrazovce Hotovo. Pokud ne, můžete "
-"vybrat jiné rozvržení nebo spustit automatické zjišťování znovu.\n"
-"\n"
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Rozvržení"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr "Varianta"
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Stiskněte jednu z následujících kláves:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr "Vstup nebyl rozpoznán, zkuste to znovu"
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "Nachází se následující klávesa na vaší klávesnici?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Uplatňování nastavení"
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-"Budete potřebovat způsob jak přepínat klávesnici mezi národním rozvržením a "
-"standardním pro latinku.\n"
-"\n"
-"Pravý Alt nebo Caps Lock jsou obvykle voleny z důvodu ergonomie (ve druhém z "
-"uvedených příkladů, použijete pro běžnou funkci Caps kombinaci Shift+Caps "
-"Lock). Alt+Shift je také oblíbená kombinace, nicméně ztratí své obvyklé "
-"chování v Emacs a ostatních programech, které ji používají pro specifické "
-"potřeby.\n"
-"\n"
-"Ne všechny vypsané klávesy se nacházejí na všech klávesnicích. "
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Pravý Alt (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Pravý Ctrl"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Pravý Shift"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr "Pravá klávesa logo"
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "Klávesa Menu"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Control+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr "Control+Alt"
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "Levý Control+levý Shift"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Levý Alt"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Levý Ctrl"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Levý Shift"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr "Levá klávesa logo"
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "Klávesa Scroll Lock"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr "Bez přepínání"
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr "Klávesová zkratka: "
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr "Vyberte přepínání rozvržení"
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "Rozvržení:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr "Varianta:"
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr "Nastavení klávesnice"
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-"Vyberte rozvržení klávesnice, která je přímo připojená k systému (pokud je "
-"připojená)."
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-"Níže vyberte rozvržení své klávesnice, nebo vyberte „identifikovat "
-"klávesnici“ pro automatické zjištění rozvržení."
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr "Identifikujte klávesnici"
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr "Postup instalace"
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Restartovat nyní"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr "Zobrazit hlášení chyb"
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr "Zobrazit celý záznam událostí"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr "Úplný výstup z instalátoru"
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Instaluje se systém"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Instalace dokončena!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr "Zrušit aktualizaci a restartovat"
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Restartovat"
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr "Restartování…"
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "V průběhu instalace došlo k chybě"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2459,36 +2125,241 @@ msgstr ""
 "\n"
 "Opravdu chcete pokračovat?"
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr "Potvrdit destruktivní akci"
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
 "\n"
 "You can wait for this to complete or switch to a shell.\n"
-msgstr ""
+msgstr "Instalátor spuštěný na {tty} v tuto chvíli instaluje systém.\n"
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
-msgstr "Přepnout do příkazového řádku"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "Automatické zjištění rozvržení klávesnice"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+"Spouští se zjištění rozvržení klávesnice. Bude vám položena série dotazů o "
+"vaší klávesnici. Stiskem klávesy Esc se kdykoli můžete vrátit na předchozí "
+"obrazovku."
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+"Automatické zjištění rozvržení klávesnice dokončeno.\n"
+"\n"
+"Vaše klávesnice rozpoznána jako:\n"
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+"\n"
+"Pokud je toto správně, vyberte na příští obrazovce Hotovo. Pokud ne, můžete "
+"vybrat jiné rozvržení nebo spustit automatické zjišťování znovu.\n"
+"\n"
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Rozvržení"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr "Varianta"
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Stiskněte jednu z následujících kláves:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr "Vstup nebyl rozpoznán, zkuste to znovu"
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Nachází se následující klávesa na vaší klávesnici?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+"Budete potřebovat způsob jak přepínat klávesnici mezi národním rozvržením a "
+"standardním pro latinku.\n"
+"\n"
+"Pravý Alt nebo Caps Lock jsou obvykle voleny z důvodu ergonomie (ve druhém z "
+"uvedených příkladů, použijete pro běžnou funkci Caps kombinaci Shift+Caps "
+"Lock). Alt+Shift je také oblíbená kombinace, nicméně ztratí své obvyklé "
+"chování v Emacs a ostatních programech, které ji používají pro specifické "
+"potřeby.\n"
+"\n"
+"Ne všechny vypsané klávesy se nacházejí na všech klávesnicích. "
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Pravý Alt (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Pravý Ctrl"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Pravý Shift"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr "Pravá klávesa logo"
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Klávesa Menu"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Control+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Control+Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Levý Control+levý Shift"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Levý Alt"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Levý Ctrl"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Levý Shift"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr "Levá klávesa logo"
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Klávesa Scroll Lock"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr "Bez přepínání"
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr "Klávesová zkratka: "
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr "Vyberte přepínání rozvržení"
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Rozvržení:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr "Varianta:"
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "Nastavení klávesnice"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+"Vyberte rozvržení klávesnice, která je přímo připojená k systému (pokud je "
+"připojená)."
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+"Níže vyberte rozvržení své klávesnice, nebo vyberte „identifikovat "
+"klávesnici“ pro automatické zjištění rozvržení."
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr "Identifikujte klávesnici"
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Uplatňování nastavení"
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+"Je možné zadat zrcadlo archivu, které bude použito namísto toho výchozího."
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "Adresa zrcadla:"
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr "Nastavit zrcadlo Ubuntu archivu"
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+msgstr ""
+"Pokud používáte alternativní zrcadlo pro Ubuntu, zadejte podrobnosti o něm "
+"sem."
 
 #: ../subiquity/ui/views/proxy.py:33
 msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "Pokud pro přístup do okolního světa potřebujete HTTP proxy, zadejte "
 "informace o proxy sem. Jinak ponechte nevyplněné.\n"
 "\n"
-"Informace o proxy by měly být zadány ve standardní podobě „http://[[uzivatel]"
-"[:heslo]@]stroj[:port]/“."
+"Informace o proxy by měly být zadány ve standardní podobě "
+"„http://[[uzivatel][:heslo]@]stroj[:port]/“."
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
@@ -2506,259 +2377,364 @@ msgstr ""
 "Pokud tento systém potřebuje pro připojení k Internetu proxy, zadejte "
 "podrobnosti o ní sem."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr "Zjišťuje se aktualizace instalátoru…"
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+"Kontaktuje se sklad snap balíčků aby se zjistilo, zda je k dispozici novější "
+"verze instalátoru."
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr "Kontaktování skladu se snap balíčky se nezdařilo"
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr "Kontaktování skladu se snap balíčky se nezdařilo:"
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Je k dispozici aktualizace instalátoru"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr "Je k dispozici instalátor verze {new} (nyní je spuštěná {current})."
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Stahování aktualizace…"
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+"Vyčkejte na dokončení stažení aktualizovaného instalátoru. Instalátor se "
+"poté automaticky zrestartuje."
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr "Aktualizace se nezdařila"
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr "Stahování a instalace aktualizace:"
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Pokračovat bez aktualizace"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Zkusit znovu"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr "Poznámky k vydání pro každou z verzí je možné si přečíst na:"
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+"Pokud zvolíte aktualizovat, aktualizace bude stažená a instalace bude "
+"pokračovat odtud."
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr "Aktualizovat na nový instalátor"
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Zrušit aktualizaci"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "právě teď"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "minutou"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "minutami"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "hodinou"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "hodinami"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "dnem"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "dny"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr "před {amount:2} {unit}"
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr "LICENCE: "
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr "NAPOSLEDY AKTUALIZOVÁNO: "
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr "KANÁL"
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr "VERZE"
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr "VYDÁNO"
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr "OHRANIČENÍ"
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr "od: "
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr "Propagované serverové snap balíčky"
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr "Načítání serverových snap balíčků ze skladu, čekejte…"
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr "Je nám líto, načítání snap balíčků ze skladu se nezdařilo."
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+"Toto jsou oblíbené snap balíčky pro serverová prostředí. Vybírejte je (nebo "
+"výběr rušte) pomocí MEZERNÍKU. Podrobnosti o balíčku, vydavateli a verzích "
+"obdržíte stiskem ENTER."
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Uživatelské jméno importu:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Github uživatelské jméno:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr "Zadejte své uživatelské jméno z portálu Github"
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+"Uživatelské jméno z portálu Github může obsahovat pouze písmena a číslice, "
+"případně ještě spojovníky."
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Launchpad uživatelské jméno:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+"Uživatelské jméno z portálu Launchpad může obsahovat pouze malá písmena a "
+"číslice, spojovníky, plus nebo tečky."
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr "Nainstalovat OpenSSH server"
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Importovat SSH identitu:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "z účtu na Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "z účtu na Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Můžete importovat své SSH klíče z portálů Github nebo Launchpad."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr "Umožnit ověřovat se pro SSH heslem"
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Tuto kolonku je třeba vyplnit."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "SSH identifikátor je příliš dlouhý – je třeba, aby byl kratší než "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+"Je třeba, aby uživatelské jméno z portálu Launchpad začínalo na písmeno nebo "
+"číslici. Dále je třeba, aby všechna písmena byla malá. Znaky +,- a . jsou "
+"povolené až někde za prvním znakem."
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"Github uživatelské jméno může obsahovat pouze písmena a číslice a jednotlivé "
+"spojovníky a nemůže začínat nebo končit na spojovník."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr "Stahování SSH klíčů…"
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "Potvrďte SSH klíče"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr "Byly staženy klíče s následujícími otisky. Chcete je použít?"
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "Potvrďte SSH klíč"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr "Byl stažen klíč s následujícím otiskem. Chcete ho použít?"
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "Nastavení SSH"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+"Je možné zvolit instalaci serverového balíčku OpenSSH a zapnout tak "
+"zabezpečený vzdálený přístup ke svému serveru."
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 "\n"
-"Omlouváme se, došlo k problému při zkoumání úložných zařízení na tomto "
-"systému.\n"
+"Vyberte jazyk, který použít v instalátoru a nastavit pro instalovaný "
+"systém.\n"
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
-msgstr ""
-"\n"
-"Omlouváme se, došlo k problému s dokončováním instalace.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Pomocí kláves šipka nahoru nebo dolů a Enter vyberte svůj jazyk."
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
-msgstr ""
-"\n"
-"Omlouváme se, došlo k problému s uplatněním nastavení sítě.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
+msgstr "Pomozte zvolením jazyka"
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
-msgstr ""
-"\n"
-"Omlouváme se, instalátor byl kvůli chybě restartován.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
+msgstr "nezdařilo se"
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-"\n"
-"Omlouváme se, došlo k neznámé chybě.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
+msgstr "automaticky"
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-"\n"
-"Ze systému jsou shromažďovány informace, které vývojářům\n"
-"pomohou s diagnostikou hlášení.\n"
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
+msgstr "online"
 
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-"\n"
-"Načítání hlášení…\n"
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-"\n"
-"Shromažďování informací ze systému se nezdařilo. Další informace\n"
-"viz soubory ve /var/log/installer\n"
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-"\n"
-"Načítání hlášení se nezdařilo. Viz soubory ve /var/log/installer\n"
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-"\n"
-"Můžete pokračovat a instalátor pouze představí disky, přítomné v systému\n"
-"a ne ostatní bloková zařízení, nebo můžete být schopní opravit\n"
-"tento problém přepnutím do příkazového řádku a ručním\n"
-"přenastavením systémových blokových zařízení.\n"
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-"\n"
-"Může být možné problém opravit přepnutím se do příkazového\n"
-"řádku a ručním přenastavením systémových blokových zařízení.\n"
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-"\n"
-"V instalaci je možné pokračovat, ale bude se předpokládat, že síť není\n"
-"funkční.\n"
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-"\n"
-"Chcete zkusit spustit instalaci znovu?\n"
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr "Pro opětovný pokus o instalaci vyberte Pokračovat."
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-"\n"
-"Pokud chcete pomoci ve zlepšení instalátoru, můžete nám poslat hlášení "
-"chyby.\n"
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr "Zrušit odesílání"
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr "Zavřít hlášení"
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr "Restartovat instalátor"
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr "Odeslat společnosti Canonical"
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr "Odesláno společnosti Canonical"
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr "Zobrazit celé hlášení"
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-"Hlášení chyby bylo uloženo do\n"
-"\n"
-"  {loc}\n"
-"\n"
-"na souborový systém se štítkem {label!r}."
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr "DATUM"
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr "DRUH"
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr "STAV"
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr "Vyberte hlášení chyby, které zobrazit:"
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr "ZOBRAZENO"
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr "NEZOBRAZENO"
-
-#: ../subiquity/ui/views/zdev.py:64
+#: ../subiquity/ui/views/zdev.py:77
 msgid "No zdev devices found."
 msgstr "Nenalezena žádná zdev zařízení."
 
-#: ../subiquity/ui/views/zdev.py:77
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr "IDENTIF"
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr "ONLINE"
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr "NÁZVY"
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr "Zapnout"
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr "Vypnout"
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr "Nastavení Zdev zařízení"
 
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr "Ostatní"
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr "Ponechat nepřipojené"
-
-#~ msgid "formatted as {}"
-#~ msgstr "se souborovým systémem {}"
-
-#~ msgid ", mounted at {}"
-#~ msgstr ", připojeno do {}"
-
-#~ msgid "{} partition"
-#~ msgstr "{} oddíl"
-
-#~ msgid "Adding {} to {}"
-#~ msgstr "Přidává se {} do {}"
-
-#~ msgid "Editing {} of {}"
-#~ msgstr "Upravuje se {} z {}"
-
-#~ msgid "partition"
-#~ msgstr "oddíl"
-
-#~ msgid "Toggle color on/off"
-#~ msgstr "Vyp/zap. barvy"
-
 #~ msgid "Filesystem setup"
 #~ msgstr "Nastavení souborového systému"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Došlo k chybě"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Instalace dokončena!"
 
 #~ msgid "starting..."
 #~ msgstr "spouštění…"
@@ -2772,20 +2748,136 @@ msgstr "Ponechat nepřipojené"
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr "Vyberte rozhraní které nastavit nebo pokračujte výběrem Hotovo"
 
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Je třeba, aby obsahem této kolonky byla URL adresa %s"
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "„%s“ není obsaženo v „%s“"
+
+#~ msgid "partition of {}"
+#~ msgstr "oddíl {}"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} není platné zadání"
+
 #~ msgid "Choose guided or manual partitioning"
 #~ msgstr "Zvolte mezi automatickým nebo ručním rozdělením"
 
 #~ msgid "Choose the installation target"
 #~ msgstr "Zvolte cíl instalace"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formát a/nebo připojení {}"
+
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr "Klávesnici vyberte klávesami šipka nahoru nebo dolů a Enter."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Vyžadován oddíl pro zavaděč systému\n"
+#~ "\n"
+#~ "GRUB bude nainstalován do MBR cílového disku.\n"
+#~ "\n"
+#~ "Nicméně, na disku s GPT tabulkou oddílů, není dostatek prostoru za MBR pro "
+#~ "uložení druhé fáze GRUB, core.img, takže je třeba malého, nezformátovaného "
+#~ "oddílu na začátku disku. Nebude obsahovat souborový systém a nebude připojen "
+#~ "a není možné ho zde upravit."
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Je třeba, aby uživatelské jméno odpovídalo regulárnímu výrazu NAME_REGEX, "
+#~ "tj. [a-z_][a-z0-9_-]*"
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Automatické zjištění rozvržení klávesnice se nezdařilo, je nám líto"
 
 #~ msgid "Exit To Shell"
 #~ msgstr "Ukončit do shellu"
 
+#~ msgid "Edit IPv6"
+#~ msgstr "Upravit IPv6"
+
+#~ msgid "Info"
+#~ msgstr "Informace"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Upravit IPv4"
+
+#~ msgid "should be in CIDR form ({})"
+#~ msgstr "mělo by být v podobě CIDR ({})"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s už existuje"
+
+#~ msgid "Info for {}"
+#~ msgstr "Informace pro {}"
+
+#~ msgid "enslaved to {}"
+#~ msgstr "podřízeno {}"
+
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
+
+#~ msgid "unknown state {}"
+#~ msgstr "neznámý stav {}"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "Nastavit jako zařízení pro zavádění systému"
+
+#~ msgid "Edit"
+#~ msgstr "Upravit"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Odebrat z RAID/LVM"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Vytvořit logický svazek"
+
+#~ msgid "Add Partition"
+#~ msgstr "Přidat oddíl"
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
+#~ msgstr ""
+#~ "{selflabel} není možné smazat, protože je z něho připojeno (mount) {count} "
+#~ "oddílů."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has 1 mounted partition."
+#~ msgstr ""
+#~ "{selflabel} není možné smazat, protože je z něho připojen (mount) oddíl."
+
+#~ msgid "partition {} of {}"
+#~ msgstr "oddíl {} na {}"
+
+#~ msgid "partition {}"
+#~ msgstr "oddíl {}"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has logical volumes."
+#~ msgstr "{selflabel} není možné upravit, protože obsahuje logické svazky."
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has partitions."
+#~ msgstr "{selflabel} není možné upravit, protože obsahuje oddíly."
+
+#~ msgid "unused {}"
+#~ msgstr "nepoužito {}"
+
+#~ msgid "Remove from {}"
+#~ msgstr "Odebrat z {}"
 
 #~ msgid "Use An Entire Disk And Set Up LVM"
 #~ msgstr "Využít celé úložiště a nastavit LVM"
@@ -2793,26 +2885,103 @@ msgstr "Ponechat nepřipojené"
 #~ msgid "Select Done to begin the installation."
 #~ msgstr "Pro pokračování v instalaci vyberte Hotovo."
 
+#~ msgid "Passphrases"
+#~ msgstr "Heslové fráze"
+
+#~ msgid "Rounded size up to {}"
+#~ msgstr "Velikost zaokrouhlena na {}"
+
+#~ msgid "There is already a volume group named '{}'"
+#~ msgstr "Už zde je skupina svazků nazvaná „{}“"
+
+#~ msgid "Edit volume group \"{}\""
+#~ msgstr "Upravit skupinu svazků „{}“"
+
+#~ msgid "Capped partition size at {}"
+#~ msgstr "Zastropována velikost oddílu na {}"
+
+#~ msgid "Size (max {}):"
+#~ msgstr "Velikost (nejvýše {}):"
+
+#~ msgid "There is already a logical volume named {}."
+#~ msgstr "Už zde je logický svazek nazvaný {}."
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "Název logického svazku nemůže obsahovat „{}“"
+
+#~ msgid "A logical volume may not be called {}"
+#~ msgstr "Logický svazek nemůže být nazván {}"
+
+#~ msgid "logical volume"
+#~ msgstr "logický svazek"
+
+#~ msgid "partition"
+#~ msgstr "oddíl"
+
+#~ msgid "Editing {} of {}"
+#~ msgstr "Upravuje se {} z {}"
+
+#~ msgid "Adding {} to {}"
+#~ msgstr "Přidává se {} do {}"
+
+#~ msgid "logical volume {}"
+#~ msgstr "logický svazek {}"
+
+#~ msgid "There is already a RAID named '{}'"
+#~ msgstr "Už zde je RAID pole nazvané „{}“"
+
+#~ msgid "Reboot"
+#~ msgstr "Restartovat"
+
 #~ msgid "Please choose your preferred language."
 #~ msgstr "Vyberte vámi upřednostňovaný jazyk."
 
+#~ msgid "There is already a network device named \"{}\""
+#~ msgstr "Už zde je síťové zařízení nazvané „{}“"
+
+#~ msgid "{} is not a valid name for a volume group"
+#~ msgstr "{} není platný název pro skupinu svazků"
+
+#~ msgid "Fetching info for {} failed"
+#~ msgstr "Stahování informací pro {} se nezdařilo"
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "Stahování informací pro {}"
+
 #~ msgid ""
-#~ "The LVM guided partitioning scheme creates three partitions on the "
-#~ "selected disk: one as required by the bootloader, one for '/boot', and "
-#~ "one covering the rest of the disk.\n"
+#~ "Required bootloader partition\n"
 #~ "\n"
-#~ "A LVM volume group is created containing the large partition. A 4 "
-#~ "gigabyte logical volume is created for the root filesystem. It can easily "
-#~ "be enlarged with standard LVM command line tools."
+#~ "This is the PReP partion which is required on POWER. Grub will be installed "
+#~ "onto this partition."
+#~ msgstr ""
+#~ "Vyžadován oddíl pro zavaděč systému\n"
+#~ "\n"
+#~ "Toto je PReP oddíl, který je vyžadován na architektuře POWER. Grub bude "
+#~ "nainstalován na tento oddíl."
+
+#~ msgid "RAID Level \"{}\" requires at least {} active devices"
+#~ msgstr "Úroveň RAID „{}“ vyžaduje alespoň {} aktivních zařízení"
+
+#~ msgid "Edit software RAID disk \"{}\""
+#~ msgstr "Upravit softwarové RAID úložiště „{}“"
+
+#~ msgid ""
+#~ "The LVM guided partitioning scheme creates three partitions on the selected "
+#~ "disk: one as required by the bootloader, one for '/boot', and one covering "
+#~ "the rest of the disk.\n"
+#~ "\n"
+#~ "A LVM volume group is created containing the large partition. A 4 gigabyte "
+#~ "logical volume is created for the root filesystem. It can easily be enlarged "
+#~ "with standard LVM command line tools."
 #~ msgstr ""
 #~ "LVM vedené schéma rozdělení na oddíly vytvoří na vybraném úložišti tři "
 #~ "oddíly: jednu pro zavaděč systému, jednu pro „/boot“ a jednu pokrývající "
 #~ "zbytek úložiště.\n"
 #~ "\n"
-#~ "Dále je vytvořena LVM skupina svazků, obsahující posledně zmíněný oddíl. "
-#~ "V ní je vytvořen 4 gigabajtový logický svazek pro kořenový souborový "
-#~ "systém. Ten je snadno možné zvětšit pomocí standardních LVM nástrojů pro "
-#~ "příkazový řádek."
+#~ "Dále je vytvořena LVM skupina svazků, obsahující posledně zmíněný oddíl. V "
+#~ "ní je vytvořen 4 gigabajtový logický svazek pro kořenový souborový systém. "
+#~ "Ten je snadno možné zvětšit pomocí standardních LVM nástrojů pro příkazový "
+#~ "řádek."
 
 #~ msgid "-"
 #~ msgstr "–"
@@ -2820,20 +2989,40 @@ msgstr "Ponechat nepřipojené"
 #~ msgid "Install in progress:"
 #~ msgstr "Provádí se instalace:"
 
+#~ msgid "Finished install!"
+#~ msgstr "Instalace dokončena!"
+
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Prosíme nahlaste tuto chybu prostřednictvím portálu Launchpad"
 
+#, python-brace-format
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+#~ msgstr ""
+#~ "{selflabel} není možné smazat, protože oddíl {partnum} je součástí {cdtype} "
+#~ "{cdname}."
+
+#~ msgid "Format"
+#~ msgstr "Vytvořit souborový systém"
+
+#~ msgid ", mounted at {}"
+#~ msgstr ", připojeno do {}"
+
+#~ msgid "formatted as {}"
+#~ msgstr "se souborovým systémem {}"
+
+#~ msgid ""
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
 #~ "\n"
 #~ "Are you sure you want to continue?"
 #~ msgstr ""
-#~ "Vybrání Pokračovat (níže) zahájí proces instalace a povede ke ztrátě dat "
-#~ "na úložištích, na kterých mají být vytvořeny souborové systémy.\n"
+#~ "Vybrání Pokračovat (níže) zahájí proces instalace a povede ke ztrátě dat na "
+#~ "úložištích, na kterých mají být vytvořeny souborové systémy.\n"
 #~ "\n"
 #~ "Jakmile se instalace spustí, nebude už možné se vrátit na tuto nebo "
 #~ "předchozí obrazovky.\n"
@@ -2845,8 +3034,8 @@ msgstr "Ponechat nepřipojené"
 
 #~ msgid "Select available disks to format and mount"
 #~ msgstr ""
-#~ "Vyberte dostupná úložiště, na kterých vytvořit souborové systémy a "
-#~ "připojit je"
+#~ "Vyberte dostupná úložiště, na kterých vytvořit souborové systémy a připojit "
+#~ "je"
 
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Využít celé úložiště"
@@ -2857,9 +3046,9 @@ msgstr "Ponechat nepřipojené"
 #~ "the rest of the disk, formatted as ext4 and mounted at '/'."
 #~ msgstr ""
 #~ "Zvolené schéma vedeného rozdělení na oddíly vytvoří potřebný oddíl pro "
-#~ "zavaděč systému na zvoleném úložišti a pak vytvoří jediný oddíl "
-#~ "pokrývající zbytek úložiště, na kterém bude vytvořen souborový systém "
-#~ "ext4 a připojen jako „/“."
+#~ "zavaděč systému na zvoleném úložišti a pak vytvoří jediný oddíl pokrývající "
+#~ "zbytek úložiště, na kterém bude vytvořen souborový systém ext4 a připojen "
+#~ "jako „/“."
 
 #~ msgid ""
 #~ "The installer can guide you through partitioning an entire disk either "
@@ -2871,11 +3060,83 @@ msgstr "Ponechat nepřipojené"
 #~ "Instalátor vás může provést rozdělením celého úložiště buď přímo, nebo s "
 #~ "použitím LVM. Nebo – pokud upřednostňujete – je možné to udělat ručně.\n"
 #~ "\n"
-#~ "Pokud zvolíte rozdělení celého úložiště, pořád máte možnost prohlédnout "
-#~ "si a upravit výsledky."
+#~ "Pokud zvolíte rozdělení celého úložiště, pořád máte možnost prohlédnout si a "
+#~ "upravit výsledky."
 
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Zvolte úložiště, na které nainstalovat:"
 
+#~ msgid "{} is already mounted at {}."
+#~ msgstr "{} už je připojeno do {}."
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "Název serveru je příliš dlouhý – je třeba, aby byl kratší než "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "Uživatelské jméno je příliš dlouhé – je třeba, aby bylo kratší než "
+
+#, python-brace-format
+#~ msgid "It contains {n} {things}:"
+#~ msgstr "Obsahuje {n} {things}:"
+
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "Opravdu chcete odebrat existující souborový systém z {}?"
+
+#~ msgid "Remove filesystem from {}"
+#~ msgstr "Odebrat souborový systém z {}"
+
+#, python-brace-format
 #~ msgid "Cannot remove selflabel from pre-exsting {cdtype} {cdlabel}"
 #~ msgstr "Není možné odebrat selflabel z už existujícího {cdtype} {cdlabel}"
+
+#~ msgid ""
+#~ "Mounting an existing filesystem at {} is usually a bad idea, proceed only "
+#~ "with caution."
+#~ msgstr ""
+#~ "Připojování existujícího souborového systému do {} je obvykle špatný nápad, "
+#~ "pokračujte pouze s obezřetností."
+
+#~ msgid " The only aspect of this partition that can be edited is the size."
+#~ msgstr " Jediné hledisko tohoto oddílu, který je možné měnit, je velikost."
+
+#~ msgid ""
+#~ " You can choose whether to use the existing filesystem on this partition or "
+#~ "reformat it."
+#~ msgstr ""
+#~ " Je možné zvolit zda použít stávající souborový systém na tomto oddílu, nebo "
+#~ "ho vytvořit znovu."
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Upravit Wi-Fi"
+
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Wi-Fi nastavení síťového rozhraní {}"
+
+#~ msgid "bond master for {}"
+#~ msgstr "řídí spřažení pro {}"
+
+#~ msgid "software RAID {}"
+#~ msgstr "softwarové RAID pole {}"
+
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Skutečné jméno je příliš dlouhé – je třeba, aby bylo kratší než "
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Je třeba, aby se název stroje odpovídal regulárnímu výrazu NAME_REGEX, tj. "
+#~ "[a-z_][a-z0-9_-]*"
+
+#~ msgid "Leave formatted as {}"
+#~ msgstr "Ponechat se souborovým systémem jako {}"
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
+#~ "installed onto this partition, which must be formatted as fat32."
+#~ msgstr ""
+#~ "Vyžadován oddíl pro zavaděč systému\n"
+#~ "\n"
+#~ "Toto je ESP / „EFI system partition“ vyžadované UEFI firmwarem. Grub bude "
+#~ "nainstalován na tento oddíl, na kterém je třeba, aby byl vytvořen souborový "
+#~ "systém fat32."

--- a/po/de.po
+++ b/po/de.po
@@ -7,84 +7,418 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-04-07 19:00+0000\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2019-12-30 09:29+0000\n"
 "Last-Translator: Dan Cooper <Unknown>\n"
 "Language-Team: German <de@li.org>\n"
-"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: de\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr "Eine Bestätigung wird benötigt, um fortzufahren."
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr "Fortfahren mit autoinstall?"
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr "Importieren der Schlüssel gescheitert:"
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+"ssh-keygen konnte nicht den Fingerprint des heruntergeladenen Schlüssels "
+"anzeigen:"
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+"Kann {selflabel} nicht bearbeiten, da es Teil des {cdtype} {cdname} ist."
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr "Bereits vorhandene RAIDs können nicht bearbeitet werden."
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+"Bereits vorhandene Datenträgergruppen können nicht bearbeitet werden."
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+"Das Entfernen von {selflabel} würde das {cdtype} {cdlabel} mit weniger als "
+"{min_devices} Geräten belassen."
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+"Das Entfernen von {selflabel} würde das {cdtype} {cdlabel} ohne Geräte "
+"zurücklassen."
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+"Kann {selflabel} nicht löschen, da es Teil des {cdtype} {cdname} ist."
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+"Eine einzelne Partition kann nicht von einem Gerät gelöscht werden, das "
+"bereits Partitionen hat."
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr "Kann benötigte Bootloader-Partition nicht löschen"
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+"Ein einzelnes logisches Volume aus einer Datenträgergruppe, die bereits "
+"logische Datenträger enthält, kann nicht gelöscht werden."
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr "vorhanden"
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr "neu"
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr "konfiguriert"
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "lokaler Datenträger"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr "Partition von {device}"
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr "Software-RAID {level}"
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr "Partition {number}"
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr "Partition {number} auf {device}"
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr "{component_name} von {desc} {name}"
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr "bereits als {fstype} formatiert"
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr "umformatiert werden als {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr "formatiert werden als {fstype}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr "Nach {path} eingebunden"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr "nicht eingehängt"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "unbenutzt"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "verwendet"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr "Installations-Fehler"
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "Unbekannter Fehler"
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "Automatische Konfiguration fehlgeschlagen"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "Info"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Bearbeite Wifi"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Bearbeite IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Bearbeite IPv6"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "Bearbeite Bond"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
-#, fuzzy
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
-msgstr "Füge eine VLAN-Bezeichnung hinzu"
+msgid "Edit Wifi"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:45
-#, fuzzy
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Löschen"
-
-#: ../subiquitycore/ssh.py:50
-msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:59
+msgid "The host key fingerprints are:\n"
+msgstr "Die Fingerabdrücke der Host-Schlüssel sind:\n"
+
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Schließen"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -95,34 +429,55 @@ msgid " or "
 msgstr " oder "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Dieses Feld muss eine %s URL sein."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Erledigt"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Abbrechen"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Ja"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Nein"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Schließen"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Speichern"
 
@@ -155,14 +510,14 @@ msgid "Domains, comma separated"
 msgstr "Domänen, kommagetrennt"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr "sollte in CIDR-Form vorliegen ({})"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr ">>%s<< ist nicht in >>%s<< enthalten"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -184,87 +539,133 @@ msgstr "Deaktiviert"
 msgid "IPv{v} Method: "
 msgstr "IPv{v} Methode: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Erstellen"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "VLAN-ID:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr "VLAN-ID muss zwischen 1 und 4095 liegen"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s existiert bereits"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr "Füge eine VLAN-Bezeichnung hinzu"
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
+#, python-brace-format
 msgid "Info for {device}"
-msgstr "Info für {}"
+msgstr "Information für {device}"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Name:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Geräte: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr "Bond-Modus:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr "XMIT-hash-Richtlinie:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr "LACP-Rate:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
+#, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr "Es existiert bereits ein Netzwerk mit dem Namen \"{}\""
+msgstr "Es gibt bereits ein Netzwerkgerät namens \"{netdev}\"."
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "Name darf nicht leer sein"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr "Name darf nicht länger als 16 Zeichen sein"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr "Erstelle Bond"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr "Bearbeite Bond"
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr "Netzwerkschnittstelle {nic} WiFi-Konfiguration"
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr "VLAN {id} auf der Schnittstelle {link}"
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "nicht verbunden"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "Zeitüberschreitung"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "statisch"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "deaktiviert"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Netzwerkverbindungen"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -274,639 +675,266 @@ msgstr ""
 "Zugriff für Aktualisierungen bietet."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Zurück"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "Ohne Netzwerk fortfahren"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "Änderungen werden übernommen"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr "nicht verbunden"
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "Zeitüberschreitung"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, fuzzy, python-brace-format
-msgid "unknown state {state}"
-msgstr "unbekannter Zustand {}"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "statisch"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr "deaktiviert"
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr "VLAN {id} auf der Schnittstelle {link}"
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "Eine Bootfestplatte auswählen"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Netzwerk-Interface {} WIFI-Konfiguration"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Ja"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Nein"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Ein Fehler ist aufgetreten"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Installation komplett!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Installation fertiggestellt!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Installation des Grundsystems"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Installation komplett!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Ein Fehler ist während der Installation aufgetreten"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr "1 (gespiegelt)"
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Name darf nicht leer sein"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} ist keine gültige Eingabe"
-
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Info"
-
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Umformatieren"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "Partition hinzufügen"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "Logisches Volumen erstellen"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Formatieren"
-
-#: ../subiquity/models/filesystem.py:424
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr "Aus RAID/LVM entfernen"
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Löschen"
-
-#: ../subiquity/models/filesystem.py:426
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr "Boot-Gerät erstellen"
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-"Kann {selflabel} nicht bearbeiten, da es Teil des {cdtype} {cdname} ist."
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "Andere"
+
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
+msgstr "Uneingebunden verlassen"
+
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-"Das Entfernen von {selflabel} würde das {cdtype} {cdlabel} mit weniger als "
-"{min_devices} Geräten belassen."
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-"Das Entfernen von {selflabel} würde das {cdtype} {cdlabel} ohne Geräte "
-"zurücklassen."
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "Kann {selflabel} nicht löschen, da es Teil des {cdtype} {cdname} ist."
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr "vorhanden"
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr "neu"
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr "{component_name} von {desc} {name}"
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr "bereits als {fstype} formatiert"
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr "umformatiert werden als {fstype}"
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr "formatiert werden als {fstype}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr "Nach {path} eingebunden"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr "nicht eingehängt"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr "unbenutzt"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr "verwendet"
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-"Kann {selflabel} nicht löschen, da die Partition {partnum} Teil des {cdtype} "
-"{cdname} ist."
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-"Kann {selflabel} nicht löschen, da es {count} eingebundene Partitionen hat."
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr "Kann {selflabel} nicht löschen, da es 1 eingebundene Partitionen hat."
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "lokaler Datenträger"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Proxy konfigurieren"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "Automatische Konfiguration fehlgeschlagen"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-#, fuzzy
-msgid "unused ESP"
-msgstr "unbenutzt"
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "logisches Volumen"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "Partition von {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "Partition {} von {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "Partition {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-"Eine einzelne Partition kann nicht von einem Gerät gelöscht werden, das "
-"bereits Partitionen hat."
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr "Kann benötigte Bootloader-Partition nicht löschen"
-
-#: ../subiquity/models/filesystem.py:1049
-#, fuzzy, python-brace-format
-msgid "software RAID {level}"
-msgstr "Software-RAID {}"
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr "Bereits vorhandene RAIDs können nicht bearbeitet werden."
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr "Kann {selflabel} nicht bearbeiten, da es Partitionen hat."
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-#, fuzzy
-msgid "LVM volume group"
-msgstr "LVM-Volumengruppe erstellen"
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr "Bereits vorhandene Datenträgergruppen können nicht bearbeitet werden."
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr "Kann {selflabel} nicht bearbeiten, da es logische Datenträger hat."
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "logisches Volumen"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-"Ein einzelnes logisches Volume aus einer Datenträgergruppe, die bereits "
-"logische Datenträger enthält, kann nicht gelöscht werden."
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "Die Zeichen: , und = sind in diesem Feld nicht erlaubt"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr "Die einzigen erlaubten Zeichen in diesem Feld sind a-z. 0-9, _ und -"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Ihr Name:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Name Ihres Servers:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-"Der Name, der bei der Kommunikation mit anderen Rechnern verwendet wird."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Bitte Benutzernamen auswählen:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Bitte Passwort auswählen:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Passwort bestätigen:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Realname zu lang, muss < sein "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Servername darf nicht leer sein"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Servername zu lang, muss < sein "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Der Hostname muss mit NAME_REGEX übereinstimmen, d.h. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Benutzername fehlt"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Benutzername zu lang, muss < sein "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Der Benutzername muss mit NAME_REGEX übereinstimmen, d.h. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-"Der Benutzername \"{username}\" ist für die Nutzung durch das System "
-"reserviert."
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Passwort muss festgelegt werden"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Passwörter stimmen nicht überein"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr "{desc} nicht identisch"
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Profileinrichtung"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
-"Geben Sie den Benutzernamen und das Passwort ein, mit dem Sie sich am System "
-"anmelden möchten. Sie können den SSH-Zugang auf dem nächsten Bildschirm "
-"konfigurieren, aber für sudo wird weiterhin ein Passwort benötigt."
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "Passwörter"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Fortfahren"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
+#, python-brace-format
 msgid "formatted as {fstype}"
-msgstr "formatiert werden als {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:132
+#, python-brace-format
 msgid ", mounted at {path}"
-msgstr "Nach {path} eingebunden"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ", nicht eingehängt"
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:136
+#, python-brace-format
 msgid "unused {device}"
-msgstr "ungenutzt {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
@@ -914,461 +942,235 @@ msgstr ""
 "Wenn Sie alle Festplatten in RAIDs oder LVM-VGs einlegen, gibt es keinen "
 "Platz, um die Boot-Partition einzurichten."
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr "/ ist nicht im Namen eines RAID-Gerätes erlaubt"
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr "Leerzeichen sind im Namen eines RAID-Gerätes nicht erlaubt."
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr "RAID-Level:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Geräte:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Größe:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, fuzzy, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr "Es gibt bereits ein RAID mit dem Namen '{}'"
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ". und .. sind keine gültigen Namen für RAID-Geräte"
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, fuzzy, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr "RAID-Level '{}' erfordert mindestens {} aktive Geräte"
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr "Erstelle Software-RAID (\"MD\")-Datenträger"
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, fuzzy, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr "Software-RAID-Laufwerk »{}« bearbeiten"
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr "Unformatiert lassen"
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, fuzzy, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr "Unformatiert lassen als {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, fuzzy, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr "Partitionsgröße auf {} begrenzt"
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, fuzzy, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr "Größe aufgerundet auf {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"Die einzigen Zeichen, die im Namen eines logischen Volumens erlaubt sind, "
-"sind a-z, A-Z, 0-9, +, _, . und -"
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, fuzzy, python-brace-format
-msgid "Size (max {size}):"
-msgstr "Größe (max {}):"
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Name: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "Format:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr "Mount:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr "Als Swap verwenden"
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr "Diese Swap-Partition im installierten System verwenden."
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr "Der Name eines logischen Volumens darf nicht leer sein"
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-"Der Name eines logischen Volumes darf nicht mit einem Bindestrich beginnen"
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, fuzzy, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr "Ein logisches Volumen darf nicht {} genannt werden"
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, fuzzy, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr "Der Name eines logischen Volumen darf nicht \"{}\" enthalten"
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, fuzzy, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr "Es existiert bereits ein logisches Volumen mit dem Namen {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Pfad übersteigt PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, fuzzy, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr "{} ist schon nach {} eingebunden."
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, fuzzy, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-"Das Einbinden eines vorhandenen Dateisystems unter {} ist in der Regel eine "
-"schlechte Idee, gehen Sie nur mit Vorsicht vor."
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Erforderliche Bootloader-Partition\n"
-"\n"
-"GRUB wird auf dem MBR des Ziellaufwerks installiert.\n"
-"\n"
-"Auf einer Festplatte mit einer GPT-Partitionstabelle ist jedoch nicht "
-"genügend Platz nach dem MBR vorhanden, damit GRUB seine zweite Stufe core."
-"img speichern kann, so dass eine kleine unformatierte Partition am Anfang "
-"der Festplatte benötigt wird. Es enthält kein Dateisystem und wird nicht "
-"eingebunden und kann hier nicht bearbeitet werden."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-"Erforderliche Bootloader-Partition\n"
-"\n"
-"Dies ist die von UEFI geforderte ESP / »EFI Systempartition«. Grub wird auf "
-"dieser Partition installiert, die als fat32 formatiert werden muss."
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-"Erforderliche Bootloader-Partition\n"
-"\n"
-"Dies ist die von UEFI geforderte ESP / »EFI Systempartition«. Grub wird auf "
-"dieser Partition installiert, die als fat32 formatiert werden muss."
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-#, fuzzy
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-" Der einzige Aspekt dieser Partition, der bearbeitet werden kann, ist die "
-"Größe."
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-#, fuzzy
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-" Sie können wählen, ob Sie das vorhandene Dateisystem auf dieser Partition "
-"verwenden oder neu formatieren möchten."
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-"Erforderliche Bootloader-Partition\n"
-"\n"
-"Dies ist der PReP-Teil, der für POWER erforderlich ist. Grub wird auf dieser "
-"Partition installiert."
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-"Erforderliche Bootloader-Partition\n"
-"\n"
-"Dies ist der PReP-Teil, der für POWER erforderlich ist. Grub wird auf dieser "
-"Partition installiert."
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "OK"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr "Existierendes FAT32-Dateisystem verwenden"
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr "Umformatierung als frisches FAT32-Dateisystem"
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "logisches Volumen {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "Partition {} von {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-"Das Formatieren und direkte Einbinden einer Festplatte ist ungewöhnlich. Sie "
-"möchten wahrscheinlich stattdessen eine Partition hinzufügen."
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formatieren und/oder Einhängen"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr "Möchten Sie wirklich das {desc} {label} löschen?"
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr "Es ist als {fstype} formatiert und wird bei {path} eingebunden"
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr "Es ist als {fstype} formatiert und nicht eingebunden"
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "logisches Volumen"
-msgstr[1] "logisches Volumen"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:70
+#, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
-msgstr[0] "Es beinhaltet {n} {things}:"
-msgstr[1] "Es beinhaltet {n} {things}:"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr "Es ist nicht formatiert oder eingebunden."
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:112
+#, python-brace-format
 msgid "Remove filesystem from {device}"
-msgstr "Entferne Dateisystem von {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:116
+#, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
-msgstr "Möchten Sie wirklich das bestehende Dateisystem aus {} entfernen?"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr "logische Volumen"
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "Partitionen"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr "Entferne alle {things} von {obj}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr "Möchten Sie wirklich alle {things} von {obj} entfernen?"
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr "Umformatieren"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"Die einzigen zulässigen Zeichen im Namen einer Datenträgergruppe sind a-z, A-"
-"Z, 0-9, +, _, . und -."
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
+#, python-brace-format
+msgid "existing {fstype}"
+msgstr "existierendes {fstype}"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "Passphrasen"
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
+#, python-brace-format
+msgid "new {fstype}"
+msgstr "neues {fstype}"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "Verschlüsselten Datenträger erstellen"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Keine Datenträger oder Partitionen eingebunden."
 
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr "Passphrase:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "EINHÄNGEPUNKT"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr "Passphrase bestätigen:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "GRÖSSE"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-"Wählen Sie mindestens ein Gerät aus, das Teil der Volume-Gruppe sein soll"
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TYP"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr "Der Name einer Volumengruppe darf nicht leer sein"
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "GERÄTETYP"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-"Der Name einer Datenträgergruppe darf nicht mit einem Bindestrich beginnen"
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Aushängen"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:113
-#, fuzzy, python-brace-format
-msgid "{name} is not a valid name for a volume group"
-msgstr "{} ist kein gültiger Name für eine Volumengruppe"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "Keine verfügbaren Geräte"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
-#, fuzzy, python-brace-format
-msgid "There is already a volume group named '{name}'"
-msgstr "Es existiert bereits eine Volumengruppe mit dem Namen '{}'"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr "Keine genutzten Geräte"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
-msgstr "Passphrase muss gesetzt werden"
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
+#, python-brace-format
+msgid "Remove from {device}"
+msgstr "Entferne von {device}"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr "Passphrasen stimmen nicht überein"
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr "Füge {ptype} Partition hinzu"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr "LVM-Volumengruppe erstellen"
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr "Benutze nicht mehr als Boot-Device"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
-#, fuzzy, python-brace-format
-msgid "Edit volume group \"{name}\""
-msgstr "Volumengruppe \"{}\" bearbeiten"
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr "Füge als weitere Boot-Device hinzu"
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr "Als Boot-Device benutzen"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "GERÄT"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "freier Speicherplatz"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr "Speicherplatzkonfiguration"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr "Software-RAID (md) erstellen"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr "Datenträgergruppe (LVM) anlegen"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "ZUSAMMENFASSUNG DES DATEISYSTEMS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "VERFÜGBARE GERÄTE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr "GENUTZTE GERÄTE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr "Ein Dateisystem nach / einbinden"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr "Eine Bootfestplatte auswählen"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr "Um fortzufahren, müssen Sie:"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr "Passphrase:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr "Passphrase bestätigen:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Passwort muss festgelegt werden"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Passwörter stimmen nicht überein"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr "Die LVM-Gruppe mit LUKS verschlüsseln"
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr "Diese Festplatte als LVM-Gruppe konfigurieren"
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr "Eine ganze Festplatte verwenden"
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
-msgstr ""
+msgstr "Benutzerdefinierte Partitionierung"
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1402,7 +1204,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1410,138 +1212,300 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr "Begleitete Speicherplatzkonfiguration"
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "OK"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr "Hilfe bei der geführten Speicherplatzkonfiguration"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
-#, fuzzy, python-brace-format
-msgid "existing {fstype}"
-msgstr "vorhanden"
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+"Die einzigen zulässigen Zeichen im Namen einer Datenträgergruppe sind a-z, A-"
+"Z, 0-9, +, _, . und -."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Geräte:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Größe:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Verschlüsselten Datenträger erstellen"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+"Wählen Sie mindestens ein Gerät aus, das Teil der Volume-Gruppe sein soll"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr "Der Name einer Volumengruppe darf nicht leer sein"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+"Der Name einer Datenträgergruppe darf nicht mit einem Bindestrich beginnen"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "new {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Keine Datenträger oder Partitionen eingebunden."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "EINHÄNGEPUNKT"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "GRÖSSE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TYP"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "GERÄTETYP"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "Aushängen"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr "Keine verfügbaren Geräte"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr "Keine genutzten Geräte"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
-#, fuzzy, python-brace-format
-msgid "Remove from {device}"
-msgstr "Aus {} entfernen"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "Partition hinzufügen"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/lvm.py:119
+#, python-brace-format
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-#, fuzzy
-msgid "Add As Another Boot Device"
-msgstr "Boot-Gerät erstellen"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
+msgstr "Passphrase muss gesetzt werden"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-#, fuzzy
-msgid "Use As Boot Device"
-msgstr "Boot-Gerät erstellen"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
+msgstr "Passphrasen stimmen nicht überein"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "GERÄT"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
+msgstr "LVM-Volumengruppe erstellen"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "freier Speicherplatz"
+#: ../subiquity/ui/views/filesystem/lvm.py:157
+#, python-brace-format
+msgid "Edit volume group \"{name}\""
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
-msgstr "Speicherplatzkonfiguration"
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr "Unformatiert lassen"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
-msgstr "Software-RAID (md) erstellen"
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
+msgstr "Als {fstype} formatiert lassen"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
-msgstr "Datenträgergruppe (LVM) anlegen"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "ZUSAMMENFASSUNG DES DATEISYSTEMS"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
+msgstr "Größe auf {size} aufgerundet"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "VERFÜGBARE GERÄTE"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
+msgstr ""
+"Die einzigen Zeichen, die im Namen eines logischen Volumens erlaubt sind, "
+"sind a-z, A-Z, 0-9, +, _, . und -"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
-msgstr "GENUTZTE GERÄTE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
+msgstr "Größe (max. {size}):"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
-msgstr "Ein Dateisystem nach / einbinden"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Name: "
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
-msgstr "Eine Bootfestplatte auswählen"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Format:"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "Ohne Netzwerk fortfahren"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
+msgstr "Mount:"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Zurücksetzen"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr "Als Swap verwenden"
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
+msgstr "Diese Swap-Partition im installierten System verwenden."
+
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr "Der Name eines logischen Volumens darf nicht leer sein"
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr ""
+"Der Name eines logischen Volumes darf nicht mit einem Bindestrich beginnen"
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Pfad übersteigt PATH_MAX"
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr "{device} ist bereits nach {path} eingebunden."
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+"Sie können wählen, ob ein bestehendes Dateisystem auf dieser\n"
+"Partition genutzt werden soll oder sie neu formatieren.\n"
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr "Existierendes FAT32-Dateisystem verwenden"
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr "Umformatierung als frisches FAT32-Dateisystem"
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr "Hinzufügen eines logischen Volumens zu {vgname}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr "Bearbeite Partition {number} von {device}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+"Das Formatieren und direkte Einbinden einer Festplatte ist ungewöhnlich. Sie "
+"möchten wahrscheinlich stattdessen eine Partition hinzufügen."
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1569,114 +1533,45 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr "Suche nach Geräten zur Installation fehlgeschlagen"
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
-msgstr "Fehlerbericht anzeigen"
+msgstr "Zeige Fehlerbericht"
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
-msgstr "Prüfe auf Installer-Aktualisierung"
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
+msgstr "/ ist nicht im Namen eines RAID-Gerätes erlaubt"
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
-msgstr ""
-"Sie können den Snap Store verwenden, um zu überprüfen, ob eine neue Version "
-"des Installationsprogramms verfügbar ist."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
+msgstr "Leerzeichen sind im Namen eines RAID-Gerätes nicht erlaubt."
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr "Kontaktieren des snap-Stores fehlgeschlagen"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "RAID-Level:"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr "Kontaktieren des snap-Stores fehlgeschlagen:"
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "Installer-Aktualisierung verfügbar"
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
-msgstr ""
-"Version {new} des Installers ist jetzt verfügbar ({current} läuft aktuell)."
-
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "Lade Aktualisierung herunter …"
-
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
-msgstr ""
-"Bitte warten Sie während der aktualisierte Installer heruntergeladen wird. "
-"Der Installer wird automatisch neugestartet, wenn das Herunterladen "
-"abgeschlossen ist."
-
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
-msgstr "Aktualisierung fehlgeschlagen"
-
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr "Lade die Aktualisierung herunter und wende sie an:"
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "Ohne Aktualisierung fortfahren"
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Erneut versuchen"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
+msgstr ". und .. sind keine gültigen Namen für RAID-Geräte"
+
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
-"Wenn Sie sich für eine Aktualisierung entscheiden, wird dies heruntergeladen "
-"und die Installation wird von hier aus fortgesetzt."
+"RAID-Level {level} verlangt mindestens {min_active} aktive Festplatten"
 
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr "Aktualisieren auf neuen Installer"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
+msgstr "Erstelle Software-RAID (\"MD\")-Datenträger"
 
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "Aktualisierung abbrechen"
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-"Sie können einen Archivspiegel angeben, der anstelle des Standardwertes "
-"verwendet wird."
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr "Mirror-Adresse:"
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr "Konfiguriere Ubuntu-Archiv-Mirror"
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
-msgstr ""
-"Wenn Sie einen alternativen Spiegelserver für Ubuntu verwenden, geben Sie "
-"dessen Details hier an."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
+msgstr "Software-RAID \"{name}\" bearbeiten"
 
 #: ../subiquity/ui/views/help.py:70
 #, python-brace-format
@@ -1732,407 +1627,357 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
-#, fuzzy
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
-msgstr "Fehlerbericht anzeigen"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
-#, fuzzy
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
-msgstr "Fehlerbericht anzeigen"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Strg+Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr "Aktualisieren auf neuen Installer"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "Die Zeichen: , und = sind in diesem Feld nicht erlaubt"
+
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
+msgstr "Die einzigen erlaubten Zeichen in diesem Feld sind a-z. 0-9, _ und -"
+
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Ihr Name:"
+
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Name Ihres Servers:"
+
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
-"\n"
-"Wählen Sie die Sprache, die für das Installationsprogramm verwendet und im "
-"installierten \n"
-"System konfiguriert werden soll.\n"
+"Der Name, der bei der Kommunikation mit anderen Rechnern verwendet wird."
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Nutzen sie HOCH, RUNTER und ENTER um Ihre Sprache festzulegen."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Bitte Benutzernamen auswählen:"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr "Hilfe bei der Auswahl einer Sprache"
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Bitte Passwort auswählen:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Importiere Benutzername:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Passwort bestätigen:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "GitHub-Benutzername:"
-
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "GitHub-Benutzername:"
-
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-"Ein GitHub-Benutzername darf nur alphanumerische Zeichen oder einzelne "
-"Bindestriche enthalten und nicht mit einem Bindestrich beginnen oder enden."
-
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Launchpad-Benutzername:"
-
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"Ein GitHub-Benutzername darf nur alphanumerische Zeichen oder einzelne "
-"Bindestriche enthalten und nicht mit einem Bindestrich beginnen oder enden."
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr "OpenSSH-Server installieren"
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "SSH-Identität importieren:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "aus GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "aus Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Sie können Ihre SSH-Schlüssel aus GitHub oder Launchpad importieren."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr "Kennwortauthentifizierung über SSH erlauben"
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Das Feld darf nicht leer sein."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "SSH-ID ist zu lang, muss <  sein "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-"Ein Launchpad-Benutzername muss mit einem Buchstaben oder einer Zahl "
-"beginnen. Alle Zeichen müssen kleingeschrieben sein. Die Zeichen +, - und . "
-"sind nach dem ersten Zeichen auch erlaubt"
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"Ein GitHub-Benutzername darf nur alphanumerische Zeichen oder einzelne "
-"Bindestriche enthalten und nicht mit einem Bindestrich beginnen oder enden."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr "Hole SSH-Schlüssel..."
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr "Bestätige SSH-Schlüssel"
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-"Schlüssel mit den folgenden Fingerabdrücken wurden geholt. Möchten Sie sie "
-"benutzen?"
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr "Bestätige SSH-Schlüssel"
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-"Ein Schlüssel mit dem folgenden Fingerabdruck wurde geholt. Möchten Sie ihn "
-"benutzen?"
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr "SSH-Einrichtung"
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-"Sie können auswählen das OpenSSH-Server-Paket zu installieren um sicheren "
-"Fernzugriff auf Ihren Server zu aktivieren."
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "gerade jetzt"
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr "Minute"
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr "Minuten"
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr "Stunde"
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr "Stunden"
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr "Tag"
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr "Tage"
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
-msgstr "vor {amount:2} {unit}"
-
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Servername darf nicht leer sein"
+
+#: ../subiquity/ui/views/identity.py:109
+#, python-brace-format
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Benutzername fehlt"
+
+#: ../subiquity/ui/views/identity.py:123
+#, python-brace-format
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
+"Der Benutzername \"{username}\" ist für die Nutzung durch das System "
+"reserviert."
 
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr "{desc} nicht identisch"
 
-#: ../subiquity/ui/views/snaplist.py:256
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap}"
-msgstr "Hole Info für {}"
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Profileinrichtung"
 
-#: ../subiquity/ui/views/snaplist.py:282
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap} failed"
-msgstr "Abrufen von Informationen für {} fehlgeschlagen"
-
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
-msgstr "Unterstützte Server-Snaps"
-
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Fortfahren"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
-msgstr "Lade Server-Snaps aus dem Store, bitte warten..."
-
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr "Entschuldigung, das Laden der Snaps aus dem Store ist fehlgeschlagen."
-
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
-"Dies sind beliebte Snaps in Serverumgebungen. Aktivieren oder deaktivieren "
-"Sie die Auswahl mit SPACE, drücken Sie ENTER, um weitere Details zu Paket, "
-"Herausgeber und verfügbaren Versionen anzuzeigen."
+"Geben Sie den Benutzernamen und das Passwort ein, mit dem Sie sich am System "
+"anmelden möchten. Sie können den SSH-Zugang auf dem nächsten Bildschirm "
+"konfigurieren, aber für sudo wird weiterhin ein Passwort benötigt."
 
-#: ../subiquity/ui/views/keyboard.py:64
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "Passwörter"
+
+#: ../subiquity/ui/views/installprogress.py:52
+msgid "Install progress"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
+msgid "Reboot Now"
+msgstr "Jetzt neustarten"
+
+#: ../subiquity/ui/views/installprogress.py:61
+msgid "View error report"
+msgstr "Fehlerbericht anzeigen"
+
+#: ../subiquity/ui/views/installprogress.py:63
+msgid "View full log"
+msgstr "Vollständigen Log anzeigen"
+
+#: ../subiquity/ui/views/installprogress.py:79
+msgid "Full installer output"
+msgstr "Vollständige Installer-Ausgabe"
+
+#: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Installation des Grundsystems"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Installation komplett!"
+
+#: ../subiquity/ui/views/installprogress.py:159
+msgid "Cancel update and reboot"
+msgstr "Aktualisierung abbrechen und neustarten"
+
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
+msgid "Rebooting..."
+msgstr "Neustarten …"
+
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Ein Fehler ist während der Installation aufgetreten"
+
+#: ../subiquity/ui/views/installprogress.py:230
+msgid ""
+"Selecting Continue below will begin the installation process and\n"
+"result in the loss of data on the disks selected to be formatted.\n"
+"\n"
+"You will not be able to return to this or a previous screen once\n"
+"the installation has started.\n"
+"\n"
+"Are you sure you want to continue?"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:251
+msgid "Confirm destructive action"
+msgstr "Bestätigen Sie destruktive Aktionen"
+
+#: ../subiquity/ui/views/installprogress.py:271
+#, python-brace-format
+msgid ""
+"The installer running on {tty} is currently installing the system.\n"
+"\n"
+"You can wait for this to complete or switch to a shell.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:67
 msgid "Keyboard auto-detection"
 msgstr "Tastatur-Autoerkennung"
 
-#: ../subiquity/ui/views/keyboard.py:90
+#: ../subiquity/ui/views/keyboard.py:93
 msgid ""
 "Keyboard detection starting. You will be asked a series of questions about "
 "your keyboard. Press escape at any time to go back to the previous screen."
@@ -2141,11 +1986,7 @@ msgstr ""
 "Tastatur gestellt. Drücken Sie Escape, um jederzeit zum vorherigen "
 "Bildschirm zurückzukehren."
 
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Tastatur-Autoerkennung fehlgeschlagen, Entschuldigung"
-
-#: ../subiquity/ui/views/keyboard.py:116
+#: ../subiquity/ui/views/keyboard.py:106
 msgid ""
 "Keyboard auto detection completed.\n"
 "\n"
@@ -2155,7 +1996,7 @@ msgstr ""
 "\n"
 "Ihre Tastatur wurde erkannt als:\n"
 
-#: ../subiquity/ui/views/keyboard.py:121
+#: ../subiquity/ui/views/keyboard.py:111
 msgid ""
 "\n"
 "If this is correct, select Done on the next screen. If not you can select "
@@ -2168,38 +2009,34 @@ msgstr ""
 "automatische Erkennung erneut ausführen.\n"
 "\n"
 
-#: ../subiquity/ui/views/keyboard.py:135
+#: ../subiquity/ui/views/keyboard.py:128
 msgid "Layout"
 msgstr "Tastaturbelegung"
 
-#: ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:129
 msgid "Variant"
 msgstr "Variante"
 
-#: ../subiquity/ui/views/keyboard.py:161
+#: ../subiquity/ui/views/keyboard.py:152
 msgid "Please press one of the following keys:"
 msgstr "Bitte drücken Sie eine der folgenden Tasten:"
 
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
 msgid "Input was not recognized, try again"
 msgstr "Eingabe wurde nicht erkannt, versuchen Sie es erneut"
 
-#: ../subiquity/ui/views/keyboard.py:222
+#: ../subiquity/ui/views/keyboard.py:213
 msgid "Is the following key present on your keyboard?"
 msgstr "Ist die folgende Taste auf Ihrer Tastatur vorhanden?"
 
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Übernehme Konfiguration"
-
-#: ../subiquity/ui/views/keyboard.py:303
+#: ../subiquity/ui/views/keyboard.py:277
 msgid ""
 "You will need a way to toggle the keyboard between the national layout and "
 "the standard Latin layout.\n"
 "\n"
 "Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
 "behavior in Emacs and other programs that use it for specific needs.\n"
 "\n"
 "Not all listed keys are present on all keyboards. "
@@ -2215,95 +2052,95 @@ msgstr ""
 "\n"
 "Nicht alle aufgeführten Tasten sind auf allen Tastaturen vorhanden. "
 
-#: ../subiquity/ui/views/keyboard.py:316
+#: ../subiquity/ui/views/keyboard.py:290
 msgid "Caps Lock"
 msgstr "Feststelltaste"
 
-#: ../subiquity/ui/views/keyboard.py:317
+#: ../subiquity/ui/views/keyboard.py:291
 msgid "Right Alt (AltGr)"
 msgstr "Alt rechts (AltGr)"
 
-#: ../subiquity/ui/views/keyboard.py:318
+#: ../subiquity/ui/views/keyboard.py:292
 msgid "Right Control"
 msgstr "Strg rechts"
 
-#: ../subiquity/ui/views/keyboard.py:319
+#: ../subiquity/ui/views/keyboard.py:293
 msgid "Right Shift"
 msgstr "Umschalttaste rechts"
 
-#: ../subiquity/ui/views/keyboard.py:320
+#: ../subiquity/ui/views/keyboard.py:294
 msgid "Right Logo key"
 msgstr "Windows-Taste rechts"
 
-#: ../subiquity/ui/views/keyboard.py:321
+#: ../subiquity/ui/views/keyboard.py:295
 msgid "Menu key"
 msgstr "Menütaste"
 
-#: ../subiquity/ui/views/keyboard.py:322
+#: ../subiquity/ui/views/keyboard.py:296
 msgid "Alt+Shift"
 msgstr "Alt+Umschalttaste"
 
-#: ../subiquity/ui/views/keyboard.py:323
+#: ../subiquity/ui/views/keyboard.py:297
 msgid "Control+Shift"
 msgstr "Strg+Umschalttaste"
 
-#: ../subiquity/ui/views/keyboard.py:324
+#: ../subiquity/ui/views/keyboard.py:298
 msgid "Control+Alt"
 msgstr "Strg+Alt"
 
-#: ../subiquity/ui/views/keyboard.py:325
+#: ../subiquity/ui/views/keyboard.py:299
 msgid "Alt+Caps Lock"
 msgstr "Alt+Feststelltaste"
 
-#: ../subiquity/ui/views/keyboard.py:326
+#: ../subiquity/ui/views/keyboard.py:300
 msgid "Left Control+Left Shift"
 msgstr "Strg-Links+Umschalttaste-Links"
 
-#: ../subiquity/ui/views/keyboard.py:327
+#: ../subiquity/ui/views/keyboard.py:301
 msgid "Left Alt"
 msgstr "Alt-links"
 
-#: ../subiquity/ui/views/keyboard.py:328
+#: ../subiquity/ui/views/keyboard.py:302
 msgid "Left Control"
 msgstr "Strg-links"
 
-#: ../subiquity/ui/views/keyboard.py:329
+#: ../subiquity/ui/views/keyboard.py:303
 msgid "Left Shift"
 msgstr "Umschalt links"
 
-#: ../subiquity/ui/views/keyboard.py:330
+#: ../subiquity/ui/views/keyboard.py:304
 msgid "Left Logo key"
 msgstr "Symboltaste links"
 
-#: ../subiquity/ui/views/keyboard.py:331
+#: ../subiquity/ui/views/keyboard.py:305
 msgid "Scroll Lock key"
 msgstr "Rollen-Taste"
 
-#: ../subiquity/ui/views/keyboard.py:332
+#: ../subiquity/ui/views/keyboard.py:306
 msgid "No toggling"
 msgstr "Keine Umschaltung"
 
-#: ../subiquity/ui/views/keyboard.py:353
+#: ../subiquity/ui/views/keyboard.py:327
 msgid "Shortcut: "
 msgstr "Tastenkombination: "
 
-#: ../subiquity/ui/views/keyboard.py:363
+#: ../subiquity/ui/views/keyboard.py:337
 msgid "Select layout toggle"
 msgstr "Layoutumschaltung auswählen"
 
-#: ../subiquity/ui/views/keyboard.py:381
+#: ../subiquity/ui/views/keyboard.py:355
 msgid "Layout:"
 msgstr "Belegung:"
 
-#: ../subiquity/ui/views/keyboard.py:382
+#: ../subiquity/ui/views/keyboard.py:356
 msgid "Variant:"
 msgstr "Variante:"
 
-#: ../subiquity/ui/views/keyboard.py:387
+#: ../subiquity/ui/views/keyboard.py:361
 msgid "Keyboard configuration"
 msgstr "Tastatur-Konfiguration"
 
-#: ../subiquity/ui/views/keyboard.py:417
+#: ../subiquity/ui/views/keyboard.py:382
 msgid ""
 "Please select the layout of the keyboard directly attached to the system, if "
 "any."
@@ -2311,7 +2148,7 @@ msgstr ""
 "Bitte wählen Sie das Layout, der an das System angeschlossenen Tastatur aus, "
 "falls vorhanden."
 
-#: ../subiquity/ui/views/keyboard.py:420
+#: ../subiquity/ui/views/keyboard.py:385
 msgid ""
 "Please select your keyboard layout below, or select \"Identify keyboard\" to "
 "detect your layout automatically."
@@ -2319,83 +2156,48 @@ msgstr ""
 "Bitte wählen Sie unten Ihr Tastaturlayout aus oder wählen Sie »Tastatur "
 "identifizieren«, um Ihr Layout automatisch zu erkennen."
 
-#: ../subiquity/ui/views/keyboard.py:429
+#: ../subiquity/ui/views/keyboard.py:394
 msgid "Identify keyboard"
 msgstr "Tastatur erkennen"
 
-#: ../subiquity/ui/views/installprogress.py:50
-msgid "Install progress"
-msgstr ""
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Übernehme Konfiguration"
 
-#: ../subiquity/ui/views/installprogress.py:57
-msgid "Reboot Now"
-msgstr "Jetzt neustarten"
-
-#: ../subiquity/ui/views/installprogress.py:59
-msgid "View error report"
-msgstr "Fehlerbericht anzeigen"
-
-#: ../subiquity/ui/views/installprogress.py:61
-msgid "View full log"
-msgstr "Vollständigen Log anzeigen"
-
-#: ../subiquity/ui/views/installprogress.py:77
-msgid "Full installer output"
-msgstr "Vollständige Installer-Ausgabe"
-
-#: ../subiquity/ui/views/installprogress.py:142
-msgid "Cancel update and reboot"
-msgstr "Aktualisierung abbrechen und neustarten"
-
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Neustart"
-
-#: ../subiquity/ui/views/installprogress.py:179
-msgid "Rebooting..."
-msgstr "Neustarten …"
-
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/mirror.py:32
 msgid ""
-"Selecting Continue below will begin the installation process and\n"
-"result in the loss of data on the disks selected to be formatted.\n"
-"\n"
-"You will not be able to return to this or a previous screen once\n"
-"the installation has started.\n"
-"\n"
-"Are you sure you want to continue?"
+"You may provide an archive mirror that will be used instead of the default."
 msgstr ""
+"Sie können einen Archivspiegel angeben, der anstelle des Standardwertes "
+"verwendet wird."
 
-#: ../subiquity/ui/views/installprogress.py:217
-msgid "Confirm destructive action"
-msgstr "Bestätigen Sie destruktive Aktionen"
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "Mirror-Adresse:"
 
-#: ../subiquity/ui/views/installprogress.py:235
-#, python-brace-format
-msgid ""
-"The installer running on {tty} is currently installing the system.\n"
-"\n"
-"You can wait for this to complete or switch to a shell.\n"
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr "Konfiguriere Ubuntu-Archiv-Mirror"
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
-msgstr ""
+"Wenn Sie einen alternativen Spiegelserver für Ubuntu verwenden, geben Sie "
+"dessen Details hier an."
 
 #: ../subiquity/ui/views/proxy.py:33
 msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "Wenn Sie einen HTTP-Proxy verwenden müssen, um die Außenwelt zu erreichen, "
 "geben Sie die Proxy-Informationen hier an. Ansonsten lassen Sie dies leer.\n"
 "\n"
-"Die Proxy-Informationen sollten in der Standardform von \"http://[[Benutzer]"
-"[:Kennwort]@]Host[:Port]/\" angegeben werden."
+"Die Proxy-Informationen sollten in der Standardform von "
+"\"http://[[Benutzer][:Kennwort]@]Host[:Port]/\" angegeben werden."
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
@@ -2413,208 +2215,359 @@ msgstr ""
 "Wenn dieses System einen Proxy erfordert, um mit dem Internet verbunden zu "
 "werden, geben Sie seine Details hier an."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr "Prüfe auf Installer-Aktualisierung"
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+"Sie können den Snap Store verwenden, um zu überprüfen, ob eine neue Version "
+"des Installationsprogramms verfügbar ist."
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr "Kontaktieren des snap-Stores fehlgeschlagen"
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr "Kontaktieren des snap-Stores fehlgeschlagen:"
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Installer-Aktualisierung verfügbar"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+"Version {new} des Installers ist jetzt verfügbar ({current} läuft aktuell)."
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Lade Aktualisierung herunter …"
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+"Bitte warten Sie während der aktualisierte Installer heruntergeladen wird. "
+"Der Installer wird automatisch neugestartet, wenn das Herunterladen "
+"abgeschlossen ist."
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr "Aktualisierung fehlgeschlagen"
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr "Lade die Aktualisierung herunter und wende sie an:"
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Ohne Aktualisierung fortfahren"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Erneut versuchen"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr "Sie können die Versionsinformationen für jede Version lesen unter:"
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+"Wenn Sie sich für eine Aktualisierung entscheiden, wird dies heruntergeladen "
+"und die Installation wird von hier aus fortgesetzt."
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr "Aktualisieren auf neuen Installer"
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Aktualisierung abbrechen"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "gerade jetzt"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "Minute"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "Minuten"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "Stunde"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "Stunden"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "Tag"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "Tage"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr "vor {amount:2} {unit}"
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr "Unterstützte Server-Snaps"
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr "Lade Server-Snaps aus dem Store, bitte warten..."
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+"Entschuldigung, das Laden der Snaps aus dem Store ist fehlgeschlagen."
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+"Dies sind beliebte Snaps in Serverumgebungen. Aktivieren oder deaktivieren "
+"Sie die Auswahl mit SPACE, drücken Sie ENTER, um weitere Details zu Paket, "
+"Herausgeber und verfügbaren Versionen anzuzeigen."
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Importiere Benutzername:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Github-Benutzername:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Launchpad-Benutzername:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr "OpenSSH-Server installieren"
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "SSH-Identität importieren:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "aus Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "aus Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Sie können Ihre SSH-Schlüssel aus Github oder Launchpad importieren."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr "Kennwortauthentifizierung über SSH erlauben"
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Das Feld darf nicht leer sein."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "SSH-ID ist zu lang, muss <  sein "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+"Ein Launchpad-Benutzername muss mit einem Buchstaben oder einer Zahl "
+"beginnen. Alle Zeichen müssen kleingeschrieben sein. Die Zeichen +, - und . "
+"sind nach dem ersten Zeichen auch erlaubt"
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"Ein Github-Benutzername darf nur alphanumerische Zeichen oder einzelne "
+"Bindestriche enthalten und nicht mit einem Bindestrich beginnen oder enden."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr "Hole SSH-Schlüssel..."
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "Bestätige SSH-Schlüssel"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+"Schlüssel mit den folgenden Fingerabdrücken wurden geholt. Möchten Sie sie "
+"benutzen?"
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "Bestätige SSH-Schlüssel"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+"Ein Schlüssel mit dem folgenden Fingerabdruck wurde geholt. Möchten Sie ihn "
+"benutzen?"
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "SSH-Einrichtung"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+"Sie können auswählen das OpenSSH-Server-Paket zu installieren um sicheren "
+"Fernzugriff auf Ihren Server zu aktivieren."
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
-
-#: ../subiquity/ui/views/error.py:72
-msgid ""
 "\n"
-"Sorry, there was a problem completing the installation.\n"
+"Wählen Sie die Sprache, die für das Installationsprogramm verwendet und im "
+"installierten \n"
+"System konfiguriert werden soll.\n"
+
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Nutzen sie HOCH, RUNTER und ENTER um Ihre Sprache festzulegen."
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
+msgstr "Hilfe bei der Auswahl einer Sprache"
+
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr "Andere"
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr "Uneingebunden verlassen"
-
-#~ msgid "formatted as {}"
-#~ msgstr "formatiert als {}"
-
-#~ msgid ", mounted at {}"
-#~ msgstr ", nach {} eingehängt"
-
-#~ msgid "Adding {} to {}"
-#~ msgstr "Füge {} zu {} hinzu"
-
-#~ msgid "Editing {} of {}"
-#~ msgstr "Editiere {} von {}"
-
-#~ msgid "partition"
-#~ msgstr "Partition"
 
 #~ msgid "Filesystem setup"
 #~ msgstr "Dateisystem einrichten"
@@ -2628,6 +2581,12 @@ msgstr "Uneingebunden verlassen"
 #~ msgid "Choose the installation target"
 #~ msgstr "Wähle Installationsziel"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formatieren und/oder Einhängen"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Ein Fehler ist aufgetreten"
+
 #~ msgid "Install complete"
 #~ msgstr "Installation abgeschlossen"
 
@@ -2640,11 +2599,45 @@ msgstr "Uneingebunden verlassen"
 #~ msgid "starting..."
 #~ msgstr "Starten..."
 
+#~ msgid "Edit IPv6"
+#~ msgstr "Bearbeite IPv6"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Bearbeite IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Bearbeite Wifi"
+
+#~ msgid "Info"
+#~ msgstr "Info"
+
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Bitte melden Sie diesen Fehler in Launchpad"
 
 #~ msgid "Please choose your preferred language."
 #~ msgstr "Bitte wählen Sie Ihre bevorzugte Sprache."
+
+#~ msgid "There is already a RAID named '{}'"
+#~ msgstr "Es gibt bereits ein RAID mit dem Namen '{}'"
+
+#~ msgid "RAID Level \"{}\" requires at least {} active devices"
+#~ msgstr "RAID-Level '{}' erfordert mindestens {} aktive Geräte"
+
+#~ msgid "Reboot"
+#~ msgstr "Neustart"
+
+#~ msgid "Finished install!"
+#~ msgstr "Installation fertiggestellt!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Installation komplett!"
+
+#~ msgid "Info for {}"
+#~ msgstr "Info für {}"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s existiert bereits"
 
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr ""
@@ -2653,6 +2646,39 @@ msgstr "Uneingebunden verlassen"
 
 #~ msgid "-"
 #~ msgstr "-"
+
+#~ msgid "Edit"
+#~ msgstr "Bearbeiten"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Aus RAID/LVM entfernen"
+
+#~ msgid "Format"
+#~ msgstr "Formatieren"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Logisches Volumen erstellen"
+
+#~ msgid "Add Partition"
+#~ msgstr "Partition hinzufügen"
+
+#~ msgid "software RAID {}"
+#~ msgstr "Software-RAID {}"
+
+#~ msgid "logical volume"
+#~ msgstr "logisches Volumen"
+
+#~ msgid ", mounted at {}"
+#~ msgstr ", nach {} eingehängt"
+
+#~ msgid "formatted as {}"
+#~ msgstr "formatiert als {}"
+
+#~ msgid "partition"
+#~ msgstr "Partition"
+
+#~ msgid "Remove from {}"
+#~ msgstr "Aus {} entfernen"
 
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Einen gesamten Datenträger nutzen"
@@ -2663,19 +2689,169 @@ msgstr "Uneingebunden verlassen"
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Wählen Sie den Datenträger, auf den installiert werden soll:"
 
+#~ msgid "{} is not a valid name for a volume group"
+#~ msgstr "{} ist kein gültiger Name für eine Volumengruppe"
+
+#~ msgid "There is already a volume group named '{}'"
+#~ msgstr "Es existiert bereits eine Volumengruppe mit dem Namen '{}'"
+
+#~ msgid "Edit volume group \"{}\""
+#~ msgstr "Volumengruppe \"{}\" bearbeiten"
+
+#~ msgid "There is already a logical volume named {}."
+#~ msgstr "Es existiert bereits ein logisches Volumen mit dem Namen {}."
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "Der Name eines logischen Volumen darf nicht \"{}\" enthalten"
+
+#~ msgid "A logical volume may not be called {}"
+#~ msgstr "Ein logisches Volumen darf nicht {} genannt werden"
+
+#~ msgid "Adding {} to {}"
+#~ msgstr "Füge {} zu {} hinzu"
+
+#~ msgid "logical volume {}"
+#~ msgstr "logisches Volumen {}"
+
+#~ msgid "{} is already mounted at {}."
+#~ msgstr "{} ist schon nach {} eingebunden."
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "Servername zu lang, muss < sein "
+
+#~ msgid "There is already a network device named \"{}\""
+#~ msgstr "Es existiert bereits ein Netzwerk mit dem Namen \"{}\""
+
 #~ msgid "You need to mount a device at / to continue."
 #~ msgstr "Sie müssen ein Gerät nach / einbinden um fortzufahren."
 
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr ">>%s<< ist nicht in >>%s<< enthalten"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Dieses Feld muss eine %s URL sein."
+
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Netzwerk-Interface {} WIFI-Konfiguration"
+
+#~ msgid "unknown state {}"
+#~ msgstr "unbekannter Zustand {}"
+
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} ist keine gültige Eingabe"
+
+#~ msgid "partition of {}"
+#~ msgstr "Partition von {}"
+
+#~ msgid "partition {} of {}"
+#~ msgstr "Partition {} von {}"
+
+#~ msgid "partition {}"
+#~ msgstr "Partition {}"
+
+#~ msgid "unused {}"
+#~ msgstr "ungenutzt {}"
 
 #~ msgid "Select Done to begin the installation."
 #~ msgstr "Wählen Sie ERLEDIGT zum Starten der Installation."
 
+#~ msgid "Passphrases"
+#~ msgstr "Passphrasen"
+
+#~ msgid "Rounded size up to {}"
+#~ msgstr "Größe aufgerundet auf {}"
+
+#~ msgid "Size (max {}):"
+#~ msgstr "Größe (max {}):"
+
+#~ msgid "Editing {} of {}"
+#~ msgstr "Editiere {} von {}"
+
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Realname zu lang, muss < sein "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "Benutzername zu lang, muss < sein "
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Tastatur-Autoerkennung fehlgeschlagen, Entschuldigung"
+
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr ""
-#~ "Nutzen Sie die Tasten HOCH, RUNTER und ENTER, um Ihre Tastatur "
-#~ "auszuwählen."
+#~ "Nutzen Sie die Tasten HOCH, RUNTER und ENTER, um Ihre Tastatur auszuwählen."
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "Hole Info für {}"
+
+#~ msgid "Capped partition size at {}"
+#~ msgstr "Partitionsgröße auf {} begrenzt"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "Boot-Gerät erstellen"
+
+#~ msgid "Leave formatted as {}"
+#~ msgstr "Unformatiert lassen als {}"
+
+#~ msgid " The only aspect of this partition that can be edited is the size."
+#~ msgstr ""
+#~ " Der einzige Aspekt dieser Partition, der bearbeitet werden kann, ist die "
+#~ "Größe."
+
+#~ msgid ""
+#~ " You can choose whether to use the existing filesystem on this partition or "
+#~ "reformat it."
+#~ msgstr ""
+#~ " Sie können wählen, ob Sie das vorhandene Dateisystem auf dieser Partition "
+#~ "verwenden oder neu formatieren möchten."
+
+#~ msgid "should be in CIDR form ({})"
+#~ msgstr "sollte in CIDR-Form vorliegen ({})"
+
+#, python-brace-format
+#~ msgid ""
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+#~ msgstr ""
+#~ "Kann {selflabel} nicht löschen, da die Partition {partnum} Teil des {cdtype} "
+#~ "{cdname} ist."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
+#~ msgstr ""
+#~ "Kann {selflabel} nicht löschen, da es {count} eingebundene Partitionen hat."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has 1 mounted partition."
+#~ msgstr ""
+#~ "Kann {selflabel} nicht löschen, da es 1 eingebundene Partitionen hat."
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has partitions."
+#~ msgstr "Kann {selflabel} nicht bearbeiten, da es Partitionen hat."
+
+#, python-brace-format
+#~ msgid "It contains {n} {things}:"
+#~ msgstr "Es beinhaltet {n} {things}:"
+
+#~ msgid "Remove filesystem from {}"
+#~ msgstr "Entferne Dateisystem von {}"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has logical volumes."
+#~ msgstr "Kann {selflabel} nicht bearbeiten, da es logische Datenträger hat."
+
+#~ msgid ""
+#~ "Mounting an existing filesystem at {} is usually a bad idea, proceed only "
+#~ "with caution."
+#~ msgstr ""
+#~ "Das Einbinden eines vorhandenen Dateisystems unter {} ist in der Regel eine "
+#~ "schlechte Idee, gehen Sie nur mit Vorsicht vor."
 
 #~ msgid ""
 #~ "The selected guided partitioning scheme creates the required bootloader "
@@ -2683,9 +2859,9 @@ msgstr "Uneingebunden verlassen"
 #~ "the rest of the disk, formatted as ext4 and mounted at '/'."
 #~ msgstr ""
 #~ "Das ausgewählte geführte Partitionsschema erstellt die erforderliche "
-#~ "Bootloader-Partition auf der ausgewählten Festplatte und erstellt dann "
-#~ "eine einzige Partition, die den Rest der Festplatte abdeckt, als ext4 "
-#~ "formatiert und auf »/« eingebunden ist."
+#~ "Bootloader-Partition auf der ausgewählten Festplatte und erstellt dann eine "
+#~ "einzige Partition, die den Rest der Festplatte abdeckt, als ext4 formatiert "
+#~ "und auf »/« eingebunden ist."
 
 #~ msgid ""
 #~ "The installer can guide you through partitioning an entire disk either "
@@ -2695,16 +2871,15 @@ msgstr "Uneingebunden verlassen"
 #~ "review and modify the results."
 #~ msgstr ""
 #~ "Der Installer kann Sie durch die Partitionierung einer ganzen Festplatte "
-#~ "führen, entweder direkt oder mit LVM, oder, wenn Sie es wünschen, "
-#~ "manuell.\n"
+#~ "führen, entweder direkt oder mit LVM, oder, wenn Sie es wünschen, manuell.\n"
 #~ "\n"
 #~ "Wenn Sie sich für die Partitionierung einer kompletten Festplatte "
-#~ "entscheiden, haben Sie dennoch die Möglichkeit, die Ergebnisse zu "
-#~ "überprüfen und zu ändern."
+#~ "entscheiden, haben Sie dennoch die Möglichkeit, die Ergebnisse zu überprüfen "
+#~ "und zu ändern."
 
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
@@ -2719,23 +2894,81 @@ msgstr "Uneingebunden verlassen"
 #~ "\n"
 #~ "Sind Sie sicher, dass Sie weitermachen wollen?"
 
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "Möchten Sie wirklich das bestehende Dateisystem aus {} entfernen?"
+
 #~ msgid ""
-#~ "The LVM guided partitioning scheme creates three partitions on the "
-#~ "selected disk: one as required by the bootloader, one for '/boot', and "
-#~ "one covering the rest of the disk.\n"
+#~ "The LVM guided partitioning scheme creates three partitions on the selected "
+#~ "disk: one as required by the bootloader, one for '/boot', and one covering "
+#~ "the rest of the disk.\n"
 #~ "\n"
-#~ "A LVM volume group is created containing the large partition. A 4 "
-#~ "gigabyte logical volume is created for the root filesystem. It can easily "
-#~ "be enlarged with standard LVM command line tools."
+#~ "A LVM volume group is created containing the large partition. A 4 gigabyte "
+#~ "logical volume is created for the root filesystem. It can easily be enlarged "
+#~ "with standard LVM command line tools."
 #~ msgstr ""
 #~ "Das LVM-Partitionsschema erstellt drei Partitionen auf der ausgewählten "
-#~ "Festplatte: eine nach Bedarf des Bootloaders, eine für »/boot« und eine "
-#~ "für den Rest der Festplatte.\n"
+#~ "Festplatte: eine nach Bedarf des Bootloaders, eine für »/boot« und eine für "
+#~ "den Rest der Festplatte.\n"
 #~ "\n"
 #~ "Es wird eine LVM-Volumengruppe erstellt, die die große Partition enthält. "
-#~ "Für das Root-Dateisystem wird ein logisches Volumen von 4 Gigabyte "
-#~ "angelegt. Es kann einfach mit Standard LVM Kommandozeilenwerkzeugen "
-#~ "erweitert werden."
+#~ "Für das Root-Dateisystem wird ein logisches Volumen von 4 Gigabyte angelegt. "
+#~ "Es kann einfach mit Standard LVM Kommandozeilenwerkzeugen erweitert werden."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the PReP partion which is required on POWER. Grub will be installed "
+#~ "onto this partition."
+#~ msgstr ""
+#~ "Erforderliche Bootloader-Partition\n"
+#~ "\n"
+#~ "Dies ist der PReP-Teil, der für POWER erforderlich ist. Grub wird auf dieser "
+#~ "Partition installiert."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
+#~ "installed onto this partition, which must be formatted as fat32."
+#~ msgstr ""
+#~ "Erforderliche Bootloader-Partition\n"
+#~ "\n"
+#~ "Dies ist die von UEFI geforderte ESP / »EFI Systempartition«. Grub wird auf "
+#~ "dieser Partition installiert, die als fat32 formatiert werden muss."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Erforderliche Bootloader-Partition\n"
+#~ "\n"
+#~ "GRUB wird auf dem MBR des Ziellaufwerks installiert.\n"
+#~ "\n"
+#~ "Auf einer Festplatte mit einer GPT-Partitionstabelle ist jedoch nicht "
+#~ "genügend Platz nach dem MBR vorhanden, damit GRUB seine zweite Stufe "
+#~ "core.img speichern kann, so dass eine kleine unformatierte Partition am "
+#~ "Anfang der Festplatte benötigt wird. Es enthält kein Dateisystem und wird "
+#~ "nicht eingebunden und kann hier nicht bearbeitet werden."
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Der Hostname muss mit NAME_REGEX übereinstimmen, d.h. [a-z_][a-z0-9_-]*"
+
+#~ msgid "Edit software RAID disk \"{}\""
+#~ msgstr "Software-RAID-Laufwerk »{}« bearbeiten"
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Der Benutzername muss mit NAME_REGEX übereinstimmen, d.h. [a-z_][a-z0-9_-]*"
 
 #~ msgid "Exit To Shell"
 #~ msgstr "Beenden und zur Shell"
+
+#~ msgid "Fetching info for {} failed"
+#~ msgstr "Abrufen von Informationen für {} fehlgeschlagen"

--- a/po/el.po
+++ b/po/el.po
@@ -7,77 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2018-04-12 21:16+0000\n"
+"Last-Translator: Simos Xenitellis  <Unknown>\n"
 "Language-Team: Greek <el@li.org>\n"
-"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: el\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Κλείσιμο"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -88,34 +416,55 @@ msgid " or "
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Αυτό το πεδία δεν πρέπει να αφεθεί κενό."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Ολοκληρώθηκε"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Ακύρωση"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Ναι"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Όχι"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Κλείσιμο"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Αποθήκευση"
 
@@ -177,87 +526,133 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Συνδέσεις δικτύου"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -267,1017 +662,500 @@ msgstr ""
 "πακέτων."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Πίσω"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Ναι"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Όχι"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Η εγκατάσταση ολοκληρώθηκε!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Ολοκληρώθηκε η εγκατάσταση!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Εγκατάσταση συστήματος"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Η εγκατάσταση ολοκληρώθηκε!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Παρουσιάστηκε σφάλμα κατά την εγκατάσταση"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Το όνομα του διακομιστή δεν πρέπει να είναι κενό"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Το όνομά σας:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Το όνομα του διακομιστή σας:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "Το όνομα που χρησιμοποιεί, όταν επικοινωνεί με άλλους υπολογιστές."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Επιλέξτε ένα όνομα χρήστη:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Επιλέξτε έναν κωδικό πρόσβασης:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Επιβεβαιώστε τον κωδικό πρόσβασης:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Το ονοματεπώνυμο είναι πολύ μεγάλο, πρέπει να είναι < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Το όνομα του διακομιστή δεν πρέπει να είναι κενό"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Το όνομα διακομιστή είναι πολύ μεγάλο, πρέπει να είναι < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Το όνομα υπολογιστή πρέπει να ταιριάζει με NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Λείπει το όνομα χρήστη"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Το όνομα χρήστη είναι πολύ μεγάλο, πρέπει να είναι < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Το όνομα χρήστη πρέπει να ταιριάζει με NAME_REGEX, δηλαδή [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Πρέπει να καθοριστεί κωδικός πρόσβασης"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Δε συμπίπτουν οι κωδικοί πρόσβασης"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Ρύθμιση προφίλ"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Συνέχεια"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Μορφοποίηση και/ή προσάρτηση {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "ΠΕΡΙΛΗΨΗ ΣΥΣΤΗΜΑΤΟΣ ΑΡΧΕΙΩΝ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "ΔΙΑΘΕΣΙΜΕΣ ΣΥΣΚΕΥΕΣ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Επαναφορά ρυθμίσεων"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Πρέπει να καθοριστεί κωδικός πρόσβασης"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Δε συμπίπτουν οι κωδικοί πρόσβασης"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1311,7 +1189,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1319,135 +1197,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "ΠΕΡΙΛΗΨΗ ΣΥΣΤΗΜΑΤΟΣ ΑΡΧΕΙΩΝ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "ΔΙΑΘΕΣΙΜΕΣ ΣΥΣΚΕΥΕΣ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Επαναφορά ρυθμίσεων"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1470,100 +1502,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1620,576 +1595,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Πλοήγηση με πλήκτρα βέλη ΠΑΝΩ, ΚΑΤΩ, και επιλογή γλώσσας με ENTER"
-
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Όνομα χρήστη εισαγωγής:"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Το όνομά σας:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Το όνομα του διακομιστή σας:"
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Το όνομα που χρησιμοποιεί, όταν επικοινωνεί με άλλους υπολογιστές."
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Επιλέξτε ένα όνομα χρήστη:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Επιλέξτε έναν κωδικό πρόσβασης:"
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Επιβεβαιώστε τον κωδικό πρόσβασης:"
 
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Εισαγωγή ταυτότητας SSH:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "από GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "από Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Αυτό το πεδία δεν πρέπει να αφεθεί κενό."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "Η ταυτότητα SSH είναι πολύ μεγάλη, πρέπει να είναι < "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Το όνομα του διακομιστή δεν πρέπει να είναι κενό"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Λείπει το όνομα χρήστη"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Συνέχεια"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Ρύθμιση προφίλ"
+
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Επανεκκίνηση τώρα"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr "Πλήρης καταγραφή του εγκαταστάτη"
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Εγκατάσταση συστήματος"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Η εγκατάσταση ολοκληρώθηκε!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Παρουσιάστηκε σφάλμα κατά την εγκατάσταση"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2200,11 +1923,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr "Επιβεβαιώστε την καταστρεπτική ενέργεια"
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2212,9 +1935,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2222,8 +2123,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2240,192 +2141,331 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Όνομα χρήστη εισαγωγής:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Εισαγωγή ταυτότητας SSH:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "από Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "από Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Αυτό το πεδία δεν πρέπει να αφεθεί κενό."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "Η ταυτότητα SSH είναι πολύ μεγάλη, πρέπει να είναι < "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Πλοήγηση με πλήκτρα βέλη ΠΑΝΩ, ΚΑΤΩ, και επιλογή γλώσσας με ENTER"
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""
 
 #~ msgid "Filesystem setup"
@@ -2437,11 +2477,29 @@ msgstr ""
 #~ msgid "Choose the installation target"
 #~ msgstr "Επιλογή του χώρου εγκατάστασης"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Μορφοποίηση και/ή προσάρτηση {}"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Ευχαριστούμε που χρησιμοποιείτε το Ubuntu!"
 
+#~ msgid "Finished install!"
+#~ msgstr "Ολοκληρώθηκε η εγκατάσταση!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Η εγκατάσταση ολοκληρώθηκε!"
+
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Παρακαλώ αναφέρετε αυτό το σφάλμα στο Launchpad"
+
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Το ονοματεπώνυμο είναι πολύ μεγάλο, πρέπει να είναι < "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "Το όνομα διακομιστή είναι πολύ μεγάλο, πρέπει να είναι < "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "Το όνομα χρήστη είναι πολύ μεγάλο, πρέπει να είναι < "
 
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Επιλέξτε το δίσκο που θα γίνει η εγκατάσταση:"
@@ -2451,6 +2509,14 @@ msgstr ""
 
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Χρήση ολόκληρου του δίσκου"
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Το όνομα υπολογιστή πρέπει να ταιριάζει με NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Το όνομα χρήστη πρέπει να ταιριάζει με NAME_REGEX, δηλαδή [a-z_][a-z0-9_-]*"
 
 #~ msgid "Exit To Shell"
 #~ msgstr "Έξοδος σε φλοιό"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,86 +7,420 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-04-09 15:57+0000\n"
-"Last-Translator: Anthony Harrington <Unknown>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2021-06-09 02:14+0000\n"
+"Last-Translator: Michael Hudson-Doyle <mwhudsonlp@fastmail.fm>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-10 04:53+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: \n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by holding Ctrl + D or typing 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment: Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr "yes"
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr "no"
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr "Confirmation is required to continue."
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr "Add 'autoinstall' to your kernel command line to avoid this"
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr "Continue with autoinstall?"
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr "Importing keys failed:"
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr "ssh-keygen failed to show fingerprint of downloaded keys:"
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr "Cannot edit pre-existing RAIDs."
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr "Cannot edit pre-existing volume groups."
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+"Cannot delete a single partition from a device that already has partitions."
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr "Cannot delete required bootloader partition"
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr "existing"
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr "new"
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr "configured"
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr "unconfigured"
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr "primary ESP"
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr "backup ESP"
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr "unused ESP"
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr "extended"
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr "logical"
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr "encrypted"
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr "multipath device"
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "local disk"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr "partition of {device}"
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr "software RAID {level}"
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr "LVM volume group"
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr "LVM Logical Volume"
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr "partition {number}"
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr "partition {number} of {device}"
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr "{component_name} of {desc} {name}"
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr "already formatted as {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr "to be reformatted as {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr "to be formatted as {fstype}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr "mounted at {path}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr "not mounted"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "unused"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "used"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr "Block device probe failure"
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr "Disk probe failure"
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr "Install failure"
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr "Installer crash"
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr "Network error"
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "Unknown error"
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "autoconfiguration failed"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "Info"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Edit Wifi"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Edit IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Edit IPv6"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "Edit bond"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
-#, fuzzy
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
-msgstr "Add a VLAN tag"
+msgid "Edit Wifi"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:45
-#, fuzzy
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Delete"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr "The host key fingerprints are:\n"
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-"The {keytype} host key fingerprints is:\n"
-"    {fingerprint}\n"
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Close"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -97,34 +431,55 @@ msgid " or "
 msgstr " or "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "This field must be a %s URL."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Done"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Cancel"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Yes"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "No"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Close"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Save"
 
@@ -157,14 +512,14 @@ msgid "Domains, comma separated"
 msgstr "Domains, comma separated"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr "should be in CIDR form ({})"
+msgstr "should be in CIDR form ({example})"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "'%s' is not contained in '%s'"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -186,87 +541,133 @@ msgstr "Disabled"
 msgid "IPv{v} Method: "
 msgstr "IPv{v} Method: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Create"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "VLAN ID:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr "VLAN ID must be between 1 and 4095"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s already exists"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr "Add a VLAN tag"
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
+#, python-brace-format
 msgid "Info for {device}"
-msgstr "Info for {}"
+msgstr "Info for {device}"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Name:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Devices: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr "Bond mode:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr "XMIT hash policy:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr "LACP rate:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
+#, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr "There is already a network device named \"{}\""
+msgstr "There is already a network device named \"{netdev}\""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "Name cannot be empty"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr "Name cannot be more than 16 characters long"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr "Create bond"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr "Edit bond"
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr "Select a network"
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr "Network interface {nic} WIFI configuration"
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr "VLAN {id} on interface {link}"
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr "bond master for {interfaces}"
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "not connected"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr "enslaved to {device}"
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "timed out"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "static"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "disabled"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Network connections"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -275,639 +676,306 @@ msgstr ""
 "machines, and which preferably provides sufficient access for updates."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Back"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "Continue without network"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "Applying changes"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr "not connected"
-
-#: ../subiquitycore/ui/views/network.py:188
-#, fuzzy, python-brace-format
-msgid "enslaved to {device}"
-msgstr "enslaved to {}"
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "timed out"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, fuzzy, python-brace-format
-msgid "unknown state {state}"
-msgstr "unknown state {}"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "static"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr "disabled"
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr "VLAN {id} on interface {link}"
-
-#: ../subiquitycore/ui/views/network.py:360
-#, fuzzy, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr "bond master for {}"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "Select a boot disk"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Network interface {} WIFI configuration"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Yes"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "No"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr "Importing keys failed:"
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr "ssh-keygen failed to show fingerprint of downloaded keys:"
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "An error has occurred"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Installation complete!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Finished install!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Installing system"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Install complete!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "An error occurred during installation"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr "Block device probe failure"
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr "Disk probe failure"
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr "Install failure"
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr "Installer crash"
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr "Network error"
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr "Unknown error"
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr "failed"
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr "auto"
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr "online"
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr "0 (striped)"
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr "1 (mirrored)"
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Name cannot be empty"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} is not valid input"
+msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "Other"
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
+msgstr "Leave unmounted"
 
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Reformat"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "Add Partition"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "Create Logical Volume"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Format"
-
-#: ../subiquity/models/filesystem.py:424
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr "Remove from RAID/LVM"
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Delete"
-
-#: ../subiquity/models/filesystem.py:426
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr "Make Boot Device"
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr "existing"
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr "new"
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr "{component_name} of {desc} {name}"
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr "already formatted as {fstype}"
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr "to be reformatted as {fstype}"
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr "to be formatted as {fstype}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr "mounted at {path}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr "not mounted"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr "unused"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr "used"
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr "Cannot delete {selflabel} because it has {count} mounted partitions."
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr "Cannot delete {selflabel} because it has 1 mounted partition."
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "local disk"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Configure proxy"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "autoconfiguration failed"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-#, fuzzy
-msgid "unused ESP"
-msgstr "unused"
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "logical volume"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "partition of {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "partition {} of {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "partition {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-"Cannot delete a single partition from a device that already has partitions."
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr "Cannot delete required bootloader partition"
-
-#: ../subiquity/models/filesystem.py:1049
-#, fuzzy, python-brace-format
-msgid "software RAID {level}"
-msgstr "software RAID {}"
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr "Cannot edit pre-existing RAIDs."
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr "Cannot edit {selflabel} because it has partitions."
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-#, fuzzy
-msgid "LVM volume group"
-msgstr "Create LVM volume group"
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr "Cannot edit pre-existing volume groups."
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr "Cannot edit {selflabel} because it has logical volumes."
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "logical volume"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by holding Ctrl + D or typing 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment: Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 
-#: ../subiquity/core.py:224
-#, fuzzy, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr "the installer running on {} will perform the autoinstall"
-
-#: ../subiquity/core.py:237
-#, fuzzy, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr "waiting for installer running on {} to run early commands"
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr "yes"
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr "no"
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr "Confirmation is required to continue."
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr "Add 'autoinstall' to your kernel command line to avoid this"
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr "Continue with autoinstall?"
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "The characters : , and = are not permitted in this field"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr "The only characters permitted in this field are a-z, 0-9, _ and -"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Your name:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Your server's name:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "The name it uses when it talks to other computers."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Pick a username:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Choose a password:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Confirm your password:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Realname too long, must be < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Server name must not be empty"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Server name too long, must be < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Username missing"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Username too long, must be < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr "The username \"{username}\" is reserved for use by the system."
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Password must be set"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Passwords do not match"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr "{desc} do not match"
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Profile setup"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+"\n"
+"Loading report...\n"
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+"\n"
+"You can continue and the installer will just display the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+"\n"
+"Do you want to try starting the installation again?\n"
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr "Select continue to try the installation again."
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr "Cancel upload"
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr "Close report"
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Continue"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr "Switch to a shell"
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr "Restart the installer"
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr "Send to Canonical"
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr "Sent to Canonical"
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr "View full report"
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr "DATE"
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr "KIND"
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr "STATUS"
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr "Select an error report to view:"
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr "VIEWED"
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr "UNVIEWED"
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
+#, python-brace-format
 msgid "formatted as {fstype}"
-msgstr "to be formatted as {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:132
+#, python-brace-format
 msgid ", mounted at {path}"
-msgstr "mounted at {path}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ", not mounted"
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:136
+#, python-brace-format
 msgid "unused {device}"
-msgstr "unused {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
@@ -915,456 +983,235 @@ msgstr ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr "/ is not permitted in the name of a RAID device"
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr "Whitespace is not permitted in the name of a RAID device"
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr "RAID Level:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Devices:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Size:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, fuzzy, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr "There is already a RAID named >>{}<<"
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ". and .. are not valid names for RAID devices"
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, fuzzy, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr "RAID Level \"{}\" requires at least {} active devices"
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr "Create software RAID (\"MD\") disk"
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, fuzzy, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr "Edit software RAID disk \"{}\""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr "Leave unformatted"
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, fuzzy, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr "Leave formatted as {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, fuzzy, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr "Capped partition size at {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, fuzzy, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr "Rounded size up to {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, fuzzy, python-brace-format
-msgid "Size (max {size}):"
-msgstr "Size (max {}):"
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Name: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "Format:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr "Mount:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr "Use as swap"
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr "Use this swap partition in the installed system."
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr "The name of a logical volume cannot be empty"
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr "The name of a logical volume cannot start with a hyphen"
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, fuzzy, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr "A logical volume may not be called {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, fuzzy, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr "The name of a logical volume may not contain \"{}\""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, fuzzy, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr "There is already a logical volume named {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Path exceeds PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, fuzzy, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr "{} is already mounted at {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, fuzzy, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-"Mounting an existing filesystem at {} is usually a bad idea, proceed only "
-"with caution."
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Required bootloader partition\n"
-"\n"
-"GRUB will be installed onto the target disk's MBR.\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough space "
-"after the MBR for GRUB to store its second-stage core.img, so a small "
-"unformatted partition is needed at the start of the disk. It will not "
-"contain a filesystem and will not be mounted, and cannot be edited here."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-"Required bootloader partition\n"
-"\n"
-"This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
-"installed onto this partition, which must be formatted as fat32."
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-"Required bootloader partition\n"
-"\n"
-"This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
-"installed onto this partition, which must be formatted as fat32."
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-#, fuzzy
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr " The only aspect of this partition that can be edited is the size."
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-#, fuzzy
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-" You can choose whether to use the existing filesystem on this partition or "
-"reformat it."
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. Grub will be installed "
-"onto this partition."
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. Grub will be installed "
-"onto this partition."
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "OK"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr "Use existing fat32 filesystem"
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr "Reformat as fresh fat32 filesystem"
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "logical volume {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "partition {} of {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Format and/or mount {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr "Do you really want to delete the {desc} {label}?"
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr "It is formatted as {fstype} and mounted at {path}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr "It is formatted as {fstype} and not mounted."
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "logical volume"
-msgstr[1] "logical volume"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:70
+#, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
-msgstr[0] "It contains {n} {things}:"
-msgstr[1] "It contains {n} {things}:"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr "It is not formatted or mounted."
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Delete"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:112
+#, python-brace-format
 msgid "Remove filesystem from {device}"
-msgstr "Remove filesystem from {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:116
+#, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
-msgstr "Do you really want to remove the existing filesystem from {}?"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr "logical volumes"
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "partitions"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr "Remove all {things} from {obj}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr "Do you really want to remove all {things} from {obj}?"
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr "Reformat"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
+#, python-brace-format
+msgid "existing {fstype}"
+msgstr "existing {fstype}"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "Passphrases"
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
+#, python-brace-format
+msgid "new {fstype}"
+msgstr "new {fstype}"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "Create encrypted volume"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "No disks or partitions mounted."
 
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr "Passphrase:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "MOUNT POINT"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr "Confirm passphrase:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "SIZE"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr "Select at least one device to be part of the volume group."
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TYPE"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr "The name of a volume group cannot be empty"
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "DEVICE TYPE"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr "The name of a volume group cannot start with a hyphen"
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Unmount"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:113
-#, fuzzy, python-brace-format
-msgid "{name} is not a valid name for a volume group"
-msgstr "{} is not a valid name for a volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "No available devices"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
-#, fuzzy, python-brace-format
-msgid "There is already a volume group named '{name}'"
-msgstr "There is already a volume group named >>{}<<"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr "No used devices"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
-msgstr "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
+#, python-brace-format
+msgid "Remove from {device}"
+msgstr "Remove from {device}"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr "Add {ptype} Partition"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr "Stop Using As Boot Device"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
-#, fuzzy, python-brace-format
-msgid "Edit volume group \"{name}\""
-msgstr "Edit volume group \"{}\""
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr "Add As Another Boot Device"
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr "Use As Boot Device"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "DEVICE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "free space"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr "Storage configuration"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr "Create software RAID (md)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr "Create volume group (LVM)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "FILE SYSTEM SUMMARY"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "AVAILABLE DEVICES"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr "USED DEVICES"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr "Mount a filesystem at /"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr "Select a boot disk"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr "To continue you need to:"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Reset"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr "Configure a guided storage layout, or create a custom one:"
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr "Passphrase:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr "Confirm passphrase:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Password must be set"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Passwords do not match"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr "Encrypt the LVM group with LUKS"
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr "Set up this disk as an LVM group"
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr "Use an entire disk"
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr "Custom storage layout"
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1406,9 +1253,10 @@ msgstr ""
 "\n"
 "If you choose to use LVM, two additional partitions are then created,\n"
 "one for /boot and one covering the rest of the disk. An LVM volume\n"
-"group is created containing the large partition. A 4 gigabyte logical\n"
-"volume is created for the root filesystem. It can easily be enlarged\n"
-"with standard LVM command line tools.\n"
+"group is created containing the large partition. A logical volume is\n"
+"created for the root filesystem, sized using some simple heuristic. It\n"
+"can easily be enlarged with standard LVM command line tools (or on the\n"
+"next screen).\n"
 "\n"
 "You can also choose to encrypt LVM volume group. This will require\n"
 "setting a password, that one will need to type on every boot before\n"
@@ -1427,7 +1275,7 @@ msgstr ""
 "at /.\n"
 "\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1439,7 +1287,7 @@ msgstr ""
 "storage\n"
 "configuration. Manual configuration may still be possible.\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
@@ -1449,131 +1297,324 @@ msgstr ""
 "Block probing did not discover any disks. Unfortunately, this means that\n"
 "installation will not be possible.\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr "Guided storage configuration"
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "OK"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr "Help on guided storage configuration"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
-#, fuzzy, python-brace-format
-msgid "existing {fstype}"
-msgstr "existing"
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Devices:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Size:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Create encrypted volume"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr "Select at least one device to be part of the volume group."
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr "The name of a volume group cannot be empty"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr "The name of a volume group cannot start with a hyphen"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "new {fstype}"
+msgid "There is already a volume group named '{name}'"
+msgstr "There is already a volume group named '{name}'"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:119
+#, python-brace-format
+msgid "{name} is not a valid name for a volume group"
+msgstr "{name} is not a valid name for a volume group"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
+msgstr "Passphrase must be set"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
+msgstr "Passphrases do not match"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
+msgstr "Create LVM volume group"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:157
+#, python-brace-format
+msgid "Edit volume group \"{name}\""
+msgstr "Edit volume group \"{name}\""
+
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr "Leave unformatted"
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
+msgstr "Leave formatted as {fstype}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
+msgstr "Capped partition size at {size}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
+msgstr "Rounded size up to {size}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
+msgstr ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
+
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
+msgstr "Size (max {size}):"
+
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Name: "
+
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Format:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
+msgstr "Mount:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr "Use as swap"
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
+msgstr "Use this swap partition in the installed system."
+
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr "The name of a logical volume cannot be empty"
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr "The name of a logical volume cannot start with a hyphen"
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "No disks or partitions mounted."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "MOUNT POINT"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "SIZE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TYPE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "DEVICE TYPE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "Unmount"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr "No available devices"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr "No used devices"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
-#, fuzzy, python-brace-format
-msgid "Remove from {device}"
-msgstr "Remove from {}"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "Add {} Partition"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-#, fuzzy
-msgid "Add As Another Boot Device"
-msgstr "Make Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-#, fuzzy
-msgid "Use As Boot Device"
-msgstr "Make Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Path exceeds PATH_MAX"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr "{device} is already mounted at {path}."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
-msgstr "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
-msgstr "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
-msgstr "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
-msgstr "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr "The only aspect of this partition that can be edited is the size.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
-msgstr "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
-msgstr "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "Continue without network"
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr "Use existing fat32 filesystem"
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr "Reformat as fresh fat32 filesystem"
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr "Adding logical volume to {vgname}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr "Adding {ptype} partition to {device}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr "Editing logical volume {lvname} of {vgname}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr "Editing partition {number} of {device}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1601,111 +1642,44 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr "Probing for devices to install to failed"
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
-msgstr "View error report"
+msgstr "Show Error Report"
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
-msgstr "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
+msgstr "/ is not permitted in the name of a RAID device"
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
-msgstr ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
+msgstr "Whitespace is not permitted in the name of a RAID device"
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "RAID Level:"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr "Contacting the snap store failed:"
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "Installer update available"
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
-msgstr ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
-
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "Downloading update..."
-
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
-msgstr ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
-
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
-msgstr "Update failed"
-
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr "Downloading and applying the update:"
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "Continue without updating"
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Try again"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
+msgstr ". and .. are not valid names for RAID devices"
 
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr "Update to the new installer"
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
+msgstr "RAID Level \"{level}\" requires at least {min_active} active devices"
 
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "Cancel update"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
+msgstr "Create software RAID (\"MD\") disk"
 
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-"You may provide an archive mirror that will be used instead of the default."
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr "Mirror address:"
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr "Configure Ubuntu archive mirror"
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
-msgstr "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
+msgstr "Edit software RAID disk \"{name}\""
 
 #: ../subiquity/ui/views/help.py:70
 #, python-brace-format
@@ -1770,16 +1744,12 @@ msgstr ""
 "This is version {snap_version} of the installer.\n"
 
 #: ../subiquity/ui/views/help.py:102
-#, fuzzy
 msgid ""
 "\n"
 "It is possible to connect to the installer over the network, which\n"
 "might allow the use of a more capable terminal and can offer more languages\n"
 "than can be rendered in the Linux console."
 msgstr ""
-"\n"
-"It is possible to connect to the installer over the network, which\n"
-"might allow the use of a more capable terminal."
 
 #: ../subiquity/ui/views/help.py:107
 msgid ""
@@ -1793,21 +1763,44 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
-"\n"
-"To connect, SSH to installer@{ip}.\n"
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
-"\n"
-"The password you should use is \"{password}\".\n"
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
@@ -1817,7 +1810,7 @@ msgstr ""
 "Unfortunately, this system seems to have no global IP addresses at this\n"
 "time.\n"
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
@@ -1827,603 +1820,276 @@ msgstr ""
 "Unfortunately, the installer was unable to detect the password that has\n"
 "been set.\n"
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr "The following keys can be used at any time:"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr "ESC"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr "go back"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr "F1"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr "open help menu"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr "Control-Z, F2"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr "switch to shell"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr "Control-L, F3"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr "redraw screen"
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr "Control-T, F4"
 
-#: ../subiquity/ui/views/help.py:185
-#, fuzzy
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
-msgstr "toggle colour on and off"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr "Control-X"
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
-msgstr ""
+msgstr "quit"
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr "Control-E"
 
-#: ../subiquity/ui/views/help.py:190
-#, fuzzy
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
-msgstr "generate noisy error report (dry-run only)"
+msgstr "generate noisy error report"
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr "Control-R"
 
-#: ../subiquity/ui/views/help.py:191
-#, fuzzy
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
-msgstr "generate quiet error report (dry-run only)"
+msgstr "generate quiet error report"
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Control-X"
+msgstr "Control-G"
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr "Update to the new installer"
+msgstr "pretend to run an install"
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr "Control-U"
 
-#: ../subiquity/ui/views/help.py:193
-#, fuzzy
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
-msgstr "crash the ui (dry-run only)"
+msgstr "crash the ui"
 
-#: ../subiquity/ui/views/help.py:207
-#, fuzzy
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
-msgstr "quit (dry-run only)"
+msgstr "(dry-run only)"
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr "Shortcut Keys"
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr "About this installer"
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr "Keyboard shortcuts"
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr "Enter shell"
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr "Help on SSH access"
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr "Help on this screen"
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr "View error reports"
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr "Help"
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr "About the installer"
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
-msgstr ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "The characters : , and = are not permitted in this field"
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
+msgstr "The only characters permitted in this field are a-z, 0-9, _ and -"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Your name:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Your server's name:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "The name it uses when it talks to other computers."
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Pick a username:"
 
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Choose a password:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Confirm your password:"
 
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr "Install OpenSSH server"
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Import SSH identity:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "from GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "from Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "You can import your SSH keys from GitHub or Launchpad."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr "Allow password authentication over SSH"
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "This field must not be blank."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "SSH id too long, must be < "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr "Fetching SSH keys..."
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr "Confirm SSH keys"
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr "Confirm SSH key"
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr "SSH Setup"
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "just now"
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr "minute"
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr "minutes"
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr "hour"
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr "hours"
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr "day"
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr "days"
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
-msgstr "{amount:2} {unit} ago"
-
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Server name must not be empty"
+
+#: ../subiquity/ui/views/identity.py:109
+#, python-brace-format
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Username missing"
+
+#: ../subiquity/ui/views/identity.py:123
+#, python-brace-format
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
+msgstr "The username \"{username}\" is reserved for use by the system."
 
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr "{desc} do not match"
 
-#: ../subiquity/ui/views/snaplist.py:256
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap}"
-msgstr "Fetching info for {}"
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Profile setup"
 
-#: ../subiquity/ui/views/snaplist.py:282
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap} failed"
-msgstr "Fetching info for {} failed"
-
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
-msgstr "Featured Server Snaps"
-
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Continue"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
-msgstr "Loading server snaps from store, please wait..."
-
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr "Sorry, loading snaps from the store failed."
-
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "passwords"
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Keyboard auto detection failed, sorry"
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Layout"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr "Variant"
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Please press one of the following keys:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr "Input was not recognised, please try again"
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "Is the following key present on your keyboard?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Applying config"
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Right Alt (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Right Control"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Right Shift"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr "Right Logo key"
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "Menu key"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Control+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr "Control+Alt"
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "Left Control+Left Shift"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Left Alt"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Left Control"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Left Shift"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr "Left Logo key"
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "Scroll Lock key"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr "No toggling"
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr "Shortcut: "
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr "Select layout toggle"
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "Layout:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr "Variant:"
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr "Keyboard configuration"
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr "Identify keyboard"
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr "Install progress"
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Reboot Now"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr "View error report"
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr "View full log"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr "Full installer output"
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Installing system"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Install complete!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr "Cancel update and reboot"
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Reboot"
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr "Rebooting..."
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "An error occurred during installation"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2441,36 +2107,240 @@ msgstr ""
 "\n"
 "Are you sure you want to continue?"
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr "Confirm destructive action"
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
 "\n"
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
+"The installer running on {tty} is currently installing the system.\n"
+"\n"
+"You can wait for this to complete or switch to a shell.\n"
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
-msgstr "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "Keyboard auto-detection"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Layout"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr "Variant"
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Please press one of the following keys:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr "Input was not recognised, please try again"
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Is the following key present on your keyboard?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Right Alt (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Right Control"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Right Shift"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr "Right Logo key"
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Menu key"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Control+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Control+Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Left Control+Left Shift"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Left Alt"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Left Control"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Left Shift"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr "Left Logo key"
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Scroll Lock key"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr "No toggling"
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr "Shortcut: "
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr "Select layout toggle"
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Layout:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr "Variant:"
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "Keyboard configuration"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr "Identify keyboard"
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Applying config"
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+"You may provide an archive mirror that will be used instead of the default."
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "Mirror address:"
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr "Configure Ubuntu archive mirror"
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+msgstr "If you use an alternative mirror for Ubuntu, enter its details here."
 
 #: ../subiquity/ui/views/proxy.py:33
 msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
@@ -2488,254 +2358,358 @@ msgstr ""
 "If this system requires a proxy to connect to the internet, enter its "
 "details here."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr "Checking for installer update..."
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr "Contacting the snap store failed"
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr "Contacting the snap store failed:"
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Installer update available"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Downloading update..."
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr "Update failed"
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr "Downloading and applying the update:"
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Continue without updating"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Try again"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr "You can read the release notes for each version at:"
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr "Update to the new installer"
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Cancel update"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "just now"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "minute"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "minutes"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "hour"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "hours"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "day"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "days"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr "{amount:2} {unit} ago"
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr "LICENCE: "
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr "LAST UPDATED: "
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr "CHANNEL"
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr "VERSION"
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr "PUBLISHED"
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr "CONFINEMENT"
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr "by: "
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr "Featured Server Snaps"
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr "Loading server snaps from store, please wait..."
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr "Sorry, loading snaps from the store failed."
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Import Username:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Github Username:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr "Enter your Github username."
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+"A Github username may only contain alphanumeric characters or hyphens."
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Launchpad Username:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr "Install OpenSSH server"
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Import SSH identity:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "from Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "from Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "You can import your SSH keys from Github or Launchpad."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr "Allow password authentication over SSH"
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "This field must not be blank."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "SSH id too long, must be < "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr "Fetching SSH keys..."
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "Confirm SSH keys"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "Confirm SSH key"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "SSH Setup"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
-msgstr ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Use UP, DOWN and ENTER keys to select your language."
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
-msgstr ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
+msgstr "Help choosing a language"
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
-msgstr ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
+msgstr "failed"
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
+msgstr "auto"
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
+msgstr "online"
 
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-"\n"
-"Loading report...\n"
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-"\n"
-"You can continue and the installer will just display the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-"\n"
-"Do you want to try starting the installation again?\n"
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr "Select continue to try the installation again."
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr "Cancel upload"
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr "Close report"
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr "Restart the installer"
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr "Send to Canonical"
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr "Sent to Canonical"
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr "View full report"
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr "DATE"
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr "KIND"
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr "STATUS"
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr "Select an error report to view:"
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr "VIEWED"
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr "UNVIEWED"
-
-#: ../subiquity/ui/views/zdev.py:64
+#: ../subiquity/ui/views/zdev.py:77
 msgid "No zdev devices found."
 msgstr "No zdev devices found."
 
-#: ../subiquity/ui/views/zdev.py:77
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr "ID"
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr "ONLINE"
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr "NAMES"
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr "Enable"
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr "Disable"
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr "Zdev setup"
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr "Other"
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr "Leave unmounted"
-
-#~ msgid "formatted as {}"
-#~ msgstr "formatted as {}"
-
-#~ msgid ", mounted at {}"
-#~ msgstr ", mounted at {}"
-
-#~ msgid "{} partition"
-#~ msgstr "{} partition"
-
-#~ msgid "Adding {} to {}"
-#~ msgstr "Adding {} to {}"
-
-#~ msgid "Editing {} of {}"
-#~ msgstr "Editing {} of {}"
-
-#~ msgid "partition"
-#~ msgstr "partition"
-
-#~ msgid "Toggle color on/off"
-#~ msgstr "Toggle colour on/off"
 
 #~ msgid "Filesystem setup"
 #~ msgstr "Filesystem setup"
@@ -2749,6 +2723,12 @@ msgstr "Leave unmounted"
 #~ msgid "Choose the installation target"
 #~ msgstr "Choose the installation target"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Format and/or mount {}"
+
+#~ msgid "An error has occurred"
+#~ msgstr "An error has occurred"
+
 #~ msgid "starting..."
 #~ msgstr "starting..."
 
@@ -2757,6 +2737,12 @@ msgstr "Leave unmounted"
 
 #~ msgid "Install complete"
 #~ msgstr "Install complete"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Installation complete!"
+
+#~ msgid "Finished install!"
+#~ msgstr "Finished install!"
 
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Thank you for using Ubuntu!"
@@ -2770,17 +2756,34 @@ msgstr "Leave unmounted"
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr "Select an interface to configure it or select Done to continue"
 
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Network interface {} WIFI configuration"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "This field must be a %s URL."
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "'%s' is not contained in '%s'"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} is not valid input"
+
+#~ msgid "partition of {}"
+#~ msgstr "partition of {}"
+
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
 #~ "\n"
 #~ "Are you sure you want to continue?"
 #~ msgstr ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
@@ -2793,14 +2796,153 @@ msgstr "Leave unmounted"
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Choose the disk to install to:"
 
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Realname too long, must be < "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "Server name too long, must be < "
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "Username too long, must be < "
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+
 #~ msgid "Exit To Shell"
 #~ msgstr "Exit To Shell"
 
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Keyboard auto detection failed, sorry"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "Edit IPv6"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Edit IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Edit Wifi"
+
+#~ msgid "Info"
+#~ msgstr "Info"
+
+#~ msgid "should be in CIDR form ({})"
+#~ msgstr "should be in CIDR form ({})"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s already exists"
+
+#~ msgid "Info for {}"
+#~ msgstr "Info for {}"
+
+#~ msgid "There is already a network device named \"{}\""
+#~ msgstr "There is already a network device named \"{}\""
+
+#~ msgid "enslaved to {}"
+#~ msgstr "enslaved to {}"
+
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
 
+#~ msgid "bond master for {}"
+#~ msgstr "bond master for {}"
+
 #~ msgid "-"
 #~ msgstr "-"
+
+#~ msgid "unknown state {}"
+#~ msgstr "unknown state {}"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "Make Boot Device"
+
+#~ msgid "Edit"
+#~ msgstr "Edit"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Remove from RAID/LVM"
+
+#~ msgid "Format"
+#~ msgstr "Format"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Create Logical Volume"
+
+#~ msgid "Add Partition"
+#~ msgstr "Add Partition"
+
+#, python-brace-format
+#~ msgid ""
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+#~ msgstr ""
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
+#~ msgstr "Cannot delete {selflabel} because it has {count} mounted partitions."
+
+#~ msgid "partition {} of {}"
+#~ msgstr "partition {} of {}"
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has 1 mounted partition."
+#~ msgstr "Cannot delete {selflabel} because it has 1 mounted partition."
+
+#~ msgid "software RAID {}"
+#~ msgstr "software RAID {}"
+
+#~ msgid "partition {}"
+#~ msgstr "partition {}"
+
+#~ msgid "unused {}"
+#~ msgstr "unused {}"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has logical volumes."
+#~ msgstr "Cannot edit {selflabel} because it has logical volumes."
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has partitions."
+#~ msgstr "Cannot edit {selflabel} because it has partitions."
+
+#~ msgid "formatted as {}"
+#~ msgstr "formatted as {}"
+
+#~ msgid "logical volume"
+#~ msgstr "logical volume"
+
+#~ msgid "partition"
+#~ msgstr "partition"
+
+#, python-brace-format
+#~ msgid "It contains {n} {things}:"
+#~ msgstr "It contains {n} {things}:"
 
 #~ msgid ""
 #~ "The installer can guide you through partitioning an entire disk either "
@@ -2821,6 +2963,9 @@ msgstr "Leave unmounted"
 #~ msgid "Select Done to begin the installation."
 #~ msgstr "Select Done to begin the installation."
 
+#~ msgid "Remove from {}"
+#~ msgstr "Remove from {}"
+
 #~ msgid "Use An Entire Disk And Set Up LVM"
 #~ msgstr "Use An Entire Disk And Set Up LVM"
 
@@ -2834,24 +2979,136 @@ msgstr "Leave unmounted"
 #~ "the rest of the disk, formatted as ext4 and mounted at >>/<<."
 
 #~ msgid ""
-#~ "The LVM guided partitioning scheme creates three partitions on the "
-#~ "selected disk: one as required by the bootloader, one for '/boot', and "
-#~ "one covering the rest of the disk.\n"
+#~ "The LVM guided partitioning scheme creates three partitions on the selected "
+#~ "disk: one as required by the bootloader, one for '/boot', and one covering "
+#~ "the rest of the disk.\n"
 #~ "\n"
-#~ "A LVM volume group is created containing the large partition. A 4 "
-#~ "gigabyte logical volume is created for the root filesystem. It can easily "
-#~ "be enlarged with standard LVM command line tools."
+#~ "A LVM volume group is created containing the large partition. A 4 gigabyte "
+#~ "logical volume is created for the root filesystem. It can easily be enlarged "
+#~ "with standard LVM command line tools."
 #~ msgstr ""
-#~ "The LVM guided partitioning scheme creates three partitions on the "
-#~ "selected disk: one as required by the bootloader, one for >>/boot<<, and "
-#~ "one covering the rest of the disk.\n"
+#~ "The LVM guided partitioning scheme creates three partitions on the selected "
+#~ "disk: one as required by the bootloader, one for >>/boot<<, and one covering "
+#~ "the rest of the disk.\n"
 #~ "\n"
-#~ "A LVM volume group is created containing the large partition. A 4 "
-#~ "gigabyte logical volume is created for the root filesystem. It can easily "
-#~ "be enlarged with standard LVM command line tools."
+#~ "A LVM volume group is created containing the large partition. A 4 gigabyte "
+#~ "logical volume is created for the root filesystem. It can easily be enlarged "
+#~ "with standard LVM command line tools."
+
+#~ msgid "Passphrases"
+#~ msgstr "Passphrases"
+
+#~ msgid "Rounded size up to {}"
+#~ msgstr "Rounded size up to {}"
+
+#~ msgid "{} is not a valid name for a volume group"
+#~ msgstr "{} is not a valid name for a volume group"
+
+#~ msgid "There is already a volume group named '{}'"
+#~ msgstr "There is already a volume group named >>{}<<"
+
+#~ msgid "Edit volume group \"{}\""
+#~ msgstr "Edit volume group \"{}\""
+
+#~ msgid "Capped partition size at {}"
+#~ msgstr "Capped partition size at {}"
+
+#~ msgid "There is already a logical volume named {}."
+#~ msgstr "There is already a logical volume named {}."
+
+#~ msgid "Size (max {}):"
+#~ msgstr "Size (max {}):"
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "The name of a logical volume may not contain \"{}\""
+
+#~ msgid "A logical volume may not be called {}"
+#~ msgstr "A logical volume may not be called {}"
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the PReP partion which is required on POWER. Grub will be installed "
+#~ "onto this partition."
+#~ msgstr ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the PReP partion which is required on POWER. Grub will be installed "
+#~ "onto this partition."
+
+#~ msgid "Editing {} of {}"
+#~ msgstr "Editing {} of {}"
+
+#~ msgid "Adding {} to {}"
+#~ msgstr "Adding {} to {}"
+
+#~ msgid "logical volume {}"
+#~ msgstr "logical volume {}"
+
+#~ msgid "{} is already mounted at {}."
+#~ msgstr "{} is already mounted at {}."
+
+#~ msgid "There is already a RAID named '{}'"
+#~ msgstr "There is already a RAID named >>{}<<"
+
+#~ msgid "RAID Level \"{}\" requires at least {} active devices"
+#~ msgstr "RAID Level \"{}\" requires at least {} active devices"
+
+#~ msgid "Edit software RAID disk \"{}\""
+#~ msgstr "Edit software RAID disk \"{}\""
+
+#~ msgid "Reboot"
+#~ msgstr "Reboot"
+
+#~ msgid "Fetching info for {} failed"
+#~ msgstr "Fetching info for {} failed"
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "Fetching info for {}"
 
 #~ msgid "Please choose your preferred language."
 #~ msgstr "Please choose your preferred language."
 
+#~ msgid ", mounted at {}"
+#~ msgstr ", mounted at {}"
+
+#, python-brace-format
 #~ msgid "Cannot remove selflabel from pre-exsting {cdtype} {cdlabel}"
 #~ msgstr "Cannot remove selflabel from pre-exsting {cdtype} {cdlabel}"
+
+#~ msgid "Leave formatted as {}"
+#~ msgstr "Leave formatted as {}"
+
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "Do you really want to remove the existing filesystem from {}?"
+
+#~ msgid "Remove filesystem from {}"
+#~ msgstr "Remove filesystem from {}"
+
+#~ msgid ""
+#~ "Mounting an existing filesystem at {} is usually a bad idea, proceed only "
+#~ "with caution."
+#~ msgstr ""
+#~ "Mounting an existing filesystem at {} is usually a bad idea, proceed only "
+#~ "with caution."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
+#~ "installed onto this partition, which must be formatted as fat32."
+#~ msgstr ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
+#~ "installed onto this partition, which must be formatted as fat32."
+
+#~ msgid ""
+#~ " You can choose whether to use the existing filesystem on this partition or "
+#~ "reformat it."
+#~ msgstr ""
+#~ " You can choose whether to use the existing filesystem on this partition or "
+#~ "reformat it."
+
+#~ msgid " The only aspect of this partition that can be edited is the size."
+#~ msgstr " The only aspect of this partition that can be edited is the size."

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -2,79 +2,408 @@
 # Copyright (C) 2017 Canonical Ltd, and Rosetta Contributors 2017
 # This file is distributed under the same license as the subiquity package.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2021-06-04 01:14+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: en_US\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
@@ -90,30 +419,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr ""
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr ""
 
@@ -175,1101 +525,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1303,7 +1185,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1311,134 +1193,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1462,100 +1498,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1612,576 +1591,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2192,11 +1919,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2204,9 +1931,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2214,8 +2119,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2232,190 +2137,329 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,83 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-05-09 01:53+0000\n"
-"Last-Translator: Adolfo Jayme <Unknown>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2019-12-28 00:00+0000\n"
+"Last-Translator: Adolfo Jayme <fitoschido@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: es\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "disco local"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr "Fallo de instalación"
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr "Error de red"
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "Error desconocido"
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "falló la configuración automática"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "Información"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Editar"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Editar IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Editar IPv6"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "Editar"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
+msgctxt "NetDevAction"
+msgid "Edit Wifi"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:45
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Eliminar"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Cerrar"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -94,34 +416,55 @@ msgid " or "
 msgstr " o "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Este campo debe ser un URL %s."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Hecho"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Cancelar"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Sí"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "No"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Cerrar"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Guardar"
 
@@ -159,9 +502,9 @@ msgid "should be in CIDR form ({example})"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "«%s» no está contenido en «%s»"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -183,87 +526,133 @@ msgstr "Desactivado"
 msgid "IPv{v} Method: "
 msgstr "Método de IPv{v}: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Crear"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "Id. de VLAN:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s ya existe"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
+#, python-brace-format
 msgid "Info for {device}"
-msgstr "Información sobre {}"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Nombre:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Dispositivos: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
+msgstr "Tasa de LACP:"
+
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
+#, python-brace-format
+msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
-#, fuzzy, python-brace-format
-msgid "There is already a network device named \"{netdev}\""
-msgstr "Ya hay un dispositivo de red llamado «{}»"
-
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "El nombre no puede quedar vacío."
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr "El nombre no puede superar los 16 caracteres"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "se agotó el tiempo de espera"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Conexiones de red"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -273,1033 +662,500 @@ msgstr ""
 "actualizaciones."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Atrás"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "Continuar sin red"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "Aplicando cambios"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "se agotó el tiempo de espera"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Sí"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "No"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Se ha producido un error"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Se ha completado la instalación."
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Ha finalizado la instalación."
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Instalando el sistema"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Ha finalizado la instalación."
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Se produjo un error durante la instalación"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr "en línea"
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "El nombre no puede quedar vacío."
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} no es entrada válida"
-
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Información"
-
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Editar"
-
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Formato:"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "Añadir partición"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "Crear volumen lógico"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Formato:"
-
-#: ../subiquity/models/filesystem.py:424
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr "Quitar de RAID/LVM"
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Eliminar"
-
-#: ../subiquity/models/filesystem.py:426
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr "Crear dispositivo de arranque"
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "disco local"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "falló la configuración automática"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "volumen lógico"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "partición de {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "partición {} de {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "partición {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-#, fuzzy
-msgid "LVM volume group"
-msgstr "Crear grupo de volúmenes LVM"
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "volumen lógico"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "En este campo no se permiten los caracteres : , y ="
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr "Los únicos caracteres permitidos en este campo son a-z, 0-9, _ y -"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Su nombre:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "El nombre del servidor:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "El nombre que utiliza al comunicarse con otros equipos."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Elija un nombre de usuario:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Elija una contraseña:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Confirme la contraseña:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "El nombre del servidor no debe dejarse vacío"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "El nombre del servidor no debe dejarse vacío"
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Falta el nombre de usuario"
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr "El sistema ha reservado el nombre de usuario «{username}»."
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Se debe definir una contraseña"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Las contraseñas no coinciden"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Configuración de perfil"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
-"Proporcione el nombre de usuario y la contraseña que utilizará para acceder "
-"al sistema. Puede configurar el acceso SSH en la pantalla siguiente, pero "
-"aun se necesita una contraseña para sudo."
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "contraseñas"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Continuar"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr "Enviar a Canonical"
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr "Enviado a Canonical"
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr "FECHA"
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr "TIPO"
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr "ESTADO"
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr "VISTOS"
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr "NO VISTOS"
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
+#, python-brace-format
 msgid "formatted as {fstype}"
-msgstr "formateada como {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:132
+#, python-brace-format
 msgid ", mounted at {path}"
-msgstr ", montada en {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ", no montada"
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Dispositivos:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Tamaño:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, fuzzy, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr "Ya hay un dispositivo de red llamado «{}»"
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr "«.» y «..» no son nombres válidos para dispositivos RAID"
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, fuzzy, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr "formateada como {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, fuzzy, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr "Se limitó el tamaño de la partición a {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, fuzzy, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr "Se redondeó el tamaño a {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Nombre: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "Formato:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr "El nombre de un volumen lógico no puede quedar vacío"
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, fuzzy, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr "El nombre de un volumen lógico no puede contener «{}»"
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, fuzzy, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr "El nombre de un volumen lógico no puede contener «{}»"
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, fuzzy, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr "Ya hay un dispositivo de red llamado «{}»"
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "La ruta sobrepasa PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, fuzzy, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr "{} ya se ha montado en {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "Aceptar"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "volumen lógico {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "partición {} de {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formatear o montar {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "volumen lógico"
-msgstr[1] "volumen lógico"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Eliminar"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:112
+#, python-brace-format
 msgid "Remove filesystem from {device}"
-msgstr "Quitar de {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "contraseñas"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "Crear volumen cifrado"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr "El nombre de un grupo de volúmenes no puede quedar vacío"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr "El nombre de un grupo de volúmenes no puede comenzar con un guion"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
-#, fuzzy, python-brace-format
-msgid "There is already a volume group named '{name}'"
-msgstr "Ya hay un dispositivo de red llamado «{}»"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
+#, python-brace-format
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "No se montó ningún disco o partición."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "PUNTO DE MONTAJE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "TAMAÑO"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TIPO"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "TIPO DE DISPOSITIVO"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Desmontar"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr "Crear grupo de volúmenes LVM"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
-#, fuzzy, python-brace-format
-msgid "Edit volume group \"{name}\""
-msgstr "Editar grupo de volúmenes «{}»"
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
+#, python-brace-format
+msgid "Remove from {device}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "DISPOSITIVO"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "espacio disponible"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr "Crear grupo de volúmenes (LVM)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "RESUMEN DEL SISTEMA DE ARCHIVOS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "DISPOSITIVOS DISPONIBLES"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr "DISPOSITIVOS UTILIZADOS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Restablecer"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Se debe definir una contraseña"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Las contraseñas no coinciden"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1333,7 +1189,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1341,138 +1197,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "Aceptar"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Dispositivos:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Tamaño:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Crear volumen cifrado"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr "El nombre de un grupo de volúmenes no puede quedar vacío"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr "El nombre de un grupo de volúmenes no puede comenzar con un guion"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "No se montó ningún disco o partición."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "PUNTO DE MONTAJE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "TAMAÑO"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TIPO"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "TIPO DE DISPOSITIVO"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "Desmontar"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
-#, fuzzy, python-brace-format
-msgid "Remove from {device}"
-msgstr "Quitar de {}"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
+msgstr "Crear grupo de volúmenes LVM"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "Añadir partición"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/lvm.py:157
+#, python-brace-format
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-#, fuzzy
-msgid "Add As Another Boot Device"
-msgstr "Crear dispositivo de arranque"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-#, fuzzy
-msgid "Use As Boot Device"
-msgstr "Crear dispositivo de arranque"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "DISPOSITIVO"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "espacio disponible"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
-msgstr "Crear grupo de volúmenes (LVM)"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "RESUMEN DEL SISTEMA DE ARCHIVOS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "DISPOSITIVOS DISPONIBLES"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
-msgstr "DISPOSITIVOS UTILIZADOS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "Continuar sin red"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Restablecer"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Nombre: "
+
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Formato:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr "El nombre de un volumen lógico no puede quedar vacío"
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "La ruta sobrepasa PATH_MAX"
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1495,102 +1502,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "Actualización del instalador disponible"
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "Descargando actualización…"
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
+msgstr "«.» y «..» no son nombres válidos para dispositivos RAID"
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
-msgstr ""
-"Espere mientras se descarga el instalador actualizado. Este se reiniciará "
-"automáticamente tras finalizar la descarga."
-
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
-msgstr "Falló la actualización"
-
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr "Descargando y aplicando la actualización:"
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "Continuar sin actualizar"
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Intentar de nuevo"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr "Actualizar al instalador nuevo"
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "Cancelar actualización"
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1647,583 +1595,327 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Ctrl+Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr "Actualizar al instalador nuevo"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "En este campo no se permiten los caracteres : , y ="
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Utilice ↑, ↓ e INTRO para seleccionar el idioma."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
+msgstr "Los únicos caracteres permitidos en este campo son a-z, 0-9, _ y -"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr "Ayuda para escoger un idioma"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Su nombre:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Importar nombre de usuario:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "El nombre del servidor:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "Nombre de usuario de GitHub:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "El nombre que utiliza al comunicarse con otros equipos."
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "Nombre de usuario de GitHub:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Elija un nombre de usuario:"
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Elija una contraseña:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Nombre de usuario de Launchpad:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Confirme la contraseña:"
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr "Instalar servidor OpenSSH"
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Importar identidad SSH:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "de GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "de Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Puede importar sus claves SSH desde GitHub o Launchpad."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr "Permitir autenticación con contraseña por SSH"
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Este campo no debe estar vacío."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr "Confirmar claves SSH"
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr "Se recuperaron claves con las huellas siguientes. ¿Quiere utilizarlas?"
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr "Confirmar clave SSH"
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr "Se recuperó una clave con la huella siguiente. ¿Quiere utilizarla?"
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr "Configuración de SSH"
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "ahora mismo"
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
-msgstr "Hace {amount:2} {unit}"
-
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "El nombre del servidor no debe dejarse vacío"
+
+#: ../subiquity/ui/views/identity.py:109
+#, python-brace-format
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Falta el nombre de usuario"
+
+#: ../subiquity/ui/views/identity.py:123
+#, python-brace-format
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
+msgstr "El sistema ha reservado el nombre de usuario «{username}»."
+
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Configuración de perfil"
 
-#: ../subiquity/ui/views/snaplist.py:256
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap}"
-msgstr "Recuperando información sobre {}"
-
-#: ../subiquity/ui/views/snaplist.py:282
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap} failed"
-msgstr "Recuperando información sobre {}"
-
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Continuar"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
+"Proporcione el nombre de usuario y la contraseña que utilizará para acceder "
+"al sistema. Puede configurar el acceso SSH en la pantalla siguiente, pero "
+"aun se necesita una contraseña para sudo."
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr "Detección automática del teclado"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "contraseñas"
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Disposición"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Presione una de las teclas siguientes:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr "No se reconoció la entrada; inténtelo de nuevo"
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "¿Su teclado incluye esta tecla?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Aplicando la configuración"
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Bloq Mayús"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Alt derecha (Alt Gr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Ctrl derecha"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Mayús derecha"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "Menú"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Mayús"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Ctrl+Mayús"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr "Ctrl+Alt"
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Bloq Mayús"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "Ctrl izquierda+Mayús izquierda"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Alt izquierda"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Ctrl izquierda"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Mayús izquierda"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "Bloq Despl"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr "Atajo: "
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "Disposición:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr "Configuración del teclado"
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-"Seleccione la disposición del teclado conectado directamente al sistema, si "
-"lo hay."
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-"Seleccione a continuación la disposición del teclado o elija «Identificar "
-"teclado» para detectarla automáticamente."
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr "Identificar teclado"
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Reiniciar ahora"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr "Ver el registro completo"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr "Salida completa del instalador"
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Instalando el sistema"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Ha finalizado la instalación."
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr "Cancelar actualización y reiniciar"
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Reiniciar"
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Se produjo un error durante la instalación"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2234,11 +1926,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr "Confirmar acción destructiva"
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2246,9 +1938,191 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "Detección automática del teclado"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Disposición"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Presione una de las teclas siguientes:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr "No se reconoció la entrada; inténtelo de nuevo"
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "¿Su teclado incluye esta tecla?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Bloq Mayús"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Alt derecha (Alt Gr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Ctrl derecha"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Mayús derecha"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Menú"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Mayús"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Ctrl+Mayús"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Ctrl+Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Bloq Mayús"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Ctrl izquierda+Mayús izquierda"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Alt izquierda"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Ctrl izquierda"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Mayús izquierda"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Bloq Despl"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr "Atajo: "
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Disposición:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "Configuración del teclado"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+"Seleccione la disposición del teclado conectado directamente al sistema, si "
+"lo hay."
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+"Seleccione a continuación la disposición del teclado o elija «Identificar "
+"teclado» para detectarla automáticamente."
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr "Identificar teclado"
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Aplicando la configuración"
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2256,8 +2130,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2274,196 +2148,335 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Actualización del instalador disponible"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Descargando actualización…"
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+"Espere mientras se descarga el instalador actualizado. Este se reiniciará "
+"automáticamente tras finalizar la descarga."
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr "Falló la actualización"
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr "Descargando y aplicando la actualización:"
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Continuar sin actualizar"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Intentar de nuevo"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr "Actualizar al instalador nuevo"
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Cancelar actualización"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "ahora mismo"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr "Hace {amount:2} {unit}"
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Importar nombre de usuario:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Nombre de usuario de GitHub:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Nombre de usuario de Launchpad:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr "Instalar servidor OpenSSH"
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Importar identidad SSH:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "de GitHub"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "de Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Puede importar sus claves SSH desde GitHub o Launchpad."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr "Permitir autenticación con contraseña por SSH"
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Este campo no debe estar vacío."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "Confirmar claves SSH"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+"Se recuperaron claves con las huellas siguientes. ¿Quiere utilizarlas?"
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "Confirmar clave SSH"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr "Se recuperó una clave con la huella siguiente. ¿Quiere utilizarla?"
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "Configuración de SSH"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Utilice ↑, ↓ e INTRO para seleccionar el idioma."
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
+msgstr "Ayuda para escoger un idioma"
+
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
-msgstr ""
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
+msgstr "en línea"
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr "Enviar a Canonical"
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr "Enviado a Canonical"
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr "FECHA"
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr "TIPO"
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr "ESTADO"
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr "VISTOS"
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr "NO VISTOS"
-
-#: ../subiquity/ui/views/zdev.py:64
+#: ../subiquity/ui/views/zdev.py:77
 msgid "No zdev devices found."
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:77
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr "EN LÍNEA"
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr "NOMBRES"
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr ""
-
-#~ msgid "partition"
-#~ msgstr "partición"
 
 #~ msgid "Filesystem setup"
 #~ msgstr "Configuración de sistema de archivos"
@@ -2477,8 +2490,17 @@ msgstr ""
 #~ msgid "Choose the installation target"
 #~ msgstr "Elija el destino de instalación"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formatear o montar {}"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "¡Gracias por utilizar Ubuntu!"
+
+#~ msgid "Finished install!"
+#~ msgstr "Ha finalizado la instalación."
+
+#~ msgid "Installation complete!"
+#~ msgstr "Se ha completado la instalación."
 
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Informe de este error en Launchpad"
@@ -2489,6 +2511,9 @@ msgstr ""
 
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Elija el disco en el cual instalar:"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Se ha producido un error"
 
 #~ msgid "starting..."
 #~ msgstr "comenzando…"
@@ -2502,20 +2527,114 @@ msgstr ""
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Utilizar un disco entero"
 
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "«%s» no está contenido en «%s»"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Este campo debe ser un URL %s."
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} no es entrada válida"
+
+#~ msgid "partition of {}"
+#~ msgstr "partición de {}"
+
 #~ msgid "Exit To Shell"
 #~ msgstr "Salir a la consola"
 
+#~ msgid "Info"
+#~ msgstr "Información"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "Editar IPv6"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Editar IPv4"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s ya existe"
+
+#~ msgid "Info for {}"
+#~ msgstr "Información sobre {}"
+
+#~ msgid "There is already a network device named \"{}\""
+#~ msgstr "Ya hay un dispositivo de red llamado «{}»"
+
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
+
+#~ msgid "Edit"
+#~ msgstr "Editar"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Crear volumen lógico"
+
+#~ msgid "Add Partition"
+#~ msgstr "Añadir partición"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Quitar de RAID/LVM"
+
+#~ msgid "partition {} of {}"
+#~ msgstr "partición {} de {}"
+
+#~ msgid "partition {}"
+#~ msgstr "partición {}"
+
+#~ msgid ", mounted at {}"
+#~ msgstr ", montada en {}"
+
+#~ msgid "formatted as {}"
+#~ msgstr "formateada como {}"
+
+#~ msgid "Remove from {}"
+#~ msgstr "Quitar de {}"
 
 #~ msgid "You need to mount a device at / to continue."
 #~ msgstr "Necesita montar un dispositivo en / para continuar."
 
+#~ msgid "{} is already mounted at {}."
+#~ msgstr "{} ya se ha montado en {}."
+
+#~ msgid "logical volume"
+#~ msgstr "volumen lógico"
+
+#~ msgid "partition"
+#~ msgstr "partición"
+
+#~ msgid "Reboot"
+#~ msgstr "Reiniciar"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "Crear dispositivo de arranque"
+
 #~ msgid "Use An Entire Disk And Set Up LVM"
 #~ msgstr "Utilizar un disco entero y configurar LVM"
+
+#~ msgid "Edit volume group \"{}\""
+#~ msgstr "Editar grupo de volúmenes «{}»"
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "El nombre de un volumen lógico no puede contener «{}»"
+
+#~ msgid "logical volume {}"
+#~ msgstr "volumen lógico {}"
+
+#~ msgid "Rounded size up to {}"
+#~ msgstr "Se redondeó el tamaño a {}"
+
+#~ msgid "Capped partition size at {}"
+#~ msgstr "Se limitó el tamaño de la partición a {}"
 
 #~ msgid "Select Done to begin the installation."
 #~ msgstr "Elija Hecho para comenzar la instalación."
 
 #~ msgid "Please choose your preferred language."
 #~ msgstr "Elija su idioma preferido."
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "Recuperando información sobre {}"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,78 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2018-04-22 17:46+0000\n"
+"Last-Translator: Jiri Grönroos <Unknown>\n"
 "Language-Team: Finnish <fi@li.org>\n"
-"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: fi\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Poista"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Sulje"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -89,34 +416,55 @@ msgid " or "
 msgstr " tai "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Tämä kenttä ei voi olla tyhjä."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Valmis"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Peru"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Kyllä"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Ei"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Sulje"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Tallenna"
 
@@ -178,1103 +526,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Luo"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Verkkoyhteydet"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Takaisin"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Kyllä"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Ei"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Tapahtui virhe"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Asennus valmistui!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Asennetaan järjestelmää"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Asennuksen aikana tapahtui virhe"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Palvelimen nimi ei voi olla tyhjä"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Poista"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Nimesi:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Palvelimesi nimi:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Valitse salasana:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Vahvista salasana:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Palvelimen nimi ei voi olla tyhjä"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Palvelimen nimi ei voi olla tyhjä"
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Salasana tulee olla asetettu"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Salasanat eivät vastaa toisiaan"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Profiilin asetukset"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Jatka"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "OK"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Poista"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Ei levyjä tai osioita liitetty."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "LIITOSPISTE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "KOKO"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TYYPPI"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "LAITE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Salasana tulee olla asetettu"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Salasanat eivät vastaa toisiaan"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1308,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1316,134 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "OK"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Ei levyjä tai osioita liitetty."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "LIITOSPISTE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "KOKO"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TYYPPI"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "LAITE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1467,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1617,578 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Control+Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Nimesi:"
+
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Palvelimesi nimi:"
+
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "GitHub-käyttäjätunnus:"
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Valitse salasana:"
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "GitHub-käyttäjätunnus:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Vahvista salasana:"
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Launchpad-käyttäjätunnus:"
-
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Tuo SSH-identiteetti:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "GitHubista"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "Launchpadilta"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Tämä kenttä ei voi olla tyhjä."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Palvelimen nimi ei voi olla tyhjä"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Jatka"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Profiilin asetukset"
+
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Asettelu"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Paina yhtä seuraavista näppäimistä:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "Löytyykö seuraava näppäin näppäimistöstäsi?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Oikea Alt (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Oikea Control"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Oikea Shift"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "Menu-näppäin"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Control+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr "Control+Alt"
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "Vasen Control+Vasen Shift"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Vasen Alt"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Vasen Control"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Vasen Shift"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "Scroll Lock -näppäin"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "Asettelu:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr "Näppäimistön asetukset"
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr "Tunnista näppäimistö"
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Käynnistä uudelleen nyt"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr "Näytä koko loki"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Asennetaan järjestelmää"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Asennuksen aikana tapahtui virhe"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2199,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2211,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Asettelu"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Paina yhtä seuraavista näppäimistä:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Löytyykö seuraava näppäin näppäimistöstäsi?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Oikea Alt (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Oikea Control"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Oikea Shift"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Menu-näppäin"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Control+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Control+Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Vasen Control+Vasen Shift"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Vasen Alt"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Vasen Control"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Vasen Shift"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Scroll Lock -näppäin"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Asettelu:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "Näppäimistön asetukset"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr "Tunnista näppäimistö"
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2221,8 +2120,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2239,196 +2138,341 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Github-käyttäjätunnus:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Launchpad-käyttäjätunnus:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Tuo SSH-identiteetti:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "Githubista"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "Launchpadilta"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Tämä kenttä ei voi olla tyhjä."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
 
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr ""
+#~ msgid "An error has occurred"
+#~ msgstr "Tapahtui virhe"
 
 #~ msgid "Install complete"
 #~ msgstr "Asennus valmis"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Asennus valmistui!"
 
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Kiitos kun käytät Ubuntua!"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,78 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2018-05-03 10:44+0000\n"
+"Last-Translator: François Lallevé <Unknown>\n"
 "Language-Team: French <fr@li.org>\n"
-"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: fr\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "disque local"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Supprimer"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Fermer"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -89,34 +416,55 @@ msgid " or "
 msgstr " ou "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Ce champ doit être une URL %s."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Terminé"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Annuler"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Oui"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Non"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Fermer"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Sauvegarder"
 
@@ -154,9 +502,9 @@ msgid "should be in CIDR form ({example})"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "« %s » n'est pas contenu dans « %s »"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -178,87 +526,133 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Créer"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Connections réseau"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -268,1032 +662,500 @@ msgstr ""
 "aux mises à jour."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Retour"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "Sélectionner la disposition des boutons"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Interface réseau {} configuration WIFI"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Oui"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Non"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Une erreur est survenue"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "L'installation est terminée!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "L'installation est finie!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Installation du système"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Installation terminée !"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Une erreur est survenue durant l'installation"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Le nom de la machine ne doit pas être vide"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} n'est pas une entrée valide"
-
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Supprimer"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "disque local"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Configurer le proxy"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "partition de {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "partition de {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "partition de {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "Les caractères : , et = ne sont pas autorisés dans ce champ"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr "Les seuls caractères autorisés dans ce champ sont a-z, 0-9, _ et -"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Votre nom :"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Le nom de cette machine:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "Le nom qu’il utilise pour communiquer avec d’autres ordinateurs."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Choisir un nom d’utilisateur :"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Choisir un mot de passe :"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Confirmer votre mot de passe:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Le nom réel est trop long, doit être moins de   caractères "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Le nom de la machine ne doit pas être vide"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-"Le nom de la machine est trop long, doit être moins de    charactères. "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Le nom d'hôte doit correspondre à NAME_REGEX, c'est-à-dire [a-z_] [a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Le nom d'utilisateur est manquant"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Le nom d'utilisateur est trop long, doit être moins de   caractères. "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Le nom d'utilisateur doit correspondre à NAME_REGEX, c'est-à-dire [a-z_][a-"
-"z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Le mot de passe doit être défini"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Les mots de passe ne correspondent pas."
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Configuration du profil"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Continuer"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Le Path excède PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Partition bootloader requise\n"
-"\n"
-"GRUB sera installé sur le MBR du disque cible.\n"
-"\n"
-"Cependant, sur un disque avec une table de partition GPT, il n'y a pas "
-"suffisamment d'espace après le MBR de GRUB pour stocker cette seconde couche "
-"core.img, donc une petite partition non-formatée est nécessaire au démarrage "
-"du disque. Elle ne contiendra pas de système de fichier et ne sera pas "
-"montée, et ne peut pas être éditée ici."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "Valider"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formater et/ou monter {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Aucun disque ou partition monté."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "POINT DE MONTAGE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "TAILLE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TYPE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "TYPE DE PÉRIPHÉRIQUE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "PÉRIPHÉRIQUE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "espace libre"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "SOMMAIRE DU SYSTÈME DE FICHIERS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "DISQUES DISPONIBLES"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Rétablir"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Le mot de passe doit être défini"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Les mots de passe ne correspondent pas."
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1327,7 +1189,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1335,135 +1197,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "Valider"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Aucun disque ou partition monté."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "POINT DE MONTAGE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "TAILLE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TYPE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "TYPE DE PÉRIPHÉRIQUE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "PÉRIPHÉRIQUE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "espace libre"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "SOMMAIRE DU SYSTÈME DE FICHIERS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "DISQUES DISPONIBLES"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Rétablir"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Le Path excède PATH_MAX"
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1486,100 +1502,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1636,393 +1595,351 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Ctrl[bnsp]+ Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "Les caractères : , et = ne sont pas autorisés dans ce champ"
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr ""
-"Utilisez les flèches HAUT et BAS, et ENTRÉE pour sélectionner la langue "
-"d'installation"
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
+msgstr "Les seuls caractères autorisés dans ce champ sont a-z, 0-9, _ et -"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Votre nom :"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Importer le nom d'utilisateur :"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Le nom de cette machine:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "Nom d'utilisateur GitHub :"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Le nom qu’il utilise pour communiquer avec d’autres ordinateurs."
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "Nom d'utilisateur GitHub :"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Choisir un nom d’utilisateur :"
 
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-"Un nom d'utilisateur GitHub ne peut contenir que des caractères "
-"alphanumériques ou des traits d'union simples et ne peut pas commencer ou se "
-"terminer par un trait d'union."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Choisir un mot de passe :"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Nom d'utilisateur Launchpad :"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Confirmer votre mot de passe:"
 
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"Un nom d'utilisateur GitHub ne peut contenir que des caractères "
-"alphanumériques ou des traits d'union simples et ne peut pas commencer ou se "
-"terminer par un trait d'union."
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Importer une identité SSH:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "depuis GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "depuis Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Vous pouvez importer vos clés SSH depuis GitHub ou Launchpad."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Ce champ ne doit pas être vide."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "L'identité SSH est trop longue, doit être moins de   caractères. "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"Un nom d'utilisateur GitHub ne peut contenir que des caractères "
-"alphanumériques ou des traits d'union simples et ne peut pas commencer ou se "
-"terminer par un trait d'union."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Le nom de la machine ne doit pas être vide"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Le nom d'utilisateur est manquant"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
+msgstr ""
+
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Configuration du profil"
+
+#: ../subiquity/ui/views/identity.py:159
+msgid ""
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:52
+msgid "Install progress"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
+msgid "Reboot Now"
+msgstr "Redémarrer maintenant"
+
+#: ../subiquity/ui/views/installprogress.py:61
+msgid "View error report"
+msgstr ""
+
 #: ../subiquity/ui/views/installprogress.py:63
+msgid "View full log"
+msgstr "Voir le journal complet"
+
+#: ../subiquity/ui/views/installprogress.py:79
+msgid "Full installer output"
+msgstr "Sortie complète de l'installateur"
+
+#: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Installation du système"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Installation terminée !"
+
+#: ../subiquity/ui/views/installprogress.py:159
+msgid "Cancel update and reboot"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:166
 #: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Continuer"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr ""
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Une erreur est survenue durant l'installation"
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Selecting Continue below will begin the installation process and\n"
+"result in the loss of data on the disks selected to be formatted.\n"
+"\n"
+"You will not be able to return to this or a previous screen once\n"
+"the installation has started.\n"
+"\n"
+"Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
+#: ../subiquity/ui/views/installprogress.py:251
+msgid "Confirm destructive action"
+msgstr "Confirmer l'action"
+
+#: ../subiquity/ui/views/installprogress.py:271
+#, python-brace-format
+msgid ""
+"The installer running on {tty} is currently installing the system.\n"
+"\n"
+"You can wait for this to complete or switch to a shell.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:67
 msgid "Keyboard auto-detection"
 msgstr "Auto-détection du clavier"
 
-#: ../subiquity/ui/views/keyboard.py:90
+#: ../subiquity/ui/views/keyboard.py:93
 msgid ""
 "Keyboard detection starting. You will be asked a series of questions about "
 "your keyboard. Press escape at any time to go back to the previous screen."
@@ -2031,11 +1948,7 @@ msgstr ""
 "votre clavier. Appuyez sur Échap à tout moment pour revenir à l'écran "
 "précédent."
 
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "La détection automatique du clavier a échoué, désolé"
-
-#: ../subiquity/ui/views/keyboard.py:116
+#: ../subiquity/ui/views/keyboard.py:106
 msgid ""
 "Keyboard auto detection completed.\n"
 "\n"
@@ -2045,7 +1958,7 @@ msgstr ""
 "\n"
 "Votre clavier a été détecté comme :\n"
 
-#: ../subiquity/ui/views/keyboard.py:121
+#: ../subiquity/ui/views/keyboard.py:111
 msgid ""
 "\n"
 "If this is correct, select Done on the next screen. If not you can select "
@@ -2058,38 +1971,34 @@ msgstr ""
 "automatique.\n"
 "\n"
 
-#: ../subiquity/ui/views/keyboard.py:135
+#: ../subiquity/ui/views/keyboard.py:128
 msgid "Layout"
 msgstr "Disposition"
 
-#: ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:129
 msgid "Variant"
 msgstr "Variante"
 
-#: ../subiquity/ui/views/keyboard.py:161
+#: ../subiquity/ui/views/keyboard.py:152
 msgid "Please press one of the following keys:"
 msgstr "Veuillez appuyer sur l'une des touches suivantes :"
 
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
 msgid "Input was not recognized, try again"
 msgstr "L'entrée n'a pas été reconnue, réessayez"
 
-#: ../subiquity/ui/views/keyboard.py:222
+#: ../subiquity/ui/views/keyboard.py:213
 msgid "Is the following key present on your keyboard?"
 msgstr "Cette touche est-elle présente sur votre clavier ?"
 
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Application de la configuration"
-
-#: ../subiquity/ui/views/keyboard.py:303
+#: ../subiquity/ui/views/keyboard.py:277
 msgid ""
 "You will need a way to toggle the keyboard between the national layout and "
 "the standard Latin layout.\n"
 "\n"
 "Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
 "behavior in Emacs and other programs that use it for specific needs.\n"
 "\n"
 "Not all listed keys are present on all keyboards. "
@@ -2105,95 +2014,95 @@ msgstr ""
 "\n"
 "Toutes les touches listées ne sont pas présentes sur tous les claviers. "
 
-#: ../subiquity/ui/views/keyboard.py:316
+#: ../subiquity/ui/views/keyboard.py:290
 msgid "Caps Lock"
 msgstr "Verr. Maj."
 
-#: ../subiquity/ui/views/keyboard.py:317
+#: ../subiquity/ui/views/keyboard.py:291
 msgid "Right Alt (AltGr)"
 msgstr "Alt Gr"
 
-#: ../subiquity/ui/views/keyboard.py:318
+#: ../subiquity/ui/views/keyboard.py:292
 msgid "Right Control"
 msgstr "Ctrl droit"
 
-#: ../subiquity/ui/views/keyboard.py:319
+#: ../subiquity/ui/views/keyboard.py:293
 msgid "Right Shift"
 msgstr "Majuscule de droite"
 
-#: ../subiquity/ui/views/keyboard.py:320
+#: ../subiquity/ui/views/keyboard.py:294
 msgid "Right Logo key"
 msgstr "Touche « logo » de droite"
 
-#: ../subiquity/ui/views/keyboard.py:321
+#: ../subiquity/ui/views/keyboard.py:295
 msgid "Menu key"
 msgstr "Touche Menu"
 
-#: ../subiquity/ui/views/keyboard.py:322
+#: ../subiquity/ui/views/keyboard.py:296
 msgid "Alt+Shift"
 msgstr "Alt + Maj."
 
-#: ../subiquity/ui/views/keyboard.py:323
+#: ../subiquity/ui/views/keyboard.py:297
 msgid "Control+Shift"
 msgstr "Ctrl + Majuscule"
 
-#: ../subiquity/ui/views/keyboard.py:324
+#: ../subiquity/ui/views/keyboard.py:298
 msgid "Control+Alt"
 msgstr "Ctrl[bnsp]+ Alt"
 
-#: ../subiquity/ui/views/keyboard.py:325
+#: ../subiquity/ui/views/keyboard.py:299
 msgid "Alt+Caps Lock"
 msgstr "Alt + Verr. maj."
 
-#: ../subiquity/ui/views/keyboard.py:326
+#: ../subiquity/ui/views/keyboard.py:300
 msgid "Left Control+Left Shift"
 msgstr "Ctrl gauche + Majuscule gauche"
 
-#: ../subiquity/ui/views/keyboard.py:327
+#: ../subiquity/ui/views/keyboard.py:301
 msgid "Left Alt"
 msgstr "Alt gauche"
 
-#: ../subiquity/ui/views/keyboard.py:328
+#: ../subiquity/ui/views/keyboard.py:302
 msgid "Left Control"
 msgstr "Ctrl gauche"
 
-#: ../subiquity/ui/views/keyboard.py:329
+#: ../subiquity/ui/views/keyboard.py:303
 msgid "Left Shift"
 msgstr "Majuscule gauche"
 
-#: ../subiquity/ui/views/keyboard.py:330
+#: ../subiquity/ui/views/keyboard.py:304
 msgid "Left Logo key"
 msgstr "Touche « logo » de gauche"
 
-#: ../subiquity/ui/views/keyboard.py:331
+#: ../subiquity/ui/views/keyboard.py:305
 msgid "Scroll Lock key"
 msgstr "Arrêt défil"
 
-#: ../subiquity/ui/views/keyboard.py:332
+#: ../subiquity/ui/views/keyboard.py:306
 msgid "No toggling"
 msgstr "Pas de basculement"
 
-#: ../subiquity/ui/views/keyboard.py:353
+#: ../subiquity/ui/views/keyboard.py:327
 msgid "Shortcut: "
 msgstr "Raccourci : "
 
-#: ../subiquity/ui/views/keyboard.py:363
+#: ../subiquity/ui/views/keyboard.py:337
 msgid "Select layout toggle"
 msgstr "Sélectionner la disposition des boutons"
 
-#: ../subiquity/ui/views/keyboard.py:381
+#: ../subiquity/ui/views/keyboard.py:355
 msgid "Layout:"
 msgstr "Disposition :"
 
-#: ../subiquity/ui/views/keyboard.py:382
+#: ../subiquity/ui/views/keyboard.py:356
 msgid "Variant:"
 msgstr "Variante :"
 
-#: ../subiquity/ui/views/keyboard.py:387
+#: ../subiquity/ui/views/keyboard.py:361
 msgid "Keyboard configuration"
 msgstr "Configuration clavier"
 
-#: ../subiquity/ui/views/keyboard.py:417
+#: ../subiquity/ui/views/keyboard.py:382
 msgid ""
 "Please select the layout of the keyboard directly attached to the system, if "
 "any."
@@ -2201,7 +2110,7 @@ msgstr ""
 "Veuillez sélectionner la disposition du clavier directement attaché au "
 "système, le cas échéant."
 
-#: ../subiquity/ui/views/keyboard.py:420
+#: ../subiquity/ui/views/keyboard.py:385
 msgid ""
 "Please select your keyboard layout below, or select \"Identify keyboard\" to "
 "detect your layout automatically."
@@ -2210,68 +2119,29 @@ msgstr ""
 "sélectionner \"Identifier le clavier\" afin de détecter votre disposition "
 "automatiquement."
 
-#: ../subiquity/ui/views/keyboard.py:429
+#: ../subiquity/ui/views/keyboard.py:394
 msgid "Identify keyboard"
 msgstr "Identifier le clavier"
 
-#: ../subiquity/ui/views/installprogress.py:50
-msgid "Install progress"
-msgstr ""
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Application de la configuration"
 
-#: ../subiquity/ui/views/installprogress.py:57
-msgid "Reboot Now"
-msgstr "Redémarrer maintenant"
-
-#: ../subiquity/ui/views/installprogress.py:59
-msgid "View error report"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:61
-msgid "View full log"
-msgstr "Voir le journal complet"
-
-#: ../subiquity/ui/views/installprogress.py:77
-msgid "Full installer output"
-msgstr "Sortie complète de l'installateur"
-
-#: ../subiquity/ui/views/installprogress.py:142
-msgid "Cancel update and reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
-msgid "Rebooting..."
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/mirror.py:32
 msgid ""
-"Selecting Continue below will begin the installation process and\n"
-"result in the loss of data on the disks selected to be formatted.\n"
-"\n"
-"You will not be able to return to this or a previous screen once\n"
-"the installation has started.\n"
-"\n"
-"Are you sure you want to continue?"
+"You may provide an archive mirror that will be used instead of the default."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
-msgid "Confirm destructive action"
-msgstr "Confirmer l'action"
-
-#: ../subiquity/ui/views/installprogress.py:235
-#, python-brace-format
-msgid ""
-"The installer running on {tty} is currently installing the system.\n"
-"\n"
-"You can wait for this to complete or switch to a shell.\n"
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2279,8 +2149,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "Si vous avez besoin d'utiliser un proxy HTTP pour accéder à l'extérieur, "
 "entrez les informations du proxy ici. Autrement, laissez vide.\n"
@@ -2304,192 +2174,336 @@ msgstr ""
 "Si ce système nécessite un proxy pour se connecter à Internet, entrez ses "
 "détails ici."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Importer le nom d'utilisateur :"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Nom d'utilisateur Github :"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Nom d'utilisateur Launchpad :"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Importer une identité SSH:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "depuis Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "depuis Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Vous pouvez importer vos clés SSH depuis Github ou Launchpad."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Ce champ ne doit pas être vide."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "L'identité SSH est trop longue, doit être moins de   caractères. "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"Un nom d'utilisateur Github ne peut contenir que des caractères "
+"alphanumériques ou des traits d'union simples et ne peut pas commencer ou se "
+"terminer par un trait d'union."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr ""
+"Utilisez les flèches HAUT et BAS, et ENTRÉE pour sélectionner la langue "
+"d'installation"
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""
 
 #~ msgid "Filesystem setup"
@@ -2504,8 +2518,17 @@ msgstr ""
 #~ msgid "Choose the installation target"
 #~ msgstr "Choisir la cible d'installation"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formater et/ou monter {}"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Merci d'utiliser Ubuntu!"
+
+#~ msgid "Finished install!"
+#~ msgstr "L'installation est finie!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "L'installation est terminée!"
 
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Veuillez signaler cette erreur sur Launchpad"
@@ -2518,12 +2541,42 @@ msgstr ""
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Choisir le disque où installer:"
 
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Le nom réel est trop long, doit être moins de   caractères "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr ""
+#~ "Le nom de la machine est trop long, doit être moins de    charactères. "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr ""
+#~ "Le nom d'utilisateur est trop long, doit être moins de   caractères. "
+
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Utiliser un disque entier"
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Le nom d'utilisateur doit correspondre à NAME_REGEX, c'est-à-dire [a-z_][a-"
+#~ "z0-9_-]*"
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Le nom d'hôte doit correspondre à NAME_REGEX, c'est-à-dire [a-z_] [a-z0-9_-]*"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Ce champ doit être une URL %s."
 
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr ""
 #~ "Utilisez les touches HAUT, BAS et ENTRÉE pour sélectionner votre clavier."
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "La détection automatique du clavier a échoué, désolé"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Une erreur est survenue"
 
 #~ msgid "Install complete"
 #~ msgstr "Installation terminée"
@@ -2534,23 +2587,55 @@ msgstr ""
 #~ msgid "starting..."
 #~ msgstr "démarrage..."
 
+#~ msgid "partition of {}"
+#~ msgstr "partition de {}"
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "« %s » n'est pas contenu dans « %s »"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} n'est pas une entrée valide"
+
 #~ msgid "Exit To Shell"
 #~ msgstr "Sortir Du Shell"
 
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
 #~ "\n"
 #~ "Are you sure you want to continue?"
 #~ msgstr ""
-#~ "Sélectionner Continuer ci-dessous va commencer le processus "
-#~ "d'installation dont va résulter une perte des données sur le disque "
-#~ "formaté.\n"
+#~ "Sélectionner Continuer ci-dessous va commencer le processus d'installation "
+#~ "dont va résulter une perte des données sur le disque formaté.\n"
 #~ "\n"
 #~ "Vous ne pourrez pas revenir ici ou à un écran précédent le lancement de "
 #~ "l'installation.\n"
 #~ "\n"
 #~ "Êtes-vous certain de vouloir continuer ?"
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Partition bootloader requise\n"
+#~ "\n"
+#~ "GRUB sera installé sur le MBR du disque cible.\n"
+#~ "\n"
+#~ "Cependant, sur un disque avec une table de partition GPT, il n'y a pas "
+#~ "suffisamment d'espace après le MBR de GRUB pour stocker cette seconde couche "
+#~ "core.img, donc une petite partition non-formatée est nécessaire au démarrage "
+#~ "du disque. Elle ne contiendra pas de système de fichier et ne sera pas "
+#~ "montée, et ne peut pas être éditée ici."
+
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Interface réseau {} configuration WIFI"

--- a/po/gl.po
+++ b/po/gl.po
@@ -1,23 +1,22 @@
-# Latvian translation for subiquity
-# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
+# Galician translation for subiquity
+# Copyright (c) 2021 Rosetta Contributors and Canonical Ltd 2021
 # This file is distributed under the same license as the subiquity package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2021-06-04 13:18+1200\n"
-"PO-Revision-Date: 2017-09-17 14:15+0000\n"
-"Last-Translator: Dimitri John Ledkov <dimitri.ledkov+lp@canonical.com>\n"
-"Language-Team: Latvian <lv@li.org>\n"
+"PO-Revision-Date: 2021-03-19 09:20+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Galician <gl@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2;\n"
-"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
 "X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
-"Language: lv\n"
 
 #: ../subiquity/client/client.py:70
 msgid ""
@@ -31,34 +30,44 @@ msgid ""
 "environment will not survive a reboot. If the install has started, the\n"
 "installed system will be mounted at /target."
 msgstr ""
+"Activouse a sesión de consola do instalador.\n"
+"\n"
+"Esta sesión estase a executar dentro do ambiente do instalador.\n"
+"Desde esta consola pode volver ao instalador escribindo, por exemplo,\n"
+"Control-D ou «exit».\n"
+"\n"
+"Teña en conta que este é un ambiente efémero. Os cambios que\n"
+"se fagan neste ambiente non sobreviven o reinicio. Se a instalación xa\n"
+"se iniciou, o sistema instalado móntase en /target."
 
 #: ../subiquity/client/client.py:212
 msgid "yes"
-msgstr ""
+msgstr "si"
 
 #: ../subiquity/client/client.py:213
 msgid "no"
-msgstr ""
+msgstr "non"
 
 #: ../subiquity/client/client.py:215
 msgid "Confirmation is required to continue."
-msgstr ""
+msgstr "Requírese confirmación para continuar."
 
 #: ../subiquity/client/client.py:216
 msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
+msgstr "Engada «autoinstall» á liña de ordes do seu kernel para evitar isto"
 
 #: ../subiquity/client/client.py:219
 msgid "Continue with autoinstall?"
-msgstr ""
+msgstr "Desexa continuar coa instalación automática?"
 
 #: ../subiquity/client/controllers/ssh.py:91
 msgid "Importing keys failed:"
-msgstr ""
+msgstr "Produciuse un erro ao importar as chaves:"
 
 #: ../subiquity/client/controllers/ssh.py:100
 msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
 msgstr ""
+"ssh-keygen non deu mostrado a pegada dixital ou descargado as chaves:"
 
 #. Information about a drive
 #: ../subiquity/common/filesystem/actions.py:48
@@ -111,10 +120,11 @@ msgstr ""
 #, python-brace-format
 msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
 msgstr ""
+"Non é posíbel editar {selflabel} porque é parte de {cdtype} {cdname}."
 
 #: ../subiquity/common/filesystem/actions.py:165
 msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
+msgstr "Non é posíbel editar RAID xa existentes"
 
 #: ../subiquity/common/filesystem/actions.py:168
 #, python-brace-format
@@ -123,7 +133,7 @@ msgstr ""
 
 #: ../subiquity/common/filesystem/actions.py:177
 msgid "Cannot edit pre-existing volume groups."
-msgstr ""
+msgstr "Non é posíbel editar grupos de volumes xa existentes."
 
 #: ../subiquity/common/filesystem/actions.py:180
 #, python-brace-format
@@ -134,6 +144,7 @@ msgstr ""
 #, python-brace-format
 msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
 msgstr ""
+"Non é posíbel retirar {selflabel} do {cdtype} {cdlabel} xa existente."
 
 #: ../subiquity/common/filesystem/actions.py:258
 #, python-brace-format
@@ -141,26 +152,31 @@ msgid ""
 "Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
 "{min_devices} devices."
 msgstr ""
+"Retirasr {selflabel} deixaría {cdtype} {cdlabel} con menos de {min_devices} "
+"dispositivos."
 
 #: ../subiquity/common/filesystem/actions.py:267
 #, python-brace-format
 msgid ""
 "Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
+msgstr "Retirar {selflabel} deixaría {cdtype} {cdlabel} sen dispositivos."
 
 #: ../subiquity/common/filesystem/actions.py:283
 #, python-brace-format
 msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
 msgstr ""
+"Non é posíbel eliminar {selflabel} porque é parte de {cdtype} {cdname}."
 
 #: ../subiquity/common/filesystem/actions.py:293
 msgid ""
 "Cannot delete a single partition from a device that already has partitions."
 msgstr ""
+"Non é posíbel eliminar unha única partición dun dispositivo que xa ten "
+"particións."
 
 #: ../subiquity/common/filesystem/actions.py:296
 msgid "Cannot delete required bootloader partition"
-msgstr ""
+msgstr "Non é posíbel eliminar a partición de cargador de arranque requirida"
 
 #: ../subiquity/common/filesystem/actions.py:310
 #, python-brace-format
@@ -185,16 +201,18 @@ msgid ""
 "Cannot delete a single logical volume from a volume group that already has "
 "logical volumes."
 msgstr ""
+"Non é posíbel eliminar un único volume lóxico dun grupo de volumes que xa "
+"teña volumes lóxicos."
 
 #. A pre-existing device such as a partition or RAID
 #: ../subiquity/common/filesystem/labels.py:34
 msgid "existing"
-msgstr ""
+msgstr "existente"
 
 #. A newly created device such as a partition or RAID
 #: ../subiquity/common/filesystem/labels.py:37
 msgid "new"
-msgstr ""
+msgstr "nova"
 
 #: ../subiquity/common/filesystem/labels.py:60
 msgid "PReP"
@@ -204,25 +222,25 @@ msgstr ""
 #: ../subiquity/common/filesystem/labels.py:64
 #: ../subiquity/common/filesystem/labels.py:78
 msgid "configured"
-msgstr ""
+msgstr "configurado"
 
 #. boot loader partition
 #: ../subiquity/common/filesystem/labels.py:67
 #: ../subiquity/common/filesystem/labels.py:80
 msgid "unconfigured"
-msgstr ""
+msgstr "sen configurar"
 
 #: ../subiquity/common/filesystem/labels.py:70
 msgid "primary ESP"
-msgstr ""
+msgstr "ESP primaria"
 
 #: ../subiquity/common/filesystem/labels.py:72
 msgid "backup ESP"
-msgstr ""
+msgstr "ESP de respaldo"
 
 #: ../subiquity/common/filesystem/labels.py:74
 msgid "unused ESP"
-msgstr ""
+msgstr "ESP sen utilizar"
 
 #: ../subiquity/common/filesystem/labels.py:81
 msgid "BIOS grub spacer"
@@ -231,118 +249,118 @@ msgstr ""
 #. extended partition
 #: ../subiquity/common/filesystem/labels.py:84
 msgid "extended"
-msgstr ""
+msgstr "ampliado"
 
 #. logical partition
 #: ../subiquity/common/filesystem/labels.py:87
 msgid "logical"
-msgstr ""
+msgstr "lóxica"
 
 #. Flag for a LVM volume group
 #: ../subiquity/common/filesystem/labels.py:97
 msgid "encrypted"
-msgstr ""
+msgstr "cifrado"
 
 #: ../subiquity/common/filesystem/labels.py:113
 msgid "multipath device"
-msgstr ""
+msgstr "Dispositivo multipath"
 
 #: ../subiquity/common/filesystem/labels.py:114
 msgid "local disk"
-msgstr ""
+msgstr "disco local"
 
 #: ../subiquity/common/filesystem/labels.py:119
 #, python-brace-format
 msgid "partition of {device}"
-msgstr ""
+msgstr "partición de {device}"
 
 #: ../subiquity/common/filesystem/labels.py:124
 #, python-brace-format
 msgid "software RAID {level}"
-msgstr ""
+msgstr "RAID de software {level}"
 
 #: ../subiquity/common/filesystem/labels.py:129
 msgid "LVM volume group"
-msgstr ""
+msgstr "grupo de volumes LVM"
 
 #: ../subiquity/common/filesystem/labels.py:134
 msgid "LVM logical volume"
-msgstr ""
+msgstr "Volume lóxico LVM"
 
 #: ../subiquity/common/filesystem/labels.py:168
 #: ../subiquity/ui/views/filesystem/guided.py:95
 #, python-brace-format
 msgid "partition {number}"
-msgstr ""
+msgstr "partición {number}"
 
 #: ../subiquity/common/filesystem/labels.py:170
 #, python-brace-format
 msgid "partition {number} of {device}"
-msgstr ""
+msgstr "partición {number} de {device}"
 
 #: ../subiquity/common/filesystem/labels.py:178
 #, python-brace-format
 msgid "{component_name} of {desc} {name}"
-msgstr ""
+msgstr "{component_name} de {desc} {name}"
 
 #: ../subiquity/common/filesystem/labels.py:186
 #, python-brace-format
 msgid "already formatted as {fstype}"
-msgstr ""
+msgstr "xa está formatado como {fstype}"
 
 #: ../subiquity/common/filesystem/labels.py:188
 #, python-brace-format
 msgid "to be reformatted as {fstype}"
-msgstr ""
+msgstr "vai ser reformatado como {fstype}"
 
 #: ../subiquity/common/filesystem/labels.py:190
 #, python-brace-format
 msgid "to be formatted as {fstype}"
-msgstr ""
+msgstr "vai ser formatado como {fstype}"
 
 #. A filesytem
 #: ../subiquity/common/filesystem/labels.py:196
 #, python-brace-format
 msgid "mounted at {path}"
-msgstr ""
+msgstr "montado en {path}"
 
 #. A filesytem
 #: ../subiquity/common/filesystem/labels.py:199
 msgid "not mounted"
-msgstr ""
+msgstr "sen montar"
 
 #. A filesytem that cannot be mounted (i.e. swap)
 #. is used or unused
 #: ../subiquity/common/filesystem/labels.py:204
 #: ../subiquity/common/filesystem/labels.py:211
 msgid "unused"
-msgstr ""
+msgstr "sen utilizar"
 
 #. A filesytem that cannot be mounted (i.e. swap)
 #. is used or unused
 #: ../subiquity/common/filesystem/labels.py:208
 msgid "used"
-msgstr ""
+msgstr "utilizado"
 
 #: ../subiquity/common/types.py:37
 msgid "Block device probe failure"
-msgstr ""
+msgstr "Produciuse un erro ao sondar un dispositivo de bloque"
 
 #: ../subiquity/common/types.py:38
 msgid "Disk probe failure"
-msgstr ""
+msgstr "Produciuse un erro ao sondar un disco"
 
 #: ../subiquity/common/types.py:39
 msgid "Install failure"
-msgstr ""
+msgstr "Produciuse un fallo na instalación"
 
 #: ../subiquity/common/types.py:40
 msgid "Installer crash"
-msgstr ""
+msgstr "O instalador quebrou"
 
 #: ../subiquity/common/types.py:41
 msgid "Network error"
-msgstr ""
+msgstr "Erro de rede"
 
 #: ../subiquity/common/types.py:42
 msgid "Network client error"
@@ -354,11 +372,11 @@ msgstr ""
 
 #: ../subiquity/common/types.py:44
 msgid "Unknown error"
-msgstr ""
+msgstr "Erro descoñecido"
 
 #: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
-msgstr ""
+msgstr "fallou a configuración automática"
 
 #. Information about a network interface
 #: ../subiquitycore/models/network.py:43
@@ -398,7 +416,7 @@ msgstr ""
 
 #: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
-msgstr ""
+msgstr "As pegadas dixitais da chave do servidor son:\n"
 
 #: ../subiquitycore/ssh.py:66
 #, python-brace-format
@@ -409,11 +427,11 @@ msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
-msgstr ""
+msgstr ", ou "
 
 #: ../subiquitycore/ui/form.py:367
 msgid " or "
-msgstr ""
+msgstr " ou "
 
 #: ../subiquitycore/ui/form.py:371
 #, python-brace-format
@@ -424,7 +442,7 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/filesystem.py:494
 #: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
-msgstr "Gatavs"
+msgstr "Feito"
 
 #: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
@@ -433,19 +451,19 @@ msgstr "Gatavs"
 #: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
 #: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
-msgstr "Atcelt"
+msgstr "Cancelar"
 
 #: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
 #: ../subiquity/ui/views/ssh.py:185
 msgid "Yes"
-msgstr "Jā"
+msgstr "Si"
 
 #: ../subiquitycore/ui/interactive.py:109
 #: ../subiquity/ui/views/installprogress.py:247
 #: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
 #: ../subiquity/ui/views/ssh.py:186
 msgid "No"
-msgstr "Nē"
+msgstr "Non"
 
 #: ../subiquitycore/ui/utils.py:349
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
@@ -455,7 +473,7 @@ msgstr "Nē"
 #: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
 #: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
 msgid "Close"
-msgstr "Aizvērt"
+msgstr "Pechar"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
@@ -466,40 +484,40 @@ msgstr "Aizvērt"
 #: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
 msgid "Save"
-msgstr "Saglabāt"
+msgstr "Gardar"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:88
 msgid "Subnet:"
-msgstr ""
+msgstr "Subrede:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:89
 msgid "Address:"
-msgstr "Adrese:"
+msgstr "Enderezo:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:90
 msgid "Gateway:"
-msgstr "Vārteja:"
+msgstr "Pasarela:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:91
 msgid "Name servers:"
-msgstr ""
+msgstr "Servidores de nomes:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:92
 msgid "IP addresses, comma separated"
-msgstr ""
+msgstr "Enderezos de IP, separados por vírgulas"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:93
 msgid "Search domains:"
-msgstr ""
+msgstr "Dominios de busca:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:94
 msgid "Domains, comma separated"
-msgstr ""
+msgstr "Dominios, separados por vírgulas"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
 #, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr ""
+msgstr "debería estar na forma de CIDR ({example})"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
 #, python-brace-format
@@ -509,22 +527,22 @@ msgstr ""
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
 msgid "Automatic (DHCP)"
-msgstr ""
+msgstr "Automático (DHCP)"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:145
 msgid "Manual"
-msgstr "Manuālā"
+msgstr "Manual"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:147
 msgid "Disabled"
-msgstr ""
+msgstr "Desactivada"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:165
 #, python-brace-format
 msgid "IPv{v} Method: "
-msgstr ""
+msgstr "Método de IPv{v}: "
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
@@ -532,15 +550,15 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
 msgid "Create"
-msgstr ""
+msgstr "Crear"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
-msgstr ""
+msgstr "Identificador de VLAN:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
-msgstr ""
+msgstr "O identificador da VLAN debe estar entre 1 e 4095"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
@@ -549,77 +567,77 @@ msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
-msgstr ""
+msgstr "Engadir unha etiqueta de VLAN"
 
 #. {device} is the name of a network device
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
 #: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
-msgstr ""
+msgstr "Información sobre {device}"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
 #: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
 msgid "Name:"
-msgstr ""
+msgstr "Nome:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
-msgstr ""
+msgstr "Dispositivos: "
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
-msgstr ""
+msgstr "Modo de vencello:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
-msgstr ""
+msgstr "Política de hash de XMIT:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
-msgstr ""
+msgstr "Taxa de LACP:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr ""
+msgstr "Xa existe un dispositivo de rede chamado «{netdev}»"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
-msgstr ""
+msgstr "O nome non pode estar baleiro"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
-msgstr ""
+msgstr "O nome non pode ter máis de 16 caracteres"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
 #: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
-msgstr ""
+msgstr "Crear vencello"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
-msgstr ""
+msgstr "Editar vencello"
 
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
 msgid "Select a network"
-msgstr ""
+msgstr "Seleccione unha rede"
 
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
 #, python-brace-format
 msgid "Network interface {nic} WIFI configuration"
-msgstr ""
+msgstr "Configuración de WIFI da interface de rede {nic}"
 
 #: ../subiquitycore/ui/views/network.py:118
 #, python-brace-format
 msgid "VLAN {id} on interface {link}"
-msgstr ""
+msgstr "VLAN {id} na interface {link}"
 
 #: ../subiquitycore/ui/views/network.py:121
 #, python-brace-format
 msgid "bond master for {interfaces}"
-msgstr ""
+msgstr "vencellar principal para {interfaces}"
 
 #: ../subiquitycore/ui/views/network.py:141
 #, python-brace-format
@@ -629,34 +647,37 @@ msgstr ""
 #: ../subiquitycore/ui/views/network.py:143
 #: ../subiquitycore/ui/views/network.py:145
 msgid "not connected"
-msgstr ""
+msgstr "sen conexión"
 
 #: ../subiquitycore/ui/views/network.py:148
 #, python-brace-format
 msgid "enslaved to {device}"
-msgstr ""
+msgstr "dependente de {device}"
 
 #: ../subiquitycore/ui/views/network.py:175
 msgid "timed out"
-msgstr ""
+msgstr "esgotou o tempo"
 
 #: ../subiquitycore/ui/views/network.py:180
 msgid "static"
-msgstr ""
+msgstr "estático"
 
 #: ../subiquitycore/ui/views/network.py:187
 msgid "disabled"
-msgstr ""
+msgstr "desactivado"
 
 #: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
-msgstr ""
+msgstr "Conexións de rede"
 
 #: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
+"Configure cando menos unha interface que este servidor poida empregar  para "
+"falar con outras máquinas e que, preferibelmente, forneza acceso suficiente "
+"para as actualizacións."
 
 #. See _route_watcher
 #: ../subiquitycore/ui/views/network.py:255
@@ -671,37 +692,37 @@ msgstr ""
 #: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
 #: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
-msgstr "Atpakaļ"
+msgstr "Atrás"
 
 #: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
-msgstr ""
+msgstr "Continuar sen rede"
 
 #: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
-msgstr ""
+msgstr "Estanse a aplicar os cambios"
 
 #. for translators: this is a description of a RAID level
 #: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
-msgstr ""
+msgstr "0 (liñas quitadas)"
 
 #. for translators: this is a description of a RAID level
 #: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
-msgstr ""
+msgstr "1 (replicado)"
 
 #: ../subiquity/models/filesystem.py:173
 msgid "5"
-msgstr ""
+msgstr "5"
 
 #: ../subiquity/models/filesystem.py:174
 msgid "6"
-msgstr ""
+msgstr "6"
 
 #: ../subiquity/models/filesystem.py:175
 msgid "10"
-msgstr ""
+msgstr "10"
 
 #. Attempting to convert input to a size
 #: ../subiquity/models/filesystem.py:210
@@ -715,29 +736,36 @@ msgstr ""
 
 #: ../subiquity/ui/mount.py:71
 msgid "Other"
-msgstr ""
+msgstr "Outro"
 
 #: ../subiquity/ui/mount.py:73
 msgid "Leave unmounted"
-msgstr ""
+msgstr "Deixar sen montar"
 
 #: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
 "\n"
 "Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
+"\n"
+"Desculpe, mais produciuse un problema ao examinar os dispositivos de "
+"almacenamento deste sistema.\n"
 
 #: ../subiquity/ui/views/error.py:73
 msgid ""
 "\n"
 "Sorry, there was a problem completing the installation.\n"
 msgstr ""
+"\n"
+"Desculpe, mais produciuse un problema ao completar a instalación.\n"
 
 #: ../subiquity/ui/views/error.py:76
 msgid ""
 "\n"
 "Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
+"\n"
+"Desculpe, mais produciuse un problema ao aplicar a configuración de rede.\n"
 
 #: ../subiquity/ui/views/error.py:79
 msgid ""
@@ -750,12 +778,16 @@ msgid ""
 "\n"
 "Sorry, the installer has restarted because of an error.\n"
 msgstr ""
+"\n"
+"Desculpe, mais o instalar reiniciouse debido a un erro.\n"
 
 #: ../subiquity/ui/views/error.py:85
 msgid ""
 "\n"
 "Sorry, an unknown error occurred.\n"
 msgstr ""
+"\n"
+"Desculpe, mais produciuse un erro descoñecido.\n"
 
 #: ../subiquity/ui/views/error.py:91
 msgid ""
@@ -763,12 +795,17 @@ msgid ""
 "Information is being collected from the system that will help the\n"
 "developers diagnose the report.\n"
 msgstr ""
+"\n"
+"Estase a recoller información do sistema que ha axudar os programadores\n"
+"a diagnosticar o informe.\n"
 
 #: ../subiquity/ui/views/error.py:95
 msgid ""
 "\n"
 "Loading report...\n"
 msgstr ""
+"\n"
+"Estase a cargar o informe...\n"
 
 #: ../subiquity/ui/views/error.py:98
 msgid ""
@@ -776,12 +813,18 @@ msgid ""
 "Collecting information from the system failed. See the files in\n"
 "/var/log/installer for more.\n"
 msgstr ""
+"\n"
+"Fallou a recolla de información do sistema. Vexa os ficheiros de\n"
+"/var/log/instalar para máis información.\n"
 
 #: ../subiquity/ui/views/error.py:102
 msgid ""
 "\n"
 "Loading the report failed. See the files in /var/log/installer for more.\n"
 msgstr ""
+"\n"
+"Fallou a carga do informe. Vexa os ficheiros de /var/log/installer para máis "
+"información.\n"
 
 #: ../subiquity/ui/views/error.py:108
 msgid ""
@@ -791,6 +834,11 @@ msgid ""
 "the issue by switching to a shell and reconfiguring the system's block\n"
 "devices manually.\n"
 msgstr ""
+"\n"
+"Pode continuar e o instalar simplemente mostra os discos presentes\n"
+"no sistema e non os demais dispositivos de bloque, ou pode que queira\n"
+"arranxar o problema pasando a unha consola e reconfigurando\n"
+"manualmente os dispositivos de bloque.\n"
 
 #: ../subiquity/ui/views/error.py:114
 msgid ""
@@ -798,6 +846,9 @@ msgid ""
 "You may be able to fix the issue by switching to a shell and\n"
 "reconfiguring the system's block devices manually.\n"
 msgstr ""
+"\n"
+"Pode tentar arranxar o problema pasando a unha consola e\n"
+"reconfigurando manualmente os dispositivos de bloque do sistema.\n"
 
 #: ../subiquity/ui/views/error.py:118
 msgid ""
@@ -805,6 +856,9 @@ msgid ""
 "You can continue with the installation but it will be assumed the network\n"
 "is not functional.\n"
 msgstr ""
+"\n"
+"Pode continuar coa instalación mais asúmese que a rede\n"
+"non é funcional.\n"
 
 #: ../subiquity/ui/views/error.py:122
 msgid ""
@@ -817,24 +871,28 @@ msgid ""
 "\n"
 "Do you want to try starting the installation again?\n"
 msgstr ""
+"\n"
+"Desexa probar a iniciar a instalación de novo?\n"
 
 #: ../subiquity/ui/views/error.py:129
 msgid "Select continue to try the installation again."
-msgstr ""
+msgstr "Seleccione Continuar para probar a instalación de novo."
 
 #: ../subiquity/ui/views/error.py:134
 msgid ""
 "\n"
 "If you want to help improve the installer, you can send an error report.\n"
 msgstr ""
+"\n"
+"Se desexa axudar a mellorar o instalador pode enviar un informe de erro.\n"
 
 #: ../subiquity/ui/views/error.py:156
 msgid "Cancel upload"
-msgstr ""
+msgstr "Cancelar o envío"
 
 #: ../subiquity/ui/views/error.py:157
 msgid "Close report"
-msgstr ""
+msgstr "Pechar o informe"
 
 #: ../subiquity/ui/views/error.py:158
 #: ../subiquity/ui/views/installprogress.py:65
@@ -842,29 +900,29 @@ msgstr ""
 #: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
 #: ../subiquity/ui/views/zdev.py:162
 msgid "Continue"
-msgstr "Turpināt"
+msgstr "Continuar"
 
 #: ../subiquity/ui/views/error.py:160
 #: ../subiquity/ui/views/installprogress.py:282
 #: ../subiquity/ui/views/welcome.py:113
 msgid "Switch to a shell"
-msgstr ""
+msgstr "Pasar a unha consola"
 
 #: ../subiquity/ui/views/error.py:162
 msgid "Restart the installer"
-msgstr ""
+msgstr "Reiniciar o instalador"
 
 #: ../subiquity/ui/views/error.py:164
 msgid "Send to Canonical"
-msgstr ""
+msgstr "Enviar a Canonical"
 
 #: ../subiquity/ui/views/error.py:165
 msgid "Sent to Canonical"
-msgstr ""
+msgstr "Enviado a Canonical"
 
 #: ../subiquity/ui/views/error.py:167
 msgid "View full report"
-msgstr ""
+msgstr "Ver o informe completo"
 
 #: ../subiquity/ui/views/error.py:235
 msgid ""
@@ -874,30 +932,35 @@ msgid ""
 "\n"
 "on the filesystem with label {label!r}."
 msgstr ""
+"O informe de erro foi gardado en\n"
+"\n"
+"  {loc}\n"
+"\n"
+"no Sis                  coa etiqueta {label!r}."
 
 #: ../subiquity/ui/views/error.py:317
 msgid "DATE"
-msgstr ""
+msgstr "DATA"
 
 #: ../subiquity/ui/views/error.py:318
 msgid "KIND"
-msgstr ""
+msgstr "TIPO"
 
 #: ../subiquity/ui/views/error.py:319
 msgid "STATUS"
-msgstr ""
+msgstr "ESTADO"
 
 #: ../subiquity/ui/views/error.py:330
 msgid "Select an error report to view:"
-msgstr ""
+msgstr "Seleccione o informe de erro que desexa ver:"
 
 #: ../subiquity/ui/views/error.py:344
 msgid "VIEWED"
-msgstr ""
+msgstr "VISTO"
 
 #: ../subiquity/ui/views/error.py:345
 msgid "UNVIEWED"
-msgstr ""
+msgstr "SEN VER"
 
 #: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
@@ -911,7 +974,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
-msgstr ""
+msgstr ", sen montar"
 
 #: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
@@ -923,23 +986,25 @@ msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
+"Se pon todos os discos en RAID ou VG LVM non haberá onde pór a partición de "
+"arranque."
 
 #: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
-msgstr ""
+msgstr "Confirma que desexa eliminar {desc} {label}?"
 
 #: ../subiquity/ui/views/filesystem/delete.py:53
 #: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
-msgstr ""
+msgstr "Está formatado como {fstype} e montado en {path}"
 
 #: ../subiquity/ui/views/filesystem/delete.py:59
 #: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
-msgstr ""
+msgstr "Está formatado como {fstype} e sen montar."
 
 #: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
@@ -957,11 +1022,11 @@ msgstr[1] ""
 
 #: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
-msgstr ""
+msgstr "Non está formatado nin montado."
 
 #: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
-msgstr ""
+msgstr "Borrar"
 
 #: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
@@ -975,182 +1040,184 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
-msgstr ""
+msgstr "volumes lóxicos"
 
 #: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
-msgstr ""
+msgstr "particións"
 
 #. things is either "logical volumes" or "partitions"
 #: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
-msgstr ""
+msgstr "Retirar todos os {things} de {obj}"
 
 #: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
-msgstr ""
+msgstr "Confirma que desexa eliminar todos os {things} de {obj}?"
 
 #. XXX summarize partitions here?
 #: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
-msgstr ""
+msgstr "Reformatar"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
 msgid "existing {fstype}"
-msgstr ""
+msgstr "{fstype} existente"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
 msgid "new {fstype}"
-msgstr ""
+msgstr "{fstype} novo"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:135
 msgid "No disks or partitions mounted."
-msgstr ""
+msgstr "Non hai discos nin particións montados."
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:160
 msgid "MOUNT POINT"
-msgstr ""
+msgstr "PUNTO DE MONTAXE"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:161
 #: ../subiquity/ui/views/filesystem/filesystem.py:385
 #: ../subiquity/ui/views/snaplist.py:162
 msgid "SIZE"
-msgstr ""
+msgstr "TAMAÑO"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:162
 #: ../subiquity/ui/views/filesystem/filesystem.py:384
 msgid "TYPE"
-msgstr ""
+msgstr "TIPO"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:163
 msgid "DEVICE TYPE"
-msgstr ""
+msgstr "TIPO DE DISPOSITIVO"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:186
 msgid "Unmount"
-msgstr ""
+msgstr "Desmontar"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:260
 msgid "No available devices"
-msgstr ""
+msgstr "Non hai dispositivos dispoñíbeis"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:262
 msgid "No used devices"
-msgstr ""
+msgstr "Non hai dispositivos empregados"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
 msgid "Remove from {device}"
-msgstr ""
+msgstr "Retirar de {device}"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:328
 #, python-brace-format
 msgid "Add {ptype} Partition"
-msgstr ""
+msgstr "Engadir partición {ptype}"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:333
 msgid "Stop Using As Boot Device"
-msgstr ""
+msgstr "Deixar de empregar como dispositivo de arranque"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:338
 msgid "Add As Another Boot Device"
-msgstr ""
+msgstr "Engadir como outro dispositivo de arranque"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:339
 msgid "Use As Boot Device"
-msgstr ""
+msgstr "Empregar como dispositivo de arranque"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:383
 msgid "DEVICE"
-msgstr ""
+msgstr "DISPOSITIVO"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:412
 msgid "free space"
-msgstr ""
+msgstr "espazo libre"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:426
 msgid "Storage configuration"
-msgstr ""
+msgstr "Configuración do almacenamento"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:437
 msgid "Create software RAID (md)"
-msgstr ""
+msgstr "Crear RAID por software (md)"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:440
 msgid "Create volume group (LVM)"
-msgstr ""
+msgstr "Crear grupo de volumes (LVM)"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:447
 msgid "FILE SYSTEM SUMMARY"
-msgstr ""
+msgstr "RESUMO DO SISTEMA DE FICHEIROS"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:452
 msgid "AVAILABLE DEVICES"
-msgstr ""
+msgstr "DISPOSITIVOS DISPOÑÍBEIS"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:459
 msgid "USED DEVICES"
-msgstr ""
+msgstr "DISPOSITIVOS EMPREGADOS"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:477
 msgid "Mount a filesystem at /"
-msgstr ""
+msgstr "Montar un sistema de ficheiros en /"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:479
 msgid "Select a boot disk"
-msgstr ""
+msgstr "Seleccionar un disco de arranque"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:484
 msgid "To continue you need to:"
-msgstr ""
+msgstr "Para continuar hai que:"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:498
 msgid "Reset"
-msgstr "Atstatīt"
+msgstr "Restabelecer"
 
 #: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
+"Configurar unha disposición de almacenamento guiada ou crear unha "
+"personalizada:"
 
 #: ../subiquity/ui/views/filesystem/guided.py:58
 #: ../subiquity/ui/views/filesystem/lvm.py:93
 msgid "Passphrase:"
-msgstr ""
+msgstr "Contrasinal:"
 
 #: ../subiquity/ui/views/filesystem/guided.py:59
 #: ../subiquity/ui/views/filesystem/lvm.py:94
 msgid "Confirm passphrase:"
-msgstr ""
+msgstr "Confirme o contrasinal:"
 
 #: ../subiquity/ui/views/filesystem/guided.py:63
 #: ../subiquity/ui/views/identity.py:137
 msgid "Password must be set"
-msgstr ""
+msgstr "Hai que indicar un contrasinal"
 
 #: ../subiquity/ui/views/filesystem/guided.py:67
 #: ../subiquity/ui/views/identity.py:141
 msgid "Passwords do not match"
-msgstr "Paroles nesakrīt"
+msgstr "Os contrasinais non coinciden"
 
 #: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
-msgstr ""
+msgstr "Cifrar o grupo de LVM con LUKS"
 
 #: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
-msgstr ""
+msgstr "Configurar este disco como grupo de LVM"
 
 #: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
-msgstr ""
+msgstr "Empregar un disco enteiro"
 
 #: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
-msgstr ""
+msgstr "Disposición de almacenamento personalizada"
 
 #: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
@@ -1185,6 +1252,30 @@ msgid ""
 "at /.\n"
 "\n"
 msgstr ""
+"\n"
+"\n"
+"A opción «Empregar un disco enteiro» instala Ubuntu no disco seleccionado,\n"
+"substituíndo todas as particións e datos que haxa.\n"
+"\n"
+"Se a plataforma o require, créanse dúas particións adicionais,\n"
+"unha para /boot e outra que ocupa o resto do disco. Créase un grupo de "
+"volumes\n"
+"de LVM que contén a partición grande. Créase un volume lóxico para\n"
+"o sistema de ficheiros raíz, cun tamaño calculado heuristicamente.\n"
+"Pódese aumentar facilmente coas ferramentas da liña de ordes habituais de "
+"LVM\n"
+"(ou na pantalla seguinte).\n"
+"\n"
+"Tamén pode escoller cifrar o grupo de volumes de LVM. Isto require "
+"configurar\n"
+"un contrasinal, o que faga falta escribir en cada arranque antes de que\n"
+"o sistema arranque. \n"
+"\n"
+"Se non escolle empregar LVM, créase unha única partición que ocupa o resto\n"
+"do disco e que se formata como ext4  e se monta en /.\n"
+"\n"
+"En calquera caso, aínda pode revisar e modificar os resultados.\n"
+"\n"
 
 #: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
@@ -1193,6 +1284,10 @@ msgid ""
 "storage\n"
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
+"\n"
+"A sondaxe de bloques non descubriu ningún disco de tamaño suficiente\n"
+"para admitir a configuración de almacenamento guiado. \n"
+"A pesar disto, a configuración manual podería ser posíbel.\n"
 
 #: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
@@ -1200,27 +1295,32 @@ msgid ""
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
+"\n"
+"A sondaxe de bloques non descubriu ningún disco. Desafortunadamente,\n"
+"isto significa que a instalación non é posíbel.\n"
 
 #: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
-msgstr ""
+msgstr "Configuración de almacenamento guiada"
 
 #: ../subiquity/ui/views/filesystem/guided.py:221
 #: ../subiquity/ui/views/filesystem/partition.py:422
 #: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
 #: ../subiquity/ui/views/keyboard.py:332
 msgid "OK"
-msgstr ""
+msgstr "Aceptar"
 
 #: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
-msgstr ""
+msgstr "Axuda para a configuración de almacenamento guiada"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:61
 msgid ""
 "The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
 "9, +, _, . and -"
 msgstr ""
+"Os únicos caracteres permitidos no nome dun grupo de volumes son a-z, A-Z, 0-"
+"9, +, _, . e -"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:86
 msgid "passphrases"
@@ -1229,113 +1329,116 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/lvm.py:90
 #: ../subiquity/ui/views/filesystem/raid.py:92
 msgid "Devices:"
-msgstr ""
+msgstr "Dispositivos:"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:91
 #: ../subiquity/ui/views/filesystem/raid.py:93
 msgid "Size:"
-msgstr ""
+msgstr "Tamaño:"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:92
 msgid "Create encrypted volume"
-msgstr ""
+msgstr "Crear un volume cifrado"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:105
 msgid "Select at least one device to be part of the volume group."
 msgstr ""
+"Seleccione cando menos un dispositivo que faga parte do grupo de volumes."
 
 #: ../subiquity/ui/views/filesystem/lvm.py:111
 msgid "The name of a volume group cannot be empty"
-msgstr ""
+msgstr "O nome do grupo de volumes non pode estar baleiro"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:113
 msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
+msgstr "O nome do grupo de volumes non pode comezar cun guión"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
 msgid "There is already a volume group named '{name}'"
-msgstr ""
+msgstr "Xa existe un grupo de volumes chamado «{name}»"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
 msgid "{name} is not a valid name for a volume group"
-msgstr ""
+msgstr "{name} non é un nome válido para un grupo de volumes"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:124
 msgid "Passphrase must be set"
-msgstr ""
+msgstr "Hai que indicar un contrasinal"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:129
 msgid "Passphrases do not match"
-msgstr ""
+msgstr "Os contrasinais non coinciden"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:142
 msgid "Create LVM volume group"
-msgstr ""
+msgstr "Crear un grupo de volumes LVM"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
 msgid "Edit volume group \"{name}\""
-msgstr ""
+msgstr "Editar o grupo de volumes «{name}»"
 
 #: ../subiquity/ui/views/filesystem/partition.py:76
 msgid "Leave unformatted"
-msgstr ""
+msgstr "Deixar sen formatar"
 
 #: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
 msgid "Leave formatted as {fstype}"
-msgstr ""
+msgstr "Deixar formatado como {fstype}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:112
 #, python-brace-format
 msgid "Capped partition size at {size}"
-msgstr ""
+msgstr "Tamaño de partición limitado a {size}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:119
 #, python-brace-format
 msgid "Rounded size up to {size}"
-msgstr ""
+msgstr "Tamaño arredondado a {size}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:131
 msgid ""
 "The only characters permitted in the name of a logical volume are a-z, A-Z, "
 "0-9, +, _, . and -"
 msgstr ""
+"Os únicos caracteres permitidos no nome dun volume lóxico son a-z, A-Z, 0-9, "
+"+, _, . e -"
 
 #: ../subiquity/ui/views/filesystem/partition.py:165
 #, python-brace-format
 msgid "Size (max {size}):"
-msgstr ""
+msgstr "Tamaño (máx. {size}):"
 
 #: ../subiquity/ui/views/filesystem/partition.py:202
 msgid "Name: "
-msgstr ""
+msgstr "Nome: "
 
 #: ../subiquity/ui/views/filesystem/partition.py:204
 msgid "Format:"
-msgstr ""
+msgstr "Formato:"
 
 #: ../subiquity/ui/views/filesystem/partition.py:205
 msgid "Mount:"
-msgstr ""
+msgstr "Montaxe:"
 
 #: ../subiquity/ui/views/filesystem/partition.py:207
 msgid "Use as swap"
-msgstr ""
+msgstr "Empregar como memoria de intercambio"
 
 #: ../subiquity/ui/views/filesystem/partition.py:208
 msgid "Use this swap partition in the installed system."
-msgstr ""
+msgstr "Empregar esta partición de intercambio no sistema instalado."
 
 #: ../subiquity/ui/views/filesystem/partition.py:232
 msgid "The name of a logical volume cannot be empty"
-msgstr ""
+msgstr "O nome dun volume lóxico non pode estar baleiro"
 
 #: ../subiquity/ui/views/filesystem/partition.py:234
 msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
+msgstr "O nome dun volume lóxico non pode comezar cun guión"
 
 #: ../subiquity/ui/views/filesystem/partition.py:237
 #, python-brace-format
@@ -1354,12 +1457,12 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/partition.py:258
 msgid "Path exceeds PATH_MAX"
-msgstr ""
+msgstr "A ruta excede de PATH_MAX"
 
 #: ../subiquity/ui/views/filesystem/partition.py:261
 #, python-brace-format
 msgid "{device} is already mounted at {path}."
-msgstr ""
+msgstr "{device} xa está montado en {path}."
 
 #: ../subiquity/ui/views/filesystem/partition.py:269
 #, python-brace-format
@@ -1367,6 +1470,8 @@ msgid ""
 "Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
 "proceed only with caution."
 msgstr ""
+"Normalmente, montar un sistema de ficheiros xa existente en {mountpoint} é "
+"unha mala idea; proceda con coidado."
 
 #: ../subiquity/ui/views/filesystem/partition.py:285
 #, python-brace-format
@@ -1381,18 +1486,31 @@ msgid ""
 "will not contain a filesystem and will not be mounted, and cannot be\n"
 "edited here.\n"
 msgstr ""
+"Partición do cargador de arranque\n"
+"\n"
+"{middle}\n"
+"\n"
+"Porén, nun disco cunha táboa de partición GPT non hai espazo\n"
+"abondo despois do MBR para que GRUB almacene a súa core.img\n"
+"da segunda etapa, polo que se precisa unha partición pequena sen formatar\n"
+"no inicio do disco. Non contén un sistema de ficheiros, non se monta e\n"
+"non é posíbel montala aquí.\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:297
 msgid ""
 "If this disk is selected as a boot device, GRUB will be installed onto\n"
 "the target disk's MBR."
 msgstr ""
+"Ao seleccionar este disco como dispositivo de arranque, GRUB instálase\n"
+"no MBR do disco de destino."
 
 #: ../subiquity/ui/views/filesystem/partition.py:301
 msgid ""
 "As this disk has been selected as a boot device, GRUB will be\n"
 "installed onto the target disk's MBR."
 msgstr ""
+"Dado que este disco foi seleccionado como dispositivo de arranque, \n"
+"GRUB vaise instalar no MBR do disco de destino."
 
 #: ../subiquity/ui/views/filesystem/partition.py:305
 msgid ""
@@ -1402,6 +1520,11 @@ msgid ""
 "disk is selected as a boot device, Grub will be installed onto this\n"
 "partition, which must be formatted as fat32.\n"
 msgstr ""
+"Partición do cargador de arranque\n"
+"\n"
+"Esta é unha ESP / «partición de sistema EFI», tal e como require UEFI.\n"
+"Ao seleccionar este disco como dispositivo de arranque, Grub instálase\n"
+"nesta partición, que debe ter o formato fat32.\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:313
 msgid ""
@@ -1411,16 +1534,25 @@ msgid ""
 "disk has been selected as a boot device, Grub will be installed onto\n"
 "this partition, which must be formatted as fat32.\n"
 msgstr ""
+"Partición do cargador de arranque\n"
+"\n"
+"Esta é unha ESP / «partición de sistema EFI», tal e como require UEFI.\n"
+"Ao estar seleccionado este disco como dispositivo de arranque, Grub "
+"instálase\n"
+"nesta partición, que debe ter o formato fat32.\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:321
 msgid "The only aspect of this partition that can be edited is the size.\n"
 msgstr ""
+"O único aspecto desta partición que é posíbel editar é o seu tamaño.\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:325
 msgid ""
 "You can choose whether to use the existing filesystem on this\n"
 "partition or reformat it.\n"
 msgstr ""
+"Pode escoller entre empregar o sistema de ficheiros existente\n"
+"nesta partición ou reformatala.\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:330
 msgid ""
@@ -1429,6 +1561,10 @@ msgid ""
 "This is the PReP partion which is required on POWER. If this disk is\n"
 "selected as a boot device, Grub will be installed onto this partition.\n"
 msgstr ""
+"Partición do cargador de arranque requirida\n"
+"\n"
+"Esta é a partición PReP requirida por POWER. Ao seleccionar este\n"
+"disco como dispositivo de arranque, Grub instálase nesta partición.\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:337
 msgid ""
@@ -1438,40 +1574,46 @@ msgid ""
 "been selected as a boot device, Grub will be installed onto this\n"
 "partition.\n"
 msgstr ""
+"Partición do cargador de arranque requirida\n"
+"\n"
+"Esta é a partición PReP requirida por POWER. Ao ter seleccionado este\n"
+"disco como dispositivo de arranque, Grub instálase nesta partición.\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:429
 msgid "Use existing fat32 filesystem"
-msgstr ""
+msgstr "Empregar o sistema de ficheiros fat32 existente"
 
 #: ../subiquity/ui/views/filesystem/partition.py:435
 msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
+msgstr "Reformatar como sistema de ficheiros fat32 novo"
 
 #: ../subiquity/ui/views/filesystem/partition.py:513
 #, python-brace-format
 msgid "Adding logical volume to {vgname}"
-msgstr ""
+msgstr "Estase a engadir o volume lóxico a {vgname}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:516
 #, python-brace-format
 msgid "Adding {ptype} partition to {device}"
-msgstr ""
+msgstr "Estase a engadir a partición {ptype} a {device}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:522
 #, python-brace-format
 msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
+msgstr "Estase a editar o volume lóxico {lvname} de {vgname}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:527
 #, python-brace-format
 msgid "Editing partition {number} of {device}"
-msgstr ""
+msgstr "Estase a editar a partición {number} de {device}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:580
 msgid ""
 "Formatting and mounting a disk directly is unusual. You probably want to add "
 "a partition instead."
 msgstr ""
+"Formatar e montar un disco directamente non é o normal. Posibelmente o que "
+"desexe sexa engadir unha partición."
 
 #: ../subiquity/ui/views/filesystem/partition.py:592
 #, python-brace-format
@@ -1480,13 +1622,15 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
-msgstr ""
+msgstr "Estase a agardar a que conclúa a sondaxe do almacenamento"
 
 #: ../subiquity/ui/views/filesystem/probing.py:48
 msgid ""
 "The installer is probing for block devices to install to. Please wait until "
 "it completes."
 msgstr ""
+"O instalador está sondando dispositivos de bloque para instalar. Agarde a "
+"que conclúa."
 
 #: ../subiquity/ui/views/filesystem/probing.py:61
 msgid ""
@@ -1494,26 +1638,30 @@ msgid ""
 "on Launchpad, and if possible include the contents of the /var/log/installer "
 "directory."
 msgstr ""
+"Desafortunadamente, fallou a sondaxe de dispositivos para instalar. Informe "
+"dun erro en Launchpad e, de ser posíbel, inclúa o contido do directorio "
+"/var/log/installer."
 
 #: ../subiquity/ui/views/filesystem/probing.py:68
 msgid "Probing for devices to install to failed"
-msgstr ""
+msgstr "Fallou a sondaxe de dispositivos para instalar"
 
 #: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
-msgstr ""
+msgstr "Mostrar o informe de erro"
 
 #: ../subiquity/ui/views/filesystem/raid.py:67
 msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
+msgstr "/ non está permitido no nome dun dispositivo RAID"
 
 #: ../subiquity/ui/views/filesystem/raid.py:73
 msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
+"Os espazos en branco non están permitidos no nome dun dispositivo RAID"
 
 #: ../subiquity/ui/views/filesystem/raid.py:91
 msgid "RAID Level:"
-msgstr ""
+msgstr "Nivel de RAID:"
 
 #: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
@@ -1522,21 +1670,23 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/raid.py:107
 msgid ". and .. are not valid names for RAID devices"
-msgstr ""
+msgstr ". e .. non son nomes válidos para dispositivos RAID"
 
 #: ../subiquity/ui/views/filesystem/raid.py:113
 #, python-brace-format
 msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
+"O nivel de RAID «{level}» require dun mínimo de {min_active} dispositivos "
+"activos"
 
 #: ../subiquity/ui/views/filesystem/raid.py:126
 msgid "Create software RAID (\"MD\") disk"
-msgstr ""
+msgstr "Crear disco de RAID por software («MD»)"
 
 #: ../subiquity/ui/views/filesystem/raid.py:142
 #, python-brace-format
 msgid "Edit software RAID disk \"{name}\""
-msgstr ""
+msgstr "Editar disco de RAID por software «{name}»"
 
 #: ../subiquity/ui/views/help.py:70
 #, python-brace-format
@@ -1555,6 +1705,21 @@ msgid ""
 "\n"
 "This is version {snap_version} of the installer.\n"
 msgstr ""
+"\n"
+"Reciba a benvida ao instalador de Ubuntu Server!\n"
+"\n"
+"O servidor de Linux máis popular na nube e no centro de datos, esta\n"
+"publicación de Ubuntu recibirá actualizacións durante 9 meses a partir da "
+"publicación.\n"
+"\n"
+"O instalador vai guiar agora na instalación de Ubuntu Server\n"
+"{release}.\n"
+"\n"
+"O instalador só require das teclas de frecha para arriba e para abaixo, "
+"espazo\n"
+"(ou Intro) e, ocasionalmente, escribir algo.\n"
+"\n"
+"Esta é a versión {snap_version} do instalador.\n"
 
 #: ../subiquity/ui/views/help.py:86
 #, python-brace-format
@@ -1573,6 +1738,21 @@ msgid ""
 "\n"
 "This is version {snap_version} of the installer.\n"
 msgstr ""
+"\n"
+"Reciba a benvida ao instalador de Ubuntu Server!\n"
+"\n"
+"O servidor de Linux máis popular na nube e no centro de datos, vostede pode\n"
+"confiar en Ubuntu Server e nos seus cinco anos de anovacións gratuítas "
+"garantizadas.\n"
+"\n"
+"O instalador vai guiar agora na instalación de Ubuntu Server\n"
+"{release}.\n"
+"\n"
+"O instalador só require das teclas de frecha para arriba e para abaixo, "
+"espazo\n"
+"(ou Intro) e, ocasionalmente, escribir algo.\n"
+"\n"
+"Esta é a versión {snap_version} do instalador.\n"
 
 #: ../subiquity/ui/views/help.py:102
 msgid ""
@@ -1587,6 +1767,8 @@ msgid ""
 "\n"
 "To connect, SSH to any of these addresses:\n"
 msgstr ""
+"\n"
+"Para conectar, faga SSH a un destes enderezos:\n"
 
 #: ../subiquity/ui/views/help.py:111
 #, python-brace-format
@@ -1635,6 +1817,10 @@ msgid ""
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
+"\n"
+"Desafortunadamente, semella que este sistema non ten enderezos de IP "
+"globais\n"
+"neste momento.\n"
 
 #: ../subiquity/ui/views/help.py:141
 msgid ""
@@ -1642,46 +1828,49 @@ msgid ""
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
+"\n"
+"Desafortunadamente, o instalador non foi quen de detectar  o contrasinal\n"
+"que se indicou.\n"
 
 #: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
-msgstr ""
+msgstr "Pódense empregar as teclas seguintes en calquera momento:"
 
 #: ../subiquity/ui/views/help.py:221
 msgid "ESC"
-msgstr ""
+msgstr "ESC"
 
 #: ../subiquity/ui/views/help.py:221
 msgid "go back"
-msgstr ""
+msgstr "retroceder"
 
 #: ../subiquity/ui/views/help.py:222
 msgid "F1"
-msgstr ""
+msgstr "F1"
 
 #: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
-msgstr ""
+msgstr "abrir o menú de axuda"
 
 #: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
-msgstr ""
+msgstr "Control-Z, F2"
 
 #: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
-msgstr ""
+msgstr "acceder á consola"
 
 #: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
-msgstr ""
+msgstr "Control-L, F3"
 
 #: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
-msgstr ""
+msgstr "actualizar as pantalla"
 
 #: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
-msgstr ""
+msgstr "Control-T, F4"
 
 #: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
@@ -1689,67 +1878,67 @@ msgstr ""
 
 #: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
-msgstr ""
+msgstr "Control-X"
 
 #: ../subiquity/ui/views/help.py:232
 msgid "quit"
-msgstr ""
+msgstr "saír"
 
 #: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
-msgstr ""
+msgstr "Control-E"
 
 #: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
-msgstr ""
+msgstr "xerar un informe de erro detallado"
 
 #: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
-msgstr ""
+msgstr "Control-R"
 
 #: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
-msgstr ""
+msgstr "xerar un informe de erro sucinto"
 
 #: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr ""
+msgstr "Control-G"
 
 #: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr ""
+msgstr "simular a execución dunha instalación"
 
 #: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
-msgstr ""
+msgstr "Control-U"
 
 #: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
-msgstr ""
+msgstr "quebrar a interface gráfica"
 
 #: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
-msgstr ""
+msgstr "(só en execucións simuladas)"
 
 #: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
-msgstr ""
+msgstr "Atallos de teclado"
 
 #: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
-msgstr ""
+msgstr "Sobre este instalador"
 
 #: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Atallos do teclado"
 
 #: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
-msgstr ""
+msgstr "Entrar na consola"
 
 #: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
-msgstr ""
+msgstr "Axuda sobre o acceso mediante SSH"
 
 #: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
@@ -1757,51 +1946,51 @@ msgstr ""
 
 #: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
-msgstr ""
+msgstr "Axuda sobre esta pantalla"
 
 #: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
-msgstr ""
+msgstr "Ver os informes de erro"
 
 #: ../subiquity/ui/views/help.py:399
 msgid "Help"
-msgstr ""
+msgstr "Axuda"
 
 #: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
-msgstr ""
+msgstr "Sobre o instalador"
 
 #: ../subiquity/ui/views/identity.py:55
 msgid "The characters : , and = are not permitted in this field"
-msgstr ""
+msgstr "Os caracteres :, e = non están permitidos neste campo"
 
 #: ../subiquity/ui/views/identity.py:65
 msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
+msgstr "Os únicos caracteres permitidos neste campo son a-z, 0-9, _ e -"
 
 #: ../subiquity/ui/views/identity.py:89
 msgid "Your name:"
-msgstr "Jūsu vārds:"
+msgstr "O seu nome:"
 
 #: ../subiquity/ui/views/identity.py:91
 msgid "Your server's name:"
-msgstr ""
+msgstr "O nome deste servidor:"
 
 #: ../subiquity/ui/views/identity.py:92
 msgid "The name it uses when it talks to other computers."
-msgstr "Šo nosaukumu izmanto saziņā ar citiem datoriem."
+msgstr "O nome que utiliza para falar con outros computadores."
 
 #: ../subiquity/ui/views/identity.py:93
 msgid "Pick a username:"
-msgstr "Izvēlieties lietotājvārdu:"
+msgstr "Escolla un nome de usuario:"
 
 #: ../subiquity/ui/views/identity.py:94
 msgid "Choose a password:"
-msgstr "Izvēlieties paroli:"
+msgstr "Escolla un contrasinal:"
 
 #: ../subiquity/ui/views/identity.py:95
 msgid "Confirm your password:"
-msgstr "Apstipriniet paroli:"
+msgstr "Confirme o contrasinal:"
 
 #: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
@@ -1810,7 +1999,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:105
 msgid "Server name must not be empty"
-msgstr ""
+msgstr "O nome de servidor non pode estar baleiro"
 
 #: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
@@ -1823,7 +2012,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:119
 msgid "Username missing"
-msgstr ""
+msgstr "Falta o nome de usuario"
 
 #: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
@@ -1838,16 +2027,18 @@ msgstr ""
 #, python-brace-format
 msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
+"O nome de usuario «{username}» está reservado para o seu uso por parte do "
+"sistema."
 
 #. desc is "passwords" or "passphrases"
 #: ../subiquity/ui/views/identity.py:150
 #, python-brace-format
 msgid "{desc} do not match"
-msgstr ""
+msgstr "{desc} non coincide"
 
 #: ../subiquity/ui/views/identity.py:158
 msgid "Profile setup"
-msgstr ""
+msgstr "Configuración do perfil"
 
 #: ../subiquity/ui/views/identity.py:159
 msgid ""
@@ -1855,32 +2046,35 @@ msgid ""
 "can configure SSH access on the next screen but a password is still needed "
 "for sudo."
 msgstr ""
+"Introduza o nome de usuario e o contrasinal que vai empregar para acceder a "
+"este sistema. Pode configurar o acceso mediante SSH na pantalla seguinte, "
+"mais o contrasinal é preciso para sudo."
 
 #: ../subiquity/ui/views/identity.py:188
 msgid "passwords"
-msgstr ""
+msgstr "contrasinais"
 
 #: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
-msgstr ""
+msgstr "Avance da instalación"
 
 #: ../subiquity/ui/views/installprogress.py:59
 #: ../subiquity/ui/views/installprogress.py:174
 #: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
-msgstr ""
+msgstr "Reiniciar agora"
 
 #: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
-msgstr ""
+msgstr "Ver o informe de erros"
 
 #: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
-msgstr ""
+msgstr "Ver o rexistro completo"
 
 #: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
-msgstr ""
+msgstr "Saída completa do instalador"
 
 #: ../subiquity/ui/views/installprogress.py:142
 #: ../subiquity/ui/views/installprogress.py:145
@@ -1888,26 +2082,26 @@ msgstr ""
 #: ../subiquity/ui/views/installprogress.py:151
 #: ../subiquity/ui/views/installprogress.py:154
 msgid "Installing system"
-msgstr "Instalēju sistēmu"
+msgstr "Estase a instalar o sistema"
 
 #: ../subiquity/ui/views/installprogress.py:157
 #: ../subiquity/ui/views/installprogress.py:165
 #: ../subiquity/ui/views/installprogress.py:173
 msgid "Install complete!"
-msgstr ""
+msgstr "Completouse a instalación!"
 
 #: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
-msgstr ""
+msgstr "Cancelar a actualización e reiniciar"
 
 #: ../subiquity/ui/views/installprogress.py:166
 #: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
-msgstr ""
+msgstr "Estase a reiniciar..."
 
 #: ../subiquity/ui/views/installprogress.py:180
 msgid "An error occurred during installation"
-msgstr ""
+msgstr "Produciuse un erro durante a instalación"
 
 #: ../subiquity/ui/views/installprogress.py:230
 msgid ""
@@ -1919,10 +2113,17 @@ msgid ""
 "\n"
 "Are you sure you want to continue?"
 msgstr ""
+"Ao seleccionar Continuar abaixo, o proceso de instalación comezará\n"
+"e causará a perda dos datos dos discos seleccionados para seren formatados.\n"
+"\n"
+"Non poderá retornar a esta pantalla ou a ningunha anterior unha vez\n"
+"comece a instalación.\n"
+"\n"
+"Con          des    continuar?"
 
 #: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
-msgstr ""
+msgstr "Confirme unha acción destrutiva"
 
 #: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
@@ -1931,16 +2132,22 @@ msgid ""
 "\n"
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
+"O instalador que se está a executar en {tty} está a instalar o sistema neste "
+"momento.\n"
+"\n"
+"Pode agardar a que conclúa ou pasar a unha consola.\n"
 
 #: ../subiquity/ui/views/keyboard.py:67
 msgid "Keyboard auto-detection"
-msgstr ""
+msgstr "Detección automática do teclado"
 
 #: ../subiquity/ui/views/keyboard.py:93
 msgid ""
 "Keyboard detection starting. You will be asked a series of questions about "
 "your keyboard. Press escape at any time to go back to the previous screen."
 msgstr ""
+"Comeza a detección do teclado. Faránselle unhas preguntas sobre o seu "
+"teclado. Prema escape en calquera momento para retornar á pantalla anterior."
 
 #: ../subiquity/ui/views/keyboard.py:106
 msgid ""
@@ -1948,6 +2155,9 @@ msgid ""
 "\n"
 "Your keyboard was detected as:\n"
 msgstr ""
+"Concluíu a detección automática do teclado.\n"
+"\n"
+"O teclado detectado foi:\n"
 
 #: ../subiquity/ui/views/keyboard.py:111
 msgid ""
@@ -1956,26 +2166,30 @@ msgid ""
 "another layout or run the automated detection again.\n"
 "\n"
 msgstr ""
+"\n"
+"De ser correcto, seleccione Feito na pantalla seguinte. Se non, pode "
+"seleccionar outra disposición ou executar a detección automática de novo.\n"
+"\n"
 
 #: ../subiquity/ui/views/keyboard.py:128
 msgid "Layout"
-msgstr ""
+msgstr "Disposición"
 
 #: ../subiquity/ui/views/keyboard.py:129
 msgid "Variant"
-msgstr ""
+msgstr "Variante"
 
 #: ../subiquity/ui/views/keyboard.py:152
 msgid "Please press one of the following keys:"
-msgstr ""
+msgstr "Prema nunha das teclas seguintes:"
 
 #: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
 msgid "Input was not recognized, try again"
-msgstr ""
+msgstr "Non se recoñeceu o introducido. Ténteo de novo"
 
 #: ../subiquity/ui/views/keyboard.py:213
 msgid "Is the following key present on your keyboard?"
-msgstr ""
+msgstr "Conta o seu teclado coa tecla seguinte?"
 
 #: ../subiquity/ui/views/keyboard.py:277
 msgid ""
@@ -1989,131 +2203,149 @@ msgid ""
 "\n"
 "Not all listed keys are present on all keyboards. "
 msgstr ""
+"Vai ter que buscar o xeito de alternar o teclado entre a disposición "
+"nacional e latina estándar.\n"
+"\n"
+"A tecla Alt da dereita ou a de bloqueo de maiúsculas escóllense "
+"frecuentemente por razóns de ergonomía (neste último caso, emprega a "
+"combinación Maiús.+Bloqueo de maiúsculas para alternar as maiúsculas). "
+"Alt+Maiús. tamén é unha combinación popular; porén, perderá o seu "
+"comportamento habitual en Emacs e noutros programas que a empregan para "
+"casos específicos.\n"
+"\n"
+"Non todas as teclas listadas están presentes en todos os teclados. "
 
 #: ../subiquity/ui/views/keyboard.py:290
 msgid "Caps Lock"
-msgstr ""
+msgstr "Bloq Maius"
 
 #: ../subiquity/ui/views/keyboard.py:291
 msgid "Right Alt (AltGr)"
-msgstr ""
+msgstr "Alt dereito (Alt Gr)"
 
 #: ../subiquity/ui/views/keyboard.py:292
 msgid "Right Control"
-msgstr ""
+msgstr "Control dereito"
 
 #: ../subiquity/ui/views/keyboard.py:293
 msgid "Right Shift"
-msgstr ""
+msgstr "Maiúsculas dereita"
 
 #: ../subiquity/ui/views/keyboard.py:294
 msgid "Right Logo key"
-msgstr ""
+msgstr "Tecla do logotipo da dereita"
 
 #: ../subiquity/ui/views/keyboard.py:295
 msgid "Menu key"
-msgstr ""
+msgstr "Tecla de menú"
 
 #: ../subiquity/ui/views/keyboard.py:296
 msgid "Alt+Shift"
-msgstr ""
+msgstr "Alt+Maiús."
 
 #: ../subiquity/ui/views/keyboard.py:297
 msgid "Control+Shift"
-msgstr ""
+msgstr "Control+Maiús."
 
 #: ../subiquity/ui/views/keyboard.py:298
 msgid "Control+Alt"
-msgstr ""
+msgstr "Control+Alt"
 
 #: ../subiquity/ui/views/keyboard.py:299
 msgid "Alt+Caps Lock"
-msgstr ""
+msgstr "Alt+Bloqueo de maiúsculas"
 
 #: ../subiquity/ui/views/keyboard.py:300
 msgid "Left Control+Left Shift"
-msgstr ""
+msgstr "Control esquerdo+Maiúsculas esquerdo"
 
 #: ../subiquity/ui/views/keyboard.py:301
 msgid "Left Alt"
-msgstr ""
+msgstr "Alt esquerdo"
 
 #: ../subiquity/ui/views/keyboard.py:302
 msgid "Left Control"
-msgstr ""
+msgstr "Control esquerdo"
 
 #: ../subiquity/ui/views/keyboard.py:303
 msgid "Left Shift"
-msgstr ""
+msgstr "Maiúsculas esquerdo"
 
 #: ../subiquity/ui/views/keyboard.py:304
 msgid "Left Logo key"
-msgstr ""
+msgstr "Tecla do logotipo da esquerda"
 
 #: ../subiquity/ui/views/keyboard.py:305
 msgid "Scroll Lock key"
-msgstr ""
+msgstr "Tecla de bloqueo do desprazamento"
 
 #: ../subiquity/ui/views/keyboard.py:306
 msgid "No toggling"
-msgstr ""
+msgstr "Sen alternar"
 
 #: ../subiquity/ui/views/keyboard.py:327
 msgid "Shortcut: "
-msgstr ""
+msgstr "Atallo: "
 
 #: ../subiquity/ui/views/keyboard.py:337
 msgid "Select layout toggle"
-msgstr ""
+msgstr "Seleccione como alternar a disposición"
 
 #: ../subiquity/ui/views/keyboard.py:355
 msgid "Layout:"
-msgstr ""
+msgstr "Disposición:"
 
 #: ../subiquity/ui/views/keyboard.py:356
 msgid "Variant:"
-msgstr ""
+msgstr "Variante:"
 
 #: ../subiquity/ui/views/keyboard.py:361
 msgid "Keyboard configuration"
-msgstr ""
+msgstr "Configuración do teclado"
 
 #: ../subiquity/ui/views/keyboard.py:382
 msgid ""
 "Please select the layout of the keyboard directly attached to the system, if "
 "any."
 msgstr ""
+"Seleccione a disposición do teclado ligado directamente ao sistema, de "
+"habelo."
 
 #: ../subiquity/ui/views/keyboard.py:385
 msgid ""
 "Please select your keyboard layout below, or select \"Identify keyboard\" to "
 "detect your layout automatically."
 msgstr ""
+"Seleccione a disposición do teclado aquí abaixo ou seleccione «Identificar "
+"teclado» para detectar a disposición aut maticamente."
 
 #: ../subiquity/ui/views/keyboard.py:394
 msgid "Identify keyboard"
-msgstr ""
+msgstr "Identificar teclado"
 
 #: ../subiquity/ui/views/keyboard.py:429
 msgid "Applying config"
-msgstr ""
+msgstr "Estase a aplicar a configuración"
 
 #: ../subiquity/ui/views/mirror.py:32
 msgid ""
 "You may provide an archive mirror that will be used instead of the default."
 msgstr ""
+"Pode fornecer unha réplica do arquivo para empregar no canto do "
+"predeterminado."
 
 #: ../subiquity/ui/views/mirror.py:40
 msgid "Mirror address:"
-msgstr ""
+msgstr "Enderezo da réplica:"
 
 #: ../subiquity/ui/views/mirror.py:45
 msgid "Configure Ubuntu archive mirror"
-msgstr ""
+msgstr "Configurar a réplica do arquivo de Ubuntu"
 
 #: ../subiquity/ui/views/mirror.py:46
 msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
+"Se emprega unha réplica alternativa para Ubuntu, introduza aquí os detalles."
 
 #: ../subiquity/ui/views/proxy.py:33
 msgid ""
@@ -2123,42 +2355,52 @@ msgid ""
 "The proxy information should be given in the standard form of "
 "\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
+"Se precisa empregar un proxy de HTTP para acceder ao mundo externo, "
+"introduza aquí a información do proxy. Caso contrario, deixe isto en "
+"branco.\n"
+"\n"
+"A información do proxy deberá darse na forma estándar de "
+"«http://[[usuario][:contrasinal]@]computador[:porto]/»."
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
-msgstr ""
+msgstr "Enderezo do proxy:"
 
 #: ../subiquity/ui/views/proxy.py:48
 msgid "Configure proxy"
-msgstr ""
+msgstr "Configurar proxy"
 
 #: ../subiquity/ui/views/proxy.py:49
 msgid ""
 "If this system requires a proxy to connect to the internet, enter its "
 "details here."
 msgstr ""
+"Se este sistema require dun proxy para se conectar á Internet, introduza "
+"aquí os seus detalles."
 
 #: ../subiquity/ui/views/refresh.py:111
 msgid "Checking for installer update..."
-msgstr ""
+msgstr "Estase a comprobar a actualización do instalador..."
 
 #: ../subiquity/ui/views/refresh.py:113
 msgid ""
 "Contacting the snap store to check if a new version of the installer is "
 "available."
 msgstr ""
+"Estase a contactar co almacén de snaps para comprobar se existe unha versión "
+"máis recente do instalador."
 
 #: ../subiquity/ui/views/refresh.py:117
 msgid "Contacting the snap store failed"
-msgstr ""
+msgstr "Fallou a conexión co almacén de snaps"
 
 #: ../subiquity/ui/views/refresh.py:119
 msgid "Contacting the snap store failed:"
-msgstr ""
+msgstr "Fallou a conexión co almacén de snaps:"
 
 #: ../subiquity/ui/views/refresh.py:122
 msgid "Installer update available"
-msgstr ""
+msgstr "Existe unha actualización do instalador"
 
 #: ../subiquity/ui/views/refresh.py:124
 #, python-brace-format
@@ -2166,113 +2408,119 @@ msgid ""
 "Version {new} of the installer is now available ({current} is currently "
 "running)."
 msgstr ""
+"Existe unha versión {new} do instalador dispoñíbel (estase a executar "
+"{current})."
 
 #: ../subiquity/ui/views/refresh.py:128
 msgid "Downloading update..."
-msgstr ""
+msgstr "Estase a descargar a actualización..."
 
 #: ../subiquity/ui/views/refresh.py:130
 msgid ""
 "Please wait while the updated installer is being downloaded. The installer "
 "will restart automatically when the download is complete."
 msgstr ""
+"Agarde a que se descargue a actualización do instalador. O instalador hase "
+"reiniciar automaticamente ao concluír a descarga."
 
 #: ../subiquity/ui/views/refresh.py:134
 msgid "Update failed"
-msgstr ""
+msgstr "Fallou a actualización"
 
 #: ../subiquity/ui/views/refresh.py:136
 msgid "Downloading and applying the update:"
-msgstr ""
+msgstr "Estase a descargar e aplicar a actualización:"
 
 #: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
 #: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
 msgid "Continue without updating"
-msgstr ""
+msgstr "Continuar sen actualizar"
 
 #: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
 #: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
 msgid "Try again"
-msgstr ""
+msgstr "Tentar de novo"
 
 #: ../subiquity/ui/views/refresh.py:199
 msgid "You can read the release notes for each version at:"
-msgstr ""
+msgstr "Pode ler as notas de publicación de cada versión en:"
 
 #: ../subiquity/ui/views/refresh.py:206
 msgid ""
 "If you choose to update, the update will be downloaded and the installation "
 "will continue from here."
 msgstr ""
+"Se escolle actualizar, descargarase a actualización e a instalación "
+"continuará a seguir."
 
 #: ../subiquity/ui/views/refresh.py:212
 msgid "Update to the new installer"
-msgstr ""
+msgstr "Actualizar ao novo instalador"
 
 #: ../subiquity/ui/views/refresh.py:238
 msgid "Cancel update"
-msgstr ""
+msgstr "Cancelar a actualización"
 
 #: ../subiquity/ui/views/snaplist.py:83
 msgid "just now"
-msgstr ""
+msgstr "agora mesmo"
 
 #: ../subiquity/ui/views/snaplist.py:87
 msgid "minute"
-msgstr ""
+msgstr "minuto"
 
 #: ../subiquity/ui/views/snaplist.py:89
 msgid "minutes"
-msgstr ""
+msgstr "minutos"
 
 #: ../subiquity/ui/views/snaplist.py:93
 msgid "hour"
-msgstr ""
+msgstr "hora"
 
 #: ../subiquity/ui/views/snaplist.py:95
 msgid "hours"
-msgstr ""
+msgstr "horas"
 
 #: ../subiquity/ui/views/snaplist.py:99
 msgid "day"
-msgstr ""
+msgstr "día"
 
 #: ../subiquity/ui/views/snaplist.py:101
 msgid "days"
-msgstr ""
+msgstr "días"
 
 #: ../subiquity/ui/views/snaplist.py:104
 #, python-brace-format
 msgid "{amount:2} {unit} ago"
-msgstr ""
+msgstr "hai {amount:2} {unit}"
 
 #: ../subiquity/ui/views/snaplist.py:150
 msgid "LICENSE: "
-msgstr ""
+msgstr "LICENZA: "
 
 #: ../subiquity/ui/views/snaplist.py:155
 msgid "LAST UPDATED: "
-msgstr ""
+msgstr "ÚLTIMA ACTUALIZACIÓN: "
 
 #: ../subiquity/ui/views/snaplist.py:160
 msgid "CHANNEL"
-msgstr ""
+msgstr "CANLE"
 
 #: ../subiquity/ui/views/snaplist.py:161
 msgid "VERSION"
-msgstr ""
+msgstr "VERSIÓN"
 
 #: ../subiquity/ui/views/snaplist.py:163
 msgid "PUBLISHED"
-msgstr ""
+msgstr "PUBLICACIÓN"
 
 #: ../subiquity/ui/views/snaplist.py:164
 msgid "CONFINEMENT"
-msgstr ""
+msgstr "CONFINAMENTO"
 
 #: ../subiquity/ui/views/snaplist.py:182
 msgid "by: "
-msgstr ""
+msgstr "por: "
 
 #: ../subiquity/ui/views/snaplist.py:260
 #, python-brace-format
@@ -2286,15 +2534,15 @@ msgstr ""
 
 #: ../subiquity/ui/views/snaplist.py:339
 msgid "Featured Server Snaps"
-msgstr ""
+msgstr "Snaps de servidores en destaque"
 
 #: ../subiquity/ui/views/snaplist.py:353
 msgid "Loading server snaps from store, please wait..."
-msgstr ""
+msgstr "Estanse a cargar snaps de servidor do almacén; agarde un anaquiño..."
 
 #: ../subiquity/ui/views/snaplist.py:374
 msgid "Sorry, loading snaps from the store failed."
-msgstr ""
+msgstr "Desculpe, mais fallou a carga de snaps desde o almacén."
 
 #: ../subiquity/ui/views/snaplist.py:460
 msgid ""
@@ -2302,65 +2550,72 @@ msgid ""
 "SPACE, press ENTER to see more details of the package, publisher and "
 "versions available."
 msgstr ""
+"Estas son snaps populares en ambientes de servidor. Seleccione ou anule a "
+"selección con ESPAZO, prema INTRO para ver máis detalles do paquete, quen o "
+"publica e as versións dispoñíbeis."
 
 #: ../subiquity/ui/views/ssh.py:67
 msgid "Import Username:"
-msgstr ""
+msgstr "Importar nome de usuario:"
 
 #: ../subiquity/ui/views/ssh.py:74
 msgid "Github Username:"
-msgstr ""
+msgstr "Nome de usuario de Github:"
 
 #: ../subiquity/ui/views/ssh.py:75
 msgid "Enter your Github username."
-msgstr ""
+msgstr "Introduza o seu nome de usuario de Github."
 
 #: ../subiquity/ui/views/ssh.py:77
 msgid ""
 "A Github username may only contain alphanumeric characters or hyphens."
 msgstr ""
+"Un nome de usuario de Github só pode conter caracteres alfanuméricos ou "
+"guións."
 
 #: ../subiquity/ui/views/ssh.py:81
 msgid "Launchpad Username:"
-msgstr ""
+msgstr "Nome de usuario de Launchpad:"
 
 #: ../subiquity/ui/views/ssh.py:84
 msgid ""
 "A Launchpad username may only contain lower-case alphanumeric characters, "
 "hyphens, plus, or periods."
 msgstr ""
+"Un nome de usuario de Launchpad só pode conter caracteres alfanumérico "
+"minúsculos, guións, o símbolo de máis e puntos."
 
 #: ../subiquity/ui/views/ssh.py:93
 msgid "Install OpenSSH server"
-msgstr ""
+msgstr "Instalar un servidor de OpenSSH"
 
 #: ../subiquity/ui/views/ssh.py:96
 msgid "Import SSH identity:"
-msgstr ""
+msgstr "Importar identidade de SSH:"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Github"
-msgstr ""
+msgstr "de Github"
 
 #: ../subiquity/ui/views/ssh.py:100
 msgid "from Launchpad"
-msgstr ""
+msgstr "de Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:102
 msgid "You can import your SSH keys from Github or Launchpad."
-msgstr ""
+msgstr "Pode importar as súas chaves de SSH de Github ou Launchpad."
 
 #: ../subiquity/ui/views/ssh.py:106
 msgid "Allow password authentication over SSH"
-msgstr ""
+msgstr "Permitir a autenticación mediante contrasinal con SSH"
 
 #: ../subiquity/ui/views/ssh.py:139
 msgid "This field must not be blank."
-msgstr ""
+msgstr "Este campo non pode estar baleiro."
 
 #: ../subiquity/ui/views/ssh.py:141
 msgid "SSH id too long, must be < "
-msgstr ""
+msgstr "O identificador de SSH é longo de máis; ten que ser < "
 
 #: ../subiquity/ui/views/ssh.py:145
 msgid ""
@@ -2368,44 +2623,52 @@ msgid ""
 "lower-case. The characters +, - and . are also allowed after the first "
 "character."
 msgstr ""
+"Un nome de usuario de Launchpad debe comezar cunha letra ou un número. Todas "
+"as letras deben ser minúsculas. Os caracteres +, - e . tamén se permiten "
+"despois do primeiro carácter."
 
 #: ../subiquity/ui/views/ssh.py:151
 msgid ""
 "A Github username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
+"Un nome de usuario de Github só pode conter caracteres alfanuméricos ou "
+"guións únicos e non pode comezar ou rematar cun guión."
 
 #: ../subiquity/ui/views/ssh.py:161
 msgid "Fetching SSH keys..."
-msgstr ""
+msgstr "Estanse a obter as chaves de SSH..."
 
 #: ../subiquity/ui/views/ssh.py:189
 msgid "Confirm SSH keys"
-msgstr ""
+msgstr "Confirmar chaves de SSH"
 
 #: ../subiquity/ui/views/ssh.py:190
 msgid ""
 "Keys with the following fingerprints were fetched. Do you want to use them?"
 msgstr ""
+"Obtivéronse chaves coas pegadas dixitais seguintes. Desexa empregalas?"
 
 #: ../subiquity/ui/views/ssh.py:193
 msgid "Confirm SSH key"
-msgstr ""
+msgstr "Confirmar chave de SSH"
 
 #: ../subiquity/ui/views/ssh.py:194
 msgid ""
 "A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
+msgstr "Obtívose unha chave coa pegada dixital seguinte. Desexa empregala?"
 
 #: ../subiquity/ui/views/ssh.py:220
 msgid "SSH Setup"
-msgstr ""
+msgstr "Configuración de SSH"
 
 #: ../subiquity/ui/views/ssh.py:221
 msgid ""
 "You can choose to install the OpenSSH server package to enable secure remote "
 "access to your server."
 msgstr ""
+"Pode escoller entre instalar o paquete do servidor de OpenSSH para permitir "
+"o acceso remoto seguro ao servidor."
 
 #: ../subiquity/ui/views/welcome.py:36
 msgid ""
@@ -2413,54 +2676,200 @@ msgid ""
 "Select the language to use for the installer and to be configured in the\n"
 "installed system.\n"
 msgstr ""
+"\n"
+"Seleccione o idioma para empregar no instalador e configurar no\n"
+"sistema instalado.\n"
 
 #: ../subiquity/ui/views/welcome.py:99
 msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr ""
+msgstr "Empregue as teclas ARRIBA, ABAIXO e INTRO para seleccionar o idioma."
 
 #: ../subiquity/ui/views/welcome.py:106
 msgid "Help choosing a language"
-msgstr ""
+msgstr "Axuda para escoller un idioma"
 
 #. for translator: failed is a zdev device status
 #: ../subiquity/ui/views/zdev.py:56
 msgid "failed"
-msgstr ""
+msgstr "fallou"
 
 #. for translator: auto is a zdev device status
 #: ../subiquity/ui/views/zdev.py:59
 msgid "auto"
-msgstr ""
+msgstr "automático"
 
 #. for translator: online is a zdev device status
 #: ../subiquity/ui/views/zdev.py:62
 msgid "online"
-msgstr ""
+msgstr "en liña"
 
 #: ../subiquity/ui/views/zdev.py:77
 msgid "No zdev devices found."
-msgstr ""
+msgstr "Non se atoparon dispositivos zdev."
 
 #: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
-msgstr ""
+msgstr "Identificador"
 
 #: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
-msgstr ""
+msgstr "CON CONEXIÓN"
 
 #: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
-msgstr ""
+msgstr "NOMES"
 
 #: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
-msgstr ""
+msgstr "Activar"
 
 #: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
-msgstr ""
+msgstr "Desactivar"
 
 #: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
+msgstr "Configuración de Zdev"
+
+#~ msgid "Info"
+#~ msgstr "Información"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Editar a Wifi"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Editar IPv4"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "Editar IPv6"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Este campo debe ser un URL %s."
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "«%s» non está contido en «%s»"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "Xa existe unha clase chamada «%s»."
+
+#~ msgid "An error has occurred"
+#~ msgstr "Produciuse un erro"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Completouse a instalación!"
+
+#~ msgid "Finished install!"
+#~ msgstr "Concluíu a instalación!"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} non é unha entrada válida"
+
+#~ msgid "Edit"
+#~ msgstr "Editar"
+
+#~ msgid "Add Partition"
+#~ msgstr "Engadir partición"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Crear volume lóxico"
+
+#~ msgid "Format"
+#~ msgstr "Formatar"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Retirar de RAID/LVM"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "Crear dispositivo de arranque"
+
+#, python-brace-format
+#~ msgid ""
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+#~ msgstr ""
+#~ "Non é posíbel eliminar {selflabel} porque a partición {partnum} é parte de "
+#~ "{cdtype} {cdname}."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
+#~ msgstr ""
+#~ "Non é posíbel eliminar {selflabel} porque ten {count} particións montadas."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has 1 mounted partition."
+#~ msgstr "Non é posíbel eliminar {selflabel} porque ten 1 partición montada."
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has partitions."
+#~ msgstr "Non é posíbel editar {selflabel} porque ten particións."
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has logical volumes."
+#~ msgstr "Non é posíbel editar {selflabel} porque ten volumes lóxicos."
+
+#~ msgid "Realname too long, must be < "
+#~ msgstr "O identificador de SSH é longo de máis; ten que ser < "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "O identificador de SSH é longo de máis; ten que ser < "
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "O nome debe coincidir con NAME_REGEX, ou sexa, [a-z_][a-z0-9_-]*"
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "O identificador de SSH é longo de máis; ten que ser < "
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "O nome de usuario debe coincidir con NAME_REGEX, ou sexa, [a-z_][a-z0-9_-]*"
+
+#~ msgid "Info for {}"
+#~ msgstr "Información sobre {device}"
+
+#~ msgid "formatted as {}"
+#~ msgstr "formatado como {fstype}"
+
+#~ msgid ", mounted at {}"
+#~ msgstr ", montado en {path}"
+
+#~ msgid "unused {}"
+#~ msgstr "sen utilizar"
+
+#~ msgid "There is already a RAID named '{}'"
+#~ msgstr "Xa existe un RAID chamado «{name}»"
+
+#~ msgid "A logical volume may not be called {}"
+#~ msgstr "Un volume lóxico non se pode chamar {}"
+
+#~ msgid "Reboot"
+#~ msgstr "Reiniciar"
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "O nome dun volume lóxico non pode conter «{}»"
+
+#~ msgid "There is already a logical volume named {}."
+#~ msgstr "Xa existe un volume lóxico chamado {}."
+
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formatar e/ou montar {}"
+
+#~ msgid "Remove filesystem from {}"
+#~ msgstr "Retirar o sistema de ficheiros de {}"
+
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "Confirma que desexa retirar o sistema de ficheiros existente de {}?"
+
+#~ msgid "Passphrases"
+#~ msgstr "Contrasinais"
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "Estase a obter información sobre {}"
+
+#~ msgid "Fetching info for {} failed"
+#~ msgstr "Fallou a obtención de información sobre {}"
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Fallou a detección automática do teclado. Lamentámolo."

--- a/po/he.po
+++ b/po/he.po
@@ -7,86 +7,417 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-04-24 12:50+0000\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2020-02-25 13:08+0000\n"
 "Last-Translator: Yaron <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <he@li.org>\n"
-"Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: he\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+"הופעלה התקנה במצב מעטפת.\n"
+"\n"
+"הפעלת מעטפת זו מופעלת בתוך סביבת ההתקנה. יציאה מהמעטפת\n"
+"הזו תחזיר אותך לתכנית ההתקנה, למשל על ידי לחיצה על Ctrl-D או\n"
+"הרצת הפקודה ‚exit’.\n"
+"\n"
+"נא לשים לב שמדובר בסביבה זמנית. השינויים לסביבה הזאת לא ישרדו\n"
+"הפעלה מחדש. אם תכנית ההתקנה החלה, המערכת המותקנת תעוגן\n"
+"למיקום ‎/target."
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr "כן"
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr "לא"
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr "נדרש אישור כדי להמשיך"
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+"יש להוסיף את הביטוי ‚autoinstall’ (התקנה אוטומטית) לשורת הפקודה של הליבה שלך "
+"כדי להתעלם מזה"
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr "להמשיך בהתקנה אוטומטית?"
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr "ייבוא המפתחות נכשל:"
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr "ssh-keygen נכשל בהצגת טביעות האצבע של המפתחות שהתקבלו:"
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr "לא ניתן לערוך את {selflabel} כיוון שהוא חלק מתוך {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr "לא ניתן לערוך מערכי RAID קיימים."
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr "לא ניתן לערוך קבוצות כרכים קיימות."
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr "לא ניתן להסיר את {selflabel} מתוך {cdtype} {cdlabel} קיים."
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+"הסרת {selflabel} תותיר את {cdtype} {cdlabel} עם פחות מ־{min_devices} התקנים."
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr "הסרת {selflabel} תותיר את {cdtype} {cdlabel} ללא התקנים."
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr "לא ניתן למחוק את {selflabel} כיוון שהוא חלק מתוך {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr "אי אפשר למחוק מחיצה בודדת מהתקן שכבר מחולק למחיצות."
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr "לא ניתן למחוק מחיצת אתחול הכרחית."
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr "לא ניתן למחוק כרך לוגי בודד מקבוצת כרכים שכבר יש בה כרכים לוגיים."
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr "קיים"
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr "חדש"
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr "מוגדר"
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr "לא מוגדר"
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr "ESP עיקרי"
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr "ESP כגיבוי"
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr "ESP שלא בשימוש"
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr "מורחבת"
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr "לוגית"
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr "מוצפן"
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr "התקן רב נתיבי"
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "כונן מקומי"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr "מחיצה של {device}"
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr "RAID {level} תכנתי"
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr "קבוצת כרכים ב־LVM"
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr "כרך לוגי ב־LVM"
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr "מחיצה {number}"
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr "מחיצה {number} של {device}"
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr "{component_name} מתוך {desc} {name}"
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr "כבר מפורמט בתור {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr "לפרמוט בתור {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr "לפרמוט בתור {fstype}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr "מעוגן תחת {path}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr "לא מעוגן"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "לא בשימוש"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "בשימוש"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr "תשאול התקני בלוק נכשל"
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr "תשאול כוננים נכשל"
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr "כשל בהתקנה"
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr "קריסת תכנית ההתקנה"
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr "שגיאת רשת"
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "שגיאה לא ידועה"
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "ההגדרה האוטומטית נכשלה"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "מידע"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "עריכת רשת אלחוטית"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "עריכת IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "עריכת IPv6"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "עריכת מאגד"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
-#, fuzzy
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
-msgstr "הוספת תגית VLAN"
+msgid "Edit Wifi"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:45
-#, fuzzy
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "מחיקה"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr "טביעות האצבע של מפתח המארח הן:\n"
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-"טביעות אצבע מפתח ה־{keytype} של המארח הן:\n"
-"    {fingerprint}\n"
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "סגירה"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -97,34 +428,55 @@ msgid " or "
 msgstr " או "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "שדה זה חייב להיות %s."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "סיום"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "ביטול"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "כן"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "לא"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "סגירה"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "שמירה"
 
@@ -157,14 +509,14 @@ msgid "Domains, comma separated"
 msgstr "שמות מתחם לחיפוש, מופרדים בפסיקים"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr "אמור להיות בצורת CIDR ({})"
+msgstr "אמור להיות בתצורת CIDR ‏({example})"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "‚%s’ לא נכלל בתוך ‚%s’"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -186,87 +538,133 @@ msgstr "מושבת"
 msgid "IPv{v} Method: "
 msgstr "שיטת IPv{v}: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "יצירה"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "מזהה VLAN:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr "מזהה ה־VLAN חייב להיות בין 1 ל־4095"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s כבר קיים"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr "הוספת תגית VLAN"
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
+#, python-brace-format
 msgid "Info for {device}"
-msgstr "מידע על {}"
+msgstr "מידע על {device}"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "שם:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "התקנים: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr "מצב איגוד:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr "מדיניות גיבוב XMIT:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr "קצב LACP:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
+#, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr "כבר יש התקן רשת בשם „{}”"
+msgstr "כבר יש התקן רשת בשם „{netdev}”"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "השם לא יכול להישאר ריק"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr "השם חייב להיות באורך 16 תווים ומטה"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr "יציאת מאגד"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr "עריכת מאגד"
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr "בחירת רשת"
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr "הגדרות האלחוט של מנשק הרשת {nic}"
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr "VLAN {id} במנשק {link}"
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr "מוביל המאגד של {interfaces}"
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "לא מחובר"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr "משועבד ל־{device}"
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "זמן הגישה פג"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "סטטי"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "מושבת"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "חיבורי רשת"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -275,639 +673,303 @@ msgstr ""
 "שגם יאפשר גישה מספקת לעדכונים."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "חזרה"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "להמשיך בלי רשת"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "השינויים חלים"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr "לא מחובר"
-
-#: ../subiquitycore/ui/views/network.py:188
-#, fuzzy, python-brace-format
-msgid "enslaved to {device}"
-msgstr "משועבד אל {}"
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "זמן הגישה פג"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, fuzzy, python-brace-format
-msgid "unknown state {state}"
-msgstr "מצב לא ידוע {}"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "סטטי"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr "מושבת"
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr "VLAN {id} במנשק {link}"
-
-#: ../subiquitycore/ui/views/network.py:360
-#, fuzzy, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr "מוביל המאגד עבור {}"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "בחירה בכונן אתחול"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "הגדרות רשת אלחוטית למנשק הרשת {}"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "כן"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "לא"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr "ייבוא המפתחות נכשל:"
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr "ssh-keygen נכשל בהצגת טביעות האצבע של המפתחות שהתקבלו:"
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "אירעה שגיאה"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "ההתקנה הושלמה!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "ההתקנה הסתיימה!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "המערכת בהליכי התקנה"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "ההתקנה הושלמה!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "אירעה שגיאה במהלך ההתקנה"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr "תשאול התקני בלוק נכשל"
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr "תשאול כוננים נכשל"
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr "כשל בהתקנה"
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr "קריסת תכנית ההתקנה"
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr "שגיאת רשת"
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr "שגיאה לא ידועה"
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr "כשל"
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr "אוטומטי"
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr "מחובר"
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr "0 (פיצול)"
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr "1 (שיקוף)"
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "השם לא יכול להישאר ריק"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} אינו קלט תקני"
+msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "מידע"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "אחר"
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "עריכה"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
+msgstr "להשאיר לא מעוגן"
 
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "פרמוט מחדש"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "הוספת מחיצה"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "יצירת כרך לוגי"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "פרמוט"
-
-#: ../subiquity/models/filesystem.py:424
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr "הסרה מ־RAID/LVM"
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "מחיקה"
-
-#: ../subiquity/models/filesystem.py:426
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr "להפוך להתקן אתחול"
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "לא ניתן לערוך את {selflabel} כיוון שהוא חלק מתוך {cdtype} {cdname}."
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr "לא ניתן להסיר את {selflabel} מתוך {cdtype} {cdlabel} קיים."
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-"הסרת {selflabel} תותיר את {cdtype} {cdlabel} עם פחות מ־{min_devices} התקנים."
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr "הסרת {selflabel} תותיר את {cdtype} {cdlabel} ללא התקנים."
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "לא ניתן למחוק את {selflabel} כיוון שהוא חלק מתוך {cdtype} {cdname}."
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr "קיים"
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr "חדש"
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr "{component_name} מתוך {desc} {name}"
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr "כבר מפורמט בתור {fstype}"
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr "לפרמוט בתור {fstype}"
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr "לפרמוט בתור {fstype}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr "מעוגן תחת {path}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr "לא מעוגן"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr "לא בשימוש"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr "בשימוש"
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-"לא ניתן למחוק את {selflabel} כיוון שהמחיצה {partnum} היא חלק מתוך {cdtype} "
-"{cdname}."
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr "לא ניתן למחוק את {selflabel} כיוון שיש לו {count} מחיצות מעוגנות."
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr "לא ניתן למחוק את {selflabel} כיוון שיש לו מחיצה אחת מעוגנת."
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "כונן מקומי"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "הגדרת מתווך"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "ההגדרה האוטומטית נכשלה"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-#, fuzzy
-msgid "unused ESP"
-msgstr "לא בשימוש"
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "כרך לוגי"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "מחיצה בתוך {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "מחיצה {} מתוך {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "מחיצה {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr "אי אפשר למחוק מחיצה בודדת מהתקן שכבר מחולק למחיצות."
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr "לא ניתן למחוק מחיצת אתחול הכרחית."
-
-#: ../subiquity/models/filesystem.py:1049
-#, fuzzy, python-brace-format
-msgid "software RAID {level}"
-msgstr "RAID תכנתי {}"
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr "לא ניתן לערוך מערכי RAID קיימים."
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr "לא ניתן לערוך את {selflabel} כיוון שיש לו מחיצות."
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-#, fuzzy
-msgid "LVM volume group"
-msgstr "יצירת קבוצת כרכים ב־LVM"
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr "לא ניתן לערוך קבוצות כרכים קיימות."
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr "לא ניתן לערוך את {selflabel} כיוון שהוא מכיל כרכים לוגיים."
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "כרך לוגי"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr "לא ניתן למחוק כרך לוגי בודד מקבוצת כרכים שכבר יש בה כרכים לוגיים."
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
+"Sorry, there was a problem examining the storage devices on this system.\n"
+msgstr ""
 "\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
-msgstr ""
-"הופעלה התקנה במצב מעטפת.\n"
-"\n"
-"הפעלת מעטפת זו מופעלת בתוך סביבת ההתקנה. יציאה מהמעטפת\n"
-"הזו תחזיר אותך לתכנית ההתקנה, למשל על ידי לחיצה על Ctrl-D או\n"
-"הרצת הפקודה ‚exit’.\n"
-"\n"
-"נא לשים לב שמדובר בסביבה זמנית. השינויים לסביבה הזאת לא ישרדו\n"
-"הפעלה מחדש. אם תכנית ההתקנה החלה, המערכת המותקנת תעוגן\n"
-"למיקום ‎/target."
+"בחינת התקני האחסון במערכת הזאת לא הצליחה, עמך הסליחה.\n"
 
-#: ../subiquity/core.py:224
-#, fuzzy, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr "תכנית ההתקנה שמופעלת על {} תבצע את ההתקנה האוטומטית"
-
-#: ../subiquity/core.py:237
-#, fuzzy, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr "בהמתנה לתכנית ההתקנה שמופעלת על {} כדי שתריץ פקודות מוקדמות"
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr "כן"
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr "לא"
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr "נדרש אישור כדי להמשיך"
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-"יש להוסיף את הביטוי ‚autoinstall’ (התקנה אוטומטית) לשורת הפקודה של הליבה שלך "
-"כדי להתעלם מזה"
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr "להמשיך בהתקנה אוטומטית?"
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "אסור להשתמש בתווים: , ו־= בשדה זה"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr "התווים היחידים בהם מותר להשתמש בשדה זה הם a-z,‏ 0-9, _ ו־-"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "השם שלך:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "שם השרת שלך:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "השם בו ייעשה שימוש לטובת תקשורת עם מחשבים אחרים."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "נא לבחור שם משתמש:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "נא לבחור ססמה:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "אימות הססמה שלך:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "השם האמתי ארוך מדי, עליו להיות < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "שם השרת לא יכול להישאר ריק"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "שם השרת ארוך מדי, עליו להיות < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"שם המארח חייב להתאים להגדרת ביטויים רגולריים לשמות - NAME_REGEX, למשל: ‎[a-z_]"
-"[a-z0-9_-]*‎"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "שם המשתמש חסר"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "שם המשתמש ארוך מדי, עליו להיות < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"שם המשתמש חייב להתאים להגדרת ביטויים רגולריים לשמות - NAME_REGEX, למשל: ‎[a-"
-"z_][a-z0-9_-]*‎"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr "שם המשתמש „{username}” שמור לשימוש המערכת."
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "יש להגדיר ססמה"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "הססמאות אינן תואמות"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr "{desc} אינו תואם"
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "הגדרת פרופיל"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
-"נא למלא את שם המשתמש והססמה שישמשו אותך לכניסה למערכת. ניתן להגדיר גישה ב־"
-"SSH במסך הבא אך ססמה עדיין תידרש לטובת sudo."
+"\n"
+"השלמת ההתקנה לא הצליחה, עמך הסליחה.\n"
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "ססמאות"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
+"\n"
+"החלת תצורת הרשת לא הצליחה, עמך הסליחה.\n"
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+"\n"
+"תכנית ההתקנה התחילה מחדש עקב שגיאה, עמך הסליחה.\n"
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+"\n"
+"אירעה שגיאה בלתי ידועה, עמך הסליחה.\n"
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+"\n"
+"המידע שנאסף מהמערכת יסייע למפתחים לנתח את הדוח.\n"
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+"\n"
+"הדוח נטען…\n"
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+"\n"
+"איסוף המידע מהמערכת נכשל. בקבצים שבתוך\n"
+"‎/var/log/installer יש מידע נוסף על כך.\n"
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+"\n"
+"טעינת הדוח נכשלה. נא לעיין בקבצים שב־‎/var/log/installer לפרטים נוספים.\n"
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+"\n"
+"ניתן להמשיך ותכנית ההתקנה תציג את הכוננים שנמצאו במערכת ולא\n"
+"התקני בלוק נוספים או שתהיה לך אפשרות לתקן את המצב הזה על ידי\n"
+"מעבר למעטפת והגדרת התקני הבלוק של המכונה הזאת ידנית.\n"
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+"\n"
+"יש לך אפשרות לתקן את המצב הזה על ידי מעבר למעטפת\n"
+"והגדרת התקני הבלוג של המערכת ידנית.\n"
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+"\n"
+"ניתן להמשיך בהתקנה אבל בהנחה שהרשת אינה מתפקדת.\n"
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+"\n"
+"לנסות להפעיל את ההתקנה שוב?\n"
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr "יש לבחור בהמשך או לנסות את ההתקנה שוב."
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+"\n"
+"כדי לסייע לשפר את תכנית ההתקנה ניתן לשלוח דוח שגיאות.\n"
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr "ביטול ההעלאה"
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr "סגירת הדוח"
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "להמשיך"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr "העברה למעטפת"
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr "הפעלת תכנית ההתקנה מחדש"
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr "שליחה ל־Canonical"
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr "נשלח ל־Canonical"
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr "הצגת הדוח המלא"
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+"דוח השגיאה נשמר אל\n"
+"\n"
+"  {loc}\n"
+"\n"
+"במערכת הקבצים עם התווית {label!r}."
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr "תאריך"
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr "סוג"
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr "מצב"
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr "נא לבחור את דוח השגיאה להצגה:"
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr "נצפה"
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr "לא נצפה"
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
+#, python-brace-format
 msgid "formatted as {fstype}"
-msgstr "לפרמוט בתור {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:132
+#, python-brace-format
 msgid ", mounted at {path}"
-msgstr "מעוגן תחת {path}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ", לא מעוגן"
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:136
+#, python-brace-format
 msgid "unused {device}"
-msgstr "לא בשימוש {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
@@ -915,451 +977,235 @@ msgstr ""
 "אם כל הכוננים יוצבו בתוך RAID או קבוצות כרכים (VG) במנהל כרכים לוגי (LVM) לא "
 "יהיה איפה להציב את מחיצת האתחול."
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr "/ לא יכול להיות חלק משם של התקן RAID"
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr "אין להשתמש ברווח בשם של התקן RAID"
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr "רמת RAID:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "התקנים:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "גודל:‏"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, fuzzy, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr "כבר קיים RAID בשם ‚{}’"
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ". וגם .. אינם שמות תקניים להתקני RAID"
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, fuzzy, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr "רמת ה־RAID „{}” דורשת לפחות {} התקנים פעילים"
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr "יצירת כונן RAID בתכנה („MD”)"
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, fuzzy, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr "עריכת כונן RAID בתכנה „{}”"
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr "להשאיר לא מפורמט"
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, fuzzy, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr "להשאיר מפורמט בתור {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, fuzzy, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr "גודל המחיצה הוגבל לכדי {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, fuzzy, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr "הגודל עוגל לכדי {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"התווים היחידים בהם מותר להשתמש בשם של כרך לוגי הם a-z,‏ A-Z,‏ 0-9, +, _, . וגם "
-"-"
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, fuzzy, python-brace-format
-msgid "Size (max {size}):"
-msgstr "גודל ({} לכל היותר):"
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "שם: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "פרמוט:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr "עיגון:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr "להשתמש כהחלפה"
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr "להשתמש במחיצת החלפה זו במערכת המותקנת."
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr "שם הכרך הלוגי לא יכול להישאר ריק"
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr "שם הכרך הלוגי לא יכול להתחיל במינוס"
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, fuzzy, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr "אי אפשר לקרוא לכרך לוגי בשם {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, fuzzy, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr "שם הכרך הלוגי לא יכול להכיל „{}”"
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, fuzzy, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr "כבר יש כרך לוגי בשם {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "הנתיב חורג מ־PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, fuzzy, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr "{} כבר מעוגן תחת {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, fuzzy, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-"לעגן מערכת קבצים קיימת תחת {} היא רעיון די גרוע, ניתן להמשיך אם המצב הזה "
-"ברור לך."
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"מחיצת אתחול נחוצה\n"
-"\n"
-"GRUB יותקן על ה־MBR (רשומת אתחול ראשית) של כונן היעד.\n"
-"\n"
-"עם זאת, על כונן עם טבלת מחיצות GPT אין מספיק מקום אחרי שה־MBR עבור GRUB "
-"לאחסון ה־core.img שלו עבור השלב השני, לכן, מחיצה קטנה בלתי מפורמטטת נדרשת "
-"בתחילת הכונן. היא לא תכיל מערכת קבצים ולא תעוגן ולא ניתן לערוך אותה דרך כאן."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-"מחיצת אתמול נחוצה\n"
-"\n"
-"זו ESP‏ / \"EFI system partition\" (מחיצת מערכת מנשק קושחה גמיש) שנדרשת על "
-"ידי UEFI. על מחיצה זו, אותה יש לפרמט ל־fat32, יותקן Grub."
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-"מחיצת אתמול נחוצה\n"
-"\n"
-"זו ESP‏ / \"EFI system partition\" (מחיצת מערכת מנשק קושחה גמיש) שנדרשת על "
-"ידי UEFI. על מחיצה זו, אותה יש לפרמט ל־fat32, יותקן Grub."
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-#, fuzzy
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr " ההיבט היחידי בו ניתן לערוך מחיצה זו היא הגודל."
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-#, fuzzy
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-" ניתן לבחור האם להשתמש במערכת הקבצים הקיימת במחיצה זו או לפרמט אותה מחדש."
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-"מחיצת אתחול נחוצה\n"
-"\n"
-"זו מחיצת PReP שנחוצה למערכות POWER. למחיצה הזאת יותקן Grub."
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-"מחיצת אתחול נחוצה\n"
-"\n"
-"זו מחיצת PReP שנחוצה למערכות POWER. למחיצה הזאת יותקן Grub."
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "אישור"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr "להשתמש במערכת קבצים fat32 קיימת"
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr "לפרמט מחדש כמערכת קבצים fat32 רעננה"
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "כרך לוגי {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "מחיצה {} מתוך {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-"פרמוט ועיגון של כונן ישירות היא פעולה חריגה. יכול להיות שברצונך להוסיף מחיצה "
-"במקום."
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "פרמוט ו/או עיגון של {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr "למחוק את {desc} {label}?"
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr "הוא מפורמט בתור {fstype} ומעוגן תחת {path}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr "הוא מפורמט בתור {fstype} ולא מעוגן."
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "כרך לוגי"
-msgstr[1] "כרך לוגי"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:70
+#, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
-msgstr[0] "הוא מכיל {n} {things}:"
-msgstr[1] "הוא מכיל {n} {things}:"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr "אינו מפורמט או מעוגן."
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "מחיקה"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:112
+#, python-brace-format
 msgid "Remove filesystem from {device}"
-msgstr "הסרת מערכת קבצים מ־{}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:116
+#, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
-msgstr "להסיר את את מערכת הקבצים הקיימת מ־{}?"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr "כרכים לוגיים"
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "מחיצות"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr "להסיר את כל ה{things} מתוך {obj}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr "להסיר את כל ה{things} מתוך {obj}?"
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr "פרמוט מחדש"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"התווים היחידים שמותר להשתמש בהם בשם הכרך הם a-z,‏ A-Z,‏ 0-9, +, _, . וגם -"
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
+#, python-brace-format
+msgid "existing {fstype}"
+msgstr "{fstype} קיים"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "מילות צופן:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
+#, python-brace-format
+msgid "new {fstype}"
+msgstr "{fstype} חדש"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "יצירת כרך מוצפן"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "לא עוגנו כוננים או מחיצות."
 
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr "מילת צופן:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "נקודת עגינה"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr "אימות מילת צופן:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "גודל"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr "יש לבחור בהתקן אחד לפחות לצירוף לקבוצת הכרכים."
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "סוג"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr "שם קבוצת הכרכים לא יכול להישאר ריק"
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "סוג התקן"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr "שם קבוצת הכרכים לא יכול להתחיל במינוס"
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "ביטול עיגון"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:113
-#, fuzzy, python-brace-format
-msgid "{name} is not a valid name for a volume group"
-msgstr "{} אינו שם תקני לקבוצת הכרכים"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "אין התקנים זמינים"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
-#, fuzzy, python-brace-format
-msgid "There is already a volume group named '{name}'"
-msgstr "כבר יש קבוצת כרכים בשם ‚{}’"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr "אין התקנים בשימוש"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
-msgstr "יש להגדיר מילת צופן"
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
+#, python-brace-format
+msgid "Remove from {device}"
+msgstr "הסרה מתוך {device}"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr "מילות הצופן אינן תואמות"
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr "הוספת מחיצת {ptype}"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr "יצירת קבוצת כרכים ב־LVM"
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr "להפסיק להשתמש כהתקן אתחול"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
-#, fuzzy, python-brace-format
-msgid "Edit volume group \"{name}\""
-msgstr "עריכת קבוצת הכרכים „{}”"
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr "להוסיף כהתקן אתחול נוסף"
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr "להשתמש כהתקן אתחול"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "התקן"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "שטח פנוי"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr "הגדרות אחסון"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr "יצירת RAID בתכנה (md)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr "ליצור קבוצת כרכים (LVM)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "תקציר מערכת קבצים"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "התקנים זמינים"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr "התקנים בשימוש"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr "עיגון מערכת קבצים תחת /"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr "בחירה בכונן אתחול"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr "כדי להמשיך עליך:"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "איפוס"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr "הגדרת פריסה מודרכת של חלוקה למחיצות או יצירה של פריסה משלך:"
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr "מילת צופן:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr "אימות מילת צופן:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "יש להגדיר ססמה"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "הססמאות אינן תואמות"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr "הצפנת קבוצת ה־LVM עם LUKS"
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr "הגדרת הכונן הזה בתור קבוצת LVM"
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr "להשתמש בכונן כולו"
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr "פריסת אחסון מותאמת אישית"
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1392,31 +1238,8 @@ msgid ""
 "at /.\n"
 "\n"
 msgstr ""
-"\n"
-"\n"
-"האפשרות „ניצול מלוא הכונן” מתקינה את אובונטו לכונן הנבחר,\n"
-"תוך החלפת המחיצות והנתונים שקיימים בו.\n"
-"\n"
-"בהתאם לדרישת המערכת, נוצרת מחיצת אתחול בכונן.\n"
-"\n"
-"הבחירה ב־LVM תוביל ליצירת שתי מחיצות נוספות, אחת לטובת /boot ואחת נוספת\n"
-"שתחלוש על שאר השטח הפנוי בכונן. תיווצר קבוצת כרכים של LVM ובתוכה מחיצה\n"
-"גדולה. ייווצר כרך לוגי בנפח של 4 גיגה בתים עבור שורש מערכת הקבצים. ניתן\n"
-"להגדיל אותו בקלות עם כלי שורת פקודה תקניים של LVM.\n"
-"\n"
-"ניתן גם לבחור להצפין קבוצת כרכים של LVM. מצב זה ייאלץ אותך להגדיר\n"
-"ססמה, אותה יהיה עליך להקליד בטרם טעינת המערכת.\n"
-"\n"
-"אם בחרת שלא להשתמש ב־LVM, תיווצר מחיצה בודדת שתחלוש על שאר הכונן\n"
-"שיפורמט לכדי ext4 ויעוגן תחת /.\n"
-"\n"
-"בכל מקרה, בהמשך תינתן לך האפשרות לסקור ולשנות את תוצאות בחירותיך.\n"
-"\n"
-"אם בחירתך היא להשתמש בפריסת אחסון בהתאמה אישית, לא יבוצעו כל שינויים בכוננים "
-"ויהיה עליך לבחור, לכל הפחות, בכונן אתחול ולעגון מערכת קבצים תחת /.\n"
-"\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1427,7 +1250,7 @@ msgstr ""
 "תשאול התקני בלוק, לא גילה כוננים גדולים מספיק מכדי לתמוך בתצורת אחסון\n"
 "מודרכת. עדיין אפשר להגדיר אותה ידנית.\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
@@ -1437,131 +1260,302 @@ msgstr ""
 "תשאול התקני בלוק לא זיהה כוננים כלשהם. לרוע המזל המשמעות\n"
 "היא שלא ניתן להתקין כלל.\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr "הגדרת אחסון מודרכת"
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "אישור"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr "עזרה בהגדרת אחסון מודרכת"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
-#, fuzzy, python-brace-format
-msgid "existing {fstype}"
-msgstr "קיים"
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+"התווים היחידים שמותר להשתמש בהם בשם הכרך הם a-z,‏ A-Z,‏ 0-9, +, _, . וגם -"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "התקנים:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "גודל:‏"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "יצירת כרך מוצפן"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr "יש לבחור בהתקן אחד לפחות לצירוף לקבוצת הכרכים."
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr "שם קבוצת הכרכים לא יכול להישאר ריק"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr "שם קבוצת הכרכים לא יכול להתחיל במינוס"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "new {fstype}"
+msgid "There is already a volume group named '{name}'"
+msgstr "כבר יש קבוצת כרכים בשם ‚{name}’"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:119
+#, python-brace-format
+msgid "{name} is not a valid name for a volume group"
+msgstr "{name} אינו שם תקני לקבוצת כרכים"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
+msgstr "יש להגדיר מילת צופן"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
+msgstr "מילות הצופן אינן תואמות"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
+msgstr "יצירת קבוצת כרכים ב־LVM"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:157
+#, python-brace-format
+msgid "Edit volume group \"{name}\""
+msgstr "לערוך את קבוצת הכרכים „{name}”"
+
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr "להשאיר לא מפורמט"
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
+msgstr "להשאיר בפרמוט {fstype}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
+msgstr "גודל המחיצה נחתך ב־{size}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
+msgstr "הגודל עוגל לכדי {size}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
+msgstr ""
+"התווים היחידים בהם מותר להשתמש בשם של כרך לוגי הם a-z,‏ A-Z,‏ 0-9, +, _, . "
+"וגם -"
+
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
+msgstr "גודל ({size} לכל היותר):"
+
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "שם: "
+
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "פרמוט:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
+msgstr "עיגון:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr "להשתמש כהחלפה"
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
+msgstr "להשתמש במחיצת החלפה זו במערכת המותקנת."
+
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr "שם הכרך הלוגי לא יכול להישאר ריק"
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr "שם הכרך הלוגי לא יכול להתחיל במינוס"
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "לא עוגנו כוננים או מחיצות."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "נקודת עגינה"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "גודל"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "סוג"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "סוג התקן"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "ביטול עיגון"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr "אין התקנים זמינים"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr "אין התקנים בשימוש"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
-#, fuzzy, python-brace-format
-msgid "Remove from {device}"
-msgstr "הסרה מ־{}"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "הוספת מחיצת {}"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-#, fuzzy
-msgid "Add As Another Boot Device"
-msgstr "להפוך להתקן אתחול"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-#, fuzzy
-msgid "Use As Boot Device"
-msgstr "להפוך להתקן אתחול"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "הנתיב חורג מ־PATH_MAX"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "התקן"
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr "{device} כבר מעוגן תחת {path}."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "שטח פנוי"
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+"עיגון מערכת קבצים קיימת תחת {mountpoint} זה רעיון גרוע בדרך כלל, אפשר להמשיך "
+"אך בזהירות."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
-msgstr "הגדרות אחסון"
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+"מחיצת מערכת אתחול\n"
+"\n"
+"{middle}\n"
+"\n"
+"עם זאת, בכונן עם טבלת מחיצות מסוג GPT, אין ל־GRUB מספיק\n"
+"מקום אחרי ה־MBR לאחסן את ה־core.img של השלב השני, לכן\n"
+"מחיצה נדרשת מחיצה קטנה ולא מפורמטת בתחילת הכונן. לא\n"
+"תהיה בא מערכת קבצים והיא לא תעוגן ולא ניתן יהיה לערוך\n"
+"אותה מכאן.\n"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
-msgstr "יצירת RAID בתכנה (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+"אם הכונן הזה נבחר כהתקן אתחול, GRUB יותקן על\n"
+"ה־MBR של כונן היעד."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
-msgstr "ליצור קבוצת כרכים (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+"כיוון שהכונן הזה נבחר כהתקן אתחול, GRUB יותקן על\n"
+"ה־MBR של כונן היעד."
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "תקציר מערכת קבצים"
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "התקנים זמינים"
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
-msgstr "התקנים בשימוש"
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
-msgstr "עיגון מערכת קבצים תחת /"
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
-msgstr "בחירה בכונן אתחול"
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "להמשיך בלי רשת"
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "איפוס"
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr "להשתמש במערכת קבצים fat32 קיימת"
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr "לפרמט מחדש כמערכת קבצים fat32 רעננה"
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr "כרך לוגי מתווסף אל {vgname}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr "נוספת מחיצת {ptype} אל {device}"
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr "הכרך הלוגי {lvname} של {vgname} בעריכה"
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr "מחיצה {number} של {device} בעריכה"
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+"פרמוט ועיגון של כונן ישירות היא פעולה חריגה. יכול להיות שברצונך להוסיף מחיצה "
+"במקום."
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1588,104 +1582,44 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr "תשאול התקנים להתקנה נכשל"
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
-msgstr "הצגת דוח שגיאות"
+msgstr "להציג דוח שגיאות"
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
-msgstr "מתבצע איתור לעדכון תכנית ההתקנה…"
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
+msgstr "/ לא יכול להיות חלק משם של התקן RAID"
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
-msgstr "נוצר קשר עם חנות ה־snap כדי לבדוק אם יש גרסה חדשה של תכנית ההתקנה."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
+msgstr "אין להשתמש ברווח בשם של התקן RAID"
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr "יצירת קשר עם חנות ה־snap נכשלה"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "רמת RAID:"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr "יצירת קשר עם חנות ה־snap נכשלה:"
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "קיים עדכון לתכנית ההתקנה"
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
-msgstr "גרסה {new} של תכנית ההתקנה זמינה ({current} פועלת כעת)."
-
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "העדכון מתקבל…"
-
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
-msgstr ""
-"נא להמתין להורדת תכנית ההתקנה העדכנית. תכנית ההתקנה תפעיל את עצמה מחדש "
-"אוטומטית עם השלמת ההורדה."
-
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
-msgstr "העדכון נכשל"
-
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr "העדכון מתקבל ומת"
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "להמשיך בלי לעדכן"
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "ניסיון חוזר"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr "אם בחירתך תהיה לעדכן, העדכון יתקבל וההתקנה תמשיך מכאן."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
+msgstr ". וגם .. אינם שמות תקניים להתקני RAID"
 
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr "עדכון לתכנית ההתקנה החדשה"
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
+msgstr "רמת ה־RAID‏ „{level}” דורשת {min_active} התקנים פעילים לפחות"
 
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "ביטול עדכון"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
+msgstr "יצירת כונן RAID בתכנה („MD”)"
 
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr "ניתן לספק אתר מראת ארכיונים שבה ייעשה שימוש במקום בררת המחדל."
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr "כתובת אתר המראה:"
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr "הגדרת אתר מראת ארכיונים של אובונטו"
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
-msgstr "אם משמש אותך אתר מראה חלופי עבור אובונטו, יש להקליד כאן את פרטיו."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
+msgstr "לערוך את כונן ה־RAID התכנתי „{name}”"
 
 #: ../subiquity/ui/views/help.py:70
 #, python-brace-format
@@ -1750,16 +1684,12 @@ msgstr ""
 "זו גרסה מבוססת {snap_version} של תכנית ההתקנה.\n"
 
 #: ../subiquity/ui/views/help.py:102
-#, fuzzy
 msgid ""
 "\n"
 "It is possible to connect to the installer over the network, which\n"
 "might allow the use of a more capable terminal and can offer more languages\n"
 "than can be rendered in the Linux console."
 msgstr ""
-"\n"
-"אפשר להתחבר לתכנית ההתקנה דרך הרשת, מה שיכול לאפשר\n"
-"שימוש בתכנית מסוף מוצלחת יותר.ֿ"
 
 #: ../subiquity/ui/views/help.py:107
 msgid ""
@@ -1773,21 +1703,44 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
-"\n"
-"יש להתחבר ב־SSH אל installer@{ip}.\n"
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
-"\n"
-"הססמה בה עליך להשתמש היא „{password}”.\n"
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
@@ -1796,7 +1749,7 @@ msgstr ""
 "\n"
 "לרוע המזל כנראה שלמערכת זו אין כתובות IP גלובליות כרגע.\n"
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
@@ -1805,596 +1758,275 @@ msgstr ""
 "\n"
 "לרוע המזל תכנית ההתקנה לא הצליח לזהות את הססמה שהוגדרה.\n"
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr "ניתן להשתמש במקשים הבאים בכל עת:"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr "ESC"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr "לחזור אחורה"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr "F1"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr "לפתוח את תפריט העזרה"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr "Control-Z, F2"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr "מעבר למעטפת"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr "Control-L, F3"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr "לצייר את המסך מחדש"
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr "Control-T, F4"
 
-#: ../subiquity/ui/views/help.py:185
-#, fuzzy
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
-msgstr "הפעלת וכיבוי צבעים"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr "Control-X"
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
-msgstr ""
+msgstr "יציאה"
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr "Control-E"
 
-#: ../subiquity/ui/views/help.py:190
-#, fuzzy
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
-msgstr "לייצר דוח שגיאה רועש (במצב תרגול בלבד)"
+msgstr "לייצר דוח שגיאות רועש"
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr "Control-R"
 
-#: ../subiquity/ui/views/help.py:191
-#, fuzzy
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
-msgstr "לייצר דוח שגיאה שקט (במצב תרגול בלבד)"
+msgstr "לייצר דוח שגיאות שקט"
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Control-X"
+msgstr "Control-G"
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr "עדכון לתכנית ההתקנה החדשה"
+msgstr "לדמות הרצת התקנה"
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr "Control-U"
 
-#: ../subiquity/ui/views/help.py:193
-#, fuzzy
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
-msgstr "להקריס את מנשק המשתמש (במצב תרגול בלבד)"
+msgstr "הקרסת מנשק המשתמש"
 
-#: ../subiquity/ui/views/help.py:207
-#, fuzzy
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
-msgstr "יציאה (במצב תרגול בלבד)"
+msgstr "(הרצת דמה בלבד)"
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr "מקשי קיצור"
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr "על תכנית ההתקנה"
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr "קיצורי מקלדת"
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr "כניסה למעטפת"
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr "עזרה בגישה ל־SSH"
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr "עזרה על המסך הזה"
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr "הצגת דוחות שגיאה"
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr "עזרה"
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr "על תכנית ההתקנה"
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
-msgstr ""
-"\n"
-"נא לבחור את השפה בה תוצג תכנית ההתקנה וגם תוגדר\n"
-"במערכת המותקנת.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "אסור להשתמש בתווים: , ו־= בשדה זה"
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "יש להשתמש בחצים: למעלה, למטה וב־Enter כדי לבחור את השפה שלך."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
+msgstr "התווים היחידים בהם מותר להשתמש בשדה זה הם a-z,‏ 0-9, _ ו־-"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr "עזרה בבחירת השפה"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "השם שלך:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "יבוא שם משתמש:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "שם השרת שלך:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "שם משתמש ב־GitHub:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "השם בו ייעשה שימוש לטובת תקשורת עם מחשבים אחרים."
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "שם משתמש ב־GitHub:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "נא לבחור שם משתמש:"
 
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-"שם משתמש ב־GitHub יכול להכיל רק תווים אלפאנומריים או סימני מינוס בודדים ולא "
-"יכול להתחיל או להסתיים במינוס."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "נא לבחור ססמה:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "שם משתמש ב־Launchpad:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "אימות הססמה שלך:"
 
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"שם משתמש ב־GitHub יכול להכיל רק תווים אלפאנומריים או סימני מינוס בודדים ולא "
-"יכול להתחיל או להסתיים במינוס."
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr "התקנת שרת OpenSSH"
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "יבוא זהות SSH:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "מ־GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "מ־Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "ניתן לייבא את מפתחות ה־SSH שלך מ־GitHub או מ־Launchpad."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr "לאפשר אימות עם ססמה דרך SSH"
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "שדה זה לא יכול להישאר ריק."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "מזהה ה־SSH ארוך מדי, עליו להיות < "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-"שם משתמש ב־Launchpad חייב להתחיל באות או במספר. כל האותיות חייביות להיות "
-"קטנות. מותר להשתמש גם בתווים +,- ו־. לאחר התו הראשון."
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"שם משתמש ב־GitHub יכול להכיל רק תווים אלפאנומריים או סימני מינוס בודדים ולא "
-"יכול להתחיל או להסתיים במינוס."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr "מפתחות ה־SSH מתקבלים…"
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr "אישור מפתחות SSH"
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr "התקבלו מפתחות עם טביעות האצבעות הבאות. להשתמש בהם?"
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr "אישור מפתח SSH"
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr "התקבל מפתח עם טביעת האצבע הבאה. להשתמש בו?"
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr "הקמת SSH"
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-"ניתן לבחור להתקין את חבילת שרת ה־OpenSSH כדי להפעיל גישה מאובטחת מרחוק לשרת "
-"שלך."
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "ממש עכשיו"
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr "דקה"
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr "דקות"
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr "שעה"
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr "שעות"
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr "יום"
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr "ימים"
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
-msgstr "לפני {amount:2} {unit}"
-
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "שם השרת לא יכול להישאר ריק"
+
+#: ../subiquity/ui/views/identity.py:109
+#, python-brace-format
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "שם המשתמש חסר"
+
+#: ../subiquity/ui/views/identity.py:123
+#, python-brace-format
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
+msgstr "שם המשתמש „{username}” שמור לשימוש המערכת."
 
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr "{desc} אינו תואם"
 
-#: ../subiquity/ui/views/snaplist.py:256
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap}"
-msgstr "מתקבל מידע על {}"
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "הגדרת פרופיל"
 
-#: ../subiquity/ui/views/snaplist.py:282
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap} failed"
-msgstr "קבלת המידע על {} נכשלה"
-
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
-msgstr "חבילות Snap מומלצות לשרתים"
-
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "להמשיך"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
-msgstr "חבילות ה־snap נטענות מהחנות, נא להמתין…"
-
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr "טעינת חבילות snap מהחנות נכשלה, עמך הסליחה."
-
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
-"אלו חבילות snap נפוצות לסביבות שרתים. ניתן לבחור או לסלק עם רווח, Enter "
-"להצגת פרטים נוספים על החבילה, מפיץ וגרסאות זמינות."
+"נא למלא את שם המשתמש והססמה שישמשו אותך לכניסה למערכת. ניתן להגדיר גישה "
+"ב־SSH במסך הבא אך ססמה עדיין תידרש לטובת sudo."
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr "זיהוי מקלדת אוטומטית"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "ססמאות"
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-"הליך זיהוי המקלדת מתחיל. בפניך תופענה סדרה של שאלות על המקלדת שלך. ניתן "
-"ללחוץ על Esc בכל עת כדי לחזור למסך הקודם."
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "זיהוי המקלדת אוטומטית נכשל"
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-"זיהוי המקלדת האוטומטי הצליח.\n"
-"\n"
-"המקלדת שלך זוהתה בתור:\n"
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-"\n"
-"אם הצעה זו נכונה, יש לבחור בסיום במסך הבא. אם לא, ניתן לבחור בפריסה אחרת "
-"ולהריץ את הזיהוי האוטומטי שוב.\n"
-"\n"
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "פריסה"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr "הגוון"
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "נא ללחוץ על אחד מהתווים הבאים:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr "הקלט לא זוהה, נא לנסות שוב"
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "האם המקש הבא מופיע במקלדת שלך?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "ההגדרות חלות"
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-"יהיה לך צורך להחליף בין פריסה מקומית לפריסה הלטיני התקנית.\n"
-"\n"
-"לרוב משתמשים במקשי ה־Alt השמאלי או ב־Caps Lock מטעמים ארגונומיים (במקרה "
-"השני, יש להשתמש ב־Shift+Caps Lock כדי להחליף מצב אותיות גדולות). Alt+Shift "
-"הוא גם צירוף מקובל, עם זאת הוא עשוי לאבד את ההתנהגות הנפוצה שלו ב־Emacs "
-"ובתכניות אחרות שמשתמשים בצירוף לצרכים מסוימים.\n"
-"\n"
-"לא כל המקשים שמופיעים קיימים בכל המקלדות. "
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Alt ימני (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Control ימני"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Shift ימני"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr "כפתור סמל ימני"
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "כפתור תפריט"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Control+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr "Control+Alt"
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "שמאלי Control+שמאלי Shift"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Alt שמאלי"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Control שמאלי"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Shift שמאלי"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr "כפתור סמל שמאלי"
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "מקש ה־Scroll Lock"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr "ללא החלפה"
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr "קיצור דרך: "
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr "נא לבחור צירוף להחלפת פריסה"
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "פריסה:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr "הגוון:"
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr "הגדרות מקלדת"
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr "נא לבחור את פריסת המקלדת שמחוברת ישירות למערכת, אם יש כזאת."
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-"נא לבחור את פריסת המקלדת שלך להלן, או לבחור ב„זיהוי מקלדת” כדי לזהות את "
-"הפריסה שלך אוטומטית."
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr "זיהוי מקלדת"
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr "תהליך התקנה"
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "הפעלה מחדש כעת"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr "הצגת דוח שגיאות"
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr "הצגת יומן מלא"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr "פלט תכנית ההתקנה המלא"
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "המערכת בהליכי התקנה"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "ההתקנה הושלמה!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr "ביטול העדכון והפעלה מחדש"
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "הפעלה מחדש"
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr "המכונה מופעלת מחדש…"
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "אירעה שגיאה במהלך ההתקנה"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2412,30 +2044,230 @@ msgstr ""
 "\n"
 "שנמשיך?"
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr "אישור פעולה הרסנית"
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
 "\n"
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
+"תכנית ההתקנה שפועל על גבי {tty} מתקינה כעת את המערכת.\n"
+"\n"
+"ניתן להמתין לסיום ההתקנה או לעבור למעטפת.\n"
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
-msgstr "העברה למעטפת"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "זיהוי מקלדת אוטומטית"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+"הליך זיהוי המקלדת מתחיל. בפניך תופענה סדרה של שאלות על המקלדת שלך. ניתן "
+"ללחוץ על Esc בכל עת כדי לחזור למסך הקודם."
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+"זיהוי המקלדת האוטומטי הצליח.\n"
+"\n"
+"המקלדת שלך זוהתה בתור:\n"
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+"\n"
+"אם הצעה זו נכונה, יש לבחור בסיום במסך הבא. אם לא, ניתן לבחור בפריסה אחרת "
+"ולהריץ את הזיהוי האוטומטי שוב.\n"
+"\n"
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "פריסה"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr "הגוון"
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "נא ללחוץ על אחד מהתווים הבאים:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr "הקלט לא זוהה, נא לנסות שוב"
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "האם המקש הבא מופיע במקלדת שלך?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+"יהיה לך צורך להחליף בין פריסה מקומית לפריסה הלטיני התקנית.\n"
+"\n"
+"לרוב משתמשים במקשי ה־Alt השמאלי או ב־Caps Lock מטעמים ארגונומיים (במקרה "
+"השני, יש להשתמש ב־Shift+Caps Lock כדי להחליף מצב אותיות גדולות). Alt+Shift "
+"הוא גם צירוף מקובל, עם זאת הוא עשוי לאבד את ההתנהגות הנפוצה שלו ב־Emacs "
+"ובתכניות אחרות שמשתמשים בצירוף לצרכים מסוימים.\n"
+"\n"
+"לא כל המקשים שמופיעים קיימים בכל המקלדות. "
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Alt ימני (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Control ימני"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Shift ימני"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr "כפתור סמל ימני"
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "כפתור תפריט"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Control+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Control+Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "שמאלי Control+שמאלי Shift"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Alt שמאלי"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Control שמאלי"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Shift שמאלי"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr "כפתור סמל שמאלי"
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "מקש ה־Scroll Lock"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr "ללא החלפה"
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr "קיצור דרך: "
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr "נא לבחור צירוף להחלפת פריסה"
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "פריסה:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr "הגוון:"
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "הגדרות מקלדת"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr "נא לבחור את פריסת המקלדת שמחוברת ישירות למערכת, אם יש כזאת."
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+"נא לבחור את פריסת המקלדת שלך להלן, או לבחור ב„זיהוי מקלדת” כדי לזהות את "
+"הפריסה שלך אוטומטית."
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr "זיהוי מקלדת"
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "ההגדרות חלות"
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr "ניתן לספק אתר מראת ארכיונים שבה ייעשה שימוש במקום בררת המחדל."
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "כתובת אתר המראה:"
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr "הגדרת אתר מראת ארכיונים של אובונטו"
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+msgstr "אם משמש אותך אתר מראה חלופי עבור אובונטו, יש להקליד כאן את פרטיו."
 
 #: ../subiquity/ui/views/proxy.py:33
 msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "אם נדרש מתווך HTTP כדי לגשת לעולם, יש להקליד את פרטי המתווך להלן. אם לא, "
 "להשאיר ריק.\n"
@@ -2457,251 +2289,347 @@ msgid ""
 msgstr ""
 "אם המערכת הזאת דורשת מתווך כדי להתחבר לאינטרנט, יש להקליד את הפרטים שלו כאן."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr "מתבצע איתור לעדכון תכנית ההתקנה…"
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr "נוצר קשר עם חנות ה־snap כדי לבדוק אם יש גרסה חדשה של תכנית ההתקנה."
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr "יצירת קשר עם חנות ה־snap נכשלה"
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr "יצירת קשר עם חנות ה־snap נכשלה:"
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "קיים עדכון לתכנית ההתקנה"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr "גרסה {new} של תכנית ההתקנה זמינה ({current} פועלת כעת)."
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "העדכון מתקבל…"
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+"נא להמתין להורדת תכנית ההתקנה העדכנית. תכנית ההתקנה תפעיל את עצמה מחדש "
+"אוטומטית עם השלמת ההורדה."
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr "העדכון נכשל"
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr "העדכון מתקבל ומת"
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "להמשיך בלי לעדכן"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "ניסיון חוזר"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr "ניתן לקרוא את הערות השחרור של כל גרסה וגרסה תחת:"
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr "אם בחירתך תהיה לעדכן, העדכון יתקבל וההתקנה תמשיך מכאן."
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr "עדכון לתכנית ההתקנה החדשה"
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "ביטול עדכון"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "ממש עכשיו"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "דקה"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "דקות"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "שעה"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "שעות"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "יום"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "ימים"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr "לפני {amount:2} {unit}"
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr "רישיון: "
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr "עדכון אחרון: "
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr "ערוץ"
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr "גרסה"
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr "פורסם"
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr "ריתוק"
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr "מאת: "
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr "חבילות Snap מומלצות לשרתים"
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr "חבילות ה־snap נטענות מהחנות, נא להמתין…"
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr "טעינת חבילות snap מהחנות נכשלה, עמך הסליחה."
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+"אלו חבילות snap נפוצות לסביבות שרתים. ניתן לבחור או לסלק עם רווח, Enter "
+"להצגת פרטים נוספים על החבילה, מפיץ וגרסאות זמינות."
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "יבוא שם משתמש:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "שם משתמש ב־Github:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr "נא למלא את שם המשתמש שלך ב־GitHub."
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr "שם המשתמש ב־GitHub יכול להיות מורכב רק מאותיות באנגלית ומינוסים."
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "שם משתמש ב־Launchpad:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+"שם המשתמש ב־Launchpad יכול להיות מורכב רק מאותיות קטנות באנגלית, מינוסים, "
+"פלוסים או נקודות."
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr "התקנת שרת OpenSSH"
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "יבוא זהות SSH:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "מ־Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "מ־Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "ניתן לייבא את מפתחות ה־SSH שלך מ־Github או מ־Launchpad."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr "לאפשר אימות עם ססמה דרך SSH"
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "שדה זה לא יכול להישאר ריק."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "מזהה ה־SSH ארוך מדי, עליו להיות < "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+"שם משתמש ב־Launchpad חייב להתחיל באות או במספר. כל האותיות חייביות להיות "
+"קטנות. מותר להשתמש גם בתווים +,- ו־. לאחר התו הראשון."
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"שם משתמש ב־Github יכול להכיל רק תווים אלפאנומריים או סימני מינוס בודדים ולא "
+"יכול להתחיל או להסתיים במינוס."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr "מפתחות ה־SSH מתקבלים…"
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "אישור מפתחות SSH"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr "התקבלו מפתחות עם טביעות האצבעות הבאות. להשתמש בהם?"
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "אישור מפתח SSH"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr "התקבל מפתח עם טביעת האצבע הבאה. להשתמש בו?"
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "הקמת SSH"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+"ניתן לבחור להתקין את חבילת שרת ה־OpenSSH כדי להפעיל גישה מאובטחת מרחוק לשרת "
+"שלך."
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 "\n"
-"בחינת התקני האחסון במערכת הזאת לא הצליחה, עמך הסליחה.\n"
+"נא לבחור את השפה בה תוצג תכנית ההתקנה וגם תוגדר\n"
+"במערכת המותקנת.\n"
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
-msgstr ""
-"\n"
-"השלמת ההתקנה לא הצליחה, עמך הסליחה.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "יש להשתמש בחצים: למעלה, למטה וב־Enter כדי לבחור את השפה שלך."
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
-msgstr ""
-"\n"
-"החלת תצורת הרשת לא הצליחה, עמך הסליחה.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
+msgstr "עזרה בבחירת השפה"
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
-msgstr ""
-"\n"
-"תכנית ההתקנה התחילה מחדש עקב שגיאה, עמך הסליחה.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
+msgstr "כשל"
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-"\n"
-"אירעה שגיאה בלתי ידועה, עמך הסליחה.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
+msgstr "אוטומטי"
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-"\n"
-"המידע שנאסף מהמערכת יסייע למפתחים לנתח את הדוח.\n"
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
+msgstr "מחובר"
 
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-"\n"
-"הדוח נטען…\n"
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-"\n"
-"איסוף המידע מהמערכת נכשל. בקבצים שבתוך\n"
-"‎/var/log/installer יש מידע נוסף על כך.\n"
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-"\n"
-"טעינת הדוח נכשלה. נא לעיין בקבצים שב־‎/var/log/installer לפרטים נוספים.\n"
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-"\n"
-"ניתן להמשיך ותכנית ההתקנה תציג את הכוננים שנמצאו במערכת ולא\n"
-"התקני בלוק נוספים או שתהיה לך אפשרות לתקן את המצב הזה על ידי\n"
-"מעבר למעטפת והגדרת התקני הבלוק של המכונה הזאת ידנית.\n"
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-"\n"
-"יש לך אפשרות לתקן את המצב הזה על ידי מעבר למעטפת\n"
-"והגדרת התקני הבלוג של המערכת ידנית.\n"
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-"\n"
-"ניתן להמשיך בהתקנה אבל בהנחה שהרשת אינה מתפקדת.\n"
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-"\n"
-"לנסות להפעיל את ההתקנה שוב?\n"
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr "יש לבחור בהמשך או לנסות את ההתקנה שוב."
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-"\n"
-"כדי לסייע לשפר את תכנית ההתקנה ניתן לשלוח דוח שגיאות.\n"
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr "ביטול ההעלאה"
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr "סגירת הדוח"
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr "הפעלת תכנית ההתקנה מחדש"
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr "שליחה ל־Canonical"
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr "נשלח ל־Canonical"
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr "הצגת הדוח המלא"
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-"דוח השגיאה נשמר אל\n"
-"\n"
-"  {loc}\n"
-"\n"
-"במערכת הקבצים עם התווית {label!r}."
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr "תאריך"
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr "סוג"
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr "מצב"
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr "נא לבחור את דוח השגיאה להצגה:"
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr "נצפה"
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr "לא נצפה"
-
-#: ../subiquity/ui/views/zdev.py:64
+#: ../subiquity/ui/views/zdev.py:77
 msgid "No zdev devices found."
 msgstr "לא נמצאו התקני zdev."
 
-#: ../subiquity/ui/views/zdev.py:77
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr "מזהה"
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr "מחובר"
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr "שמות"
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr "הפעלה"
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr "השבתה"
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr "הקמת Zdev"
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr "אחר"
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr "להשאיר לא מעוגן"
-
-#~ msgid "formatted as {}"
-#~ msgstr "מפורמט בתור {}"
-
-#~ msgid ", mounted at {}"
-#~ msgstr ", מעוגן תחת {}"
-
-#~ msgid "{} partition"
-#~ msgstr "מחיצת {}"
-
-#~ msgid "Adding {} to {}"
-#~ msgstr "{} מתווסף אל {}"
-
-#~ msgid "Editing {} of {}"
-#~ msgstr "נערך {} מתוך {}"
-
-#~ msgid "partition"
-#~ msgstr "מחיצה"
-
-#~ msgid "Toggle color on/off"
-#~ msgstr "כיבוי/הפעלה של צבע"
 
 #~ msgid "Filesystem setup"
 #~ msgstr "הגדרת מערכת קבצים"
@@ -2715,8 +2643,17 @@ msgstr "להשאיר לא מעוגן"
 #~ msgid "Choose the installation target"
 #~ msgstr "נא לבחור את יעד ההתקנה"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "פרמוט ו/או עיגון של {}"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "תודה לך על השימוש באובונטו!"
+
+#~ msgid "Finished install!"
+#~ msgstr "ההתקנה הסתיימה!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "ההתקנה הושלמה!"
 
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr "נא לבחור מנשק כדי להגדיר אותו או ללחוץ על סיום כדי להמשיך"
@@ -2730,11 +2667,49 @@ msgstr "להשאיר לא מעוגן"
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "נא לבחור כונן לביצוע ההתקנה אליו:"
 
+#~ msgid "Realname too long, must be < "
+#~ msgstr "השם האמתי ארוך מדי, עליו להיות < "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "שם השרת ארוך מדי, עליו להיות < "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "שם המשתמש ארוך מדי, עליו להיות < "
+
 #~ msgid "Exit To Shell"
 #~ msgstr "יציאה למעטפת"
 
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "שם המארח חייב להתאים להגדרת ביטויים רגולריים לשמות - NAME_REGEX, למשל: ‎[a-"
+#~ "z_][a-z0-9_-]*‎"
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "שם המשתמש חייב להתאים להגדרת ביטויים רגולריים לשמות - NAME_REGEX, למשל: ‎[a-"
+#~ "z_][a-z0-9_-]*‎"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "שדה זה חייב להיות %s."
+
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr "ניתן להשתמש בחצים למעלה, למטה וב־Enter כדי לבחור את המקלדת שלך."
+
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "הגדרות רשת אלחוטית למנשק הרשת {}"
+
+#~ msgid "partition of {}"
+#~ msgstr "מחיצה בתוך {}"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} אינו קלט תקני"
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "זיהוי המקלדת אוטומטית נכשל"
+
+#~ msgid "An error has occurred"
+#~ msgstr "אירעה שגיאה"
 
 #~ msgid "Install complete"
 #~ msgstr "ההתקנה הושלמה"
@@ -2743,16 +2718,16 @@ msgstr "להשאיר לא מעוגן"
 #~ msgstr "מתבצעת התקנה:"
 
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
 #~ "\n"
 #~ "Are you sure you want to continue?"
 #~ msgstr ""
-#~ "בחירה באפשרות המשך שלהלן תתחיל את ההתקנה ותגרום לאבדן הנתונים בכוננים "
-#~ "שנבחרו לאתחול.\n"
+#~ "בחירה באפשרות המשך שלהלן תתחיל את ההתקנה ותגרום לאבדן הנתונים בכוננים שנבחרו "
+#~ "לאתחול.\n"
 #~ "\n"
 #~ "לא תהיה לך אפשרות לחזור למסך הזה או לכל מסך קודם לאחר התחלת ההתקנה.\n"
 #~ "\n"
@@ -2761,24 +2736,260 @@ msgstr "להשאיר לא מעוגן"
 #~ msgid "starting..."
 #~ msgstr "בהפעלה…"
 
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "‚%s’ לא נכלל בתוך ‚%s’"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "עריכת IPv6"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "עריכת IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "עריכת רשת אלחוטית"
+
+#~ msgid "Info"
+#~ msgstr "מידע"
+
+#~ msgid "should be in CIDR form ({})"
+#~ msgstr "אמור להיות בצורת CIDR ({})"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s כבר קיים"
+
+#~ msgid "Info for {}"
+#~ msgstr "מידע על {}"
+
+#~ msgid "There is already a network device named \"{}\""
+#~ msgstr "כבר יש התקן רשת בשם „{}”"
+
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
 
 #~ msgid "-"
 #~ msgstr "-"
 
+#~ msgid "unknown state {}"
+#~ msgstr "מצב לא ידוע {}"
+
+#~ msgid "Edit"
+#~ msgstr "עריכה"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "הסרה מ־RAID/LVM"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "יצירת כרך לוגי"
+
+#~ msgid "Add Partition"
+#~ msgstr "הוספת מחיצה"
+
+#~ msgid "partition {} of {}"
+#~ msgstr "מחיצה {} מתוך {}"
+
+#~ msgid "partition {}"
+#~ msgstr "מחיצה {}"
+
+#~ msgid "logical volume"
+#~ msgstr "כרך לוגי"
+
+#~ msgid "partition"
+#~ msgstr "מחיצה"
+
+#~ msgid "Remove from {}"
+#~ msgstr "הסרה מ־{}"
+
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "להסיר את את מערכת הקבצים הקיימת מ־{}?"
+
+#~ msgid "Remove filesystem from {}"
+#~ msgstr "הסרת מערכת קבצים מ־{}"
+
+#~ msgid "{} is not a valid name for a volume group"
+#~ msgstr "{} אינו שם תקני לקבוצת הכרכים"
+
+#~ msgid "Passphrases"
+#~ msgstr "מילות צופן:"
+
+#~ msgid "Rounded size up to {}"
+#~ msgstr "הגודל עוגל לכדי {}"
+
+#~ msgid "There is already a volume group named '{}'"
+#~ msgstr "כבר יש קבוצת כרכים בשם ‚{}’"
+
+#~ msgid "Edit volume group \"{}\""
+#~ msgstr "עריכת קבוצת הכרכים „{}”"
+
+#~ msgid "Size (max {}):"
+#~ msgstr "גודל ({} לכל היותר):"
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "שם הכרך הלוגי לא יכול להכיל „{}”"
+
+#~ msgid "{} is already mounted at {}."
+#~ msgstr "{} כבר מעוגן תחת {}."
+
+#~ msgid "There is already a logical volume named {}."
+#~ msgstr "כבר יש כרך לוגי בשם {}."
+
+#~ msgid "logical volume {}"
+#~ msgstr "כרך לוגי {}"
+
+#~ msgid "There is already a RAID named '{}'"
+#~ msgstr "כבר קיים RAID בשם ‚{}’"
+
+#~ msgid "Reboot"
+#~ msgstr "הפעלה מחדש"
+
+#~ msgid "enslaved to {}"
+#~ msgstr "משועבד אל {}"
+
+#~ msgid "bond master for {}"
+#~ msgstr "מוביל המאגד עבור {}"
+
+#~ msgid "software RAID {}"
+#~ msgstr "RAID תכנתי {}"
+
+#~ msgid "unused {}"
+#~ msgstr "לא בשימוש {}"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has logical volumes."
+#~ msgstr "לא ניתן לערוך את {selflabel} כיוון שהוא מכיל כרכים לוגיים."
+
+#~ msgid ", mounted at {}"
+#~ msgstr ", מעוגן תחת {}"
+
+#, python-brace-format
+#~ msgid "It contains {n} {things}:"
+#~ msgstr "הוא מכיל {n} {things}:"
+
 #~ msgid "Use An Entire Disk And Set Up LVM"
 #~ msgstr "להשתמש בכונן שלם ולהגדיר LVM"
+
+#~ msgid "A logical volume may not be called {}"
+#~ msgstr "אי אפשר לקרוא לכרך לוגי בשם {}"
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "מתקבל מידע על {}"
+
+#~ msgid "Fetching info for {} failed"
+#~ msgstr "קבלת המידע על {} נכשלה"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "להפוך להתקן אתחול"
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
+#~ msgstr "לא ניתן למחוק את {selflabel} כיוון שיש לו {count} מחיצות מעוגנות."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has 1 mounted partition."
+#~ msgstr "לא ניתן למחוק את {selflabel} כיוון שיש לו מחיצה אחת מעוגנת."
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has partitions."
+#~ msgstr "לא ניתן לערוך את {selflabel} כיוון שיש לו מחיצות."
+
+#~ msgid "Format"
+#~ msgstr "פרמוט"
+
+#~ msgid "formatted as {}"
+#~ msgstr "מפורמט בתור {}"
+
+#~ msgid ""
+#~ "Mounting an existing filesystem at {} is usually a bad idea, proceed only "
+#~ "with caution."
+#~ msgstr ""
+#~ "לעגן מערכת קבצים קיימת תחת {} היא רעיון די גרוע, ניתן להמשיך אם המצב הזה "
+#~ "ברור לך."
+
+#~ msgid "Leave formatted as {}"
+#~ msgstr "להשאיר מפורמט בתור {}"
+
+#~ msgid "Editing {} of {}"
+#~ msgstr "נערך {} מתוך {}"
+
+#~ msgid "Adding {} to {}"
+#~ msgstr "{} מתווסף אל {}"
+
+#~ msgid ""
+#~ " You can choose whether to use the existing filesystem on this partition or "
+#~ "reformat it."
+#~ msgstr ""
+#~ " ניתן לבחור האם להשתמש במערכת הקבצים הקיימת במחיצה זו או לפרמט אותה מחדש."
+
+#~ msgid "Capped partition size at {}"
+#~ msgstr "גודל המחיצה הוגבל לכדי {}"
+
+#, python-brace-format
+#~ msgid ""
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+#~ msgstr ""
+#~ "לא ניתן למחוק את {selflabel} כיוון שהמחיצה {partnum} היא חלק מתוך {cdtype} "
+#~ "{cdname}."
+
+#~ msgid " The only aspect of this partition that can be edited is the size."
+#~ msgstr " ההיבט היחידי בו ניתן לערוך מחיצה זו היא הגודל."
+
+#~ msgid "RAID Level \"{}\" requires at least {} active devices"
+#~ msgstr "רמת ה־RAID „{}” דורשת לפחות {} התקנים פעילים"
+
+#~ msgid "Edit software RAID disk \"{}\""
+#~ msgstr "עריכת כונן RAID בתכנה „{}”"
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the PReP partion which is required on POWER. Grub will be installed "
+#~ "onto this partition."
+#~ msgstr ""
+#~ "מחיצת אתחול נחוצה\n"
+#~ "\n"
+#~ "זו מחיצת PReP שנחוצה למערכות POWER. למחיצה הזאת יותקן Grub."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
+#~ "installed onto this partition, which must be formatted as fat32."
+#~ msgstr ""
+#~ "מחיצת אתמול נחוצה\n"
+#~ "\n"
+#~ "זו ESP‏ / \"EFI system partition\" (מחיצת מערכת מנשק קושחה גמיש) שנדרשת על "
+#~ "ידי UEFI. על מחיצה זו, אותה יש לפרמט ל־fat32, יותקן Grub."
 
 #~ msgid ""
 #~ "The selected guided partitioning scheme creates the required bootloader "
 #~ "partition on the chosen disk and then creates a single partition covering "
 #~ "the rest of the disk, formatted as ext4 and mounted at '/'."
 #~ msgstr ""
-#~ "סכמת החלוקה המודרכת למחיצות הנבחרות יוצרת את מחיצת האתחול על הכונן הנבחר "
-#~ "ואז יוצרת מחיצה בודדת שחולשת על כל שאר הכונן, מפורמטת בתור ext4 ומעוגנת "
-#~ "תחת ‚/’."
+#~ "סכמת החלוקה המודרכת למחיצות הנבחרות יוצרת את מחיצת האתחול על הכונן הנבחר ואז "
+#~ "יוצרת מחיצה בודדת שחולשת על כל שאר הכונן, מפורמטת בתור ext4 ומעוגנת תחת ‚/’."
 
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "מחיצת אתחול נחוצה\n"
+#~ "\n"
+#~ "GRUB יותקן על ה־MBR (רשומת אתחול ראשית) של כונן היעד.\n"
+#~ "\n"
+#~ "עם זאת, על כונן עם טבלת מחיצות GPT אין מספיק מקום אחרי שה־MBR עבור GRUB "
+#~ "לאחסון ה־core.img שלו עבור השלב השני, לכן, מחיצה קטנה בלתי מפורמטטת נדרשת "
+#~ "בתחילת הכונן. היא לא תכיל מערכת קבצים ולא תעוגן ולא ניתן לערוך אותה דרך כאן."
+
+#, python-brace-format
 #~ msgid "Cannot remove selflabel from pre-exsting {cdtype} {cdlabel}"
 #~ msgstr "לא ניתן להסיר את selflabel מתוך {cdtype} {cdlabel} קיים"
 
@@ -2789,20 +3000,20 @@ msgstr "להשאיר לא מעוגן"
 #~ "If you choose to partition an entire disk you will still have a chance to "
 #~ "review and modify the results."
 #~ msgstr ""
-#~ "תכנית ההתקנה יכולה להנחות אותך כיצד לחלק כונן שלם למחיצות, הן באופן ישיר "
-#~ "והן עם LVM (מנהל כרכים לוגיים), או, אם זו העדפתך, ניתן לבצע זאת ידנית.\n"
+#~ "תכנית ההתקנה יכולה להנחות אותך כיצד לחלק כונן שלם למחיצות, הן באופן ישיר והן "
+#~ "עם LVM (מנהל כרכים לוגיים), או, אם זו העדפתך, ניתן לבצע זאת ידנית.\n"
 #~ "\n"
 #~ "בחירה בחלוקה של כל הכונן למחיצות עדיין תהיה לך הזדמנות לסקור ולשנות את "
 #~ "התוצאות."
 
 #~ msgid ""
-#~ "The LVM guided partitioning scheme creates three partitions on the "
-#~ "selected disk: one as required by the bootloader, one for '/boot', and "
-#~ "one covering the rest of the disk.\n"
+#~ "The LVM guided partitioning scheme creates three partitions on the selected "
+#~ "disk: one as required by the bootloader, one for '/boot', and one covering "
+#~ "the rest of the disk.\n"
 #~ "\n"
-#~ "A LVM volume group is created containing the large partition. A 4 "
-#~ "gigabyte logical volume is created for the root filesystem. It can easily "
-#~ "be enlarged with standard LVM command line tools."
+#~ "A LVM volume group is created containing the large partition. A 4 gigabyte "
+#~ "logical volume is created for the root filesystem. It can easily be enlarged "
+#~ "with standard LVM command line tools."
 #~ msgstr ""
 #~ "הסכמת החלוקה המודרכת למחיצות בתצורת LVM (מנהל כרכים לוגיים) יוצרת שלוש "
 #~ "מחיצות על הכונן הנבחר: אחת נדרשת לטובת מנהל אתחול, אחת לטובת ‚‎/boot’ ואחת "

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,86 +7,422 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-04-09 20:16+0000\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2020-01-17 15:48+0000\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
-"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: hr\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+"Sesija ljuske instalacijskog programa je aktivirana.\n"
+"\n"
+"Ova sesija ljuske je pokrenuta unutar instalacijskog okruženja.\n"
+"Vratiti ćete se u instalacijski program kada se ova  ljuska zatvori,\n"
+"na primjer tipkama Control-D ili naredbom 'exit'.\n"
+"\n"
+"Zapamtite da je ovo okruženje privremeno.  Promjene u ovome\n"
+"okruženju biti će izgubljene nakon ponovnog pokretanja. Ako je\n"
+"instalacija pokrenuta, instalirani sustav će biti montiran na /target."
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr "da"
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr "ne"
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr "Potvrda je potrebna za nastavak."
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+"Dodajte 'autoinstall' u vaš naredbeni redak kernela kako bi ovo izbjegli"
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr "Nastavi s automatskom instalacijom?"
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr "Uvoženje kljućeva je neuspjelo:"
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr "ssh-keygen nije uspio prikazati otisak preuzetih ključeva::"
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr "Nemoguće je urediti {selflabel} jer je dio {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr "Nemoguće uređivanje predpostojećih RAID-a."
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr "Nemoguće je uređivanje predpostojećih grupa uređaja."
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+"Nemoguće je ukloniti {selflabel} iz predpostojećeg {cdtype} {cdlabel}."
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+"Uklanjanje {selflabel} će ostaviti {cdtype} {cdlabel} s manje od "
+"{min_devices} uređaja."
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr "Uklanjanje {selflabel} će ostaviti {cdtype} {cdlabel} bez uređaja."
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr "Nemoguće je obrisati {selflabel} jer je dio {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+"Nemoguće brisanje jedne particije s uređaja koji već sadrži particije."
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr "Nemoguće brisanje paritcije koja sadrži učitač pokretanja sustava"
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+"Nemoguće je brisanje pojedinog logičkog uređaja iz grupe uređaja koja već "
+"sadrži logičke uređaje."
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr "postoji"
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr "novi"
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "lokalni disk"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr "{component_name} od {desc} {name}"
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr "već formatirana kao {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr "mora se ponovno formatirati kao {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr "mora se formatirati kao {fstype}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr "montirana na {path}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr "nije montirana"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "neiskorišteno"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "iskorišteno"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr "Neuspjelo sondiranje blokovskog uređaja"
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr "Neuspjelo sondiranje diska"
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr "Neuspjela instalacija"
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr "Instalacijski program se srušio"
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr "Mrežna greška"
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "Nepoznata greška"
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "automatsko podešavanje neuspjelo"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "Informacije"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Uredi bežičnu mrežu"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Uredi IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Uredi IPv6"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "Uredi povezivanje"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
-#, fuzzy
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
-msgstr "Dodaj VLAN oznaku"
+msgid "Edit Wifi"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:45
-#, fuzzy
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Obriši"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr "Otisci ključa poslužitelja su:\n"
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-"Otisci {keytype} ključa poslužitelja su:\n"
-"    {fingerprint}\n"
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Zatvori"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -97,34 +433,55 @@ msgid " or "
 msgstr " ili "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Ovo polje mora biti %s URL."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Završi"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Odustani"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Da"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Ne"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Zatvori"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Spremi"
 
@@ -157,14 +514,14 @@ msgid "Domains, comma separated"
 msgstr "Domene, zarezom odvojene"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr "treba bit u CIDR obliku ({})"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "'%s' nije sadržano u '%s'"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -186,87 +543,133 @@ msgstr "Onemogućeno"
 msgid "IPv{v} Method: "
 msgstr "IPv{v} način: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Stvori"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "VLAN ID:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr "VLAN ID mora biti između 1 i 4095"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s već postoji"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr "Dodaj VLAN oznaku"
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
+#, python-brace-format
 msgid "Info for {device}"
-msgstr "Informacije za {}"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Naziv:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Uređaji: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr "Način povezivanja:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr "XMIT hash pravilo:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr "LACP brzina:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
+#, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr "Već postoji mrežni uređaj naziva \"{}\""
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "Naziv ne može biti prazan"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr "Naziv ne može sadržavati više od 16 znakova"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr "Stvori povezivanje"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr "Uredi povezivanje"
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr "VLAN {id} na sučelju {link}"
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "nije povezano"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "vrijeme isteklo"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "nepromjenjivo"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "onemogućeno"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Mrežna povezivanja"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -276,647 +679,309 @@ msgstr ""
 "pristup nadopunama."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Natrag"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "Nastavi bez mrežnog pristupa"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "Primijenjivanje promjena"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr "nije povezano"
-
-#: ../subiquitycore/ui/views/network.py:188
-#, fuzzy, python-brace-format
-msgid "enslaved to {device}"
-msgstr "povezano na {}"
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "vrijeme isteklo"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, fuzzy, python-brace-format
-msgid "unknown state {state}"
-msgstr "nepoznato stanje {}"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "nepromjenjivo"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr "onemogućeno"
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr "VLAN {id} na sučelju {link}"
-
-#: ../subiquitycore/ui/views/network.py:360
-#, fuzzy, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr "glavno povezivanje za {}"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "Odaberi disk pokretanja sustava"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Mrežno sučelje {} bežično podešavanje"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Da"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Ne"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr "Uvoženje kljućeva je neuspjelo:"
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr "ssh-keygen nije uspio prikazati otisak preuzetih ključeva::"
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Dogodila se greška"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Instalacija završena!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Instalacija završena!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Instalacija sustava"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Instalacija završena!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Greška se dogodila tijekom instalacije"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr "Neuspjelo sondiranje blokovskog uređaja"
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr "Neuspjelo sondiranje diska"
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr "Neuspjela instalacija"
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr "Instalacijski program se srušio"
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr "Mrežna greška"
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr "Nepoznata greška"
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr "neuspjelo"
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr "automatski"
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr "mrežno"
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr "0 (trakasto)"
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr "1 (zrcaljeno)"
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Naziv ne može biti prazan"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} nije valjan unos"
+msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Informacije"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "Ostalo"
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Uredi"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
+msgstr "Ostavi odmontirano"
 
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Ponovno formatiraj"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "Dodaj particiju"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "Stvori Logički uređaj"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Formatiraj"
-
-#: ../subiquity/models/filesystem.py:424
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr "Ukloni sa RAID/ULU"
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Obriši"
-
-#: ../subiquity/models/filesystem.py:426
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr "Učini uređaj pokretljivim"
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "Nemoguće je urediti {selflabel} jer je dio {cdtype} {cdname}."
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr "Nemoguće je ukloniti {selflabel} iz predpostojećeg {cdtype} {cdlabel}."
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-"Uklanjanje {selflabel} će ostaviti {cdtype} {cdlabel} s manje od "
-"{min_devices} uređaja."
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr "Uklanjanje {selflabel} će ostaviti {cdtype} {cdlabel} bez uređaja."
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr "Nemoguće je obrisati {selflabel} jer je dio {cdtype} {cdname}."
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr "postoji"
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr "novi"
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr "{component_name} od {desc} {name}"
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr "već formatirana kao {fstype}"
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr "mora se ponovno formatirati kao {fstype}"
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr "mora se formatirati kao {fstype}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr "montirana na {path}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr "nije montirana"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr "neiskorišteno"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr "iskorišteno"
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-"Nemoguće je obrisati {selflabel} jer je particija {partnum} dio {cdtype} "
-"{cdname}."
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-"Nemoguće je obrisati {selflabel} zato jer sadrži {count} montiranih "
-"particija."
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-"Nemoguće je obrisati {selflabel} zato jer sadrži 1 montiranu particiju."
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "lokalni disk"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Podešavanje proxya"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "automatsko podešavanje neuspjelo"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-#, fuzzy
-msgid "unused ESP"
-msgstr "neiskorišteno"
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "logički uređaj"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "partiticija {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "particija {} od {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "particija {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr "Nemoguće brisanje jedne particije s uređaja koji već sadrži particije."
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr "Nemoguće brisanje paritcije koja sadrži učitač pokretanja sustava"
-
-#: ../subiquity/models/filesystem.py:1049
-#, fuzzy, python-brace-format
-msgid "software RAID {level}"
-msgstr "softverski RAID {}"
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr "Nemoguće uređivanje predpostojećih RAID-a."
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr "Nemoguće je urediti {selflabel} zato jer sadrži particiju."
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-#, fuzzy
-msgid "LVM volume group"
-msgstr "Stvori ULU grupu uređaja"
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr "Nemoguće je uređivanje predpostojećih grupa uređaja."
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr "Nemoguće je urediti {selflabel} zato jer sadrži logičke uređaje."
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "logički uređaj"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-"Nemoguće je brisanje pojedinog logičkog uređaja iz grupe uređaja koja već "
-"sadrži logičke uređaje."
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
+"Sorry, there was a problem examining the storage devices on this system.\n"
+msgstr ""
 "\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
-msgstr ""
-"Sesija ljuske instalacijskog programa je aktivirana.\n"
-"\n"
-"Ova sesija ljuske je pokrenuta unutar instalacijskog okruženja.\n"
-"Vratiti ćete se u instalacijski program kada se ova  ljuska zatvori,\n"
-"na primjer tipkama Control-D ili naredbom 'exit'.\n"
-"\n"
-"Zapamtite da je ovo okruženje privremeno.  Promjene u ovome\n"
-"okruženju biti će izgubljene nakon ponovnog pokretanja. Ako je\n"
-"instalacija pokrenuta, instalirani sustav će biti montiran na /target."
+"Nažalost, došlo je do problema pri provjeri uređaja pohrane na ovom "
+"sustavu.\n"
 
-#: ../subiquity/core.py:224
-#, fuzzy, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-"instalacijski program pokrenut na {} će pokrenuti automatsku instalaciju"
-
-#: ../subiquity/core.py:237
-#, fuzzy, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-"čekanje instalacijskog programa pokrenutog na {} za pokretanje ranijih "
-"naredbi"
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr "da"
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr "ne"
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr "Potvrda je potrebna za nastavak."
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-"Dodajte 'autoinstall' u vaš naredbeni redak kernela kako bi ovo izbjegli"
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr "Nastavi s automatskom instalacijom?"
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "Znakovi : , i = nisu dopušteni u ovom polju"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr "Jedini dopušteni znakovi u ovom polju su a-z, 0-9, _ i -"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Vaše ime:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Naziv vašeg poslužitelja:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "Naziv koji će se koristiti za komunikaciju s ostalim računalima."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Odaberite korisničko ime:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Odaberite lozinku:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Potvrdite vašu lozinku:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Stvarno ime je predugačko, mora biti < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Naziv poslužitelja ne smije biti prazan"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Naziv poslužitelja je predugačak, mora biti < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Naziv računala mora sadržavati NAZIV_UOBIČAJENI-IZRAZ, npr. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Korisničko ime nedostaje"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Korisničko ime je predugačko, mora biti < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Korisničko ime mora sadržavati NAZIV_UOBIČAJENI-IZRAZ, npr. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-"Korisničko ime \"{username}\" je rezervirano za korištenje od strane sustava."
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Lozinka mora biti postavljena"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Lozinke se ne podudaraju"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr "{desc} se ne podudara"
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Postavljanje profila"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
-"Upišite korisničko ime i lozinku koju ćete koristiti za prijavu u sustav. "
-"Možete podesiti SSH pristup na sljedećem zaslonu ali lozinka će još uvijek "
-"biti potrebna za sudo."
+"\n"
+"Nažalost, došlo je do problema pri završetku instalacije.\n"
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "lozinke"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
+"\n"
+"Nažalost, došlo je do problema pri primijeni podešavanja mreže.\n"
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+"\n"
+"Nažalost, instalacijski program se ponovno pokrenuo zbog greške.\n"
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+"\n"
+"Nažalost, došlo je do nepoznate greške.\n"
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+"\n"
+"Informacije se prikupljaju iz sustava koje će pomoći\n"
+"razvijateljima da dijagnosticiraju problem.\n"
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+"\n"
+"Učitavanje izvještaja...\n"
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+"\n"
+"Neuspjelo prikupljanje informacija iz sustava. Pogledajte datoteke u\n"
+"/var/log/installer za više pojedinosti.\n"
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+"\n"
+"Neuspjelo učitavanje izvještaja. Pogledajte datoteke u /var/log/installer za "
+"više pojedinosti.\n"
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+"\n"
+"Možete nastaviti i instalacijski program će samo obuhvatiti prisutne\n"
+"diskove u sustavu, a ne ostale blokovske uređaje, ili možda možete\n"
+"popraviti problem pokretanjem ljuske i ručnim ponovnim\n"
+"podešavanjem blokovskih uređaja sustava.\n"
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+"\n"
+"Možda možete popraviti problem pokretanjem ljuske i ručnim\n"
+"ponovnim podešavanjem blokovskih uređaja sustava.\n"
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+"\n"
+"Možete nastaviti s instalacijom ali pretpostavit\n"
+"će se da mreža nije funkcionalna.\n"
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+"\n"
+"Želite li ponovno pokušati pokrenuti instalaciju?\n"
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr "Odaberie Nastavi za ponovni pokušaj instalacije."
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+"\n"
+"Ako želite pomoći poboljšati instalacijski program, možete poslati izvještaj "
+"greške.\n"
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr "Prekini slanje"
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr "Zatvori izvještaj"
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Nastavi"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr "Pokreni ljusku"
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr "Ponovno pokreni instalacijski program"
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr "Pošalji u Canonical"
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr "Pošalji u Canonical"
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr "Prikaži cjeloviti izvještaj"
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+"Izvještaj greške je spremljen u\n"
+"\n"
+"  {loc}\n"
+"\n"
+"na datotečnom sustavu naziva {label!r}."
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr "DATUM"
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr "VRSTA"
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr "STANJE"
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr "Odaberi izvještaj greške za prikaz:"
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr "PRIKAZANO"
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr "NEPRIKAZANO"
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
+#, python-brace-format
 msgid "formatted as {fstype}"
-msgstr "mora se formatirati kao {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:132
+#, python-brace-format
 msgid ", mounted at {path}"
-msgstr "montirana na {path}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ", nije montiran"
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:136
+#, python-brace-format
 msgid "unused {device}"
-msgstr "neiskorišten {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
@@ -924,458 +989,235 @@ msgstr ""
 "Ako stavite sve diskove u RAID-e ili GU ULU-a, neće biti prostora za "
 "stavljanje particije pokretanja sustava."
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr "/ nije dopušteno u nazivu RAID uređaja"
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr "Razmaci nisu dopušteni u nazivu RAID uređaja"
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr "RAID razina:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Uređaji:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Veličina:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, fuzzy, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr "Već postoji RAID naziva '{}'"
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ". i .. nisu valjani nazivi RAID uređaja"
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, fuzzy, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr "RAID razina \"{}\" zahtijeva najmanje {} aktivnih uređaja"
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr "Stvori softverski RAID (\"VD\") disk"
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, fuzzy, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr "Uredi softverski RAID disk \"{}\""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr "Ostavi neformatirano"
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, fuzzy, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr "Ostavi formatirano kao {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, fuzzy, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr "Veličina ograničene particije na {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, fuzzy, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr "Zaokružena veličina do {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"Jedini dopušteni znakovi u nazivu logičkog uređaja su a-z, A-Z, 0-9, +, _, . "
-"i -"
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, fuzzy, python-brace-format
-msgid "Size (max {size}):"
-msgstr "Veličina (najveća {}):"
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Naziv: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "Formatiraj:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr "Montiraj:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr "Koristi kao swap"
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr "Koristite swap particiju na instaliranome sustavu."
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr "Naziv logičkog uređaja ne može biti prazan"
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr "Naziv logičkog uređaja ne može započeti s crticom"
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, fuzzy, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr "Logički uređaj ne može se nazivati {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, fuzzy, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr "Naziv logičkog uređaja ne smije sadržavati \"{}\""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, fuzzy, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr "Već postoji logički uređaj naziva {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Putanja premašena PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, fuzzy, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr "{} je već montiran na {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, fuzzy, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-"Montiranje postojećeg datotečnog uređaja na {} uobičajeno je loša ideja, "
-"nastavite dalje s oprezom."
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Potrebna je particija za učitača pokretanja sustava\n"
-"\n"
-"GRUB će biti instaliran na odabrani disk glavnog zapisa pokretanja (MBR).\n"
-"\n"
-"Međutim, na disk sa GPT particijskom tablicom, nema dovoljno prostora nakon "
-"glavnog zapisa pokretanja (MBR) kako bi GRUB mogao spremiti drugo-faznu core."
-"img sliku, stoga je potrebna mala neformatirana partiticija na početku "
-"diska. Ta particija neće sadržavati datotečni sustav, neće biti montirana i "
-"neće se moći uređivati."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-"Potrebna je particija za učitača pokretanja sustava\n"
-"\n"
-"To je ESP / \"EFI particija sustava\" koju zahtijeva UEFI. Grub će biti "
-"instaliran na tu particiju,\n"
-"koja mora biti formatirana u fat32 datotečnom sustavu."
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-"Potrebna je particija za učitača pokretanja sustava\n"
-"\n"
-"To je ESP / \"EFI particija sustava\" koju zahtijeva UEFI. Grub će biti "
-"instaliran na tu particiju,\n"
-"koja mora biti formatirana u fat32 datotečnom sustavu."
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-#, fuzzy
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr " Jedina značajka ove particije koja se može uređivati je veličina."
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-#, fuzzy
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-" Možete odabrati korištenje postojećeg datotečnog sustava na ovoj particiji "
-"ili ju možete ponovno formatirati."
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-"Potrebna je particija za učitača pokretanja sustava\n"
-"\n"
-"To je PReP particija koju zahtijeva POWER. Grub će biti instaliran na tu "
-"particiju."
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-"Potrebna je particija za učitača pokretanja sustava\n"
-"\n"
-"To je PReP particija koju zahtijeva POWER. Grub će biti instaliran na tu "
-"particiju."
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "U redu"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr "Koristi postojeći fat32 datotečni sustav"
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr "Ponovno formatiraj kao svježi fat32 datotečni sustav"
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "logički uređaj {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "particija {} od {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-"Formatiranje i montiranje diska izravno je neuobičajeno. Najvjerojatnije "
-"umjesto želite dodati particiju."
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formatiraj i/ili montiraj {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr "Sigurno želite obrisati {desc} {label}?"
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr "Formatiran je kao {fstype} i montiran na {path}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr "Formatiran je kao {fstype} i nije montiran."
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "logički uređaj"
-msgstr[1] "logički uređaj"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:70
+#, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
-msgstr[0] "Sadrži {n} {things}:"
-msgstr[1] "Sadrži {n} {things}:"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr "Nije formatiran ili montiran."
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Obriši"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:112
+#, python-brace-format
 msgid "Remove filesystem from {device}"
-msgstr "Ukloni datotečni sustav iz {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:116
+#, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
-msgstr "Sigurno želite ukloniti postojeći datotečni sustav iz {}?"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr "logički uređaji"
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "particije"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr "Ukloni sve {things} iz {obj}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr "Sigurno želite ukloniti sve {things} iz {obj}?"
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr "Ponovno formatiraj"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
+#, python-brace-format
+msgid "existing {fstype}"
 msgstr ""
-"Jedini dopušteni znakovi u nazivu grupe uređaja su a-z, A-Z, 0-9, +, _, . i -"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "Lozinke"
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
+#, python-brace-format
+msgid "new {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "Stvori šifrirani uređaj"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Nema montiranih diskova ili particija."
 
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr "Lozinka:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "TOČKA MONTIRANJA"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr "Potvrdi lozinku:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "VELIČINA"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr "Odaberite najmanje jedan uređaj kao dijela grupe uređaja."
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "VRSTA"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr "Naziv grupe uređaja ne može biti prazan"
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "VRSTA UREĐAJA"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr "Naziv grupe uređaja ne može započeti s crticom"
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Odmontiraj"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:113
-#, fuzzy, python-brace-format
-msgid "{name} is not a valid name for a volume group"
-msgstr "{} nije valjani naziv grupe uređaja"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "Nema dostupnih uređaja"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
-#, fuzzy, python-brace-format
-msgid "There is already a volume group named '{name}'"
-msgstr "Već postoji grupa uređaja naziva '{}'"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr "Nema iskorištenih uređaja"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
-msgstr "Lozinka mora biti postavljena"
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
+#, python-brace-format
+msgid "Remove from {device}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr "Lozinke se ne podudaraju"
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr "Stvori ULU grupu uređaja"
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
-#, fuzzy, python-brace-format
-msgid "Edit volume group \"{name}\""
-msgstr "Uredi grupu uređaja \"{}\""
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "UREĐAJ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "slobodni prostor"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr "Podešavanje pohrane"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr "Stvori softverski RAID (VU) višediskovni uređaj"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr "Stvori grupu uređaja (ULU)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "SAŽETAK DATOTEČNOG SUSTAVA"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "DOSTUPNI UREĐAJI"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr "ISKORIŠTENI UREĐAJI"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr "Montiraj datotečni sustav na /"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr "Odaberi disk pokretanja sustava"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Poništi"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr "Podesite navođeni raspored pohrane, ili stvorite jedan prilagođeni:"
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr "Lozinka:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr "Potvrdi lozinku:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Lozinka mora biti postavljena"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Lozinke se ne podudaraju"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr "Šifriraj ULU grupu s LUKS"
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr "Postavi ovaj disk kao ULU grupu"
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr "Koristi cijeli disk"
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr "Prilagođeni raspored pohrane"
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1408,36 +1250,8 @@ msgid ""
 "at /.\n"
 "\n"
 msgstr ""
-"\n"
-"\n"
-"Mogućnost \"Koristi cijeli disk\" će instalirati Ubuntu na odabrani disk,\n"
-"zamjenjujući sve postojeće particije i sadržane podatke.\n"
-"\n"
-"Ako ga platforma zahtijeva, particija učitača pokretanja sustava\n"
-"će biti stvorena na disku.\n"
-"\n"
-"Ako odaberete korištenje ULU, dvije dodatne particije se tada stvore,\n"
-"jedna za /boot a druga obuhvaća ostatak diska. ULU grupa uređaja\n"
-"je stvorena koja sadrži veliku particiju. 4 gigabajta logički uređaj\n"
-"je stvoren za korijenski datotečni sustav. Može se lako povećati\n"
-"sa standardnim ULU alatima naredbenog retka.\n"
-"\n"
-"Možete još odabrati i šifriranje ULU grupe uređaja. To će zahtijevati\n"
-"postavljanje lozinke, koju ćete trebati utipkati pri svakom pokretanju "
-"sustava.\n"
-"\n"
-"Ako ne odaberete korištenje ULU-a, stvoriti će se jedna particija koja će\n"
-"obuhvatiti ostatak diska i biti će formatirana kao ext4 i montirana na /.\n"
-"\n"
-"U oba slučaja i dalje ćete moći pregledati i promijeniti rezultate.\n"
-"\n"
-"Ako odaberete korištenje prilagođenog rasporeda pohrane, neće biti promjena\n"
-"na disku i morati ćete najmanje, odabrati disk pokretanja sustava i "
-"montirati\n"
-"datotečni sustav na /.\n"
-"\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1448,7 +1262,7 @@ msgstr ""
 "Sondiranje bloka nije otkrilo dovoljno velik disk za podršku podešavanja\n"
 "navođenog particioniranja pohrane. Ručno podešavanje je još uvijek moguće.\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
@@ -1458,131 +1272,287 @@ msgstr ""
 "Sondiranje bloka nije otkrilo nijedan disk. Nažalost,\n"
 "ovo znači da instalacija neće biti moguća.\n"
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr "Navođeno podešavanje pohrane"
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "U redu"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr "Pomoć za navođeno podešavanje pohrane"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
-#, fuzzy, python-brace-format
-msgid "existing {fstype}"
-msgstr "postoji"
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+"Jedini dopušteni znakovi u nazivu grupe uređaja su a-z, A-Z, 0-9, +, _, . i -"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Uređaji:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Veličina:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Stvori šifrirani uređaj"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr "Odaberite najmanje jedan uređaj kao dijela grupe uređaja."
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr "Naziv grupe uređaja ne može biti prazan"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr "Naziv grupe uređaja ne može započeti s crticom"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "new {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Nema montiranih diskova ili particija."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "TOČKA MONTIRANJA"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "VELIČINA"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "VRSTA"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "VRSTA UREĐAJA"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "Odmontiraj"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr "Nema dostupnih uređaja"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr "Nema iskorištenih uređaja"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
-#, fuzzy, python-brace-format
-msgid "Remove from {device}"
-msgstr "Ukloni iz {}"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "Dodaj {} particiju"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/lvm.py:119
+#, python-brace-format
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-#, fuzzy
-msgid "Add As Another Boot Device"
-msgstr "Učini uređaj pokretljivim"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
+msgstr "Lozinka mora biti postavljena"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-#, fuzzy
-msgid "Use As Boot Device"
-msgstr "Učini uređaj pokretljivim"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
+msgstr "Lozinke se ne podudaraju"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "UREĐAJ"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
+msgstr "Stvori ULU grupu uređaja"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "slobodni prostor"
+#: ../subiquity/ui/views/filesystem/lvm.py:157
+#, python-brace-format
+msgid "Edit volume group \"{name}\""
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
-msgstr "Podešavanje pohrane"
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr "Ostavi neformatirano"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
-msgstr "Stvori softverski RAID (VU) višediskovni uređaj"
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
-msgstr "Stvori grupu uređaja (ULU)"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "SAŽETAK DATOTEČNOG SUSTAVA"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "DOSTUPNI UREĐAJI"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
+msgstr ""
+"Jedini dopušteni znakovi u nazivu logičkog uređaja su a-z, A-Z, 0-9, +, _, . "
+"i -"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
-msgstr "ISKORIŠTENI UREĐAJI"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
-msgstr "Montiraj datotečni sustav na /"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Naziv: "
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
-msgstr "Odaberi disk pokretanja sustava"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Formatiraj:"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "Nastavi bez mrežnog pristupa"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
+msgstr "Montiraj:"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Poništi"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr "Koristi kao swap"
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
+msgstr "Koristite swap particiju na instaliranome sustavu."
+
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr "Naziv logičkog uređaja ne može biti prazan"
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr "Naziv logičkog uređaja ne može započeti s crticom"
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Putanja premašena PATH_MAX"
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr "Koristi postojeći fat32 datotečni sustav"
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr "Ponovno formatiraj kao svježi fat32 datotečni sustav"
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+"Formatiranje i montiranje diska izravno je neuobičajeno. Najvjerojatnije "
+"umjesto želite dodati particiju."
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1609,114 +1579,44 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr "Sondiranje uređaja za instalaciju nije uspjelo"
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
-#, fuzzy
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
-msgstr "Pogledaj izvještaj greške"
-
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
-msgstr "Provjera daopuna instalacijskog programa..."
-
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
 msgstr ""
-"Kontaktiranje snap trgovine u svrhu provjere dostupnosti nove inačice "
-"instalacijskog programa."
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr "Kontaktiranje snap trgovine neuspjelo"
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
+msgstr "/ nije dopušteno u nazivu RAID uređaja"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr "Kontaktiranje snap trgovine neuspjelo:"
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
+msgstr "Razmaci nisu dopušteni u nazivu RAID uređaja"
 
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "Dostupne su nadopune instalacijskog programa"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "RAID razina:"
 
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
-msgstr ""
-"Inačica {new} instalacijskog programa je dostupna, a inačica {current} je "
-"trenutno pokrenuta."
-
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "Preuzimanje nadopune..."
-
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
-msgstr ""
-"Pričekajte dok se nadopuna instalacijskog programa preuzima. Instalacijski "
-"program će se automatski ponovno pokrenuti kada se preuzimanje završi."
-
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
-msgstr "Neuspjela nadopuna"
-
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr "Preuzimanje i primijenjivanje nadopune:"
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "Nastavi bez nadopunjivanja"
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Pokušaj ponovno"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
+msgstr ". i .. nisu valjani nazivi RAID uređaja"
+
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
-"Ako odaberete nadopunu, nadopuna će se preuzeti i instalacija će se "
-"nastaviti odavdje."
 
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr "Nadopuni na novu inačicu instalcijski program"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
+msgstr "Stvori softverski RAID (\"VD\") disk"
 
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "Prekini nadopunu"
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
-"Ovdje upišite zrcalni poslužitelj arhive koji će se koristiti umjesto "
-"zadanog."
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr "Adresa zrcalnog poslužitelja:"
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr "Podešavanje zrcalnog poslužitelja Ubuntu arhive"
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
-msgstr ""
-"Ako koristite alternativni zrcalni poslužitelj za Ubuntu, upišite njegove "
-"pojedinosti ovdje."
 
 #: ../subiquity/ui/views/help.py:70
 #, python-brace-format
@@ -1783,16 +1683,12 @@ msgstr ""
 "Ovo je inačica {snap_version} instalacijskog programa.\n"
 
 #: ../subiquity/ui/views/help.py:102
-#, fuzzy
 msgid ""
 "\n"
 "It is possible to connect to the installer over the network, which\n"
 "might allow the use of a more capable terminal and can offer more languages\n"
 "than can be rendered in the Linux console."
 msgstr ""
-"\n"
-"Moguće je povezivanje s instalacijskim programom putem mreže,\n"
-"što omogućuje upotrebu složenijeg terminala"
 
 #: ../subiquity/ui/views/help.py:107
 msgid ""
@@ -1806,21 +1702,44 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
-"\n"
-"Za povezivanje, SSH-a sa installer@{ip}.\n"
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
-"\n"
-"Lozinka koju bi trebali koristiti je \"{password}\".\n"
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
@@ -1830,7 +1749,7 @@ msgstr ""
 "Nažalost, izgleda da ovaj sustav trenutno\n"
 "nema dostupnih globalnih IP adresa.\n"
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
@@ -1840,601 +1759,277 @@ msgstr ""
 "Nažalost, instalacijski program nije mogao\n"
 "otkriti lozinku koja je postavljena.\n"
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr "Sljedeće tipke mogu se koristiti u bilo koje vrijeme:"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr "ESC"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr "idi natrag"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr "F1"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr "otvori izbornik pomoći"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr "Control-Z, F2"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr "prebaci u ljusku"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr "Control-L, F3"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr "ponovno iscrtaj zaslon"
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr "Control-T, F4"
 
-#: ../subiquity/ui/views/help.py:185
-#, fuzzy
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
-msgstr "uklj/isklj boju"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr "Control-X"
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr "Control-E"
 
-#: ../subiquity/ui/views/help.py:190
-#, fuzzy
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
-msgstr "stvori opširniji izvještaj greške (samo testiranje)"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr "Control-R"
 
-#: ../subiquity/ui/views/help.py:191
-#, fuzzy
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
-msgstr "stvori sažetiji izvještaj greške (samo testiranje)"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Control-X"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr "Nadopuni na novu inačicu instalcijski program"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr "Control-U"
 
-#: ../subiquity/ui/views/help.py:193
-#, fuzzy
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
-msgstr "sruši korisničko sučelje (samo testiranje)"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
-#, fuzzy
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
-msgstr "zatvori (samo testiranje)"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr "Tipke prečaca"
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr "O ovom instalacijskom programu"
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr "Prečaci tipkovnice"
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr "Pokreni ljusku"
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr "Pomoć za SSH pristup"
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr "Pomoć ovog zaslona"
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr "Prikaži izvještaje greške"
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr "Pomoć"
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr "O instalcijskom programu"
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
-msgstr ""
-"\n"
-"Odaberite jezik za korištenje u instalacijskom programu, i za podešavanje\n"
-"i upotrebu na instaliranome sustavu.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "Znakovi : , i = nisu dopušteni u ovom polju"
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Koristite UP, DOWN i ENTER tipke za odabir svoga jezika."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
+msgstr "Jedini dopušteni znakovi u ovom polju su a-z, 0-9, _ i -"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr "Pomoć u odabiru jezika"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Vaše ime:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Uvezi korisničko ime:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Naziv vašeg poslužitelja:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "GitHub korisničko ime:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Naziv koji će se koristiti za komunikaciju s ostalim računalima."
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "GitHub korisničko ime:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Odaberite korisničko ime:"
 
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-"GitHub korisničko ime može sadržavati samo slovno-brojčane znakove ili "
-"pojedinačne crtice i ne može započeti niti završavati crticom."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Odaberite lozinku:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Launchpad korisničko ime:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Potvrdite vašu lozinku:"
 
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"GitHub korisničko ime može sadržavati samo slovno-brojčane znakove ili "
-"pojedinačne crtice i ne može započeti niti završavati crticom."
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr "Instaliraj OpenSSH poslužitelja"
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Uvezi SSH identitet:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "iz GitHuba"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "iz Launchpada"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Možete uvesti vaše SSH ključeve iz GitHuba ili Launchpada."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr "Dopusti ovjeru lozinkom putem SSH-a"
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Polje ne smije ostati prazno."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "SSH id je predugačak, mora biti < "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-"Launchpad korisničko ime mora započeti s brojem ili slovom. Sva slova moraju "
-"biti mala. Znakovi +, - i . su isto dopušteni nakon prvog znaka."
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"GitHub korisničko ime može sadržavati samo slovno-brojčane znakove ili "
-"pojedinačne crtice i ne može započeti niti završavati crticom."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr "Preuzimanje  SSH keys..."
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr "Potvrdite SSH ključeve"
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr "Ključevi sa sljedećim otiscima su preuzeti. Želite li ih koristiti?"
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr "Potvrdite SSH ključ"
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr "Ključ sa sljedećim otiskom je preuzet. Želite li ga koristiti?"
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr "SSH podešavanje"
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-"Možete odabrati instalaciju OpenSSH paketa kako bi omogućili siguran "
-"udaljeni pristup vašemu poslužitelju."
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "upravo sada"
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr "minuta"
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr "minuta"
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr "sat"
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr "sata"
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr "dan"
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr "dana"
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
-msgstr "{amount:2} {unit} prije"
-
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Naziv poslužitelja ne smije biti prazan"
+
+#: ../subiquity/ui/views/identity.py:109
+#, python-brace-format
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Korisničko ime nedostaje"
+
+#: ../subiquity/ui/views/identity.py:123
+#, python-brace-format
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
+"Korisničko ime \"{username}\" je rezervirano za korištenje od strane sustava."
 
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr "{desc} se ne podudara"
 
-#: ../subiquity/ui/views/snaplist.py:256
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap}"
-msgstr "Preuzimanje informacija za {}"
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Postavljanje profila"
 
-#: ../subiquity/ui/views/snaplist.py:282
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap} failed"
-msgstr "Preuzimanje informacija za {} neuspjelo"
-
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
-msgstr "Istaknuti snap paketi za poslužitelje"
-
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Nastavi"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
-msgstr "Učitavanje snap paketa poslužitelja iz trgovine, pričekajte..."
-
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr "Nažalost, učitavanje snap paketa iz trgovine nije uspjelo."
-
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
-"Ovo su popularni snap paketi u radnim okruženjima poslužitelja. Odaberite "
-"ili uklonite odabir sa SPACE tipkom, ili pritisnite ENTER tipku kako bi "
-"vidjeli više pojedinosti paketa, izdavač i inačica su dostupni."
+"Upišite korisničko ime i lozinku koju ćete koristiti za prijavu u sustav. "
+"Možete podesiti SSH pristup na sljedećem zaslonu ali lozinka će još uvijek "
+"biti potrebna za sudo."
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr "Automatsko otkrivanje tipkovnice"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "lozinke"
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-"Otkrivanje tipkovnice će započeti. Biti će vam postavljeno niz pitanja o "
-"vašoj tipkovnici. Pritisnite 'escape' tipku u bilo koje vrijeme kako bi se "
-"vratili na prijašnji zaslon."
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Nažalost, automatsko otkrivanje tipkovnice nije uspjelo"
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-"Automatsko otkrivanje tipkovnice je završeno.\n"
-"\n"
-"Vaša tipkovnica je otkrivena:\n"
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-"\n"
-"Ako je raspored ispravno otkriven, odaberite 'Završi' na sljedećem zaslonu. "
-"A ako nije možete odabrati drugi raspored tipkovnice ili ponovno pokrenuti "
-"automatsko otkrivanje tipkovnice.\n"
-"\n"
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Raspored"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr "Varijanta"
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Pritisnite jednu od sljedećih tipki:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr "Upis nije prepoznat, pokušajte ponovno"
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "Je li sljedeća tipka prisutna na vašoj tipkovnici?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Primijenjivanje podešavanja"
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-"Trebati će vam način prebacivanja tipkovnice između nacionalnog i "
-"standardnog latiničnog rasporeda.\n"
-"\n"
-"Desni Alt ili Caps Lock tipke uobičajeno su odabrane iz ergonomskih razloga "
-"(za mala slova, koristite kombinaciju Shift+Caps Lock za normalno "
-"prebacivanje veličine slova). Alt+Shift je isto tako popularna kombinacija; "
-"međutim izgubiti će svoje uobičajeno ponašanje u Emacsu i drugim programima "
-"koji se koriste za određene namjene.\n"
-"\n"
-"Nisu sve prikazane tipke prisutne na svim tipkovnicama. "
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Desni Alt (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Desni Control"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Desni Shift"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr "Desna Logo tipka"
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "Tipka Izbornika"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Control+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr "Control+Alt"
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "Lijevi Control+Lijevi Shift"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Lijevi Alt"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Lijevi Control"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Lijevi Shift"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr "Lijeva Logo tipka"
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "Scroll Lock tipka"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr "Bez prebacivanja"
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr "Prečac: "
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr "Odaberi prebacivanje rasporeda"
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "Raspored:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr "Varijanta:"
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr "Postavke tipkovnice"
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr "Odaberite raspored tipkovnice priključene na sustav, ako postoji."
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-"Odaberite raspored tipkovnice ispod ili odaberite \"Otkrij tipkovnicu\", za "
-"automatsko otkrivanje vašeg rasporeda."
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr "Otkrij tipkovnicu"
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr "Napredak instalacije"
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Ponovno pokreni odmah"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr "Pogledaj izvještaj greške"
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr "Pogledaj potpuni zapis"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr "Potpuni prikaz instalcije"
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Instalacija sustava"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Instalacija završena!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr "Prekini nadopunu i ponovno pokreni"
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Ponovno pokreni"
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr "Ponovno pokretanje..."
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Greška se dogodila tijekom instalacije"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2452,11 +2047,11 @@ msgstr ""
 "\n"
 "Sigurno želite nastaviti?"
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr "Potvrdi razornu radnju"
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2464,24 +2059,229 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
-msgstr "Pokreni ljusku"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "Automatsko otkrivanje tipkovnice"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+"Otkrivanje tipkovnice će započeti. Biti će vam postavljeno niz pitanja o "
+"vašoj tipkovnici. Pritisnite 'escape' tipku u bilo koje vrijeme kako bi se "
+"vratili na prijašnji zaslon."
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+"Automatsko otkrivanje tipkovnice je završeno.\n"
+"\n"
+"Vaša tipkovnica je otkrivena:\n"
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+"\n"
+"Ako je raspored ispravno otkriven, odaberite 'Završi' na sljedećem zaslonu. "
+"A ako nije možete odabrati drugi raspored tipkovnice ili ponovno pokrenuti "
+"automatsko otkrivanje tipkovnice.\n"
+"\n"
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Raspored"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr "Varijanta"
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Pritisnite jednu od sljedećih tipki:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr "Upis nije prepoznat, pokušajte ponovno"
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Je li sljedeća tipka prisutna na vašoj tipkovnici?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+"Trebati će vam način prebacivanja tipkovnice između nacionalnog i "
+"standardnog latiničnog rasporeda.\n"
+"\n"
+"Desni Alt ili Caps Lock tipke uobičajeno su odabrane iz ergonomskih razloga "
+"(za mala slova, koristite kombinaciju Shift+Caps Lock za normalno "
+"prebacivanje veličine slova). Alt+Shift je isto tako popularna kombinacija; "
+"međutim izgubiti će svoje uobičajeno ponašanje u Emacsu i drugim programima "
+"koji se koriste za određene namjene.\n"
+"\n"
+"Nisu sve prikazane tipke prisutne na svim tipkovnicama. "
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Desni Alt (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Desni Control"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Desni Shift"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr "Desna Logo tipka"
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Tipka Izbornika"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Control+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Control+Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Lijevi Control+Lijevi Shift"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Lijevi Alt"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Lijevi Control"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Lijevi Shift"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr "Lijeva Logo tipka"
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Scroll Lock tipka"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr "Bez prebacivanja"
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr "Prečac: "
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr "Odaberi prebacivanje rasporeda"
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Raspored:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr "Varijanta:"
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "Postavke tipkovnice"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr "Odaberite raspored tipkovnice priključene na sustav, ako postoji."
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+"Odaberite raspored tipkovnice ispod ili odaberite \"Otkrij tipkovnicu\", za "
+"automatsko otkrivanje vašeg rasporeda."
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr "Otkrij tipkovnicu"
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Primijenjivanje podešavanja"
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+"Ovdje upišite zrcalni poslužitelj arhive koji će se koristiti umjesto "
+"zadanog."
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "Adresa zrcalnog poslužitelja:"
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr "Podešavanje zrcalnog poslužitelja Ubuntu arhive"
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+msgstr ""
+"Ako koristite alternativni zrcalni poslužitelj za Ubuntu, upišite njegove "
+"pojedinosti ovdje."
 
 #: ../subiquity/ui/views/proxy.py:33
 msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "Ako trebate HTTP proxy za pristup internetu, ovdje upišite proxy "
 "informacije. U suprotnome, ostavite ovo prazno.\n"
 "\n"
-"Proxy informacije moraju biti zadane u standardnom obliku \"http://"
-"[[korisnik][:lozinka]@]poslužitelj[:ulaz]/\"."
+"Proxy informacije moraju biti zadane u standardnom obliku "
+"\"http://[[korisnik][:lozinka]@]poslužitelj[:ulaz]/\"."
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
@@ -2499,257 +2299,352 @@ msgstr ""
 "Ako ovaj sustav zahtijeva proxy za povezivanje s internetom, upišite njegove "
 "pojedinosti ovdje."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr "Provjera daopuna instalacijskog programa..."
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+"Kontaktiranje snap trgovine u svrhu provjere dostupnosti nove inačice "
+"instalacijskog programa."
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr "Kontaktiranje snap trgovine neuspjelo"
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr "Kontaktiranje snap trgovine neuspjelo:"
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Dostupne su nadopune instalacijskog programa"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+"Inačica {new} instalacijskog programa je dostupna, a inačica {current} je "
+"trenutno pokrenuta."
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Preuzimanje nadopune..."
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+"Pričekajte dok se nadopuna instalacijskog programa preuzima. Instalacijski "
+"program će se automatski ponovno pokrenuti kada se preuzimanje završi."
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr "Neuspjela nadopuna"
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr "Preuzimanje i primijenjivanje nadopune:"
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Nastavi bez nadopunjivanja"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Pokušaj ponovno"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+"Ako odaberete nadopunu, nadopuna će se preuzeti i instalacija će se "
+"nastaviti odavdje."
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr "Nadopuni na novu inačicu instalcijski program"
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Prekini nadopunu"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "upravo sada"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "minuta"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "minuta"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "sat"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "sata"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "dan"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "dana"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr "{amount:2} {unit} prije"
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr "Istaknuti snap paketi za poslužitelje"
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr "Učitavanje snap paketa poslužitelja iz trgovine, pričekajte..."
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr "Nažalost, učitavanje snap paketa iz trgovine nije uspjelo."
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+"Ovo su popularni snap paketi u radnim okruženjima poslužitelja. Odaberite "
+"ili uklonite odabir sa SPACE tipkom, ili pritisnite ENTER tipku kako bi "
+"vidjeli više pojedinosti paketa, izdavač i inačica su dostupni."
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Uvezi korisničko ime:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Github korisničko ime:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Launchpad korisničko ime:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr "Instaliraj OpenSSH poslužitelja"
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Uvezi SSH identitet:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "iz Githuba"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "iz Launchpada"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Možete uvesti vaše SSH ključeve iz Githuba ili Launchpada."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr "Dopusti ovjeru lozinkom putem SSH-a"
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Polje ne smije ostati prazno."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "SSH id je predugačak, mora biti < "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+"Launchpad korisničko ime mora započeti s brojem ili slovom. Sva slova moraju "
+"biti mala. Znakovi +, - i . su isto dopušteni nakon prvog znaka."
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"Github korisničko ime može sadržavati samo slovno-brojčane znakove ili "
+"pojedinačne crtice i ne može započeti niti završavati crticom."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr "Preuzimanje  SSH keys..."
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "Potvrdite SSH ključeve"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr "Ključevi sa sljedećim otiscima su preuzeti. Želite li ih koristiti?"
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "Potvrdite SSH ključ"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr "Ključ sa sljedećim otiskom je preuzet. Želite li ga koristiti?"
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "SSH podešavanje"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+"Možete odabrati instalaciju OpenSSH paketa kako bi omogućili siguran "
+"udaljeni pristup vašemu poslužitelju."
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 "\n"
-"Nažalost, došlo je do problema pri provjeri uređaja pohrane na ovom "
-"sustavu.\n"
+"Odaberite jezik za korištenje u instalacijskom programu, i za podešavanje\n"
+"i upotrebu na instaliranome sustavu.\n"
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
-msgstr ""
-"\n"
-"Nažalost, došlo je do problema pri završetku instalacije.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Koristite UP, DOWN i ENTER tipke za odabir svoga jezika."
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
-msgstr ""
-"\n"
-"Nažalost, došlo je do problema pri primijeni podešavanja mreže.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
+msgstr "Pomoć u odabiru jezika"
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
-msgstr ""
-"\n"
-"Nažalost, instalacijski program se ponovno pokrenuo zbog greške.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
+msgstr "neuspjelo"
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-"\n"
-"Nažalost, došlo je do nepoznate greške.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
+msgstr "automatski"
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-"\n"
-"Informacije se prikupljaju iz sustava koje će pomoći\n"
-"razvijateljima da dijagnosticiraju problem.\n"
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
+msgstr "mrežno"
 
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-"\n"
-"Učitavanje izvještaja...\n"
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-"\n"
-"Neuspjelo prikupljanje informacija iz sustava. Pogledajte datoteke u\n"
-"/var/log/installer za više pojedinosti.\n"
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-"\n"
-"Neuspjelo učitavanje izvještaja. Pogledajte datoteke u /var/log/installer za "
-"više pojedinosti.\n"
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-"\n"
-"Možete nastaviti i instalacijski program će samo obuhvatiti prisutne\n"
-"diskove u sustavu, a ne ostale blokovske uređaje, ili možda možete\n"
-"popraviti problem pokretanjem ljuske i ručnim ponovnim\n"
-"podešavanjem blokovskih uređaja sustava.\n"
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-"\n"
-"Možda možete popraviti problem pokretanjem ljuske i ručnim\n"
-"ponovnim podešavanjem blokovskih uređaja sustava.\n"
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-"\n"
-"Možete nastaviti s instalacijom ali pretpostavit\n"
-"će se da mreža nije funkcionalna.\n"
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-"\n"
-"Želite li ponovno pokušati pokrenuti instalaciju?\n"
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr "Odaberie Nastavi za ponovni pokušaj instalacije."
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-"\n"
-"Ako želite pomoći poboljšati instalacijski program, možete poslati izvještaj "
-"greške.\n"
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr "Prekini slanje"
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr "Zatvori izvještaj"
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr "Ponovno pokreni instalacijski program"
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr "Pošalji u Canonical"
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr "Pošalji u Canonical"
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr "Prikaži cjeloviti izvještaj"
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-"Izvještaj greške je spremljen u\n"
-"\n"
-"  {loc}\n"
-"\n"
-"na datotečnom sustavu naziva {label!r}."
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr "DATUM"
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr "VRSTA"
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr "STANJE"
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr "Odaberi izvještaj greške za prikaz:"
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr "PRIKAZANO"
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr "NEPRIKAZANO"
-
-#: ../subiquity/ui/views/zdev.py:64
+#: ../subiquity/ui/views/zdev.py:77
 msgid "No zdev devices found."
 msgstr "Nema pronađenih zdev uređaja."
 
-#: ../subiquity/ui/views/zdev.py:77
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr "ID"
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr "MREŽA"
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr "NAZIVI"
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr "Omogući"
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr "Onemogući"
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr "Zdev podešavanje"
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr "Ostalo"
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr "Ostavi odmontirano"
-
-#~ msgid "formatted as {}"
-#~ msgstr "formatirati kao {}"
-
-#~ msgid ", mounted at {}"
-#~ msgstr ", montiran na {}"
-
-#~ msgid "{} partition"
-#~ msgstr "{} particija"
-
-#~ msgid "Adding {} to {}"
-#~ msgstr "Dodajem {} na {}"
-
-#~ msgid "Editing {} of {}"
-#~ msgstr "Uređivanje {} na {}"
-
-#~ msgid "partition"
-#~ msgstr "particija"
-
-#~ msgid "Toggle color on/off"
-#~ msgstr "Uklj/Isklj boju"
 
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr "Odaberite sučelje za podešavanje ili odaberite 'Završi' za nastavak"
@@ -2766,8 +2661,14 @@ msgstr "Ostavi odmontirano"
 #~ msgid "Choose the installation target"
 #~ msgstr "Odaberite odredište instalacije"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formatiraj i/ili montiraj {}"
+
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Prijavite ovu grešku na Launchpad"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Instalacija završena!"
 
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Hvala vam na odabiru Ubuntua!"
@@ -2775,11 +2676,31 @@ msgstr "Ostavi odmontirano"
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Odaberite disk za instalaciju:"
 
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Stvarno ime je predugačko, mora biti < "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "Naziv poslužitelja je predugačak, mora biti < "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "Korisničko ime je predugačko, mora biti < "
+
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Koristi cijeli disk"
 
 #~ msgid "Exit To Shell"
 #~ msgstr "Izađi u ljusku"
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Korisničko ime mora sadržavati NAZIV_UOBIČAJENI-IZRAZ, npr. [a-z_][a-z0-9_-]*"
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Naziv računala mora sadržavati NAZIV_UOBIČAJENI-IZRAZ, npr. [a-z_][a-z0-9_-]*"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Dogodila se greška"
 
 #~ msgid "Install complete"
 #~ msgstr "Instalacija završena"
@@ -2793,9 +2714,26 @@ msgstr "Ostavi odmontirano"
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr "Koristite UP, DOWN i ENTER tipke za odabir svoje tipkovnice."
 
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Mrežno sučelje {} bežično podešavanje"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Ovo polje mora biti %s URL."
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "'%s' nije sadržano u '%s'"
+
+#~ msgid "partition of {}"
+#~ msgstr "partiticija {}"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} nije valjan unos"
+
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
@@ -2810,8 +2748,254 @@ msgstr "Ostavi odmontirano"
 #~ "\n"
 #~ "Sigurno želite nastaviti?"
 
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Potrebna je particija za učitača pokretanja sustava\n"
+#~ "\n"
+#~ "GRUB će biti instaliran na odabrani disk glavnog zapisa pokretanja (MBR).\n"
+#~ "\n"
+#~ "Međutim, na disk sa GPT particijskom tablicom, nema dovoljno prostora nakon "
+#~ "glavnog zapisa pokretanja (MBR) kako bi GRUB mogao spremiti drugo-faznu "
+#~ "core.img sliku, stoga je potrebna mala neformatirana partiticija na početku "
+#~ "diska. Ta particija neće sadržavati datotečni sustav, neće biti montirana i "
+#~ "neće se moći uređivati."
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Nažalost, automatsko otkrivanje tipkovnice nije uspjelo"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "Uredi IPv6"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Uredi IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Uredi bežičnu mrežu"
+
+#~ msgid "Info"
+#~ msgstr "Informacije"
+
+#~ msgid "should be in CIDR form ({})"
+#~ msgstr "treba bit u CIDR obliku ({})"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s već postoji"
+
+#~ msgid "Info for {}"
+#~ msgstr "Informacije za {}"
+
+#~ msgid "There is already a network device named \"{}\""
+#~ msgstr "Već postoji mrežni uređaj naziva \"{}\""
+
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
 
+#~ msgid "bond master for {}"
+#~ msgstr "glavno povezivanje za {}"
+
 #~ msgid "-"
 #~ msgstr "-"
+
+#~ msgid "unknown state {}"
+#~ msgstr "nepoznato stanje {}"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "Učini uređaj pokretljivim"
+
+#~ msgid "Edit"
+#~ msgstr "Uredi"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Ukloni sa RAID/ULU"
+
+#~ msgid "Format"
+#~ msgstr "Formatiraj"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Stvori Logički uređaj"
+
+#~ msgid "Add Partition"
+#~ msgstr "Dodaj particiju"
+
+#~ msgid "partition {} of {}"
+#~ msgstr "particija {} od {}"
+
+#~ msgid "partition {}"
+#~ msgstr "particija {}"
+
+#~ msgid "formatted as {}"
+#~ msgstr "formatirati kao {}"
+
+#~ msgid "logical volume"
+#~ msgstr "logički uređaj"
+
+#~ msgid "partition"
+#~ msgstr "particija"
+
+#~ msgid "logical volume {}"
+#~ msgstr "logički uređaj {}"
+
+#~ msgid "Size (max {}):"
+#~ msgstr "Veličina (najveća {}):"
+
+#~ msgid "Editing {} of {}"
+#~ msgstr "Uređivanje {} na {}"
+
+#, python-brace-format
+#~ msgid ""
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+#~ msgstr ""
+#~ "Nemoguće je obrisati {selflabel} jer je particija {partnum} dio {cdtype} "
+#~ "{cdname}."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
+#~ msgstr ""
+#~ "Nemoguće je obrisati {selflabel} zato jer sadrži {count} montiranih "
+#~ "particija."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has 1 mounted partition."
+#~ msgstr ""
+#~ "Nemoguće je obrisati {selflabel} zato jer sadrži 1 montiranu particiju."
+
+#~ msgid "software RAID {}"
+#~ msgstr "softverski RAID {}"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has partitions."
+#~ msgstr "Nemoguće je urediti {selflabel} zato jer sadrži particiju."
+
+#~ msgid "unused {}"
+#~ msgstr "neiskorišten {}"
+
+#~ msgid ", mounted at {}"
+#~ msgstr ", montiran na {}"
+
+#, python-brace-format
+#~ msgid "It contains {n} {things}:"
+#~ msgstr "Sadrži {n} {things}:"
+
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "Sigurno želite ukloniti postojeći datotečni sustav iz {}?"
+
+#~ msgid "Remove filesystem from {}"
+#~ msgstr "Ukloni datotečni sustav iz {}"
+
+#~ msgid "Remove from {}"
+#~ msgstr "Ukloni iz {}"
+
+#~ msgid "Passphrases"
+#~ msgstr "Lozinke"
+
+#~ msgid "{} is not a valid name for a volume group"
+#~ msgstr "{} nije valjani naziv grupe uređaja"
+
+#~ msgid "There is already a volume group named '{}'"
+#~ msgstr "Već postoji grupa uređaja naziva '{}'"
+
+#~ msgid "Edit volume group \"{}\""
+#~ msgstr "Uredi grupu uređaja \"{}\""
+
+#~ msgid "Leave formatted as {}"
+#~ msgstr "Ostavi formatirano kao {}"
+
+#~ msgid "Capped partition size at {}"
+#~ msgstr "Veličina ograničene particije na {}"
+
+#~ msgid "Rounded size up to {}"
+#~ msgstr "Zaokružena veličina do {}"
+
+#~ msgid ""
+#~ "Mounting an existing filesystem at {} is usually a bad idea, proceed only "
+#~ "with caution."
+#~ msgstr ""
+#~ "Montiranje postojećeg datotečnog uređaja na {} uobičajeno je loša ideja, "
+#~ "nastavite dalje s oprezom."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
+#~ "installed onto this partition, which must be formatted as fat32."
+#~ msgstr ""
+#~ "Potrebna je particija za učitača pokretanja sustava\n"
+#~ "\n"
+#~ "To je ESP / \"EFI particija sustava\" koju zahtijeva UEFI. Grub će biti "
+#~ "instaliran na tu particiju,\n"
+#~ "koja mora biti formatirana u fat32 datotečnom sustavu."
+
+#~ msgid ""
+#~ " You can choose whether to use the existing filesystem on this partition or "
+#~ "reformat it."
+#~ msgstr ""
+#~ " Možete odabrati korištenje postojećeg datotečnog sustava na ovoj particiji "
+#~ "ili ju možete ponovno formatirati."
+
+#~ msgid " The only aspect of this partition that can be edited is the size."
+#~ msgstr " Jedina značajka ove particije koja se može uređivati je veličina."
+
+#~ msgid "{} is already mounted at {}."
+#~ msgstr "{} je već montiran na {}."
+
+#~ msgid "There is already a logical volume named {}."
+#~ msgstr "Već postoji logički uređaj naziva {}."
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "Naziv logičkog uređaja ne smije sadržavati \"{}\""
+
+#~ msgid "A logical volume may not be called {}"
+#~ msgstr "Logički uređaj ne može se nazivati {}"
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the PReP partion which is required on POWER. Grub will be installed "
+#~ "onto this partition."
+#~ msgstr ""
+#~ "Potrebna je particija za učitača pokretanja sustava\n"
+#~ "\n"
+#~ "To je PReP particija koju zahtijeva POWER. Grub će biti instaliran na tu "
+#~ "particiju."
+
+#~ msgid "Adding {} to {}"
+#~ msgstr "Dodajem {} na {}"
+
+#~ msgid "There is already a RAID named '{}'"
+#~ msgstr "Već postoji RAID naziva '{}'"
+
+#~ msgid "RAID Level \"{}\" requires at least {} active devices"
+#~ msgstr "RAID razina \"{}\" zahtijeva najmanje {} aktivnih uređaja"
+
+#~ msgid "Edit software RAID disk \"{}\""
+#~ msgstr "Uredi softverski RAID disk \"{}\""
+
+#~ msgid "Reboot"
+#~ msgstr "Ponovno pokreni"
+
+#~ msgid "Fetching info for {} failed"
+#~ msgstr "Preuzimanje informacija za {} neuspjelo"
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "Preuzimanje informacija za {}"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has logical volumes."
+#~ msgstr "Nemoguće je urediti {selflabel} zato jer sadrži logičke uređaje."
+
+#~ msgid "enslaved to {}"
+#~ msgstr "povezano na {}"
+
+#~ msgid "Finished install!"
+#~ msgstr "Instalacija završena!"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,90 +1,421 @@
 # Hungarian translation for subiquity
-# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
+# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
 # This file is distributed under the same license as the subiquity package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2020-02-21 21:54+0000\n"
+"Last-Translator: Meskó Balázs <Unknown>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
-"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: hu\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+"A(z) {selflabel} nem szerkeszthető, mert a következő része: {cdtype} "
+"{cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr "A meglévő RAID-tömbök nem szerkeszthetők."
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr "A meglévő kötetcsoportok nem szerkeszthetők."
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+"A(z) {selflabel} eltávolítása azt okozná, hogy a(z) {cdtype} {cdlabel} "
+"kevesebb mint {min_devices} eszközből állna."
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+"A(z) {selflabel} eltávolítása azt okozná, hogy a(z) {cdtype} {cdlabel} "
+"eszközök nélkül maradna."
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+"A(z) {selflabel} nem törölhető, mert a következő része: {cdtype} {cdname}."
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+"Nem törölhet partíciót egy olyan eszközről, amelynek már vannak partíciói."
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr "A szükséges rendszerbetöltő partíció nem törölhető"
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+"Nem törölhető egyetlen logikai kötet olyan kötetcsoportból, amelynek már "
+"vannak logikai kötetei."
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr "létező"
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr "új"
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "helyi lemez"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr "{component_name} ebben: {desc} {name}"
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr "már erre formázott: {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr "erre lesz újraformázva: {fstype}"
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr "erre lesz formázva: {fstype}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr "itt csatolva: {path}"
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr "nincs csatolva"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "nincs használatban"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "használt"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "automatikus konfiguráció sikertelen"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "Információ"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "WiFi szerkesztése"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "IPv4 szerkesztése"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "IPv6 szerkesztése"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "Párosítás szerkesztése"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
-#, fuzzy
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
-msgstr "VLAN címke hozzáadása"
+msgid "Edit Wifi"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:45
-#, fuzzy
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Törlés"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Bezárás"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -95,34 +426,55 @@ msgid " or "
 msgstr " vagy "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Ennek a mezőnek %s URL-t kell tartalmaznia."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Kész"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Mégse"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Igen"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Nem"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Bezárás"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Mentés"
 
@@ -155,14 +507,14 @@ msgid "Domains, comma separated"
 msgstr "Tartományok, vesszővel elválasztva"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr "CIDR alakban kell lennie ({})"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "A(z) „%s” nem szerepel ebben: „%s”"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -184,87 +536,133 @@ msgstr "Letiltva"
 msgid "IPv{v} Method: "
 msgstr "IPv{v} mód: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Létrehozás"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "VLAN azonosító:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr "A VLAN azonosítónak 1 és 4095 között kell lennie"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "A(z) %s már létezik"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr "VLAN címke hozzáadása"
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
+#, python-brace-format
 msgid "Info for {device}"
-msgstr "Információk ehhez: {}"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Név:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Eszközök: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr "Párosítási mód:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr "Átviteli hash házirend:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr "LACP arány:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
+#, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr "Vár létezik „{}” nevű hálózati eszköz"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "A név nem lehet üres"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr "A név nem lehet hosszabb 16 karakternél"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr "Párosítás létrehozása"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr "Párosítás szerkesztése"
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr "VLAN {id} a(z) {link} csatolón"
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "nincs csatlakozva"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "időtúllépés"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "statikus"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "letiltott"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Hálózati kapcsolatok"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -273,642 +671,266 @@ msgstr ""
 "gépekhez csatlakozhat, és amely lehetőleg alkalmas a frissítések elérésére."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Vissza"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "Folytatás hálózat nélkül"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "Változások alkalmazások"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr "nincs csatlakozva"
-
-#: ../subiquitycore/ui/views/network.py:188
-#, fuzzy, python-brace-format
-msgid "enslaved to {device}"
-msgstr "ezt szolgálja: {}"
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "időtúllépés"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, fuzzy, python-brace-format
-msgid "unknown state {state}"
-msgstr "ismeretlen {} állapot"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "statikus"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr "letiltott"
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr "VLAN {id} a(z) {link} csatolón"
-
-#: ../subiquitycore/ui/views/network.py:360
-#, fuzzy, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr "a párosítás mestere ennél: {}"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "Válasszon indítólemezt"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "{} hálózati csatoló WiFi beállítása"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Igen"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Nem"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Hiba történt"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "A telepítés befejeződött!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "A telepítés befejeződött!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "A rendszer telepítése"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "A telepítés kész!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Hiba történt a telepítés során"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr "0 (csíkozott)"
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr "1 (tükrözött)"
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "A név nem lehet üres"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "A(z) {!r} nem érvényes bemenet"
-
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Információ"
-
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Szerkesztés"
-
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Újraformázás"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "Partíció hozzáadása"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "Logikai kötet létrehozása"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Formázás"
-
-#: ../subiquity/models/filesystem.py:424
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr "Eltávolítás a RAID/LVM-ből"
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Törlés"
-
-#: ../subiquity/models/filesystem.py:426
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr "Indítóeszközzé tétel"
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-"A(z) {selflabel} nem szerkeszthető, mert a következő része: {cdtype} "
-"{cdname}."
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "Egyéb"
+
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
+msgstr "Ne csatolja"
+
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-"A(z) {selflabel} eltávolítása azt okozná, hogy a(z) {cdtype} {cdlabel} "
-"kevesebb mint {min_devices} eszközből állna."
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-"A(z) {selflabel} eltávolítása azt okozná, hogy a(z) {cdtype} {cdlabel} "
-"eszközök nélkül maradna."
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-"A(z) {selflabel} nem törölhető, mert a következő része: {cdtype} {cdname}."
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr "létező"
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr "új"
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr "{component_name} ebben: {desc} {name}"
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr "már erre formázott: {fstype}"
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr "erre lesz újraformázva: {fstype}"
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr "erre lesz formázva: {fstype}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr "itt csatolva: {path}"
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr "nincs csatolva"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr "nincs használatban"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr "használt"
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-"A(z) {selflabel} nem törölhető, mert a(z) {partnum}. partíció a következő "
-"része: {cdtype} {cdname}."
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr "A(z) {selflabel} nem törölhető, mert {count} csatolt partíciója van."
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr "A(z) {selflabel} nem törölhető, mert egy csatolt partíciója van."
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "helyi lemez"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Proxy beállítása"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "automatikus konfiguráció sikertelen"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-#, fuzzy
-msgid "unused ESP"
-msgstr "nincs használatban"
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-# Az „It contains {n} {things}” mondatban a „things” értéke
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "logikai kötetet"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "ennek a partíciója: {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "ennek a(z) {}. partíciója: {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "{}. partíció"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-"Nem törölhet partíciót egy olyan eszközről, amelynek már vannak partíciói."
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr "A szükséges rendszerbetöltő partíció nem törölhető"
-
-#: ../subiquity/models/filesystem.py:1049
-#, fuzzy, python-brace-format
-msgid "software RAID {level}"
-msgstr "szoftveres RAID {}"
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr "A meglévő RAID-tömbök nem szerkeszthetők."
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr "A(z) {selflabel} nem szerkeszthető, mert partíciói vannak."
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-#, fuzzy
-msgid "LVM volume group"
-msgstr "LVM kötetcsoport létrehozása"
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr "A meglévő kötetcsoportok nem szerkeszthetők."
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr "A(z) {selflabel} nem szerkeszthető, mert logikai kötetei vannak."
-
-# Az „It contains {n} {things}” mondatban a „things” értéke
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "logikai kötetet"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-"Nem törölhető egyetlen logikai kötet olyan kötetcsoportból, amelynek már "
-"vannak logikai kötetei."
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "A : , és = karakterek nem engedélyezettek ebben a mezőben"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-"A mezőben csak a következő karakterek engedélyezettek: a-z, 0-9, _ és -"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Az Ön neve:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "A kiszolgáló neve:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "A más számítógépekkel való kommunikációban használt név."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Válasszon egy felhasználónevet:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Válasszon jelszót:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Jelszó megerősítése:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "A valódi név túl hosszú, nem lehett hosszabb, mint "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "A kiszolgálónév nem hagyható üresen"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "A kiszolgálónév túl hosszú, nem lehet hosszabb, mint "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"A kiszolgálónévnek meg kell felelnie a NAME_REGEX kifejezésnek, például [a-"
-"z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "A felhasználónév nem hagyható üresen"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "A felhasználónév túl hosszú, nem lehet hosszabb, mint "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"A felhasználónévnek meg kell felelnie a NAME_REGEX kifejezésnek, például [a-"
-"z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr "A(z) „{username}” felhasználónév a rendszer számára van fenntartva."
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "A jelszó nem hagyható üresen"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "A jelszavak nem egyeznek"
-
-# desc = passwords
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr "a {desc} nem egyeznek"
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Profilbeállítás"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
-"Adja meg a rendszerbe bejelentkezéshez használandó felhasználónevet és "
-"jelszót. Az SSH-elérést a következő képernyőn állíthatja be, de a sudo "
-"használatához továbbra is jelszó szükséges."
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "jelszavak"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Tovább"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
+#, python-brace-format
 msgid "formatted as {fstype}"
-msgstr "erre lesz formázva: {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:132
+#, python-brace-format
 msgid ", mounted at {path}"
-msgstr "itt csatolva: {path}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ", nincs csatolva"
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/compound.py:136
+#, python-brace-format
 msgid "unused {device}"
-msgstr "nem használt {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
@@ -916,458 +938,237 @@ msgstr ""
 "Ha az összes lemezt RAID tömbbe vagy LVM kötetcsoportba szervezi, akkor nem "
 "lesz hova tenni a rendszerindító partíciót."
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr "A „/” nem engedélyezett a RAID-eszköz nevében"
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr "A szóközök nem engedélyezettek a RAID-eszköz nevében"
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr "RAID-szint:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Eszközök:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Méret:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, fuzzy, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr "Már létezik „{}” nevű RAID-tömb"
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr "A . és .. nem megfelelő név RAID-eszközökhöz"
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, fuzzy, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr "A RAID {} használatához legalább {} aktív eszköz szükséges"
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr "Szoftveres RAID-lemez („MD”) létrehozása"
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, fuzzy, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr "A(z) „{}” szoftveres RAID-lemez szerkesztése"
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr "Formázatlanul hagyás"
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, fuzzy, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr "Erre formázva hagyás: {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, fuzzy, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr "Partícióméret erre korlátozva: {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, fuzzy, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr "Méret erre felkerekítése: {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-"A logikai kötet nevében csak a következő karakterek megengedettek: a-z, A-Z, "
-"0-9, +, _, . és -"
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, fuzzy, python-brace-format
-msgid "Size (max {size}):"
-msgstr "Méret (legfeljebb {}):"
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Név: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "Formátum:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr "Csatolás:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr "Használat cserehelyként"
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr "E partíció használata cserehelyként a telepített rendszeren."
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr "A logikai kötet nem lehet üres"
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr "A logikai kötet neve nem kezdődhet kötőjellel"
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, fuzzy, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr "A logikai kötet neve nem lehet {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, fuzzy, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr "A logikai kötet neve nem tartalmazhatja ezt: „{}”"
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, fuzzy, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr "Már létezik egy meglévő „{}” logikai kötet."
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Az útvonal hossza túllépi a PATH_MAX értéket"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, fuzzy, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr "A(z) {} már csatolva van itt: {}."
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, fuzzy, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-"Egy meglévő fájlrendszer csatolása a(z) {} helyen általában rossz ötlet, "
-"csak óvatosan folytassa."
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Szükséges rendszerbetöltő partíció\n"
-"\n"
-"A GRUB telepítve lesz a céllemez MBR-jébe.\n"
-"\n"
-"Viszont egy GPT partíciós táblájú lemezen nincs elég hely az MBR után a GRUB-"
-"nak, hogy eltárolja a core.img fájl második fokozatát, így egy kis "
-"formázatlan partícióra van szükség a lemez elején. Nem fog fájlrendszert "
-"tartalmazni, és nem lesz csatolva, így itt nem szerkeszthető."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-"Szükséges rendszerbetöltő partíció\n"
-"\n"
-"Ez az UEFI számára szükséges ESP / „EFI rendszerpartíció”. A GRUB erre a "
-"partícióra lesz telepítve, és FAT32-ként kell formázni."
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-#, fuzzy
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-"Szükséges rendszerbetöltő partíció\n"
-"\n"
-"Ez az UEFI számára szükséges ESP / „EFI rendszerpartíció”. A GRUB erre a "
-"partícióra lesz telepítve, és FAT32-ként kell formázni."
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-#, fuzzy
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr " E partíciónak csak a mérete szerkeszthető."
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-#, fuzzy
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-" Választhat, hogy a meglévő fájlrendszert használja ezen a partíción, vagy "
-"újraformázza azt."
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-"Szükséges rendszerbetöltő partíció\n"
-"\n"
-"Ez a POWER számára szükséges PReP partíció. A GRUB erre a partícióra lesz "
-"telepítve."
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-#, fuzzy
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-"Szükséges rendszerbetöltő partíció\n"
-"\n"
-"Ez a POWER számára szükséges PReP partíció. A GRUB erre a partícióra lesz "
-"telepítve."
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "OK"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr "A meglévő FAT32 fájlrendszer használata"
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr "Újraformázás friss FAT32 fájlrendszerként"
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "{} logikai kötet"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "ennek a(z) {}. partíciója: {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-"Egy lemez közvetlen formázása és csatolása szokatlan. Lehet, hogy inkább egy "
-"partíciót kellene hozzáadnia."
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "A(z) {} formázása és csatolása"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr "Biztos, hogy törli a következőt: {desc} {label}?"
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr "Erre van formázva: {fstype}, és ide van csatolva: {path}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr "Erre van formázva: {fstype}, és nincs csatolva."
 
-# Az „It contains {n} {things}” mondatban a „things” értéke
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "logikai kötetet"
-msgstr[1] "logikai kötetet"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:70
+#, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
-msgstr[0] "{n} {things} tartalmaz:"
-msgstr[1] "{n} {things} tartalmaz:"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr "Nincs formázva vagy csatolva."
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:112
+#, python-brace-format
 msgid "Remove filesystem from {device}"
-msgstr "Fájlrendszer eltávolítása innen: {}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:116
+#, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
-msgstr "Biztos, hogy törli a meglévő fájlrendszert innen: {}?"
+msgstr ""
 
 # Az „It contains {n} {things}” mondatban a „things” értéke
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr "logikai kötetet"
 
 # Az „It contains {n} {things}” mondatban a „things” értéke
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "partíciót"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr "Törölje az összes {things} innen: {obj}"
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr "Biztos, hogy törli az összes {things} innen: {obj}?"
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr "Újraformázás"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
+#, python-brace-format
+msgid "existing {fstype}"
 msgstr ""
-"A kötetcsoport nevében csak a következő karakterek megengedettek: a-z, A-Z, "
-"0-9, +, _, . és -"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "Jelmondatok"
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
+#, python-brace-format
+msgid "new {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "Titkosított kötet létrehozása"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Nincsenek csatolt lemezek vagy partíciók."
 
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr "Jelmondat:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "CSATOLÁSI PONT"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr "Jelmondat megerősítése:"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "MÉRET"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr "Válasszon legalább egy eszközt, amely a kötetcsoport része lesz."
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TÍPUS"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr "A kötetcsoport neve nem lehet üres"
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "ESZKÖZTÍPUS"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr "A kötetcsoport neve nem kezdődhet kötőjellel"
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Leválasztás"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:113
-#, fuzzy, python-brace-format
-msgid "{name} is not a valid name for a volume group"
-msgstr "A(z) {} nem megfelelő név egy kötetcsoportnak"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "Nincsenek elérhető eszközök"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
-#, fuzzy, python-brace-format
-msgid "There is already a volume group named '{name}'"
-msgstr "Már létezik egy meglévő „{}” kötetcsoport"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr "Nincsenek használt eszközök"
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
-msgstr "A jelmondatot meg kell adni"
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
+#, python-brace-format
+msgid "Remove from {device}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr "A jelmondatoknak egyezniük kell"
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr "LVM kötetcsoport létrehozása"
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
-#, fuzzy, python-brace-format
-msgid "Edit volume group \"{name}\""
-msgstr "„{}” kötetcsoport szerkesztése"
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "ESZKÖZ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "szabad hely"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr "Szoftveres RAID-tömb létrehozása (md)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr "Kötetcsoport létrehozása (LVM)"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "FÁJLRENDSZER ÁTTEKINTÉS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "ELÉRHETŐ ESZKÖZÖK"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr "HASZNÁLT ESZKÖZÖK"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr "Fájlrendszer csatolása ide: /"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr "Válasszon indítólemezt"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Visszaállítás"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr "Jelmondat:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr "Jelmondat megerősítése:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "A jelszó nem hagyható üresen"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "A jelszavak nem egyeznek"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1401,7 +1202,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1409,138 +1210,295 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "OK"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
-#, fuzzy, python-brace-format
-msgid "existing {fstype}"
-msgstr "létező"
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+"A kötetcsoport nevében csak a következő karakterek megengedettek: a-z, A-Z, "
+"0-9, +, _, . és -"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Eszközök:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Méret:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Titkosított kötet létrehozása"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr "Válasszon legalább egy eszközt, amely a kötetcsoport része lesz."
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr "A kötetcsoport neve nem lehet üres"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr "A kötetcsoport neve nem kezdődhet kötőjellel"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "new {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Nincsenek csatolt lemezek vagy partíciók."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "CSATOLÁSI PONT"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "MÉRET"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TÍPUS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "ESZKÖZTÍPUS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "Leválasztás"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr "Nincsenek elérhető eszközök"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr "Nincsenek használt eszközök"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
-#, fuzzy, python-brace-format
-msgid "Remove from {device}"
-msgstr "Eltávolítás innen: {}"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "Partíció hozzáadása"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/lvm.py:119
+#, python-brace-format
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-#, fuzzy
-msgid "Add As Another Boot Device"
-msgstr "Indítóeszközzé tétel"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
+msgstr "A jelmondatot meg kell adni"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-#, fuzzy
-msgid "Use As Boot Device"
-msgstr "Indítóeszközzé tétel"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
+msgstr "A jelmondatoknak egyezniük kell"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "ESZKÖZ"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
+msgstr "LVM kötetcsoport létrehozása"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "szabad hely"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/lvm.py:157
+#, python-brace-format
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
-msgstr "Szoftveres RAID-tömb létrehozása (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr "Formázatlanul hagyás"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
-msgstr "Kötetcsoport létrehozása (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "FÁJLRENDSZER ÁTTEKINTÉS"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "ELÉRHETŐ ESZKÖZÖK"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
-msgstr "HASZNÁLT ESZKÖZÖK"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
+msgstr ""
+"A logikai kötet nevében csak a következő karakterek megengedettek: a-z, A-Z, "
+"0-9, +, _, . és -"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
-msgstr "Fájlrendszer csatolása ide: /"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
-msgstr "Válasszon indítólemezt"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Név: "
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "Folytatás hálózat nélkül"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Formátum:"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Visszaállítás"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
+msgstr "Csatolás:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr "Használat cserehelyként"
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
+msgstr "E partíció használata cserehelyként a telepített rendszeren."
+
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr "A logikai kötet nem lehet üres"
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr "A logikai kötet neve nem kezdődhet kötőjellel"
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Az útvonal hossza túllépi a PATH_MAX értéket"
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr "A meglévő FAT32 fájlrendszer használata"
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr "Újraformázás friss FAT32 fájlrendszerként"
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+"Egy lemez közvetlen formázása és csatolása szokatlan. Lehet, hogy inkább egy "
+"partíciót kellene hozzáadnia."
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1568,110 +1526,44 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr "A telepítéshez használható eszközök felderítése sikertelen"
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
-msgstr "Telepítőfrissítés keresése…"
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
+msgstr "A „/” nem engedélyezett a RAID-eszköz nevében"
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
-msgstr ""
-"Kapcsolatba lépés a snap áruházzal, hogy elérhető-e a telepítő új verziója."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
+msgstr "A szóközök nem engedélyezettek a RAID-eszköz nevében"
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr "Kapcsolatba lépés a snap áruházzal sikertelen"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "RAID-szint:"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr "Kapcsolatba lépés a snap áruházzal sikertelen:"
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "Telepítőfrissítés érhető el"
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
-msgstr ""
-"A telepítő új ({new}) verziója érhető el (a jelenlegi verzió: {current})."
-
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "Frissítés letöltése…"
-
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
-msgstr ""
-"Várjon amíg a frissített telepítő letöltődik. A telepítő a letöltés "
-"végeztével automatikusan újra fog indulni."
-
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
+msgstr "A . és .. nem megfelelő név RAID-eszközökhöz"
+
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "Folytatás frissítés nélkül"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
+msgstr "Szoftveres RAID-lemez („MD”) létrehozása"
 
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Próbálja újra"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-"Ha a frissítést választja, akkor a frissítés letöltésre kerül, és a "
-"telepítés onnan fog folytatódni."
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr "Frissítés az új telepítőre"
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "Frissítés megszakítása"
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-"Megadhat egy alternatív archívum-tükörkiszolgálót, melyet az alapértelmezett "
-"helyett használhat."
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr "Tükör címe:"
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr "Ubuntu archívumtükör beállítása"
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
-msgstr ""
-"Ha egy alternatív tükröt használ az Ubuntuhoz, itt írja be a részleteit."
 
 #: ../subiquity/ui/views/help.py:70
 #, python-brace-format
@@ -1727,413 +1619,356 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Ctrl+Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr "Frissítés az új telepítőre"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "A : , és = karakterek nem engedélyezettek ebben a mezőben"
+
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
-"\n"
-"Válassza ki a telepítéshez használandó, és a telepített rendszerhez\n"
-"beállítandó nyelvet.\n"
+"A mezőben csak a következő karakterek engedélyezettek: a-z, 0-9, _ és -"
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Használja a FEL, LE és ENTER gombokat a nyelv kiválasztásához."
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Az Ön neve:"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "A kiszolgáló neve:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Importált felhasználónév:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "A más számítógépekkel való kommunikációban használt név."
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "GitHub felhasználónév:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Válasszon egy felhasználónevet:"
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "GitHub felhasználónév:"
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Válasszon jelszót:"
 
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-"A GitHub-felhasználónév csak alfanumerikus karaktereket és egyszeres "
-"kötőjeleket tartalmazhat, valamint nem kezdődhet illetve végződhet "
-"kötőjellel."
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Jelszó megerősítése:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Launchpad felhasználónév:"
-
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"A GitHub-felhasználónév csak alfanumerikus karaktereket és egyszeres "
-"kötőjeleket tartalmazhat, valamint nem kezdődhet illetve végződhet "
-"kötőjellel."
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr "OpenSSH kiszolgáló telepítése"
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "SSH azonosító importálása:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "a GitHubról"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "a Launchpadról"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Importálhatja az SSH-kulcsait a GitHubról vagy a Launchpadról."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr "Jelszavas hitelesítés engedélyezése SSH-n keresztül"
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "A mező nem hagyható üresen."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "Az SSH azonosító túl hosszú, nem lehet hosszabb, mint "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-"A Launchpad-felhasználónévnek betűvel vagy számmal kell kezdődnie. Az összes "
-"betűnek kisbetűsnek kell lennie. Az első karakter után a +, - és . "
-"karakterek is megengedettek."
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"A GitHub-felhasználónév csak alfanumerikus karaktereket és egyszeres "
-"kötőjeleket tartalmazhat, valamint nem kezdődhet illetve végződhet "
-"kötőjellel."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr "SSH-kulcsok lekérése…"
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr "SSH-kulcsok megerősítése"
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-"A következő ujjlenyomatokkal rendelkező kulcsok lettek lekérve. Biztos, hogy "
-"használja ezeket?"
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr "SSH-kulcs megerősítése"
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-"A következő ujjlenyomattal rendelkező kulcs lett lekérve. Biztos, hogy "
-"használja ezt?"
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr "SSH beállítás"
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-"Dönthet úgy, hogy telepíti az OpenSSH-kiszolgáló csomagot, hogy "
-"biztonságosan elérje távolról a kiszolgálóját."
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "épp most"
-
-# A következő mondat része: „{amount:2} {unit} ago”
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr "perccel"
-
-# A következő mondat része: „{amount:2} {unit} ago”
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr "perccel"
-
-# A következő mondat része: „{amount:2} {unit} ago”
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr "órával"
-
-# A következő mondat része: „{amount:2} {unit} ago”
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr "órával"
-
-# A következő mondat része: „{amount:2} {unit} ago”
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr "nappal"
-
-# A következő mondat része: „{amount:2} {unit} ago”
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr "nappal"
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
-msgstr "{amount:2} {unit} ezelőtt"
-
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "A kiszolgálónév nem hagyható üresen"
+
+#: ../subiquity/ui/views/identity.py:109
+#, python-brace-format
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "A felhasználónév nem hagyható üresen"
+
+#: ../subiquity/ui/views/identity.py:123
+#, python-brace-format
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
+msgstr "A(z) „{username}” felhasználónév a rendszer számára van fenntartva."
 
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
+# desc = passwords
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr "a {desc} nem egyeznek"
 
-#: ../subiquity/ui/views/snaplist.py:256
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap}"
-msgstr "Információk lekérése a következőhöz: {}"
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Profilbeállítás"
 
-#: ../subiquity/ui/views/snaplist.py:282
-#, fuzzy, python-brace-format
-msgid "Fetching info for {snap} failed"
-msgstr "Információk lekérése a következőhöz sikertelen: {}"
-
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
-msgstr "Kiemelt kiszolgálóoldali snap csomagok"
-
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Tovább"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
-msgstr "Kiszolgálóoldali snap csomagok betöltése az áruházból, várjon…"
-
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr "Sajnáljuk, a snap csomagok betöltése az áruházból sikertelen."
-
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
-"Ezek kiszolgálóoldali környezetben népszerű snap csomagok. Válasszon a SPACE "
-"billentyűvel, nyomjon ENTER-t, ha több részletre kíváncsi a csomagról, "
-"kiadóról és az elérhető verziókról."
+"Adja meg a rendszerbe bejelentkezéshez használandó felhasználónevet és "
+"jelszót. Az SSH-elérést a következő képernyőn állíthatja be, de a sudo "
+"használatához továbbra is jelszó szükséges."
 
-#: ../subiquity/ui/views/keyboard.py:64
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "jelszavak"
+
+#: ../subiquity/ui/views/installprogress.py:52
+msgid "Install progress"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
+msgid "Reboot Now"
+msgstr "Újraindítás most"
+
+#: ../subiquity/ui/views/installprogress.py:61
+msgid "View error report"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:63
+msgid "View full log"
+msgstr "Teljes napló megtekintése"
+
+#: ../subiquity/ui/views/installprogress.py:79
+msgid "Full installer output"
+msgstr "Telepítő teljes kimenete"
+
+#: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "A rendszer telepítése"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "A telepítés kész!"
+
+#: ../subiquity/ui/views/installprogress.py:159
+msgid "Cancel update and reboot"
+msgstr "Frissítés megszakítása és újraindítás"
+
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
+msgid "Rebooting..."
+msgstr "Újraindítás…"
+
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Hiba történt a telepítés során"
+
+#: ../subiquity/ui/views/installprogress.py:230
+msgid ""
+"Selecting Continue below will begin the installation process and\n"
+"result in the loss of data on the disks selected to be formatted.\n"
+"\n"
+"You will not be able to return to this or a previous screen once\n"
+"the installation has started.\n"
+"\n"
+"Are you sure you want to continue?"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:251
+msgid "Confirm destructive action"
+msgstr "Destruktív művelet jóváhagyása"
+
+#: ../subiquity/ui/views/installprogress.py:271
+#, python-brace-format
+msgid ""
+"The installer running on {tty} is currently installing the system.\n"
+"\n"
+"You can wait for this to complete or switch to a shell.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:67
 msgid "Keyboard auto-detection"
 msgstr "Billentyűzet automatikus észlelése"
 
-#: ../subiquity/ui/views/keyboard.py:90
+#: ../subiquity/ui/views/keyboard.py:93
 msgid ""
 "Keyboard detection starting. You will be asked a series of questions about "
 "your keyboard. Press escape at any time to go back to the previous screen."
@@ -2142,11 +1977,7 @@ msgstr ""
 "billentyűzetéről. Az előző képernyőhöz visszatéréshez bármikor megnyomhatja "
 "az Esc gombot."
 
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "A billentyűzet automatikus észlelése sikertelen, sajnáljuk"
-
-#: ../subiquity/ui/views/keyboard.py:116
+#: ../subiquity/ui/views/keyboard.py:106
 msgid ""
 "Keyboard auto detection completed.\n"
 "\n"
@@ -2156,7 +1987,7 @@ msgstr ""
 "\n"
 "A billentyűzetét ekként észlelte:\n"
 
-#: ../subiquity/ui/views/keyboard.py:121
+#: ../subiquity/ui/views/keyboard.py:111
 msgid ""
 "\n"
 "If this is correct, select Done on the next screen. If not you can select "
@@ -2169,38 +2000,34 @@ msgstr ""
 "észlelést.\n"
 "\n"
 
-#: ../subiquity/ui/views/keyboard.py:135
+#: ../subiquity/ui/views/keyboard.py:128
 msgid "Layout"
 msgstr "Kiosztás"
 
-#: ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:129
 msgid "Variant"
 msgstr "Változat"
 
-#: ../subiquity/ui/views/keyboard.py:161
+#: ../subiquity/ui/views/keyboard.py:152
 msgid "Please press one of the following keys:"
 msgstr "Nyomja meg a következő billentyűk egyikét:"
 
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
 msgid "Input was not recognized, try again"
 msgstr "A bemenet felismerése sikertelen, próbálja újra"
 
-#: ../subiquity/ui/views/keyboard.py:222
+#: ../subiquity/ui/views/keyboard.py:213
 msgid "Is the following key present on your keyboard?"
 msgstr "A következő billentyűk elérhetők a billentyűzetén?"
 
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Konfiguráció alkalmazása"
-
-#: ../subiquity/ui/views/keyboard.py:303
+#: ../subiquity/ui/views/keyboard.py:277
 msgid ""
 "You will need a way to toggle the keyboard between the national layout and "
 "the standard Latin layout.\n"
 "\n"
 "Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
 "behavior in Emacs and other programs that use it for specific needs.\n"
 "\n"
 "Not all listed keys are present on all keyboards. "
@@ -2217,95 +2044,95 @@ msgstr ""
 "Az itt felsorolt billentyűk nem mindegyike található meg az összes "
 "billentyűzeten. "
 
-#: ../subiquity/ui/views/keyboard.py:316
+#: ../subiquity/ui/views/keyboard.py:290
 msgid "Caps Lock"
 msgstr "Caps Lock"
 
-#: ../subiquity/ui/views/keyboard.py:317
+#: ../subiquity/ui/views/keyboard.py:291
 msgid "Right Alt (AltGr)"
 msgstr "Jobb Alt (AltGr)"
 
-#: ../subiquity/ui/views/keyboard.py:318
+#: ../subiquity/ui/views/keyboard.py:292
 msgid "Right Control"
 msgstr "Jobb Ctrl"
 
-#: ../subiquity/ui/views/keyboard.py:319
+#: ../subiquity/ui/views/keyboard.py:293
 msgid "Right Shift"
 msgstr "Jobb Shift"
 
-#: ../subiquity/ui/views/keyboard.py:320
+#: ../subiquity/ui/views/keyboard.py:294
 msgid "Right Logo key"
 msgstr "Jobb logó billentyű"
 
-#: ../subiquity/ui/views/keyboard.py:321
+#: ../subiquity/ui/views/keyboard.py:295
 msgid "Menu key"
 msgstr "Menügomb"
 
-#: ../subiquity/ui/views/keyboard.py:322
+#: ../subiquity/ui/views/keyboard.py:296
 msgid "Alt+Shift"
 msgstr "Alt+Shift"
 
-#: ../subiquity/ui/views/keyboard.py:323
+#: ../subiquity/ui/views/keyboard.py:297
 msgid "Control+Shift"
 msgstr "Ctrl+Shift"
 
-#: ../subiquity/ui/views/keyboard.py:324
+#: ../subiquity/ui/views/keyboard.py:298
 msgid "Control+Alt"
 msgstr "Ctrl+Alt"
 
-#: ../subiquity/ui/views/keyboard.py:325
+#: ../subiquity/ui/views/keyboard.py:299
 msgid "Alt+Caps Lock"
 msgstr "Alt+Caps Lock"
 
-#: ../subiquity/ui/views/keyboard.py:326
+#: ../subiquity/ui/views/keyboard.py:300
 msgid "Left Control+Left Shift"
 msgstr "Bal Ctrl+Bal Shift"
 
-#: ../subiquity/ui/views/keyboard.py:327
+#: ../subiquity/ui/views/keyboard.py:301
 msgid "Left Alt"
 msgstr "Bal Alt"
 
-#: ../subiquity/ui/views/keyboard.py:328
+#: ../subiquity/ui/views/keyboard.py:302
 msgid "Left Control"
 msgstr "Bal Ctrl"
 
-#: ../subiquity/ui/views/keyboard.py:329
+#: ../subiquity/ui/views/keyboard.py:303
 msgid "Left Shift"
 msgstr "Bal Shift"
 
-#: ../subiquity/ui/views/keyboard.py:330
+#: ../subiquity/ui/views/keyboard.py:304
 msgid "Left Logo key"
 msgstr "Bal logó billentyű"
 
-#: ../subiquity/ui/views/keyboard.py:331
+#: ../subiquity/ui/views/keyboard.py:305
 msgid "Scroll Lock key"
 msgstr "Scroll Lock billentyű"
 
-#: ../subiquity/ui/views/keyboard.py:332
+#: ../subiquity/ui/views/keyboard.py:306
 msgid "No toggling"
 msgstr "Nincs átváltás"
 
-#: ../subiquity/ui/views/keyboard.py:353
+#: ../subiquity/ui/views/keyboard.py:327
 msgid "Shortcut: "
 msgstr "Gyorsbillentyű: "
 
-#: ../subiquity/ui/views/keyboard.py:363
+#: ../subiquity/ui/views/keyboard.py:337
 msgid "Select layout toggle"
 msgstr "Kiosztásváltó megadása"
 
-#: ../subiquity/ui/views/keyboard.py:381
+#: ../subiquity/ui/views/keyboard.py:355
 msgid "Layout:"
 msgstr "Kiosztás:"
 
-#: ../subiquity/ui/views/keyboard.py:382
+#: ../subiquity/ui/views/keyboard.py:356
 msgid "Variant:"
 msgstr "Változat:"
 
-#: ../subiquity/ui/views/keyboard.py:387
+#: ../subiquity/ui/views/keyboard.py:361
 msgid "Keyboard configuration"
 msgstr "Billentyűzet beállítása"
 
-#: ../subiquity/ui/views/keyboard.py:417
+#: ../subiquity/ui/views/keyboard.py:382
 msgid ""
 "Please select the layout of the keyboard directly attached to the system, if "
 "any."
@@ -2313,7 +2140,7 @@ msgstr ""
 "Válassza ki a rendszerhez közvetlenül csatlakoztatott billentyűzet "
 "kiosztását, ha van ilyen."
 
-#: ../subiquity/ui/views/keyboard.py:420
+#: ../subiquity/ui/views/keyboard.py:385
 msgid ""
 "Please select your keyboard layout below, or select \"Identify keyboard\" to "
 "detect your layout automatically."
@@ -2321,83 +2148,47 @@ msgstr ""
 "Válassza ki a billentyűzete kiosztását lent, vagy válassza a „Billentyűzet "
 "azonosítása” lehetőséget az automatikus észleléshez."
 
-#: ../subiquity/ui/views/keyboard.py:429
+#: ../subiquity/ui/views/keyboard.py:394
 msgid "Identify keyboard"
 msgstr "Billentyűzet azonosítása"
 
-#: ../subiquity/ui/views/installprogress.py:50
-msgid "Install progress"
-msgstr ""
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Konfiguráció alkalmazása"
 
-#: ../subiquity/ui/views/installprogress.py:57
-msgid "Reboot Now"
-msgstr "Újraindítás most"
-
-#: ../subiquity/ui/views/installprogress.py:59
-msgid "View error report"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:61
-msgid "View full log"
-msgstr "Teljes napló megtekintése"
-
-#: ../subiquity/ui/views/installprogress.py:77
-msgid "Full installer output"
-msgstr "Telepítő teljes kimenete"
-
-#: ../subiquity/ui/views/installprogress.py:142
-msgid "Cancel update and reboot"
-msgstr "Frissítés megszakítása és újraindítás"
-
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Újraindítás"
-
-#: ../subiquity/ui/views/installprogress.py:179
-msgid "Rebooting..."
-msgstr "Újraindítás…"
-
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/mirror.py:32
 msgid ""
-"Selecting Continue below will begin the installation process and\n"
-"result in the loss of data on the disks selected to be formatted.\n"
-"\n"
-"You will not be able to return to this or a previous screen once\n"
-"the installation has started.\n"
-"\n"
-"Are you sure you want to continue?"
+"You may provide an archive mirror that will be used instead of the default."
 msgstr ""
+"Megadhat egy alternatív archívum-tükörkiszolgálót, melyet az alapértelmezett "
+"helyett használhat."
 
-#: ../subiquity/ui/views/installprogress.py:217
-msgid "Confirm destructive action"
-msgstr "Destruktív művelet jóváhagyása"
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "Tükör címe:"
 
-#: ../subiquity/ui/views/installprogress.py:235
-#, python-brace-format
-msgid ""
-"The installer running on {tty} is currently installing the system.\n"
-"\n"
-"You can wait for this to complete or switch to a shell.\n"
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr "Ubuntu archívumtükör beállítása"
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
-msgstr ""
+"Ha egy alternatív tükröt használ az Ubuntuhoz, itt írja be a részleteit."
 
 #: ../subiquity/ui/views/proxy.py:33
 msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "Ha HTTP proxyt kell használnia a külvilág eléréséhez, akkor itt adja meg a "
 "proxy információkat. Egyébként hagyja üresen.\n"
 "\n"
-"A proxyinformációkat a következő szabványos formában adja meg: „http://"
-"[[felhasználónév][:jelszó]@]kiszolgáló[:port]/”."
+"A proxyinformációkat a következő szabványos formában adja meg: "
+"„http://[[felhasználónév][:jelszó]@]kiszolgáló[:port]/”."
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
@@ -2415,209 +2206,362 @@ msgstr ""
 "Ha a rendszernek proxyra van szüksége az internethez csatlakozáshoz, akkor "
 "itt adja meg a részleteit."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr "Telepítőfrissítés keresése…"
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+"Kapcsolatba lépés a snap áruházzal, hogy elérhető-e a telepítő új verziója."
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr "Kapcsolatba lépés a snap áruházzal sikertelen"
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr "Kapcsolatba lépés a snap áruházzal sikertelen:"
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Telepítőfrissítés érhető el"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+"A telepítő új ({new}) verziója érhető el (a jelenlegi verzió: {current})."
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Frissítés letöltése…"
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+"Várjon amíg a frissített telepítő letöltődik. A telepítő a letöltés "
+"végeztével automatikusan újra fog indulni."
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Folytatás frissítés nélkül"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Próbálja újra"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+"Ha a frissítést választja, akkor a frissítés letöltésre kerül, és a "
+"telepítés onnan fog folytatódni."
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr "Frissítés az új telepítőre"
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Frissítés megszakítása"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "épp most"
+
+# A következő mondat része: „{amount:2} {unit} ago”
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "perccel"
+
+# A következő mondat része: „{amount:2} {unit} ago”
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "perccel"
+
+# A következő mondat része: „{amount:2} {unit} ago”
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "órával"
+
+# A következő mondat része: „{amount:2} {unit} ago”
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "órával"
+
+# A következő mondat része: „{amount:2} {unit} ago”
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "nappal"
+
+# A következő mondat része: „{amount:2} {unit} ago”
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "nappal"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr "{amount:2} {unit} ezelőtt"
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr "Kiemelt kiszolgálóoldali snap csomagok"
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr "Kiszolgálóoldali snap csomagok betöltése az áruházból, várjon…"
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr "Sajnáljuk, a snap csomagok betöltése az áruházból sikertelen."
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+"Ezek kiszolgálóoldali környezetben népszerű snap csomagok. Válasszon a SPACE "
+"billentyűvel, nyomjon ENTER-t, ha több részletre kíváncsi a csomagról, "
+"kiadóról és az elérhető verziókról."
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Importált felhasználónév:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "GitHub felhasználónév:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Launchpad felhasználónév:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr "OpenSSH kiszolgáló telepítése"
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "SSH azonosító importálása:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "a GitHubról"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "a Launchpadról"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Importálhatja az SSH-kulcsait a GitHubról vagy a Launchpadról."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr "Jelszavas hitelesítés engedélyezése SSH-n keresztül"
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "A mező nem hagyható üresen."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "Az SSH azonosító túl hosszú, nem lehet hosszabb, mint "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+"A Launchpad-felhasználónévnek betűvel vagy számmal kell kezdődnie. Az összes "
+"betűnek kisbetűsnek kell lennie. Az első karakter után a +, - és . "
+"karakterek is megengedettek."
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"A GitHub-felhasználónév csak alfanumerikus karaktereket és egyszeres "
+"kötőjeleket tartalmazhat, valamint nem kezdődhet illetve végződhet "
+"kötőjellel."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr "SSH-kulcsok lekérése…"
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "SSH-kulcsok megerősítése"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+"A következő ujjlenyomatokkal rendelkező kulcsok lettek lekérve. Biztos, hogy "
+"használja ezeket?"
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "SSH-kulcs megerősítése"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+"A következő ujjlenyomattal rendelkező kulcs lett lekérve. Biztos, hogy "
+"használja ezt?"
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "SSH beállítás"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+"Dönthet úgy, hogy telepíti az OpenSSH-kiszolgáló csomagot, hogy "
+"biztonságosan elérje távolról a kiszolgálóját."
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
-
-#: ../subiquity/ui/views/error.py:72
-msgid ""
 "\n"
-"Sorry, there was a problem completing the installation.\n"
+"Válassza ki a telepítéshez használandó, és a telepített rendszerhez\n"
+"beállítandó nyelvet.\n"
+
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Használja a FEL, LE és ENTER gombokat a nyelv kiválasztásához."
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr "Egyéb"
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr "Ne csatolja"
-
-#~ msgid "formatted as {}"
-#~ msgstr "erre formázva: {}"
-
-#~ msgid ", mounted at {}"
-#~ msgstr ", ide csatolva: {}"
-
-#~ msgid "Adding {} to {}"
-#~ msgstr "A(z) {} hozzáadása ehhez: {}"
-
-#~ msgid "Editing {} of {}"
-#~ msgstr "A(z) {} szerkesztése ezen: {}"
-
-# Az „It contains {n} {things}” mondatban a „things” értéke
-#~ msgid "partition"
-#~ msgstr "partíciót"
 
 #~ msgid "Choose the installation target"
 #~ msgstr "Válassza ki a telepítési célt"
@@ -2634,6 +2578,12 @@ msgstr "Ne csatolja"
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Köszönjük, hogy az Ubuntut választotta!"
 
+#~ msgid "Finished install!"
+#~ msgstr "A telepítés befejeződött!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "A telepítés befejeződött!"
+
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Kérjük, jelentse ezt a hibát a Launchpadon"
 
@@ -2645,28 +2595,167 @@ msgstr "Ne csatolja"
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Válassza ki a telepítés céllemezét:"
 
+#~ msgid "Realname too long, must be < "
+#~ msgstr "A valódi név túl hosszú, nem lehett hosszabb, mint "
+
+#~ msgid "An error has occurred"
+#~ msgstr "Hiba történt"
+
+#~ msgid "Info"
+#~ msgstr "Információ"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "WiFi szerkesztése"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "IPv4 szerkesztése"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "IPv6 szerkesztése"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Ennek a mezőnek %s URL-t kell tartalmaznia."
+
+#~ msgid "should be in CIDR form ({})"
+#~ msgstr "CIDR alakban kell lennie ({})"
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "A(z) „%s” nem szerepel ebben: „%s”"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "A(z) %s már létezik"
+
+#~ msgid "Info for {}"
+#~ msgstr "Információk ehhez: {}"
+
+#~ msgid "There is already a network device named \"{}\""
+#~ msgstr "Vár létezik „{}” nevű hálózati eszköz"
+
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "{} hálózati csatoló WiFi beállítása"
+
+#~ msgid "enslaved to {}"
+#~ msgstr "ezt szolgálja: {}"
+
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
 
 #~ msgid "-"
 #~ msgstr "–"
 
+#~ msgid "unknown state {}"
+#~ msgstr "ismeretlen {} állapot"
+
+#~ msgid "bond master for {}"
+#~ msgstr "a párosítás mestere ennél: {}"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "A(z) {!r} nem érvényes bemenet"
+
+#~ msgid "Edit"
+#~ msgstr "Szerkesztés"
+
+#~ msgid "Add Partition"
+#~ msgstr "Partíció hozzáadása"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Logikai kötet létrehozása"
+
+#~ msgid "Format"
+#~ msgstr "Formázás"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Eltávolítás a RAID/LVM-ből"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "Indítóeszközzé tétel"
+
+#, python-brace-format
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+#~ msgstr ""
+#~ "A(z) {selflabel} nem törölhető, mert a(z) {partnum}. partíció a következő "
+#~ "része: {cdtype} {cdname}."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
+#~ msgstr "A(z) {selflabel} nem törölhető, mert {count} csatolt partíciója van."
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has 1 mounted partition."
+#~ msgstr "A(z) {selflabel} nem törölhető, mert egy csatolt partíciója van."
+
+#~ msgid "partition of {}"
+#~ msgstr "ennek a partíciója: {}"
+
+#~ msgid "partition {} of {}"
+#~ msgstr "ennek a(z) {}. partíciója: {}"
+
+#~ msgid "partition {}"
+#~ msgstr "{}. partíció"
+
+#~ msgid "software RAID {}"
+#~ msgstr "szoftveres RAID {}"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has partitions."
+#~ msgstr "A(z) {selflabel} nem szerkeszthető, mert partíciói vannak."
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has logical volumes."
+#~ msgstr "A(z) {selflabel} nem szerkeszthető, mert logikai kötetei vannak."
+
+#~ msgid "formatted as {}"
+#~ msgstr "erre formázva: {}"
+
+#~ msgid ", mounted at {}"
+#~ msgstr ", ide csatolva: {}"
+
+#~ msgid "unused {}"
+#~ msgstr "nem használt {}"
+
+# Az „It contains {n} {things}” mondatban a „things” értéke
+#~ msgid "logical volume"
+#~ msgstr "logikai kötetet"
+
+# Az „It contains {n} {things}” mondatban a „things” értéke
+#~ msgid "partition"
+#~ msgstr "partíciót"
+
+#, python-brace-format
+#~ msgid "It contains {n} {things}:"
+#~ msgstr "{n} {things} tartalmaz:"
+
+#~ msgid "Remove filesystem from {}"
+#~ msgstr "Fájlrendszer eltávolítása innen: {}"
+
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "Biztos, hogy törli a meglévő fájlrendszert innen: {}?"
+
+#~ msgid ""
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
 #~ "\n"
 #~ "Are you sure you want to continue?"
 #~ msgstr ""
-#~ "A Folytatás választásával elindul a telepítési folyamat, és ez "
-#~ "adatvesztés okoz a formázásra kijelölt lemezeken.\n"
+#~ "A Folytatás választásával elindul a telepítési folyamat, és ez adatvesztés "
+#~ "okoz a formázásra kijelölt lemezeken.\n"
 #~ "\n"
 #~ "Amint a telepítés elindul, többé nem fog tudni visszatérni erre vagy egy "
 #~ "előző képernyőre.\n"
 #~ "\n"
 #~ "Biztos, hogy folytatja?"
+
+#~ msgid "Remove from {}"
+#~ msgstr "Eltávolítás innen: {}"
 
 #~ msgid ""
 #~ "The installer can guide you through partitioning an entire disk either "
@@ -2675,8 +2764,8 @@ msgstr "Ne csatolja"
 #~ "If you choose to partition an entire disk you will still have a chance to "
 #~ "review and modify the results."
 #~ msgstr ""
-#~ "A telepítő végigvezetheti a teljes lemez particionálásán, közvetlenül "
-#~ "vagy LVM használatával, vagy ha akarja, kézzel is megteheti.\n"
+#~ "A telepítő végigvezetheti a teljes lemez particionálásán, közvetlenül vagy "
+#~ "LVM használatával, vagy ha akarja, kézzel is megteheti.\n"
 #~ "\n"
 #~ "Ha a teljes lemez particionálását választja, akkor áttekintheti és "
 #~ "módosíthatja az eredményt."
@@ -2697,22 +2786,165 @@ msgstr "Ne csatolja"
 #~ "partíciót, amely a „/” helyen lesz csatolva, és lefedi a lemez maradékát."
 
 #~ msgid ""
-#~ "The LVM guided partitioning scheme creates three partitions on the "
-#~ "selected disk: one as required by the bootloader, one for '/boot', and "
-#~ "one covering the rest of the disk.\n"
+#~ "The LVM guided partitioning scheme creates three partitions on the selected "
+#~ "disk: one as required by the bootloader, one for '/boot', and one covering "
+#~ "the rest of the disk.\n"
 #~ "\n"
-#~ "A LVM volume group is created containing the large partition. A 4 "
-#~ "gigabyte logical volume is created for the root filesystem. It can easily "
-#~ "be enlarged with standard LVM command line tools."
+#~ "A LVM volume group is created containing the large partition. A 4 gigabyte "
+#~ "logical volume is created for the root filesystem. It can easily be enlarged "
+#~ "with standard LVM command line tools."
 #~ msgstr ""
-#~ "Az irányított LVM particionálási séma három partíciót hoz létre a "
-#~ "lemezen: egyet, amely a rendszerbetöltőhöz szükséges, egyet a „/boot” "
-#~ "könyvtárnak, és egyet, amely lefedi a lemez maradékát.\n"
+#~ "Az irányított LVM particionálási séma három partíciót hoz létre a lemezen: "
+#~ "egyet, amely a rendszerbetöltőhöz szükséges, egyet a „/boot” könyvtárnak, és "
+#~ "egyet, amely lefedi a lemez maradékát.\n"
 #~ "\n"
 #~ "Egy LVM kötetcsoport lesz létrehozva, amely a nagy partíciót fogja "
 #~ "tartalmazni. A gyökérfájlrendszernek egy 4 gigabájtos logikai kötet lesz "
 #~ "létrehozva. Ez könnyedén megnövelhető az LVM szabványos parancssori "
 #~ "eszközeivel."
 
+#~ msgid "Passphrases"
+#~ msgstr "Jelmondatok"
+
+#~ msgid "{} is not a valid name for a volume group"
+#~ msgstr "A(z) {} nem megfelelő név egy kötetcsoportnak"
+
+#~ msgid "There is already a volume group named '{}'"
+#~ msgstr "Már létezik egy meglévő „{}” kötetcsoport"
+
+#~ msgid "Edit volume group \"{}\""
+#~ msgstr "„{}” kötetcsoport szerkesztése"
+
+#~ msgid "Leave formatted as {}"
+#~ msgstr "Erre formázva hagyás: {}"
+
+#~ msgid "Capped partition size at {}"
+#~ msgstr "Partícióméret erre korlátozva: {}"
+
+#~ msgid "Rounded size up to {}"
+#~ msgstr "Méret erre felkerekítése: {}"
+
+#~ msgid "Size (max {}):"
+#~ msgstr "Méret (legfeljebb {}):"
+
+#~ msgid "A logical volume may not be called {}"
+#~ msgstr "A logikai kötet neve nem lehet {}"
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "A logikai kötet neve nem tartalmazhatja ezt: „{}”"
+
+#~ msgid "There is already a logical volume named {}."
+#~ msgstr "Már létezik egy meglévő „{}” logikai kötet."
+
+#~ msgid "{} is already mounted at {}."
+#~ msgstr "A(z) {} már csatolva van itt: {}."
+
+#~ msgid ""
+#~ "Mounting an existing filesystem at {} is usually a bad idea, proceed only "
+#~ "with caution."
+#~ msgstr ""
+#~ "Egy meglévő fájlrendszer csatolása a(z) {} helyen általában rossz ötlet, "
+#~ "csak óvatosan folytassa."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Szükséges rendszerbetöltő partíció\n"
+#~ "\n"
+#~ "A GRUB telepítve lesz a céllemez MBR-jébe.\n"
+#~ "\n"
+#~ "Viszont egy GPT partíciós táblájú lemezen nincs elég hely az MBR után a GRUB-"
+#~ "nak, hogy eltárolja a core.img fájl második fokozatát, így egy kis "
+#~ "formázatlan partícióra van szükség a lemez elején. Nem fog fájlrendszert "
+#~ "tartalmazni, és nem lesz csatolva, így itt nem szerkeszthető."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the ESP / \"EFI system partition\" required by UEFI. Grub will be "
+#~ "installed onto this partition, which must be formatted as fat32."
+#~ msgstr ""
+#~ "Szükséges rendszerbetöltő partíció\n"
+#~ "\n"
+#~ "Ez az UEFI számára szükséges ESP / „EFI rendszerpartíció”. A GRUB erre a "
+#~ "partícióra lesz telepítve, és FAT32-ként kell formázni."
+
+#~ msgid " The only aspect of this partition that can be edited is the size."
+#~ msgstr " E partíciónak csak a mérete szerkeszthető."
+
+#~ msgid ""
+#~ " You can choose whether to use the existing filesystem on this partition or "
+#~ "reformat it."
+#~ msgstr ""
+#~ " Választhat, hogy a meglévő fájlrendszert használja ezen a partíción, vagy "
+#~ "újraformázza azt."
+
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "This is the PReP partion which is required on POWER. Grub will be installed "
+#~ "onto this partition."
+#~ msgstr ""
+#~ "Szükséges rendszerbetöltő partíció\n"
+#~ "\n"
+#~ "Ez a POWER számára szükséges PReP partíció. A GRUB erre a partícióra lesz "
+#~ "telepítve."
+
+#~ msgid "Adding {} to {}"
+#~ msgstr "A(z) {} hozzáadása ehhez: {}"
+
+#~ msgid "logical volume {}"
+#~ msgstr "{} logikai kötet"
+
+#~ msgid "Editing {} of {}"
+#~ msgstr "A(z) {} szerkesztése ezen: {}"
+
+#~ msgid "Format and/or mount {}"
+#~ msgstr "A(z) {} formázása és csatolása"
+
+#~ msgid "There is already a RAID named '{}'"
+#~ msgstr "Már létezik „{}” nevű RAID-tömb"
+
+#~ msgid "RAID Level \"{}\" requires at least {} active devices"
+#~ msgstr "A RAID {} használatához legalább {} aktív eszköz szükséges"
+
+#~ msgid "Edit software RAID disk \"{}\""
+#~ msgstr "A(z) „{}” szoftveres RAID-lemez szerkesztése"
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "A kiszolgálónév túl hosszú, nem lehet hosszabb, mint "
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "A kiszolgálónévnek meg kell felelnie a NAME_REGEX kifejezésnek, például [a-"
+#~ "z_][a-z0-9_-]*"
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "A felhasználónév túl hosszú, nem lehet hosszabb, mint "
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "A felhasználónévnek meg kell felelnie a NAME_REGEX kifejezésnek, például [a-"
+#~ "z_][a-z0-9_-]*"
+
 #~ msgid "Exit To Shell"
 #~ msgstr "Kilépés a parancssorba"
+
+#~ msgid "Reboot"
+#~ msgstr "Újraindítás"
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "A billentyűzet automatikus észlelése sikertelen, sajnáljuk"
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "Információk lekérése a következőhöz: {}"
+
+#~ msgid "Fetching info for {} failed"
+#~ msgstr "Információk lekérése a következőhöz sikertelen: {}"

--- a/po/id.po
+++ b/po/id.po
@@ -7,76 +7,404 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
 "PO-Revision-Date: 2019-12-13 00:14+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Indonesian <id@li.org>\n"
-"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: id\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
@@ -92,30 +420,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr ""
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr ""
 
@@ -177,1101 +526,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Terjadi suatu kesalahan"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Pemasangan komplit!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Pemasangan berakhir!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Memasang sistem"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Memasang komplit!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Sebuah kesalah terjadi selama instalasi"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1305,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1313,134 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1464,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1614,576 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Memasang sistem"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Memasang komplit!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Sebuah kesalah terjadi selama instalasi"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2194,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2206,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2216,8 +2120,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2234,199 +2138,347 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
 
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr ""
+#~ msgid "An error has occurred"
+#~ msgstr "Terjadi suatu kesalahan"
 
 #~ msgid "Install complete"
 #~ msgstr "Pemasangan komplit"
 
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Terima kasih telah memakai Ubuntu!"
+
+#~ msgid "Finished install!"
+#~ msgstr "Pemasangan berakhir!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Pemasangan komplit!"
 
 #~ msgid "Install in progress:"
 #~ msgstr "Pemasangan tengah berlangsung:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,23 +1,22 @@
-# Latvian translation for subiquity
-# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
+# Japanese translation for subiquity
+# Copyright (c) 2020 Rosetta Contributors and Canonical Ltd 2020
 # This file is distributed under the same license as the subiquity package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2021-06-04 13:18+1200\n"
-"PO-Revision-Date: 2017-09-17 14:15+0000\n"
-"Last-Translator: Dimitri John Ledkov <dimitri.ledkov+lp@canonical.com>\n"
-"Language-Team: Latvian <lv@li.org>\n"
+"PO-Revision-Date: 2020-09-07 01:40+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Japanese <ja@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
 "X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
-"Language: lv\n"
 
 #: ../subiquity/client/client.py:70
 msgid ""
@@ -424,7 +423,7 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/filesystem.py:494
 #: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
-msgstr "Gatavs"
+msgstr ""
 
 #: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
@@ -433,19 +432,19 @@ msgstr "Gatavs"
 #: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
 #: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
-msgstr "Atcelt"
+msgstr ""
 
 #: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
 #: ../subiquity/ui/views/ssh.py:185
 msgid "Yes"
-msgstr "Jā"
+msgstr ""
 
 #: ../subiquitycore/ui/interactive.py:109
 #: ../subiquity/ui/views/installprogress.py:247
 #: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
 #: ../subiquity/ui/views/ssh.py:186
 msgid "No"
-msgstr "Nē"
+msgstr ""
 
 #: ../subiquitycore/ui/utils.py:349
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
@@ -455,7 +454,7 @@ msgstr "Nē"
 #: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
 #: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
 msgid "Close"
-msgstr "Aizvērt"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
@@ -466,7 +465,7 @@ msgstr "Aizvērt"
 #: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
 msgid "Save"
-msgstr "Saglabāt"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:88
 msgid "Subnet:"
@@ -474,11 +473,11 @@ msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:89
 msgid "Address:"
-msgstr "Adrese:"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:90
 msgid "Gateway:"
-msgstr "Vārteja:"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:91
 msgid "Name servers:"
@@ -514,7 +513,7 @@ msgstr ""
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:145
 msgid "Manual"
-msgstr "Manuālā"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:147
@@ -671,7 +670,7 @@ msgstr ""
 #: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
 #: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
-msgstr "Atpakaļ"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
@@ -842,7 +841,7 @@ msgstr ""
 #: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
 #: ../subiquity/ui/views/zdev.py:162
 msgid "Continue"
-msgstr "Turpināt"
+msgstr ""
 
 #: ../subiquity/ui/views/error.py:160
 #: ../subiquity/ui/views/installprogress.py:282
@@ -1110,7 +1109,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:498
 msgid "Reset"
-msgstr "Atstatīt"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
@@ -1134,7 +1133,7 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/guided.py:67
 #: ../subiquity/ui/views/identity.py:141
 msgid "Passwords do not match"
-msgstr "Paroles nesakrīt"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
@@ -1781,7 +1780,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:89
 msgid "Your name:"
-msgstr "Jūsu vārds:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:91
 msgid "Your server's name:"
@@ -1789,19 +1788,19 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:92
 msgid "The name it uses when it talks to other computers."
-msgstr "Šo nosaukumu izmanto saziņā ar citiem datoriem."
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:93
 msgid "Pick a username:"
-msgstr "Izvēlieties lietotājvārdu:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:94
 msgid "Choose a password:"
-msgstr "Izvēlieties paroli:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:95
 msgid "Confirm your password:"
-msgstr "Apstipriniet paroli:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
@@ -1888,7 +1887,7 @@ msgstr ""
 #: ../subiquity/ui/views/installprogress.py:151
 #: ../subiquity/ui/views/installprogress.py:154
 msgid "Installing system"
-msgstr "Instalēju sistēmu"
+msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:157
 #: ../subiquity/ui/views/installprogress.py:165

--- a/po/kab.po
+++ b/po/kab.po
@@ -7,81 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-01-29 15:22+0000\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2020-01-29 15:19+0000\n"
 "Last-Translator: ButterflyOfFire <Unknown>\n"
 "Language-Team: Kabyle <kab@li.org>\n"
-"Language: kab\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: kab\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr "ih"
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr "ala"
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr "ameẓẓul"
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "ur ituseqdac ara"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "yettwaseqdec"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr "Tuccḍa deg uẓeṭṭa"
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "Erreur inconnue"
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
-msgstr "Ẓreg Wifi"
+msgstr ""
 
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
-msgstr "Ẓreg IPv4"
+msgstr ""
 
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
-msgstr "Ẓreg IPv6"
+msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Kkes"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Mdel"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -96,30 +420,51 @@ msgstr " neγ "
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
-msgstr ""
+msgstr "Immed"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Sefsex"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Ih"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Uhu"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Mdel"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Sekles"
 
@@ -169,1115 +514,645 @@ msgstr ""
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:145
 msgid "Manual"
-msgstr ""
+msgstr "Awfus"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:147
 msgid "Disabled"
-msgstr ""
+msgstr "Yensa"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:165
 #, python-brace-format
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
-msgstr ""
+msgstr "Rnu"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s yella ya kan"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Isem:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "Ittwasens"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
-msgstr ""
+msgstr "Retour"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Ih"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Uhu"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Teḍra-d tuccḍa"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Asebded n unagraw"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
-msgstr ""
+msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
-msgstr ""
+msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
-msgstr ""
+msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "Nniḍen"
+
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Ẓreg Wifi"
-
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Kkes"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Kemmel"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr "AZEMZ"
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Kkes"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Ales asbadu"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Awalen n unekcum ur nmeɣran ara"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1311,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1319,134 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "Γas"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Teɣzi:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Amasal:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1470,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1620,576 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
-msgstr ""
+msgstr "F1"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Inegzumen n unasiw"
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
-msgstr ""
+msgstr "Tallalt"
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
-msgstr ""
+msgstr "Ẓeṛ aɣmis ummid"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Asebded n unagraw"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2200,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2212,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Asettef"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Asekkeṛ n yisekkilen imeqqranen"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr "Tasarut n ulugu tayeffust"
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Tasarut n wumuɣ"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Taqeffalt n Usekkil Meqqren"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr "Tasarut n ulugu tazelmaḍt"
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Adrurel n tsarut n usekkeṛ"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr "Ulac aqluqel"
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2222,8 +2120,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2240,190 +2138,348 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Asali n lqem..."
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Ɛreḍ tikkelt-nniḍen"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "Tura kan"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "tasdat"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "tisdatin"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "asrag"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "isragen"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "ass"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "ussan"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
-msgstr ""
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
+msgstr "ixṣar"
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
+msgstr "auto"
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
-msgid "ID"
+msgid "No zdev devices found."
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:92
+msgid "ID"
+msgstr "ID"
+
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
-msgstr ""
+msgstr "Rmed"
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
-msgstr ""
+msgstr "Sens"
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
 
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
+#~ msgid "An error has occurred"
+#~ msgstr "Teḍra-d tuccḍa"
 
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr ""
+#~ msgid "Edit IPv4"
+#~ msgstr "Ẓreg IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Ẓreg Wifi"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "Ẓreg IPv6"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s yella ya kan"
+
+#~ msgid "Reboot"
+#~ msgstr "Alles asekker"

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,78 +7,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2018-07-26 20:08+0000\n"
+"Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
-"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: lt\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Ištrinti"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Užverti"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -93,30 +421,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Atlikta"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Atsisakyti"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Taip"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Ne"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Užverti"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Įrašyti"
 
@@ -178,87 +527,133 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Sukurti"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Tinklo ryšiai"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -268,1015 +663,500 @@ msgstr ""
 "pakankamai prieigos atnaujinimams."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Atgal"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Tinklo sąsaja {} WIFI konfigūracija"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Taip"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Ne"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Įvyko klaida"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Diegimas užbaigtas!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Diegimo metu įvyko klaida"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Ištrinti"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Jūsų vardas:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Pasirinkite naudotojo vardą:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Pasirinkite slaptažodį:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Patvirtinkite slaptažodį:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Naudotojo vardas yra per ilgas, privalo būti < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Naudotojo vardas yra per ilgas, privalo būti < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Trūksta naudotojo vardo"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Naudotojo vardas yra per ilgas, privalo būti < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Slaptažodžiai nesutampa"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Profilio sąranka"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Tęsti"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "Gerai"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Ištrinti"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Nėra jokių prijungtų diskų ar skaidinių."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "PRIJUNGIMO TAŠKAS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "DYDIS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TIPAS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "ĮRENGINIO TIPAS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "ĮRENGINYS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "FAILŲ SISTEMOS SANTRAUKA"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "PRIEINAMI ĮRENGINIAI"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Atstatyti"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Slaptažodžiai nesutampa"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1310,7 +1190,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1318,135 +1198,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "Gerai"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Nėra jokių prijungtų diskų ar skaidinių."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "PRIJUNGIMO TAŠKAS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "DYDIS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TIPAS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "ĮRENGINIO TIPAS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "ĮRENGINYS"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "FAILŲ SISTEMOS SANTRAUKA"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "PRIEINAMI ĮRENGINIAI"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Atstatyti"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1469,100 +1503,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1619,582 +1596,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr ""
-"Naudokite AUKŠTYN, ŽEMYN krypties klavišus ir ENTER (ĮVEDIMAS), norėdami "
-"pasirinkti kalbą."
-
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Jūsų vardas:"
+
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "GitHub naudotojo vardas:"
-
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "GitHub naudotojo vardas:"
-
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Launchpad naudotojo vardas:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Pasirinkite naudotojo vardą:"
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Pasirinkite slaptažodį:"
 
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Patvirtinkite slaptažodį:"
 
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "iš GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "iš Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Trūksta naudotojo vardo"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Tęsti"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Profilio sąranka"
+
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr "Automatinis klaviatūros aptikimas"
-
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Automatinis klaviatūros aptikimas patyrė nesėkmę, atleiskite"
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-"Automatinis klaviatūros aptikimas užbaigtas.\n"
-"\n"
-"Jūsų klaviatūra buvo atpažinta kaip:\n"
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Išdėstymas"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr "Variantas"
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Paspauskite vieną iš šių klavišų:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr "Įvestis nebuvo atpažinta, bandykite dar kartą"
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "Ar šis klavišas yra jūsų klaviatūroje?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Taikoma konfigūracija"
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Dešinysis Alt (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "Meniu klavišas"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Kairysis Alt"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "Išdėstymas:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr "Variantas:"
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr "Klaviatūros konfigūracija"
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr "Atpažinti klaviatūrą"
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Paleisti iš naujo dabar"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr "Rodyti visą žurnalą"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Diegimo metu įvyko klaida"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2205,11 +1924,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2217,9 +1936,190 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "Automatinis klaviatūros aptikimas"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+"Automatinis klaviatūros aptikimas užbaigtas.\n"
+"\n"
+"Jūsų klaviatūra buvo atpažinta kaip:\n"
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Išdėstymas"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr "Variantas"
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Paspauskite vieną iš šių klavišų:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr "Įvestis nebuvo atpažinta, bandykite dar kartą"
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Ar šis klavišas yra jūsų klaviatūroje?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Dešinysis Alt (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Meniu klavišas"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Kairysis Alt"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Išdėstymas:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr "Variantas:"
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "Klaviatūros konfigūracija"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr "Atpažinti klaviatūrą"
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Taikoma konfigūracija"
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2227,8 +2127,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2245,196 +2145,340 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Github naudotojo vardas:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Launchpad naudotojo vardas:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "iš Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "iš Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr ""
+"Naudokite AUKŠTYN, ŽEMYN krypties klavišus ir ENTER (ĮVEDIMAS), norėdami "
+"pasirinkti kalbą."
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""
 
 #~ msgid "Filesystem setup"
 #~ msgstr "Failų sistemos sąranka"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Įvyko klaida"
 
 #~ msgid "Install complete"
 #~ msgstr "Diegimas užbaigtas"
@@ -2445,13 +2489,25 @@ msgstr ""
 #~ msgid "starting..."
 #~ msgstr "Pradedama..."
 
+#~ msgid "Installation complete!"
+#~ msgstr "Diegimas užbaigtas!"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Dėkojame, kad naudojate Ubuntu!"
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "Naudotojo vardas yra per ilgas, privalo būti < "
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Automatinis klaviatūros aptikimas patyrė nesėkmę, atleiskite"
 
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr ""
 #~ "Naudokite AUKŠTYN, ŽEMYN krypties klavišus ir ENTER (ĮVEDIMAS), norėdami "
 #~ "pasirinkti klaviatūrą."
+
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Tinklo sąsaja {} WIFI konfigūracija"
 
 #~ msgid "Select available disks to format and mount"
 #~ msgstr "Pasirinkite prieinamus diskus, kuriuos formatuoti ir prijungti"

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,78 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2018-04-23 16:26+0000\n"
+"Last-Translator: Åka Sikrom <Unknown>\n"
 "Language-Team: Norwegian Bokmal <nb@li.org>\n"
-"Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: nb\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "lokal enhet"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Slett"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Lukk"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -89,34 +416,55 @@ msgid " or "
 msgstr " eller "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Dette feltet må inneholde en %s-nettadresse."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Ferdig"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Avbryt"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Ja"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Nei"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Lukk"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Lagre"
 
@@ -154,9 +502,9 @@ msgid "should be in CIDR form ({example})"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "«%s» finnes ikke i «%s»"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -178,87 +526,133 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Opprett"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Nettverkstilkoblinger"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -268,1029 +662,500 @@ msgstr ""
 "det kan hente oppdateringer."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Tilbake"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "Velg veksling mellom utforminger"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Nettverksgrensesnitt {} oppsett av trådløst nett"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Ja"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Nei"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Det har oppstått en feil"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Installasjon fullført."
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Installasjon fullført."
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Installerer system"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Installasjon fullført."
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Det oppstod en feil under installasjon"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Du må velge et tjenernavn"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} er ikke gyldig inndata"
-
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Slett"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "lokal enhet"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Sett opp mellomtjener"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "partisjon på {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "partisjon på {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "partisjon på {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "Tegnene «:» og «=» er ikke tillatt i dette feltet"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-"Du kan bare bruke bokstavene a-z, tallene 0-9, «_» og «-» i dette feltet"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Navnet ditt:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Vertsnavn:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "Navn som datamaskinen bruker når den snakker med andre maskiner."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Velg brukernavn:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Velg passord:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Bekreft passord:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Navnet ditt er for langt. Det må være < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Du må velge et tjenernavn"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Valgt tjenernavn er for langt. Det må være < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr "Vertsnavn må samsvare med NAME_REGEX, altså [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Brukernavn mangler"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Valgt brukernavn er for langt. Det må være < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr "Brukernavn må samsvare med NAME_REGEX, altså [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Du må velge passord"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Passordene er ulike"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Profiloppsett"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Fortsett"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Sti overskrider «PATH_MAX»"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Påkrevet oppstartslaster-partisjon\n"
-"\n"
-"GRUB blir installert på enhetens MBR.\n"
-"\n"
-"Enheter med GTP-partisjonstabell har ikke nok plass etter MBR til at GRUB "
-"kan lagre «core.img». Installasjonsprogrammet oppretter derfor en liten, "
-"uformatert ekstrapartisjon ved begynnelsen av enheten/disken. Denne "
-"partisjonen vil ikke inneholde et filsystem. Den blir heller ikke montert, "
-"og du kan ikke gjøre endringer på den her."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "OK"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formater og eller monter {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Slett"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Ingen enheter eller partisjoner er montert."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "MONTERINGSPUNKT"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "STØRRELSE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TYPE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "ENHETSTYPE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "ENHET"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "ledig plass"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "OPPSUMMERING AV FILSYSTEM"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "TILGJENGELIGE ENHETER"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Tilbakestill"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Du må velge passord"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Passordene er ulike"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1324,7 +1189,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1332,135 +1197,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "OK"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Ingen enheter eller partisjoner er montert."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "MONTERINGSPUNKT"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "STØRRELSE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TYPE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "ENHETSTYPE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "ENHET"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "ledig plass"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "OPPSUMMERING AV FILSYSTEM"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "TILGJENGELIGE ENHETER"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Tilbakestill"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Sti overskrider «PATH_MAX»"
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1483,100 +1502,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1633,388 +1595,352 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Ctrl + Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "Tegnene «:» og «=» er ikke tillatt i dette feltet"
+
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
+"Du kan bare bruke bokstavene a-z, tallene 0-9, «_» og «-» i dette feltet"
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Bruk PIL OPP, PIL NED og ENTER for å velge språk."
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Navnet ditt:"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Vertsnavn:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Importer brukernavn:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Navn som datamaskinen bruker når den snakker med andre maskiner."
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "GitHub-brukernavn:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Velg brukernavn:"
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "GitHub-brukernavn:"
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Velg passord:"
 
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-"GitHub-brukernavn kan bare inneholde alfanumeriske tegn og bindestreker, og "
-"de kan ikke begynne med bindestrek."
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Bekreft passord:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Launchpad-brukernavn:"
-
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"GitHub-brukernavn kan bare inneholde alfanumeriske tegn og bindestreker, og "
-"de kan ikke begynne med bindestrek."
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Importer SSH-identitet:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "fra GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "fra Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Du kan importere SSH-nøkler fra GitHub eller Launchpad."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Dette feltet kan ikke stå tomt."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "Valgt SSH-id er for lang. Den må være < "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"GitHub-brukernavn kan bare inneholde alfanumeriske tegn og bindestreker, og "
-"de kan ikke begynne med bindestrek."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Du må velge et tjenernavn"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Brukernavn mangler"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
+msgstr ""
+
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Profiloppsett"
+
+#: ../subiquity/ui/views/identity.py:159
+msgid ""
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:52
+msgid "Install progress"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
+msgid "Reboot Now"
+msgstr "Start på nytt nå"
+
+#: ../subiquity/ui/views/installprogress.py:61
+msgid "View error report"
+msgstr ""
+
 #: ../subiquity/ui/views/installprogress.py:63
+msgid "View full log"
+msgstr "Vis fullstendig logg"
+
+#: ../subiquity/ui/views/installprogress.py:79
+msgid "Full installer output"
+msgstr "Fullstendig utdata"
+
+#: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Installerer system"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Installasjon fullført."
+
+#: ../subiquity/ui/views/installprogress.py:159
+msgid "Cancel update and reboot"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:166
 #: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Fortsett"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr ""
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Det oppstod en feil under installasjon"
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Selecting Continue below will begin the installation process and\n"
+"result in the loss of data on the disks selected to be formatted.\n"
+"\n"
+"You will not be able to return to this or a previous screen once\n"
+"the installation has started.\n"
+"\n"
+"Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
+#: ../subiquity/ui/views/installprogress.py:251
+msgid "Confirm destructive action"
+msgstr "Bekreft ødeleggende handling"
+
+#: ../subiquity/ui/views/installprogress.py:271
+#, python-brace-format
+msgid ""
+"The installer running on {tty} is currently installing the system.\n"
+"\n"
+"You can wait for this to complete or switch to a shell.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:67
 msgid "Keyboard auto-detection"
 msgstr "Tastatur-autosøk"
 
-#: ../subiquity/ui/views/keyboard.py:90
+#: ../subiquity/ui/views/keyboard.py:93
 msgid ""
 "Keyboard detection starting. You will be asked a series of questions about "
 "your keyboard. Press escape at any time to go back to the previous screen."
@@ -2023,18 +1949,14 @@ msgstr ""
 "tastaturet ditt. Trykk Esc når som helst for å gå tilbake til forrige "
 "skjermbilde."
 
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Klarte ikke å finne tastaturutforming"
-
-#: ../subiquity/ui/views/keyboard.py:116
+#: ../subiquity/ui/views/keyboard.py:106
 msgid ""
 "Keyboard auto detection completed.\n"
 "\n"
 "Your keyboard was detected as:\n"
 msgstr "Tastaturet ditt ser ut til å være av følgende type:\n"
 
-#: ../subiquity/ui/views/keyboard.py:121
+#: ../subiquity/ui/views/keyboard.py:111
 msgid ""
 "\n"
 "If this is correct, select Done on the next screen. If not you can select "
@@ -2046,38 +1968,34 @@ msgstr ""
 "velge tastaturutforming manuelt eller gå gjennom denne prosessen på nytt.\n"
 "\n"
 
-#: ../subiquity/ui/views/keyboard.py:135
+#: ../subiquity/ui/views/keyboard.py:128
 msgid "Layout"
 msgstr "Utforming"
 
-#: ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:129
 msgid "Variant"
 msgstr "Variant"
 
-#: ../subiquity/ui/views/keyboard.py:161
+#: ../subiquity/ui/views/keyboard.py:152
 msgid "Please press one of the following keys:"
 msgstr "Trykk på én av følgende taster:"
 
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
 msgid "Input was not recognized, try again"
 msgstr "Tastetrykket ble ikke gjenkjent. Prøv på nytt"
 
-#: ../subiquity/ui/views/keyboard.py:222
+#: ../subiquity/ui/views/keyboard.py:213
 msgid "Is the following key present on your keyboard?"
 msgstr "Finnes følgende tast på tastaturet ditt?"
 
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Tar i bruk oppsett"
-
-#: ../subiquity/ui/views/keyboard.py:303
+#: ../subiquity/ui/views/keyboard.py:277
 msgid ""
 "You will need a way to toggle the keyboard between the national layout and "
 "the standard Latin layout.\n"
 "\n"
 "Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
 "behavior in Emacs and other programs that use it for specific needs.\n"
 "\n"
 "Not all listed keys are present on all keyboards. "
@@ -2092,101 +2010,101 @@ msgstr ""
 "\n"
 "Tastene som vises her er ikke nødvendigvis tilgjengelig på alle tastaturer. "
 
-#: ../subiquity/ui/views/keyboard.py:316
+#: ../subiquity/ui/views/keyboard.py:290
 msgid "Caps Lock"
 msgstr "Caps Lock"
 
-#: ../subiquity/ui/views/keyboard.py:317
+#: ../subiquity/ui/views/keyboard.py:291
 msgid "Right Alt (AltGr)"
 msgstr "Høyre Alt (Alt Gr)"
 
-#: ../subiquity/ui/views/keyboard.py:318
+#: ../subiquity/ui/views/keyboard.py:292
 msgid "Right Control"
 msgstr "Høyre Ctrl"
 
-#: ../subiquity/ui/views/keyboard.py:319
+#: ../subiquity/ui/views/keyboard.py:293
 msgid "Right Shift"
 msgstr "Høyre Shift"
 
-#: ../subiquity/ui/views/keyboard.py:320
+#: ../subiquity/ui/views/keyboard.py:294
 msgid "Right Logo key"
 msgstr "Høyre logotast"
 
-#: ../subiquity/ui/views/keyboard.py:321
+#: ../subiquity/ui/views/keyboard.py:295
 msgid "Menu key"
 msgstr "Menytast"
 
-#: ../subiquity/ui/views/keyboard.py:322
+#: ../subiquity/ui/views/keyboard.py:296
 msgid "Alt+Shift"
 msgstr "Alt + Shift"
 
-#: ../subiquity/ui/views/keyboard.py:323
+#: ../subiquity/ui/views/keyboard.py:297
 msgid "Control+Shift"
 msgstr "Ctrl + Shift"
 
-#: ../subiquity/ui/views/keyboard.py:324
+#: ../subiquity/ui/views/keyboard.py:298
 msgid "Control+Alt"
 msgstr "Ctrl + Alt"
 
-#: ../subiquity/ui/views/keyboard.py:325
+#: ../subiquity/ui/views/keyboard.py:299
 msgid "Alt+Caps Lock"
 msgstr "Alt + Caps Lock"
 
-#: ../subiquity/ui/views/keyboard.py:326
+#: ../subiquity/ui/views/keyboard.py:300
 msgid "Left Control+Left Shift"
 msgstr "Venste Ctrl + Venstre Shift"
 
-#: ../subiquity/ui/views/keyboard.py:327
+#: ../subiquity/ui/views/keyboard.py:301
 msgid "Left Alt"
 msgstr "Venstre Alt"
 
-#: ../subiquity/ui/views/keyboard.py:328
+#: ../subiquity/ui/views/keyboard.py:302
 msgid "Left Control"
 msgstr "Venstre Ctrl"
 
-#: ../subiquity/ui/views/keyboard.py:329
+#: ../subiquity/ui/views/keyboard.py:303
 msgid "Left Shift"
 msgstr "Venstre Shift"
 
-#: ../subiquity/ui/views/keyboard.py:330
+#: ../subiquity/ui/views/keyboard.py:304
 msgid "Left Logo key"
 msgstr "Venstre logotast"
 
-#: ../subiquity/ui/views/keyboard.py:331
+#: ../subiquity/ui/views/keyboard.py:305
 msgid "Scroll Lock key"
 msgstr "Scroll Lock-tast"
 
-#: ../subiquity/ui/views/keyboard.py:332
+#: ../subiquity/ui/views/keyboard.py:306
 msgid "No toggling"
 msgstr "Ingen veksling"
 
-#: ../subiquity/ui/views/keyboard.py:353
+#: ../subiquity/ui/views/keyboard.py:327
 msgid "Shortcut: "
 msgstr "Snarvei: "
 
-#: ../subiquity/ui/views/keyboard.py:363
+#: ../subiquity/ui/views/keyboard.py:337
 msgid "Select layout toggle"
 msgstr "Velg veksling mellom utforminger"
 
-#: ../subiquity/ui/views/keyboard.py:381
+#: ../subiquity/ui/views/keyboard.py:355
 msgid "Layout:"
 msgstr "Utforming:"
 
-#: ../subiquity/ui/views/keyboard.py:382
+#: ../subiquity/ui/views/keyboard.py:356
 msgid "Variant:"
 msgstr "Variant:"
 
-#: ../subiquity/ui/views/keyboard.py:387
+#: ../subiquity/ui/views/keyboard.py:361
 msgid "Keyboard configuration"
 msgstr "Tastaturoppsett"
 
-#: ../subiquity/ui/views/keyboard.py:417
+#: ../subiquity/ui/views/keyboard.py:382
 msgid ""
 "Please select the layout of the keyboard directly attached to the system, if "
 "any."
 msgstr "Velg utforming av evt. tastatur som er koblet direkte til systemet."
 
-#: ../subiquity/ui/views/keyboard.py:420
+#: ../subiquity/ui/views/keyboard.py:385
 msgid ""
 "Please select your keyboard layout below, or select \"Identify keyboard\" to "
 "detect your layout automatically."
@@ -2194,68 +2112,29 @@ msgstr ""
 "Velg tastaturutforming nedenfor, eller velg \"Finn tastaturutforming\" for å "
 "prøve å finne det automatisk."
 
-#: ../subiquity/ui/views/keyboard.py:429
+#: ../subiquity/ui/views/keyboard.py:394
 msgid "Identify keyboard"
 msgstr "Finn tastaturutforming"
 
-#: ../subiquity/ui/views/installprogress.py:50
-msgid "Install progress"
-msgstr ""
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Tar i bruk oppsett"
 
-#: ../subiquity/ui/views/installprogress.py:57
-msgid "Reboot Now"
-msgstr "Start på nytt nå"
-
-#: ../subiquity/ui/views/installprogress.py:59
-msgid "View error report"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:61
-msgid "View full log"
-msgstr "Vis fullstendig logg"
-
-#: ../subiquity/ui/views/installprogress.py:77
-msgid "Full installer output"
-msgstr "Fullstendig utdata"
-
-#: ../subiquity/ui/views/installprogress.py:142
-msgid "Cancel update and reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
-msgid "Rebooting..."
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/mirror.py:32
 msgid ""
-"Selecting Continue below will begin the installation process and\n"
-"result in the loss of data on the disks selected to be formatted.\n"
-"\n"
-"You will not be able to return to this or a previous screen once\n"
-"the installation has started.\n"
-"\n"
-"Are you sure you want to continue?"
+"You may provide an archive mirror that will be used instead of the default."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
-msgid "Confirm destructive action"
-msgstr "Bekreft ødeleggende handling"
-
-#: ../subiquity/ui/views/installprogress.py:235
-#, python-brace-format
-msgid ""
-"The installer running on {tty} is currently installing the system.\n"
-"\n"
-"You can wait for this to complete or switch to a shell.\n"
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2263,15 +2142,15 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "Hvis du er avhengig av en HTTP-mellomtjener for å få tilgang til Internett, "
 "må du legge inn informasjon om mellomtjeneren her. Ellers kan feltet stå "
 "tomt.\n"
 "\n"
-"Feltet må evt. fylles ut i formatet «http://[[brukernavn][:"
-"passord]@]vertsnavn[:port]/»."
+"Feltet må evt. fylles ut i formatet "
+"«http://[[brukernavn][:passord]@]vertsnavn[:port]/»."
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
@@ -2289,192 +2168,333 @@ msgstr ""
 "Hvis dette systemet krever en mellomtjener for å koble til Internett, må du "
 "skrive inn detaljer for denne her."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Importer brukernavn:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Github-brukernavn:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Launchpad-brukernavn:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Importer SSH-identitet:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "fra Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "fra Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Du kan importere SSH-nøkler fra Github eller Launchpad."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Dette feltet kan ikke stå tomt."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "Valgt SSH-id er for lang. Den må være < "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"Github-brukernavn kan bare inneholde alfanumeriske tegn og bindestreker, og "
+"de kan ikke begynne med bindestrek."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Bruk PIL OPP, PIL NED og ENTER for å velge språk."
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""
 
 #~ msgid "Filesystem setup"
@@ -2489,13 +2509,21 @@ msgstr ""
 #~ msgid "Choose the installation target"
 #~ msgstr "Velg installasjonsmål"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formater og eller monter {}"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Takk for at du bruker Ubuntu!"
 
+#~ msgid "Finished install!"
+#~ msgstr "Installasjon fullført."
+
+#~ msgid "Installation complete!"
+#~ msgstr "Installasjon fullført."
+
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr ""
-#~ "Velg et grensesnitt som skal settes opp, eller trykk Ferdig for å "
-#~ "fortsette"
+#~ "Velg et grensesnitt som skal settes opp, eller trykk Ferdig for å fortsette"
 
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Vi ber om at du rapporterer denne feilen via Launchpad"
@@ -2506,8 +2534,26 @@ msgstr ""
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Velg enhet å installere på:"
 
+#~ msgid "Username too long, must be < "
+#~ msgstr "Valgt brukernavn er for langt. Det må være < "
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "Brukernavn må samsvare med NAME_REGEX, altså [a-z_][a-z0-9_-]*"
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "Vertsnavn må samsvare med NAME_REGEX, altså [a-z_][a-z0-9_-]*"
+
 #~ msgid "Exit To Shell"
 #~ msgstr "Gå til kommandoskall"
+
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Navnet ditt er for langt. Det må være < "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "Valgt tjenernavn er for langt. Det må være < "
+
+#~ msgid "An error has occurred"
+#~ msgstr "Det har oppstått en feil"
 
 #~ msgid "Install complete"
 #~ msgstr "Installasjon fullført"
@@ -2518,22 +2564,62 @@ msgstr ""
 #~ msgid "starting..."
 #~ msgstr "starter …"
 
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Nettverksgrensesnitt {} oppsett av trådløst nett"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Dette feltet må inneholde en %s-nettadresse."
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "«%s» finnes ikke i «%s»"
+
+#~ msgid "partition of {}"
+#~ msgstr "partisjon på {}"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} er ikke gyldig inndata"
+
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
 #~ "\n"
 #~ "Are you sure you want to continue?"
 #~ msgstr ""
-#~ "Hvis du velger Fortsett nedenfor, starter installasjonsprosessen. Alle "
-#~ "data på valgte lagringsenheter blir slettet under formatering.\n"
+#~ "Hvis du velger Fortsett nedenfor, starter installasjonsprosessen. Alle data "
+#~ "på valgte lagringsenheter blir slettet under formatering.\n"
 #~ "\n"
 #~ "Du får ingen muligheter til å gå tilbake til dette skjermbildet når "
 #~ "installasjonen har begynt.\n"
 #~ "\n"
 #~ "Er du sikker på at du vil fortsette?"
 
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Påkrevet oppstartslaster-partisjon\n"
+#~ "\n"
+#~ "GRUB blir installert på enhetens MBR.\n"
+#~ "\n"
+#~ "Enheter med GTP-partisjonstabell har ikke nok plass etter MBR til at GRUB "
+#~ "kan lagre «core.img». Installasjonsprogrammet oppretter derfor en liten, "
+#~ "uformatert ekstrapartisjon ved begynnelsen av enheten/disken. Denne "
+#~ "partisjonen vil ikke inneholde et filsystem. Den blir heller ikke montert, "
+#~ "og du kan ikke gjøre endringer på den her."
+
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr "Bruk OPP, NED og ENTER for å velge tastaturutforming."
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Klarte ikke å finne tastaturutforming"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,80 +7,404 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2020-01-22 13:57+0000\n"
+"Last-Translator: Niek Wessels <Unknown>\n"
 "Language-Team: Dutch <nl@li.org>\n"
-"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:51+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: nl\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "lokale schijf"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "Automatische configuratie mislukt"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Info"
-msgstr "Informatie"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Wijzig Wifi"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Wijzig IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Wijzig IPv4"
-
 #: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
-msgid "Edit bond"
+msgid "Info"
 msgstr ""
 
 #: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
+msgid "Edit Wifi"
 msgstr ""
 
 #: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
+msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
@@ -92,34 +416,55 @@ msgid " or "
 msgstr " of "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Dit veld moet een %s URL zijn."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Klaar"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Annuleren"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Ja"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Nee"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr ""
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Opslaan"
 
@@ -157,9 +502,9 @@ msgid "should be in CIDR form ({example})"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "‘%s’ bevindt zich niet in ‘%s’"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -181,87 +526,133 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Netwerkverbindingen"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -271,1027 +662,500 @@ msgstr ""
 "tot updates biedt."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Terug"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Ja"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Nee"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Er is iets fout gegaan"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Installatie voltooid!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Klaar met installeren!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Het systeem wordt geïnstalleerd"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Installatie voltooid!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Er is tijdens de installatie een fout opgetreden"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} is geen geldige invoer"
-
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Informatie"
-
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Wijzig Wifi"
-
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "lokale schijf"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "Automatische configuratie mislukt"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "partitie van {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "partitie van {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "partitie van {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Profiel instellen"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Doorgaan"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Het pad overschrijdt PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Vereiste bootloaderpartitie\n"
-"\n"
-"GRUB zal geïnstalleerd worden op het MBR van de doelschijf.\n"
-"\n"
-"Echter, op een schijf met een GPT-partitietabel is geen ruimte achter het "
-"MBR waar GRUB het tweede deel van core.img kwijt kan, dus is er een kleine, "
-"ongeformatteerde partitie nodig aan het begin van de schijf. Deze zal geen "
-"bestandssysteem hebben en zal niet zijn aangekoppeld, en kan niet worden "
-"bewerkt."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formatteren en/of aankoppelen {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Er is geen schijf of partitie aangekoppeld."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "AANKOPPELPUNT"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "GROOTTE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TYPE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "TYPE APPARAAT"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "APPARAAT"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "vrije ruimte"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "OVERZICHT BESTANDSSYSTEEM"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "BESCHIKBARE APPARATEN"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Opnieuw instellen"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1325,7 +1189,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1333,135 +1197,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Er is geen schijf of partitie aangekoppeld."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "AANKOPPELPUNT"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "GROOTTE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "TYPE"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "TYPE APPARAAT"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "APPARAAT"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "vrije ruimte"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "OVERZICHT BESTANDSSYSTEEM"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "BESCHIKBARE APPARATEN"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Opnieuw instellen"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Het pad overschrijdt PATH_MAX"
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1484,100 +1502,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1634,576 +1595,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Gebruik de toetsen Page Up, Page Down en Enter om uw taal te kiezen."
-
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Doorgaan"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Profiel instellen"
+
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Het systeem wordt geïnstalleerd"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Installatie voltooid!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Er is tijdens de installatie een fout opgetreden"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2214,11 +1923,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr "Destructieve actie bevestigen"
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2226,9 +1935,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2236,8 +2123,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2254,192 +2141,331 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Gebruik de toetsen Page Up, Page Down en Enter om uw taal te kiezen."
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""
 
 #~ msgid "Filesystem setup"
@@ -2454,8 +2480,17 @@ msgstr ""
 #~ msgid "Choose the installation target"
 #~ msgstr "Doel van installatie kiezen"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formatteren en/of aankoppelen {}"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Bedankt dat u Ubuntu gebruikt!"
+
+#~ msgid "Finished install!"
+#~ msgstr "Klaar met installeren!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Installatie voltooid!"
 
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Gelieve deze fout in Launchpad te melden"
@@ -2463,26 +2498,72 @@ msgstr ""
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr "Kies een interface om te configureren of kies Klaar om door te gaan"
 
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Dit veld moet een %s URL zijn."
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "‘%s’ bevindt zich niet in ‘%s’"
+
+#~ msgid "partition of {}"
+#~ msgstr "partitie van {}"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} is geen geldige invoer"
+
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
 #~ "\n"
 #~ "Are you sure you want to continue?"
 #~ msgstr ""
-#~ "Met het hieronder selecteren van Volgende zal het installatieproces "
-#~ "beginnen en zullen gegevens op de schijven die gekozen zijn om te "
-#~ "formatteren verloren gaan.\n"
+#~ "Met het hieronder selecteren van Volgende zal het installatieproces beginnen "
+#~ "en zullen gegevens op de schijven die gekozen zijn om te formatteren "
+#~ "verloren gaan.\n"
 #~ "\n"
-#~ "U kunt niet terugkeren naar dit of een vorig scherm zodra de installatie "
-#~ "is gestart.\n"
+#~ "U kunt niet terugkeren naar dit of een vorig scherm zodra de installatie is "
+#~ "gestart.\n"
 #~ "\n"
 #~ "Weet u zeker dat u door wilt gaan?"
 
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Een volledige schijf gebruiken"
 
+#~ msgid ""
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Vereiste bootloaderpartitie\n"
+#~ "\n"
+#~ "GRUB zal geïnstalleerd worden op het MBR van de doelschijf.\n"
+#~ "\n"
+#~ "Echter, op een schijf met een GPT-partitietabel is geen ruimte achter het "
+#~ "MBR waar GRUB het tweede deel van core.img kwijt kan, dus is er een kleine, "
+#~ "ongeformatteerde partitie nodig aan het begin van de schijf. Deze zal geen "
+#~ "bestandssysteem hebben en zal niet zijn aangekoppeld, en kan niet worden "
+#~ "bewerkt."
+
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Kies de schijf waarnaar geïnstalleerd moet worden:"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Wijzig IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Wijzig Wifi"
+
+#~ msgid "Info"
+#~ msgstr "Informatie"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Er is iets fout gegaan"

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,120 +7,464 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-04-19 12:05+0000\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2020-04-19 12:03+0000\n"
 "Last-Translator: Quentin PAGÈS <Unknown>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: \n"
 
-#: ../subiquitycore/controllers/network.py:297
-msgid "autoconfiguration failed"
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
 msgstr ""
 
-#. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
-msgctxt "NetDevAction"
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr "òc"
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr "non"
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
 msgid "Info"
-msgstr "Info"
+msgstr ""
 
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Modificar lo Wifi"
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
 
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Modificar IPv4"
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
 
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Modificar IPv6"
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
 
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "disc local"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "pas utilizat"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "utilizat"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr "Error de ret"
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "Error desconeguda"
+
+#: ../subiquitycore/controllers/network.py:202
+msgid "autoconfiguration failed"
+msgstr "la configuracion automatica a pas foncionat"
+
+#. Information about a network interface
 #: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
-msgid "Edit bond"
+msgid "Info"
 msgstr ""
 
 #: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
+msgid "Edit Wifi"
 msgstr ""
 
 #: ../subiquitycore/models/network.py:45
-#, fuzzy
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Suprimir"
-
-#: ../subiquitycore/ssh.py:50
-msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:59
+msgid "The host key fingerprints are:\n"
+msgstr "Las emprentas numericas de l’òste son :\n"
+
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
-msgstr ""
+msgstr ", o "
 
 #: ../subiquitycore/ui/form.py:367
 msgid " or "
-msgstr ""
+msgstr " o "
 
 #: ../subiquitycore/ui/form.py:371
 #, python-brace-format
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
-msgstr ""
+msgstr "Acabat"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Anullar"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Òc"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Non"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Tampar"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Enregistrar"
 
@@ -142,7 +486,7 @@ msgstr "Nom del servidor :"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:92
 msgid "IP addresses, comma separated"
-msgstr ""
+msgstr "Adreças IP, separadas per de virgulas"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:93
 msgid "Search domains:"
@@ -165,1121 +509,650 @@ msgstr ""
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
 msgid "Automatic (DHCP)"
-msgstr ""
+msgstr "Automatic (DHCP)"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:145
 msgid "Manual"
-msgstr ""
+msgstr "Manual"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:147
 msgid "Disabled"
-msgstr ""
+msgstr "Desactivat"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:165
 #, python-brace-format
 msgid "IPv{v} Method: "
-msgstr ""
+msgstr "Metòde IPv{v} : "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
-msgstr ""
+msgstr "Crear"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
-msgstr ""
+msgstr "ID VLAN :"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
-msgstr ""
+msgstr "Apondre una etiqueta VLAN"
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
-msgstr ""
+msgstr "Info per {device}"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
-msgstr ""
+msgstr "Nom :"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
-msgstr ""
+msgstr "Aparelhs : "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
-msgstr ""
+msgstr "Lo nom pòt pas èsser void"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
-msgid "Network connections"
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr "Causir una ret"
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "pas connectat"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "estatica"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "desactivat"
+
+#: ../subiquitycore/ui/views/network.py:212
+msgid "Network connections"
+msgstr "Connexions ret"
+
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
-msgstr ""
+msgstr "Precedent"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
-msgstr ""
+msgstr "Contunhar sens ret"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
+msgstr "Aplicacion dels cambiaments"
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
-msgstr ""
+msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
-msgstr ""
+msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
-msgstr ""
+msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "Autre"
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Modificar lo Wifi"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
+msgstr "Daissar desmontat"
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Suprimir"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr "Anullar mandadís"
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr "Tampar lo senhalament"
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Contunhar"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr "Reaviar l’installador"
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr "Enviar a Canonical"
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr "Enviat a Canonical"
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr "Veire lo senhalament complèt"
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr "DATE"
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr "TIPE"
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr "ESTATUS"
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr "VIST"
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr "PAS VIST"
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Suprimir"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
-msgstr ""
+msgstr "particions"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "TALHA"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "TIPE"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Desmontar"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "Cap de periferic pas disponible"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr "Cap de periferic pas utilizat"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "PERIFERIC"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "espaci liure"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "PERIFERICS DISPONIBLES"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr "PERIFERICS UTILIZATS"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Reïnicializar"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Los senhals correspondon pas"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1313,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1321,134 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "Validar"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Periferics :"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Talha :"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Nom : "
+
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Format :"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1472,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1622,576 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
-msgstr ""
+msgstr "tornar"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
-msgstr ""
+msgstr "F1"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
-msgstr ""
+msgstr "dobrir lo menú d’ajuda"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
-msgstr ""
+msgstr "Control-Z, F2"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
-msgstr ""
+msgstr "Control-L, F3"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
-msgstr ""
+msgstr "Control-T, F4"
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
-msgstr ""
+msgstr "Control-X"
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
-msgstr ""
+msgstr "Control-E"
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
-msgstr ""
+msgstr "Control-R"
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
-msgstr ""
+msgstr "Control-U"
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
-msgstr ""
+msgstr "A prepaus d’aqueste installador"
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Acorchis clavièr"
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
-msgstr ""
+msgstr "Ajuda"
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
+msgstr "A prepaus de l’installador"
+
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Vòstre nom :"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Nom de vòstre servidor :"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Lo nom qu'utiliza per comunicar amb d'autres ordenadors."
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Causissètz un nom d'utilizaire :"
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Causissètz un senhal :"
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Confirmar lo senhal :"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Lo nom del servidor pòt pas èsser void"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "senhals"
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
-msgid "Reboot Now"
-msgstr ""
-
 #: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
+msgid "Reboot Now"
+msgstr "Reaviar ara"
+
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Installacion del sistèma"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Installacion acabada !"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
-msgstr ""
+msgstr "Reaviada..."
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Una error s’es producha pendent l’installacion"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2202,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2214,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "Auto-deteccion del clavièr"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Disposicion"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr "Varianta"
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Quichatz sus una de las tòcas seguentas :"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Vòstre clavièr es dotat d'aquesa tòca ?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Verrolhatge majusculas"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Tòca Alt de drecha (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Ctrl Drecha"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Maj Drecha"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr "Tòca « lògo » de drecha"
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Tòca menú"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Maj"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Ctrl+Maj"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Ctrl + Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt + Verrolhatge Majuscula"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Ctrl esquèrra + Majuscula esquèrra"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Alt esquèrra"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Ctrl esquèrra"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Maj esquèrra"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr "Tòca « lògo » d'esquèrra"
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Arrèst desfil. (Scroll Lock)"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr "Acorchi : "
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Disposicion :"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr "Varianta :"
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "Configuracion del clavièr"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Aplicacion de la configuracion"
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "Adreça servidor miralh :"
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2224,17 +2120,17 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
-msgstr ""
+msgstr "Adreça proxy :"
 
 #: ../subiquity/ui/views/proxy.py:48
 msgid "Configure proxy"
-msgstr ""
+msgstr "Configuracion proxy"
 
 #: ../subiquity/ui/views/proxy.py:49
 msgid ""
@@ -2242,190 +2138,388 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Mesa a jorn de l’installador disponibla"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Telecargament de la mesa a jorn..."
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Tornar ensajar"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Anullar la mesa a jorn"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "ara meteis"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "minuta"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "minutas"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "ora"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "oras"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "jorn"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "jorns"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr "fa {amount:2} {unit}"
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "de Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "de Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr "Recuperacion de la clau SSH..."
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "Confirmar las claus SSH"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "Confirmar la clau SSH"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "Parametratge SSH"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
-
-#: ../subiquity/ui/views/error.py:72
-msgid ""
 "\n"
-"Sorry, there was a problem completing the installation.\n"
+"Causissètz la lenga d’utilizacion per l’installador e aquela configurada\n"
+"pel sistèma.\n"
+
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
+msgstr "Ajuda a la causida de la lenga"
+
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
-msgstr ""
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
+msgstr "automatic"
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
+msgstr "en linha"
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
+#: ../subiquity/ui/views/zdev.py:77
 msgid "No zdev devices found."
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:77
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr "ID"
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr "CONNECTAT"
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr "NOMS"
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr "Activar"
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr "Desactivar"
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
 
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
+#~ msgid "Edit IPv6"
+#~ msgstr "Modificar IPv6"
 
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr ""
+#~ msgid "Edit IPv4"
+#~ msgstr "Modificar IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Modificar lo Wifi"
+
+#~ msgid "Info"
+#~ msgstr "Info"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Lo camp deu èsser una URL %s."
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s existís ja"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Una error s'es producha"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Installacion acabada !"
+
+#~ msgid "Edit"
+#~ msgstr "Modificar"
+
+#~ msgid "Info for {}"
+#~ msgstr "Info per {}"
+
+#~ msgid "unknown state {}"
+#~ msgstr "estat desconegut {}"
+
+#~ msgid "Finished install!"
+#~ msgstr "Installacion acabada !"
+
+#~ msgid "Add Partition"
+#~ msgstr "Apondre particion"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Tirar de RAID/LVM"
+
+#~ msgid "Format"
+#~ msgstr "Format"
+
+#~ msgid "partition"
+#~ msgstr "particion"
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "Recuperacion de las info per {}"
+
+#~ msgid "Reboot"
+#~ msgstr "Reaviar"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,78 +7,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2018-04-21 11:39+0000\n"
+"Last-Translator: GTriderXC <gtriderxc@yahoo.com>\n"
 "Language-Team: Polish <pl@li.org>\n"
-"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: pl\n"
 
-#: ../subiquitycore/controllers/network.py:297
-msgid "autoconfiguration failed"
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
 msgstr ""
 
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr "Błąd sieci"
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr "Nieznany błąd"
+
+#: ../subiquitycore/controllers/network.py:202
+msgid "autoconfiguration failed"
+msgstr "autokonfiguracja nie powiodła się"
+
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Usuń"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Zakmnij"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -89,34 +417,55 @@ msgid " or "
 msgstr " lub "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "Pole musi mieć format %s URL"
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Wykonano"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Anuluj"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Tak"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Nie"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Zamknij"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Zapisz"
 
@@ -178,87 +527,133 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Utwórz"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "upłynął limit czasu"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Połączenia sieciowe"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -267,1017 +662,500 @@ msgstr ""
 "komunikować sie z siecią."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Wstecz"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Karta sieciowa {} konfiguracja WIFI"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Tak"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Nie"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Wystąpił błąd"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Instalacja ukończona!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Instalacja ukończona!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Instalacja systemu"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Instalacja ukończona!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Błąd podczas instalacji"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
-msgstr ""
+msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
-msgstr ""
+msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
+msgstr "10"
+
+#. Attempting to convert input to a size
+#: ../subiquity/models/filesystem.py:210
+msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
-msgid "input cannot be empty"
-msgstr "Nazwa serwera nie może być pusta"
-
-#. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Usuń"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Konfiguracja proxy"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "W tym polu niedozwolone są znaki: , oraz ="
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr "Dopuszczalne są znaki A-Z, 0-9, _ oraz -"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Twoje imię:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Nazwa serwera:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "Nazwa używana podczas komunikacji z innymi komputerami."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Wybierz nazwę użytkownika:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Ustaw hasło:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Potwierdź hasło:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Nazwa jest za długa, musi być < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Nazwa serwera nie może być pusta"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Nazwa serwera za długa, musi być < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr "Nazwa hosta może zawierać NAME_REGEX, np. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Brak nazwy użytkownika"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Nazwa użytkownika jest za długa, musi być < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr "Nazwa użytkownika może zawierać NAME_REGEX, np. [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Hasło musi być ustawione"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Hasła nie pasują do siebie"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Ustawienia profilu"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Kontynuuj"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr "Wyślij do Canonical"
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr "Wysłane do Canonical"
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr "Zobacz pełen raport"
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "OK"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Formatuj i/lub montuj {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
-msgstr ""
+msgstr "partycje"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Brak zamontowanych dysków i partycji"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "MOUNT POINT"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "Rozmiar"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "Typ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "Typ urządzenia"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Odmontuj"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "Urządzenie"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "dostępna przestrzeń"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "PODSUMOWANIE SYSTEMU PLIKÓW"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "DOSTĘPNE URZĄDZENIA"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Przywróć"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr "Hasło:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Hasło musi być ustawione"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Hasła nie pasują do siebie"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
-msgstr ""
+msgstr "Wykorzystaj cały dysk"
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
-msgstr ""
+msgstr "Własny układ partycji"
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1311,7 +1189,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1319,135 +1197,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "OK"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Urządzenia:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Rozmiar:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Utwórz zaszyfrowany wolumen"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Brak zamontowanych dysków i partycji"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "MOUNT POINT"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "Rozmiar"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "Typ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "Typ urządzenia"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "Urządzenie"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "dostępna przestrzeń"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Format:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "PODSUMOWANIE SYSTEMU PLIKÓW"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "DOSTĘPNE URZĄDZENIA"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Przywróć"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1470,100 +1502,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr ""
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "Poziom RAID:"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1620,581 +1595,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
-msgstr ""
+msgstr "Esc"
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
-msgstr ""
+msgstr "przejdź wstecz"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
-msgstr ""
+msgstr "F1"
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
-msgstr ""
+msgstr "Control-Z, F2"
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
-msgstr ""
+msgstr "przełącz do powłoki"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
-msgstr ""
+msgstr "Control-L, F3"
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
-msgstr ""
+msgstr "odśwież ekran"
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
-msgstr ""
+msgstr "Control-T, F4"
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
-msgstr ""
+msgstr "Control-X"
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
-msgstr ""
+msgstr "Control-E"
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
-msgstr ""
+msgstr "Control-R"
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Ctrl+Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
-msgstr ""
+msgstr "Control-U"
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
-msgstr ""
+msgstr "Skróty klawiszowe"
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
-msgstr ""
+msgstr "O instalatorze"
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Skróty klawiszowe"
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
-msgstr ""
+msgstr "Otwórz powłokę"
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
-msgstr ""
+msgstr "Pomoc na temat dostępu przez SSH"
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
-msgstr ""
+msgstr "Zobacz raporty błędów"
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
-msgstr ""
+msgstr "Pomoc"
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
-msgstr ""
+msgstr "O instalatorze"
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "W tym polu niedozwolone są znaki: , oraz ="
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Użyj strzałek GÓRA, DÓŁ aby wybrać język"
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
+msgstr "Dopuszczalne są znaki A-Z, 0-9, _ oraz -"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Twoje imię:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Import nazwy użytkownika:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Nazwa serwera:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "Nazwa użytkownika GitHub:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Nazwa używana podczas komunikacji z innymi komputerami."
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "Nazwa użytkownika GitHub:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Wybierz nazwę użytkownika:"
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Ustaw hasło:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Nazwa użytkownika Launchpad:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Potwierdź hasło:"
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Importuj tożsamość SSH:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "z GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "z Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Możesz importować klucze SSH z GitHub lub Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "To pole nie może pozostać puste"
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "Identyfikator SSH jest zbyt długi, musi być < "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Nazwa serwera nie może być pusta"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Brak nazwy użytkownika"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Kontynuuj"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Ustawienia profilu"
+
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr "Autodetekcja klawiatury"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "hasła"
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Autodetekcja klawiatury nie powiodła się"
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Układ"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Naciśnij jeden z klawiszy:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr "Nie rozpoznano wprowadzonego znaku. Spróbuj ponownie"
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "Czy ten znak występuje na klawiaturze?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Zapisywanie konfiguracji"
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Prawy Alt (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Prawy Ctrl"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Prawy Shift"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr "Prawy klawisz logo (Win)"
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr "Klawisz menu"
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Ctrl+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr "Ctrl+Alt"
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "Lewy Ctrl+Lewy Shift"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Lewy Alt"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Lewy Ctrl"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Lewy Shift"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr "Lewy klawisz logo (Win)"
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "Klawisz Scroll Lock"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr "Skrót: "
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr "Układ:"
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr "Konfiguracja klawiatury"
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-"Wybierz układ klawiatury jeśli jest podłączona bezpośrednio do systemu."
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-"Wybierz układ klawiatury z listy lub wykryj automatycznie, używając opcji "
-"\"Identyfikacja klawiatury\""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr "Identyfikacja klawiatury"
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
-msgstr ""
+msgstr "Postęp instalacji"
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Uruchom ponownie"
 
-#: ../subiquity/ui/views/installprogress.py:59
-msgid "View error report"
-msgstr ""
-
 #: ../subiquity/ui/views/installprogress.py:61
+msgid "View error report"
+msgstr "Zobacz raport błędu"
+
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr "Wyświetl pełny log"
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Instalacja systemu"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Instalacja ukończona!"
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
-msgstr ""
+msgstr "Anuluj i uruchom ponownie"
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Błąd podczas instalacji"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2205,11 +1923,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr "Potwierdź destrukcyjne działanie"
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2217,9 +1935,190 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "Autodetekcja klawiatury"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Układ"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr "Wariant"
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Naciśnij jeden z klawiszy:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr "Nie rozpoznano wprowadzonego znaku. Spróbuj ponownie"
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Czy ten znak występuje na klawiaturze?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Prawy Alt (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Prawy Ctrl"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Prawy Shift"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr "Prawy klawisz logo (Win)"
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr "Klawisz menu"
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Ctrl+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr "Ctrl+Alt"
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Lewy Ctrl+Lewy Shift"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Lewy Alt"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Lewy Ctrl"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Lewy Shift"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr "Lewy klawisz logo (Win)"
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Klawisz Scroll Lock"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr "Bez przełączania"
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr "Skrót: "
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr "Układ:"
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr "Wariant:"
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr "Konfiguracja klawiatury"
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+"Wybierz układ klawiatury jeśli jest podłączona bezpośrednio do systemu."
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+"Wybierz układ klawiatury z listy lub wykryj automatycznie, używając opcji "
+"\"Identyfikacja klawiatury\""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr "Identyfikacja klawiatury"
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Zapisywanie konfiguracji"
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2227,8 +2126,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2247,192 +2146,331 @@ msgstr ""
 "Jeśli ten system łączy się z Internetem za pośrednictwem proxy, podaj "
 "szczegóły połączenia."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr "Sprawdzanie aktualizacji do instalatora..."
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Dostępna aktualizacja instalatora"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Pobieranie aktualizacji..."
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr "Aktualizacja nie powiodła się"
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr "Pobieranie i instalowanie aktualizacji:"
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Kontynuuj bez aktualizacji"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Spróbuj ponownie"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Import nazwy użytkownika:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Nazwa użytkownika Github:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Nazwa użytkownika Launchpad:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr "Zainstaluj serwer SSH"
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Importuj tożsamość SSH:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "z Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "z Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Możesz importować klucze SSH z Github lub Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr "Pozwól na używanie haseł przez SSH"
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "To pole nie może pozostać puste"
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "Identyfikator SSH jest zbyt długi, musi być < "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr "Pobieranie kluczy SSH..."
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr "Potwierdź klucze SSH"
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr "Potwierdź klucz SSH"
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr "Ustawienia SSH"
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Użyj strzałek GÓRA, DÓŁ aby wybrać język"
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""
 
 #~ msgid "Filesystem setup"
@@ -2447,8 +2485,17 @@ msgstr ""
 #~ msgid "Choose the installation target"
 #~ msgstr "Wybierz docelowe medium instalacji"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Formatuj i/lub montuj {}"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Dziekujemy za używanie Ubuntu!"
+
+#~ msgid "Finished install!"
+#~ msgstr "Instalacja ukończona!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Instalacja ukończona!"
 
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Zgłoś ten błąd poprzez Launchpad"
@@ -2456,12 +2503,24 @@ msgstr ""
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Wybierz dysk do instalacji:"
 
+#~ msgid "Server name too long, must be < "
+#~ msgstr "Nazwa serwera za długa, musi być < "
+
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr ""
 #~ "Wybierz intefjesf aby go skonfigurować lub wybierz Wykonano aby kontnuować"
 
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Nazwa jest za długa, musi być < "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "Nazwa użytkownika jest za długa, musi być < "
+
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Użyj całego dysku"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Wystąpił błąd"
 
 #~ msgid "Install complete"
 #~ msgstr "Instalacja zakończona"
@@ -2472,9 +2531,34 @@ msgstr ""
 #~ msgid "starting..."
 #~ msgstr "uruchamianie..."
 
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Karta sieciowa {} konfiguracja WIFI"
+
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr ""
 #~ "Aby wybrać klawiaturę, użyj klawiszy ze strzałkami w górę, dół oraz Enter."
 
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Pole musi mieć format %s URL"
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "Nazwa użytkownika może zawierać NAME_REGEX, np. [a-z_][a-z0-9_-]*"
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "Nazwa hosta może zawierać NAME_REGEX, np. [a-z_][a-z0-9_-]*"
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Autodetekcja klawiatury nie powiodła się"
+
 #~ msgid "Exit To Shell"
 #~ msgstr "Exit do Shell"
+
+#~ msgid "partition"
+#~ msgstr "partycja"
+
+#~ msgid "Passphrases"
+#~ msgstr "Hasła"
+
+#~ msgid "Reboot"
+#~ msgstr "Uruchom ponownie"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,23 +1,22 @@
-# Latvian translation for subiquity
-# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
+# Portuguese translation for subiquity
+# Copyright (c) 2021 Rosetta Contributors and Canonical Ltd 2021
 # This file is distributed under the same license as the subiquity package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2021-06-04 13:18+1200\n"
-"PO-Revision-Date: 2017-09-17 14:15+0000\n"
-"Last-Translator: Dimitri John Ledkov <dimitri.ledkov+lp@canonical.com>\n"
-"Language-Team: Latvian <lv@li.org>\n"
+"PO-Revision-Date: 2021-08-12 14:49+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Portuguese <pt@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2;\n"
-"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
-"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
-"Language: lv\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-08-13 06:30+0000\n"
+"X-Generator: Launchpad (build 70eb0c507aa7f0d883a0543623f177d263f0dd82)\n"
 
 #: ../subiquity/client/client.py:70
 msgid ""
@@ -358,7 +357,7 @@ msgstr ""
 
 #: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
-msgstr ""
+msgstr "configuração automática falhou"
 
 #. Information about a network interface
 #: ../subiquitycore/models/network.py:43
@@ -398,7 +397,7 @@ msgstr ""
 
 #: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
-msgstr ""
+msgstr "As impressões digitais da chave do hospede são:\n"
 
 #: ../subiquitycore/ssh.py:66
 #, python-brace-format
@@ -409,11 +408,11 @@ msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
-msgstr ""
+msgstr ", ou "
 
 #: ../subiquitycore/ui/form.py:367
 msgid " or "
-msgstr ""
+msgstr " ou "
 
 #: ../subiquitycore/ui/form.py:371
 #, python-brace-format
@@ -424,7 +423,7 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/filesystem.py:494
 #: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
-msgstr "Gatavs"
+msgstr "Concluído"
 
 #: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
@@ -433,19 +432,19 @@ msgstr "Gatavs"
 #: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
 #: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
-msgstr "Atcelt"
+msgstr "Cancelar"
 
 #: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
 #: ../subiquity/ui/views/ssh.py:185
 msgid "Yes"
-msgstr "Jā"
+msgstr ""
 
 #: ../subiquitycore/ui/interactive.py:109
 #: ../subiquity/ui/views/installprogress.py:247
 #: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
 #: ../subiquity/ui/views/ssh.py:186
 msgid "No"
-msgstr "Nē"
+msgstr ""
 
 #: ../subiquitycore/ui/utils.py:349
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
@@ -455,7 +454,7 @@ msgstr "Nē"
 #: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
 #: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
 msgid "Close"
-msgstr "Aizvērt"
+msgstr "Fechar"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
@@ -466,23 +465,23 @@ msgstr "Aizvērt"
 #: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
 msgid "Save"
-msgstr "Saglabāt"
+msgstr "Guardar"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:88
 msgid "Subnet:"
-msgstr ""
+msgstr "Subnet:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:89
 msgid "Address:"
-msgstr "Adrese:"
+msgstr "Endereço:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:90
 msgid "Gateway:"
-msgstr "Vārteja:"
+msgstr "Gateway:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:91
 msgid "Name servers:"
-msgstr ""
+msgstr "Nomear de servidores:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:92
 msgid "IP addresses, comma separated"
@@ -490,7 +489,7 @@ msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:93
 msgid "Search domains:"
-msgstr ""
+msgstr "Procurar em domínios:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:94
 msgid "Domains, comma separated"
@@ -499,7 +498,7 @@ msgstr ""
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
 #, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr ""
+msgstr "dever ser no CIDR forma ({example})"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
 #, python-brace-format
@@ -509,22 +508,22 @@ msgstr ""
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
 msgid "Automatic (DHCP)"
-msgstr ""
+msgstr "Automático (DHCP)"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:145
 msgid "Manual"
-msgstr "Manuālā"
+msgstr "Manual"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:147
 msgid "Disabled"
-msgstr ""
+msgstr "Desativado"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:165
 #, python-brace-format
 msgid "IPv{v} Method: "
-msgstr ""
+msgstr "Método IPv{v}: "
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
@@ -532,15 +531,15 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
 msgid "Create"
-msgstr ""
+msgstr "Criar"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
-msgstr ""
+msgstr "ID VLAN:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
-msgstr ""
+msgstr "O ID VLAN tem de ser entre 1 e 4095"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
@@ -556,29 +555,29 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
-msgstr ""
+msgstr "Info para {device}"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
 #: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
 msgid "Name:"
-msgstr ""
+msgstr "Nome:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
-msgstr ""
+msgstr "Dispositivos: "
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
-msgstr ""
+msgstr "Modo de vinculação:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
-msgstr ""
+msgstr "Política de hash XMIT:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
-msgstr ""
+msgstr "velocidade LACP:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
@@ -600,7 +599,7 @@ msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
-msgstr ""
+msgstr "Editar vínculo"
 
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
 msgid "Select a network"
@@ -671,7 +670,7 @@ msgstr ""
 #: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
 #: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
-msgstr "Atpakaļ"
+msgstr ""
 
 #: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
@@ -842,7 +841,7 @@ msgstr ""
 #: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
 #: ../subiquity/ui/views/zdev.py:162
 msgid "Continue"
-msgstr "Turpināt"
+msgstr ""
 
 #: ../subiquity/ui/views/error.py:160
 #: ../subiquity/ui/views/installprogress.py:282
@@ -961,7 +960,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
-msgstr ""
+msgstr "Apagar"
 
 #: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
@@ -1110,7 +1109,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:498
 msgid "Reset"
-msgstr "Atstatīt"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
@@ -1134,7 +1133,7 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/guided.py:67
 #: ../subiquity/ui/views/identity.py:141
 msgid "Passwords do not match"
-msgstr "Paroles nesakrīt"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
@@ -1781,7 +1780,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:89
 msgid "Your name:"
-msgstr "Jūsu vārds:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:91
 msgid "Your server's name:"
@@ -1789,19 +1788,19 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:92
 msgid "The name it uses when it talks to other computers."
-msgstr "Šo nosaukumu izmanto saziņā ar citiem datoriem."
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:93
 msgid "Pick a username:"
-msgstr "Izvēlieties lietotājvārdu:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:94
 msgid "Choose a password:"
-msgstr "Izvēlieties paroli:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:95
 msgid "Confirm your password:"
-msgstr "Apstipriniet paroli:"
+msgstr ""
 
 #: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
@@ -1888,7 +1887,7 @@ msgstr ""
 #: ../subiquity/ui/views/installprogress.py:151
 #: ../subiquity/ui/views/installprogress.py:154
 msgid "Installing system"
-msgstr "Instalēju sistēmu"
+msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:157
 #: ../subiquity/ui/views/installprogress.py:165
@@ -2464,3 +2463,27 @@ msgstr ""
 #: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Editar Wifi"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "Editar IPv6"
+
+#~ msgid "Info"
+#~ msgstr "Info"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Editar IPv4"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "Campo tem de ser um %s URL."
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "'%s' não contem em '%s'"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s já existe"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,82 +7,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2020-02-19 11:54+0000\n"
-"Last-Translator: Eugene Roskin <Unknown>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2019-05-22 15:21+0000\n"
+"Last-Translator: Dimitri John Ledkov <dimitri.ledkov+lp@canonical.com>\n"
 "Language-Team: Russian <ru@li.org>\n"
-"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: ru\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "локальный диск"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "ошибка автоматического конфигурирования"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Info"
-msgstr "Информация"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Изменить Wifi"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Изменить IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Изменить IPv6"
-
 #: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
-msgid "Edit bond"
+msgid "Info"
 msgstr ""
 
 #: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
-msgid "Add a VLAN tag"
+msgid "Edit Wifi"
 msgstr ""
 
 #: ../subiquitycore/models/network.py:45
-#, fuzzy
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
+msgctxt "NetDevAction"
+msgid "Add a VLAN tag"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Удалить"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Закрыть"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -97,30 +421,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Готово"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Отменить"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Да"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Нет"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Закрыть"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Сохранить"
 
@@ -182,1113 +527,633 @@ msgstr "Выключено"
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Создать"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s уже существует"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Имя:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Устройства: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
+#, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr "Сетевое устройство с наименованием \"{}\" уже существует"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "Имя не может быть пустым"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr "Наименование не может превышать 16 символов"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "не соединено"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "время ожидания истекло"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "статический"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "отключено"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "Сетевые соединения"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Назад"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr "Продолжить без сети"
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "Применение изменений"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr "не соединено"
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "время ожидания истекло"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "статический"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr "отключено"
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Да"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Нет"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Произошла ошибка"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Установка завершена!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Установка системы"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Обнаружена ошибка во время установки"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Имя не может быть пустым"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Информация"
-
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Изменить Wifi"
-
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Формат:"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "Добавить раздел"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "Создать логический том"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Формат:"
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Удалить"
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "локальный диск"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Настроить прокси-сервер"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "ошибка автоматического конфигурирования"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-#, fuzzy
-msgid "logical"
-msgstr "логический том"
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "раздел"
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "раздел"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "логический том"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Ваше имя:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "Имя, используемое при связи с другими компьютерами."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Введите имя пользователя:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Задайте пароль:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Подтвердите пароль:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Наименование сервера, не должно быть не заполнено"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Наименование сервера, не должно быть не заполнено"
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Отсутствует имя пользователя"
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Пароли не совпадают"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Продолжить"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Устройствa:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Размер:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, fuzzy, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr "Сетевое устройство с наименованием \"{}\" уже существует"
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Наименование: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "Формат:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr "Наименование логического тома, не может быть не заполнено"
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, fuzzy, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr "Наименование логического тома, не может быть не заполнено"
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, fuzzy, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr "Наименование логического тома, не может быть не заполнено"
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, fuzzy, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr "Сетевое устройство с наименованием \"{}\" уже существует"
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "OK"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr "Использовать существующую файловую систему FAT32"
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, fuzzy, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr "логический том {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr "Вы действительно хотите удалить {desc} {label}?"
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:65
+#, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
-msgstr[0] "логический том"
-msgstr[1] "логический том"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr "Не отформатирован или не подключён."
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
-#, fuzzy, python-brace-format
+#: ../subiquity/ui/views/filesystem/delete.py:116
+#, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
-msgstr "Вы действительно хотите удалить существующую файловую систему на {}?"
-
-#: ../subiquity/ui/views/filesystem/delete.py:132
-msgid "logical volumes"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/delete.py:134
+msgid "logical volumes"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "разделы"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
-#, fuzzy, python-brace-format
-msgid "There is already a volume group named '{name}'"
-msgstr "Сетевое устройство с наименованием \"{}\" уже существует"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Отсутствуют подключённые диски или разделы."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr "Нет доступных устройств"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
+#, python-brace-format
+msgid "Remove from {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Сбросить"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Пароли не совпадают"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1322,7 +1187,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1330,136 +1195,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "OK"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Устройствa:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Размер:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Отсутствуют подключённые диски или разделы."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr "Нет доступных устройств"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "Добавить раздел"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Наименование: "
+
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Формат:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr "Наименование логического тома, не может быть не заполнено"
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-#, fuzzy
-msgid "To continue you need to:"
-msgstr "Продолжить без сети"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Сбросить"
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr "Использовать существующую файловую систему FAT32"
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1482,100 +1500,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
-msgstr "Проверка обновлений программы установки..."
-
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "Доступно обновление программы установки"
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "Скачивание обновления..."
-
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
-msgstr "Ошибка обновления"
-
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr "Скачивание и применение обновления:"
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "Продолжить без обновления"
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Повторите снова"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "Отменить обновление"
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1632,580 +1593,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Левый Ctrl"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Ваше имя:"
+
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Имя, используемое при связи с другими компьютерами."
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Введите имя пользователя:"
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Задайте пароль:"
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Подтвердите пароль:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Наименование сервера, не должно быть не заполнено"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Отсутствует имя пользователя"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Продолжить"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
-msgstr "Автоматическое определение клавиатуры"
-
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-"Будет выполнено определение клавиатуры. Вам будут задано несколько вопросов "
-"о вашей клавиатуре. Нажмите ESC в любое время, чтобы вернуться на предыдущий "
-"экран."
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Ошибка автоматического определения клавиатуры"
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr "Раскладка"
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr "Пожалуйста, нажмите одну из следующих клавиш:"
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr "Присутствует ли эта клавиша на клавиатуре?"
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr "Правый Alt (AltGr)"
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr "Правый Ctrl"
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr "Правый Shift"
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr "Alt+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr "Control+Shift"
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr "Alt+Caps Lock"
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr "Левый Control+левый Shift"
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr "Левый Alt"
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr "Левый Ctrl"
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr "Левый Shift"
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr "Клавиша Scroll Lock"
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr "Перезагрузить сейчас"
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Установка системы"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Перезагрузить"
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr "Перезагрузка..."
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Обнаружена ошибка во время установки"
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2216,11 +1921,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2228,9 +1933,190 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr "Автоматическое определение клавиатуры"
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+"Будет выполнено определение клавиатуры. Вам будут задано несколько вопросов "
+"о вашей клавиатуре. Нажмите ESC в любое время, чтобы вернуться на предыдущий "
+"экран."
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr "Раскладка"
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr "Пожалуйста, нажмите одну из следующих клавиш:"
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr "Присутствует ли эта клавиша на клавиатуре?"
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr "Правый Alt (AltGr)"
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr "Правый Ctrl"
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr "Правый Shift"
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr "Alt+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr "Control+Shift"
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr "Alt+Caps Lock"
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr "Левый Control+левый Shift"
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr "Левый Alt"
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr "Левый Ctrl"
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr "Левый Shift"
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr "Клавиша Scroll Lock"
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2238,8 +2124,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2258,190 +2144,378 @@ msgstr ""
 "Если системе требуется прокси-сервер, для выход в интернет, тогда введите "
 "соответствующие сведения здесь."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr "Проверка обновлений программы установки..."
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Доступно обновление программы установки"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Скачивание обновления..."
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr "Ошибка обновления"
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr "Скачивание и применение обновления:"
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Продолжить без обновления"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Повторите снова"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Отменить обновление"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
 
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
+#~ msgid "An error has occurred"
+#~ msgstr "Произошла ошибка"
 
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr ""
+#~ msgid "Info"
+#~ msgstr "Информация"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "Изменить IPv6"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Изменить IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Изменить Wifi"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Установка завершена!"
+
+#~ msgid "There is already a network device named \"{}\""
+#~ msgstr "Сетевое устройство с наименованием \"{}\" уже существует"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s уже существует"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Создать логический том"
+
+#~ msgid "Add Partition"
+#~ msgstr "Добавить раздел"
+
+#~ msgid "logical volume"
+#~ msgstr "логический том"
+
+#~ msgid "partition"
+#~ msgstr "раздел"
+
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "Вы действительно хотите удалить существующую файловую систему на {}?"
+
+#~ msgid "logical volume {}"
+#~ msgstr "логический том {}"
+
+#~ msgid "Reboot"
+#~ msgstr "Перезагрузить"
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Ошибка автоматического определения клавиатуры"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,76 +7,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
 "PO-Revision-Date: 2020-03-22 13:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Serbian <sr@li.org>\n"
-"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: sr\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
@@ -92,30 +421,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr ""
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr ""
 
@@ -177,1101 +527,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1305,7 +1187,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1313,134 +1195,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1464,100 +1500,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1614,576 +1593,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2194,11 +1921,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2206,9 +1933,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2216,8 +2121,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2234,190 +2139,329 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,76 +7,404 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
 "PO-Revision-Date: 2019-12-18 11:26+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish <sv@li.org>\n"
-"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: sv\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
@@ -92,30 +420,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr ""
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr ""
 
@@ -177,1101 +526,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1305,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1313,134 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1464,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1614,576 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2194,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2206,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2216,8 +2120,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2234,190 +2138,329 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,83 +7,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
-"PO-Revision-Date: 2019-07-01 14:11+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
+"PO-Revision-Date: 2018-04-20 15:50+0000\n"
+"Last-Translator: Yuri Chornoivan <yurchor@gmail.com>\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
-"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: uk\n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr "наявний"
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr "новий"
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr "локальний диск"
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr "не змонтовано"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr "не використовується"
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr "використовується"
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr "помилка автоконфігурації"
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
-#, fuzzy
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
-msgstr "Інформація"
-
-#: ../subiquitycore/models/network.py:40
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit Wifi"
-msgstr "Редагувати Wifi"
-
-#: ../subiquitycore/models/network.py:41
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv4"
-msgstr "Редагувати IPv4"
-
-#: ../subiquitycore/models/network.py:42
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit IPv6"
-msgstr "Редагувати IPv6"
-
-#: ../subiquitycore/models/network.py:43
-#, fuzzy
-msgctxt "NetDevAction"
-msgid "Edit bond"
-msgstr "Зміни"
+msgstr ""
 
 #: ../subiquitycore/models/network.py:44
+msgctxt "NetDevAction"
+msgid "Edit Wifi"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:45
+msgctxt "NetDevAction"
+msgid "Edit IPv4"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:46
+msgctxt "NetDevAction"
+msgid "Edit IPv6"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:47
+msgctxt "NetDevAction"
+msgid "Edit bond"
+msgstr ""
+
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
-#, fuzzy
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
-msgstr "Вилучити"
+msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
 msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
-msgstr "Закрити"
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
@@ -94,34 +417,55 @@ msgid " or "
 msgstr " або "
 
 #: ../subiquitycore/ui/form.py:371
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "This field must be a {schemes} URL."
-msgstr "У цьому полі має бути адреса %s."
+msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr "Виконано"
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
 msgstr "Скасувати"
 
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr "Так"
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr "Ні"
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
+msgstr "Закрити"
+
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr "Зберегти"
 
@@ -159,9 +503,9 @@ msgid "should be in CIDR form ({example})"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "'{address}' is not contained in '{subnet}'"
-msgstr "«%s» не міститься у «%s»"
+msgstr ""
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
@@ -183,87 +527,133 @@ msgstr "Вимкнено"
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr "Створити"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr "VLAN ID:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
-#, fuzzy, python-brace-format
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#, python-brace-format
 msgid "{netdev} already exists"
-msgstr "%s вже існує"
+msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr "Ім'я:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr "Пристрої: "
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr "Режим зв'язку:"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr "Назва не може бути поржня"
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr "не з’єднано"
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr "вийшов час очікування"
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr "статична"
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr "вимкнено"
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr "З'єднання із мережею"
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
@@ -273,1041 +663,500 @@ msgstr ""
 "достатній доступ для отримання оновлень."
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr "Назад"
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr "Застосування змін"
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr "не з’єднано"
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr "вийшов час очікування"
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr "статична"
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr "вимкнено"
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-#, fuzzy
-msgid "Select a network"
-msgstr "Виберіть перемикач розкладок"
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, fuzzy, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr "Налаштовування інтерфейсу мережі WIFI {}"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr "Так"
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr "Ні"
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr "Сталася помилка"
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr "Встановлення завершено!"
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr "Встановлення завершено!"
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr "Встановлюємо систему"
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr "Встановлення завершено!"
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr "Під час спроби встановлення сталася помилка"
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr "5"
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr "6"
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr "10"
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
-#, fuzzy
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
-msgstr "Назва не може бути поржня"
+msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
-#, fuzzy
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
-msgstr "{!r} не є коректними вхідними даними"
-
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Info"
-msgstr "Інформація"
-
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Edit"
-msgstr "Зміни"
-
-#: ../subiquity/models/filesystem.py:420
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr "Формат"
-
-#: ../subiquity/models/filesystem.py:421
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr "Додати розділ"
-
-#: ../subiquity/models/filesystem.py:422
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr "Створити логічний том"
-
-#: ../subiquity/models/filesystem.py:423
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr "Формат"
-
-#: ../subiquity/models/filesystem.py:424
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr "Вилучити з RAID / LVM"
-
-#: ../subiquity/models/filesystem.py:425
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr "Вилучити"
-
-#: ../subiquity/models/filesystem.py:426
-#, fuzzy
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr "Зробити завантажувальний пристрій"
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
+msgstr "Інше"
+
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr "наявний"
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr "новий"
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr "не змонтовано"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr "не використовується"
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr "використовується"
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr "локальний диск"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-#, fuzzy
-msgid "configured"
-msgstr "Налаштувати проксі"
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-#, fuzzy
-msgid "unconfigured"
-msgstr "помилка автоконфігурації"
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-#, fuzzy
-msgid "unused ESP"
-msgstr "не використовується"
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, fuzzy, python-brace-format
-msgid "partition of {device}"
-msgstr "розділ {}"
-
-#: ../subiquity/models/filesystem.py:955
-#, fuzzy, python-brace-format
-msgid "partition {number} of {device}"
-msgstr "розділ {} з {}"
-
-#: ../subiquity/models/filesystem.py:960
-#, fuzzy, python-brace-format
-msgid "partition {number}"
-msgstr "розділ {}"
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-#, fuzzy
-msgid "LVM logical volume"
-msgstr "Створити логічний том"
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr "Не можна використовувати у цьому полі символи «:», «,» і «=»"
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr "У цьому полі можна використовувати лише символи a-z, 0-9, _ та -"
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr "Ваше ім'я:"
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr "Назва вашого сервера:"
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr "Назва, яка використовується для зв'язку з іншими комп'ютерами."
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr "Вкажіть ім'я користувача:"
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr "Виберіть пароль:"
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr "Підтвердження пароля:"
-
-#: ../subiquity/ui/views/identity.py:95
-#, fuzzy, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr "Надто довге справжнє ім'я, має бути < "
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr "Назва сервера не може бути порожньою"
-
-#: ../subiquity/ui/views/identity.py:104
-#, fuzzy, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr "Надто довга назва сервера, має бути < "
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr "Назва вузла має відповідати взірцю NAME_REGEX, тобто [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr "Не вказано імені користувача"
-
-#: ../subiquity/ui/views/identity.py:117
-#, fuzzy, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr "Надто довге ім'я користувача, має бути < "
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-"Ім'я користувача має відповідати взірцю NAME_REGEX, тобто [a-z_][a-z0-9_-]*"
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr "Слід встановити пароль"
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr "Паролі не збігаються"
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr "Налаштування профілю"
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
-msgstr "паролі"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr "Продовжити"
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr "Рівень RAID:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr "Пристрої:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr "Розмір:"
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr "Ім’я: "
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr "Формат:"
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr "Шлях перевищує PATH_MAX"
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, fuzzy, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-"Потрібен розділ для завантажувача\n"
-"\n"
-"GRUB буде встановлено до MBR диска призначення.\n"
-"\n"
-"Втім, на диску із таблицею розділів GPT недостаньо місця після MBR для того, "
-"щоб GRUB між зберігати core.img другого етапу завантаження. Отже, потрібен "
-"невеличкий неформатований розділ на початку диска. На ньому не буде файлової "
-"системи, його не буде змонтовано, і його пункту не буде у списку для "
-"редагування на цій сторінці."
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr "Гаразд"
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, fuzzy, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr "розділ {} з {}"
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, fuzzy, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr "Форматувати і/або змонтувати {}"
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr "Вилучити"
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr "розділи"
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-#, fuzzy
-msgid "passphrases"
-msgstr "Парольна фраза:"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr "Створити зашифрований том"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr "Парольна фраза:"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr "Схвалити пароль:"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
+msgstr "Дисків чи розділів не змонтовано."
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
+msgstr "ТОЧКА МОНТУВАННЯ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
+msgstr "РОЗМІР"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr "ТИП"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr "ТИП ПРИСТРОЮ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr "Розмонтувати"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
-msgstr "Паролі не збігаються"
-
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr "ПРИСТРІЙ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr "вільне місце"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr "РЕЗЮМЕ ФАЙЛОВОЇ СИСТЕМИ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr "ДОСТУПНІ ПРИСТРОЇ"
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr "Скинути"
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr "Парольна фраза:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr "Схвалити пароль:"
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr "Слід встановити пароль"
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr "Паролі не збігаються"
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1341,7 +1190,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1349,137 +1198,289 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr "Гаразд"
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
-#, fuzzy, python-brace-format
-msgid "existing {fstype}"
-msgstr "наявний"
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr "Пристрої:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr "Розмір:"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr "Створити зашифрований том"
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "new {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
-msgstr "Дисків чи розділів не змонтовано."
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
-msgstr "ТОЧКА МОНТУВАННЯ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
-msgstr "РОЗМІР"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr "ТИП"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr "ТИП ПРИСТРОЮ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr "Розмонтувати"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:119
+#, python-brace-format
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
-#, fuzzy, python-brace-format
-msgid "Remove from {device}"
-msgstr "Вилучити з RAID / LVM"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
+msgstr "Паролі не збігаються"
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
-#, fuzzy, python-brace-format
-msgid "Add {ptype} Partition"
-msgstr "Додати розділ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-#, fuzzy
-msgid "Add As Another Boot Device"
-msgstr "Зробити завантажувальний пристрій"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-#, fuzzy
-msgid "Use As Boot Device"
-msgstr "Зробити завантажувальний пристрій"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
-msgstr "ПРИСТРІЙ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
-msgstr "вільне місце"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/lvm.py:157
+#, python-brace-format
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:79
+#, python-brace-format
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
-msgstr "РЕЗЮМЕ ФАЙЛОВОЇ СИСТЕМИ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
-msgstr "ДОСТУПНІ ПРИСТРОЇ"
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
-msgstr "Скинути"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
+msgstr "Ім’я: "
+
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
+msgstr "Формат:"
+
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr "Шлях перевищує PATH_MAX"
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
+msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
@@ -1502,100 +1503,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
-msgstr ""
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
+msgstr "Рівень RAID:"
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr "Доступне оновлення встановлювача"
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
-msgstr "Завантаження оновлення ..."
-
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr "Продовжувати без оновлення"
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr "Повторити спробу"
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr "Оновлення до нового встановлювача"
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr "Скасувати оновлення"
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr "Адреса дзеркала:"
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr "Налаштувати дзеркало архіву Ubuntu"
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1652,389 +1596,351 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr "Ctrl+Alt"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
-#, fuzzy
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr "Оновлення до нового встановлювача"
+msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
+msgstr "Не можна використовувати у цьому полі символи «:», «,» і «=»"
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr "Скористайтеся клавішами ↑, ↓ та ENTER для вибору мови."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
+msgstr "У цьому полі можна використовувати лише символи a-z, 0-9, _ та -"
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
-msgstr ""
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
+msgstr "Ваше ім'я:"
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
-msgstr "Користувач імпортування:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
+msgstr "Назва вашого сервера:"
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
-msgstr "Користувач github:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
+msgstr "Назва, яка використовується для зв'язку з іншими комп'ютерами."
 
-#: ../subiquity/ui/views/ssh.py:74
-#, fuzzy
-msgid "Enter your GitHub username."
-msgstr "Користувач github:"
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
+msgstr "Вкажіть ім'я користувача:"
 
-#: ../subiquity/ui/views/ssh.py:76
-#, fuzzy
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
-msgstr ""
-"Ім'я користувача GitHub може складатися лише літер, цифр та одинарних "
-"дефісів і не може починатися або завершуватися дефісом."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
+msgstr "Виберіть пароль:"
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
-msgstr "Користувач Launchpad:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
+msgstr "Підтвердження пароля:"
 
-#: ../subiquity/ui/views/ssh.py:83
-#, fuzzy
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-"Ім'я користувача GitHub може складатися лише літер, цифр та одинарних "
-"дефісів і не може починатися або завершуватися дефісом."
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr "Імпортувати профіль SSH:"
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr "з GitHub"
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr "з Launchpad"
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr "Ви можете імпортувати ваші ключі SSH з GitHub або Launchpad."
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr "Це поле не може бути порожнім."
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr "Надто довгий ідентифікатор SSH, має бути < "
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-"Ім'я користувача GitHub може складатися лише літер, цифр та одинарних "
-"дефісів і не може починатися або завершуватися дефісом."
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr "щойно"
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr "хвилина"
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr "хвилин(и)"
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr "година"
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr "годин(и)"
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr "день"
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr "дні(в)"
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
-msgstr ""
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
+msgstr "Назва сервера не може бути порожньою"
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr "Не вказано імені користувача"
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
+msgstr ""
+
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
+msgstr "Налаштування профілю"
+
+#: ../subiquity/ui/views/identity.py:159
+msgid ""
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
+msgstr "паролі"
+
+#: ../subiquity/ui/views/installprogress.py:52
+msgid "Install progress"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
+msgid "Reboot Now"
+msgstr "Перезавантажити"
+
+#: ../subiquity/ui/views/installprogress.py:61
+msgid "View error report"
+msgstr ""
+
 #: ../subiquity/ui/views/installprogress.py:63
+msgid "View full log"
+msgstr "Переглянути увесь журнал"
+
+#: ../subiquity/ui/views/installprogress.py:79
+msgid "Full installer output"
+msgstr "Усі дані, які виведено засобом встановлення"
+
+#: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr "Встановлюємо систему"
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr "Встановлення завершено!"
+
+#: ../subiquity/ui/views/installprogress.py:159
+msgid "Cancel update and reboot"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:166
 #: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
-msgstr "Продовжити"
-
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
-msgstr ""
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr "Під час спроби встановлення сталася помилка"
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Selecting Continue below will begin the installation process and\n"
+"result in the loss of data on the disks selected to be formatted.\n"
+"\n"
+"You will not be able to return to this or a previous screen once\n"
+"the installation has started.\n"
+"\n"
+"Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
+#: ../subiquity/ui/views/installprogress.py:251
+msgid "Confirm destructive action"
+msgstr "Підтвердження руйнівної дії"
+
+#: ../subiquity/ui/views/installprogress.py:271
+#, python-brace-format
+msgid ""
+"The installer running on {tty} is currently installing the system.\n"
+"\n"
+"You can wait for this to complete or switch to a shell.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:67
 msgid "Keyboard auto-detection"
 msgstr "Автовизначення клавіатури"
 
-#: ../subiquity/ui/views/keyboard.py:90
+#: ../subiquity/ui/views/keyboard.py:93
 msgid ""
 "Keyboard detection starting. You will be asked a series of questions about "
 "your keyboard. Press escape at any time to go back to the previous screen."
@@ -2043,11 +1949,7 @@ msgstr ""
 "вашої клавіатури. Ви можете будь-коли натиснути клавішу Esc, щоб повернутися "
 "до попередньої сторінки."
 
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr "Не вдалося автоматично визначити клавіатуру, вибачте"
-
-#: ../subiquity/ui/views/keyboard.py:116
+#: ../subiquity/ui/views/keyboard.py:106
 msgid ""
 "Keyboard auto detection completed.\n"
 "\n"
@@ -2057,7 +1959,7 @@ msgstr ""
 "\n"
 "Виявлено таку клавіатуру:\n"
 
-#: ../subiquity/ui/views/keyboard.py:121
+#: ../subiquity/ui/views/keyboard.py:111
 msgid ""
 "\n"
 "If this is correct, select Done on the next screen. If not you can select "
@@ -2070,38 +1972,34 @@ msgstr ""
 "автоматичного визначення.\n"
 "\n"
 
-#: ../subiquity/ui/views/keyboard.py:135
+#: ../subiquity/ui/views/keyboard.py:128
 msgid "Layout"
 msgstr "Розкладка"
 
-#: ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:129
 msgid "Variant"
 msgstr "Варіант"
 
-#: ../subiquity/ui/views/keyboard.py:161
+#: ../subiquity/ui/views/keyboard.py:152
 msgid "Please press one of the following keys:"
 msgstr "Будь ласка, натисніть одну з таких клавіш:"
 
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
 msgid "Input was not recognized, try again"
 msgstr "Не розпізнано введені дані, повторіть спробу"
 
-#: ../subiquity/ui/views/keyboard.py:222
+#: ../subiquity/ui/views/keyboard.py:213
 msgid "Is the following key present on your keyboard?"
 msgstr "Чи є вказана нижче клавіша на вашій клавіатурі?"
 
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr "Застосовуємо налаштування"
-
-#: ../subiquity/ui/views/keyboard.py:303
+#: ../subiquity/ui/views/keyboard.py:277
 msgid ""
 "You will need a way to toggle the keyboard between the national layout and "
 "the standard Latin layout.\n"
 "\n"
 "Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
 "behavior in Emacs and other programs that use it for specific needs.\n"
 "\n"
 "Not all listed keys are present on all keyboards. "
@@ -2117,95 +2015,95 @@ msgstr ""
 "\n"
 "Клавіші з наведеного списку не обов'язково є на кожній клавіатурі. "
 
-#: ../subiquity/ui/views/keyboard.py:316
+#: ../subiquity/ui/views/keyboard.py:290
 msgid "Caps Lock"
 msgstr "Caps Lock"
 
-#: ../subiquity/ui/views/keyboard.py:317
+#: ../subiquity/ui/views/keyboard.py:291
 msgid "Right Alt (AltGr)"
 msgstr "Правий Alt (AltGr)"
 
-#: ../subiquity/ui/views/keyboard.py:318
+#: ../subiquity/ui/views/keyboard.py:292
 msgid "Right Control"
 msgstr "Правий Ctrl"
 
-#: ../subiquity/ui/views/keyboard.py:319
+#: ../subiquity/ui/views/keyboard.py:293
 msgid "Right Shift"
 msgstr "Правий Shift"
 
-#: ../subiquity/ui/views/keyboard.py:320
+#: ../subiquity/ui/views/keyboard.py:294
 msgid "Right Logo key"
 msgstr "Права клавіша з віконцем"
 
-#: ../subiquity/ui/views/keyboard.py:321
+#: ../subiquity/ui/views/keyboard.py:295
 msgid "Menu key"
 msgstr "Клавіша Menu"
 
-#: ../subiquity/ui/views/keyboard.py:322
+#: ../subiquity/ui/views/keyboard.py:296
 msgid "Alt+Shift"
 msgstr "Alt+Shift"
 
-#: ../subiquity/ui/views/keyboard.py:323
+#: ../subiquity/ui/views/keyboard.py:297
 msgid "Control+Shift"
 msgstr "Ctrl+Shift"
 
-#: ../subiquity/ui/views/keyboard.py:324
+#: ../subiquity/ui/views/keyboard.py:298
 msgid "Control+Alt"
 msgstr "Ctrl+Alt"
 
-#: ../subiquity/ui/views/keyboard.py:325
+#: ../subiquity/ui/views/keyboard.py:299
 msgid "Alt+Caps Lock"
 msgstr "Alt+Caps Lock"
 
-#: ../subiquity/ui/views/keyboard.py:326
+#: ../subiquity/ui/views/keyboard.py:300
 msgid "Left Control+Left Shift"
 msgstr "Лівий Ctrl+Лівий Shift"
 
-#: ../subiquity/ui/views/keyboard.py:327
+#: ../subiquity/ui/views/keyboard.py:301
 msgid "Left Alt"
 msgstr "Лівий Alt"
 
-#: ../subiquity/ui/views/keyboard.py:328
+#: ../subiquity/ui/views/keyboard.py:302
 msgid "Left Control"
 msgstr "Лівий Ctrl"
 
-#: ../subiquity/ui/views/keyboard.py:329
+#: ../subiquity/ui/views/keyboard.py:303
 msgid "Left Shift"
 msgstr "Лівий Shift"
 
-#: ../subiquity/ui/views/keyboard.py:330
+#: ../subiquity/ui/views/keyboard.py:304
 msgid "Left Logo key"
 msgstr "Ліва клавіша з віконцем"
 
-#: ../subiquity/ui/views/keyboard.py:331
+#: ../subiquity/ui/views/keyboard.py:305
 msgid "Scroll Lock key"
 msgstr "Клавіша Scroll Lock"
 
-#: ../subiquity/ui/views/keyboard.py:332
+#: ../subiquity/ui/views/keyboard.py:306
 msgid "No toggling"
 msgstr "Без перемикання"
 
-#: ../subiquity/ui/views/keyboard.py:353
+#: ../subiquity/ui/views/keyboard.py:327
 msgid "Shortcut: "
 msgstr "Скорочення: "
 
-#: ../subiquity/ui/views/keyboard.py:363
+#: ../subiquity/ui/views/keyboard.py:337
 msgid "Select layout toggle"
 msgstr "Виберіть перемикач розкладок"
 
-#: ../subiquity/ui/views/keyboard.py:381
+#: ../subiquity/ui/views/keyboard.py:355
 msgid "Layout:"
 msgstr "Розкладка:"
 
-#: ../subiquity/ui/views/keyboard.py:382
+#: ../subiquity/ui/views/keyboard.py:356
 msgid "Variant:"
 msgstr "Варіант:"
 
-#: ../subiquity/ui/views/keyboard.py:387
+#: ../subiquity/ui/views/keyboard.py:361
 msgid "Keyboard configuration"
 msgstr "Налаштування клавіатури"
 
-#: ../subiquity/ui/views/keyboard.py:417
+#: ../subiquity/ui/views/keyboard.py:382
 msgid ""
 "Please select the layout of the keyboard directly attached to the system, if "
 "any."
@@ -2213,7 +2111,7 @@ msgstr ""
 "Будь ласка, виберіть розкладку клавіатури, з'єднаної із вашим комп'ютером, "
 "якщо така існує."
 
-#: ../subiquity/ui/views/keyboard.py:420
+#: ../subiquity/ui/views/keyboard.py:385
 msgid ""
 "Please select your keyboard layout below, or select \"Identify keyboard\" to "
 "detect your layout automatically."
@@ -2222,68 +2120,29 @@ msgstr ""
 "«Визначити клавіатуру», щоб програма спробувала автоматично визначити "
 "розкладку."
 
-#: ../subiquity/ui/views/keyboard.py:429
+#: ../subiquity/ui/views/keyboard.py:394
 msgid "Identify keyboard"
 msgstr "Визначити клавіатуру"
 
-#: ../subiquity/ui/views/installprogress.py:50
-msgid "Install progress"
-msgstr ""
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr "Застосовуємо налаштування"
 
-#: ../subiquity/ui/views/installprogress.py:57
-msgid "Reboot Now"
-msgstr "Перезавантажити"
-
-#: ../subiquity/ui/views/installprogress.py:59
-msgid "View error report"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:61
-msgid "View full log"
-msgstr "Переглянути увесь журнал"
-
-#: ../subiquity/ui/views/installprogress.py:77
-msgid "Full installer output"
-msgstr "Усі дані, які виведено засобом встановлення"
-
-#: ../subiquity/ui/views/installprogress.py:142
-msgid "Cancel update and reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr "Перезавантажити"
-
-#: ../subiquity/ui/views/installprogress.py:179
-msgid "Rebooting..."
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/mirror.py:32
 msgid ""
-"Selecting Continue below will begin the installation process and\n"
-"result in the loss of data on the disks selected to be formatted.\n"
-"\n"
-"You will not be able to return to this or a previous screen once\n"
-"the installation has started.\n"
-"\n"
-"Are you sure you want to continue?"
+"You may provide an archive mirror that will be used instead of the default."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
-msgid "Confirm destructive action"
-msgstr "Підтвердження руйнівної дії"
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr "Адреса дзеркала:"
 
-#: ../subiquity/ui/views/installprogress.py:235
-#, python-brace-format
-msgid ""
-"The installer running on {tty} is currently installing the system.\n"
-"\n"
-"You can wait for this to complete or switch to a shell.\n"
-msgstr ""
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr "Налаштувати дзеркало архіву Ubuntu"
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2291,14 +2150,14 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 "Якщо для доступу до зовнішньої мережі вам потрібен HTTP-проксі, вкажіть тут "
 "його дані. Якщо проксі не потрібен, не заповнюйте це поле.\n"
 "\n"
-"Дані щодо проксі-сервера слід вказати у стандартній формі: «http://"
-"[[користувач][:пароль]@]вузол[:порт]/»."
+"Дані щодо проксі-сервера слід вказати у стандартній формі: "
+"«http://[[користувач][:пароль]@]вузол[:порт]/»."
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
@@ -2316,196 +2175,334 @@ msgstr ""
 "Якщо для встановлення з'єднання із інтернетом цій системі слід "
 "використовувати проксі, тут ви можете вказати його параметри."
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr "Доступне оновлення встановлювача"
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr "Завантаження оновлення ..."
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr "Продовжувати без оновлення"
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr "Повторити спробу"
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr "Оновлення до нового встановлювача"
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr "Скасувати оновлення"
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr "щойно"
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr "хвилина"
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr "хвилин(и)"
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr "година"
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr "годин(и)"
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr "день"
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr "дні(в)"
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr "Користувач імпортування:"
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr "Користувач github:"
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr "Користувач Launchpad:"
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr "Імпортувати профіль SSH:"
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr "з Github"
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr "з Launchpad"
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr "Ви можете імпортувати ваші ключі SSH з Github або Launchpad."
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr "Це поле не може бути порожнім."
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr "Надто довгий ідентифікатор SSH, має бути < "
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+"Ім'я користувача Github може складатися лише літер, цифр та одинарних "
+"дефісів і не може починатися або завершуватися дефісом."
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
+msgstr "Скористайтеся клавішами ↑, ↓ та ENTER для вибору мови."
+
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
 msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr "Інше"
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
-msgstr ""
-
-#~ msgid "partition"
-#~ msgstr "розділ"
 
 #~ msgid "Filesystem setup"
 #~ msgstr "Налаштування файлової системи"
@@ -2519,19 +2516,32 @@ msgstr ""
 #~ msgid "Choose the installation target"
 #~ msgstr "Виберіть ціль встановлення"
 
+#~ msgid "Format and/or mount {}"
+#~ msgstr "Форматувати і/або змонтувати {}"
+
 #~ msgid "Thank you for using Ubuntu!"
 #~ msgstr "Дякуємо за те, що скористалися Ubuntu!"
+
+#~ msgid "Finished install!"
+#~ msgstr "Встановлення завершено!"
+
+#~ msgid "Installation complete!"
+#~ msgstr "Встановлення завершено!"
 
 #~ msgid "Please report this error in Launchpad"
 #~ msgstr "Будь ласка, повідомте про цю помилку на Launchpad"
 
 #~ msgid "Select an interface to configure it or select Done to continue"
 #~ msgstr ""
-#~ "Виберіть інтерфейс для налаштовування або натисніть кнопку «Виконано», "
-#~ "щоб продовжити"
+#~ "Виберіть інтерфейс для налаштовування або натисніть кнопку «Виконано», щоб "
+#~ "продовжити"
 
 #~ msgid "Use UP, DOWN and ENTER keys to select your keyboard."
 #~ msgstr "Скористайтеся клавішами ↑, ↓  та ENTER для вибору клавіатури."
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "У цьому полі має бути адреса %s."
 
 #~ msgid "Use An Entire Disk"
 #~ msgstr "Використати увесь диск"
@@ -2539,25 +2549,68 @@ msgstr ""
 #~ msgid "Choose the disk to install to:"
 #~ msgstr "Виберіть диск для встановлення:"
 
+#~ msgid "Realname too long, must be < "
+#~ msgstr "Надто довге справжнє ім'я, має бути < "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "Надто довга назва сервера, має бути < "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "Надто довге ім'я користувача, має бути < "
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Ім'я користувача має відповідати взірцю NAME_REGEX, тобто [a-z_][a-z0-9_-]*"
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr ""
+#~ "Назва вузла має відповідати взірцю NAME_REGEX, тобто [a-z_][a-z0-9_-]*"
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "Не вдалося автоматично визначити клавіатуру, вибачте"
+
 #~ msgid "Exit To Shell"
 #~ msgstr "Вийти до оболонки"
 
 #~ msgid ""
-#~ "Selecting Continue below will begin the installation process and result "
-#~ "in the loss of data on the disks selected to be formatted.\n"
+#~ "Required bootloader partition\n"
+#~ "\n"
+#~ "GRUB will be installed onto the target disk's MBR.\n"
+#~ "\n"
+#~ "However, on a disk with a GPT partition table, there is not enough space "
+#~ "after the MBR for GRUB to store its second-stage core.img, so a small "
+#~ "unformatted partition is needed at the start of the disk. It will not "
+#~ "contain a filesystem and will not be mounted, and cannot be edited here."
+#~ msgstr ""
+#~ "Потрібен розділ для завантажувача\n"
+#~ "\n"
+#~ "GRUB буде встановлено до MBR диска призначення.\n"
+#~ "\n"
+#~ "Втім, на диску із таблицею розділів GPT недостаньо місця після MBR для того, "
+#~ "щоб GRUB між зберігати core.img другого етапу завантаження. Отже, потрібен "
+#~ "невеличкий неформатований розділ на початку диска. На ньому не буде файлової "
+#~ "системи, його не буде змонтовано, і його пункту не буде у списку для "
+#~ "редагування на цій сторінці."
+
+#~ msgid ""
+#~ "Selecting Continue below will begin the installation process and result in "
+#~ "the loss of data on the disks selected to be formatted.\n"
 #~ "\n"
 #~ "You will not be able to return to this or a previous screen once the "
 #~ "installation has started.\n"
 #~ "\n"
 #~ "Are you sure you want to continue?"
 #~ msgstr ""
-#~ "Натискання кнопки «Продовжити» призведе до запуску процедури встановлення "
-#~ "і, отже, втрати даних на дисках, які було позначено для форматування.\n"
+#~ "Натискання кнопки «Продовжити» призведе до запуску процедури встановлення і, "
+#~ "отже, втрати даних на дисках, які було позначено для форматування.\n"
 #~ "\n"
-#~ "Щойно встановлення буде розпочато, ви вже не зможете повернутися до цієї "
-#~ "або попередніх сторінок.\n"
+#~ "Щойно встановлення буде розпочато, ви вже не зможете повернутися до цієї або "
+#~ "попередніх сторінок.\n"
 #~ "\n"
 #~ "Ви справді хочете продовжити процедуру встановлення?"
+
+#~ msgid "An error has occurred"
+#~ msgstr "Сталася помилка"
 
 #~ msgid "Install complete"
 #~ msgstr "Встановлення завершено"
@@ -2568,8 +2621,68 @@ msgstr ""
 #~ msgid "starting..."
 #~ msgstr "розпочинаємо…"
 
+#~ msgid "partition of {}"
+#~ msgstr "розділ {}"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} не є коректними вхідними даними"
+
+#~ msgid "Network interface {} WIFI configuration"
+#~ msgstr "Налаштовування інтерфейсу мережі WIFI {}"
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "«%s» не міститься у «%s»"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "Редагувати IPv6"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "Редагувати IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "Редагувати Wifi"
+
+#~ msgid "Info"
+#~ msgstr "Інформація"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s вже існує"
+
+#, python-brace-format
 #~ msgid "DHCPv{v}"
 #~ msgstr "DHCPv{v}"
 
 #~ msgid "-"
 #~ msgstr "-"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "Зробити завантажувальний пристрій"
+
+#~ msgid "Edit"
+#~ msgstr "Зміни"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "Вилучити з RAID / LVM"
+
+#~ msgid "Format"
+#~ msgstr "Формат"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "Створити логічний том"
+
+#~ msgid "Add Partition"
+#~ msgstr "Додати розділ"
+
+#~ msgid "partition {} of {}"
+#~ msgstr "розділ {} з {}"
+
+#~ msgid "partition {}"
+#~ msgstr "розділ {}"
+
+#~ msgid "partition"
+#~ msgstr "розділ"
+
+#~ msgid "Reboot"
+#~ msgstr "Перезавантажити"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,76 +7,404 @@ msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-22 13:41+1200\n"
+"POT-Creation-Date: 2021-06-04 13:18+1200\n"
 "PO-Revision-Date: 2019-12-24 05:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Chinese (Simplified) <zh_CN@li.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2020-05-22 01:28+0000\n"
-"X-Generator: Launchpad (build 1f7bc749b40714a4cc10f5e4d787118a78037035)\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
+"X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
+"Language: \n"
 
-#: ../subiquitycore/controllers/network.py:297
+#: ../subiquity/client/client.py:70
+msgid ""
+"Installer shell session activated.\n"
+"\n"
+"This shell session is running inside the installer environment.  You\n"
+"will be returned to the installer when this shell is exited, for\n"
+"example by typing Control-D or 'exit'.\n"
+"\n"
+"Be aware that this is an ephemeral environment.  Changes to this\n"
+"environment will not survive a reboot. If the install has started, the\n"
+"installed system will be mounted at /target."
+msgstr ""
+
+#: ../subiquity/client/client.py:212
+msgid "yes"
+msgstr ""
+
+#: ../subiquity/client/client.py:213
+msgid "no"
+msgstr ""
+
+#: ../subiquity/client/client.py:215
+msgid "Confirmation is required to continue."
+msgstr ""
+
+#: ../subiquity/client/client.py:216
+msgid "Add 'autoinstall' to your kernel command line to avoid this"
+msgstr ""
+
+#: ../subiquity/client/client.py:219
+msgid "Continue with autoinstall?"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:91
+msgid "Importing keys failed:"
+msgstr ""
+
+#: ../subiquity/client/controllers/ssh.py:100
+msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
+msgstr ""
+
+#. Information about a drive
+#: ../subiquity/common/filesystem/actions.py:48
+msgctxt "DeviceAction"
+msgid "Info"
+msgstr ""
+
+#. Edit a device (partition, logical volume, RAID, etc)
+#: ../subiquity/common/filesystem/actions.py:50
+msgctxt "DeviceAction"
+msgid "Edit"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:51
+msgctxt "DeviceAction"
+msgid "Reformat"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:52
+msgctxt "DeviceAction"
+msgid "Add Partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:53
+msgctxt "DeviceAction"
+msgid "Create Logical Volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:54
+msgctxt "DeviceAction"
+msgid "Format"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:55
+msgctxt "DeviceAction"
+msgid "Remove from RAID/LVM"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:56
+msgctxt "DeviceAction"
+msgid "Delete"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:57
+msgctxt "DeviceAction"
+msgid "Make Boot Device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:151
+#, python-brace-format
+msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:165
+msgid "Cannot edit pre-existing RAIDs."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:168
+#, python-brace-format
+msgid "Cannot edit {raidlabel} because it has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:177
+msgid "Cannot edit pre-existing volume groups."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:180
+#, python-brace-format
+msgid "Cannot edit {vglabel} because it has logical volumes."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:247
+#, python-brace-format
+msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:258
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
+"{min_devices} devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:267
+#, python-brace-format
+msgid ""
+"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:283
+#, python-brace-format
+msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:293
+msgid ""
+"Cannot delete a single partition from a device that already has partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:296
+msgid "Cannot delete required bootloader partition"
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:310
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} as partition {partnum} is part of the {cdtype} "
+"{cdname}."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:319
+#, python-brace-format
+msgid ""
+"Cannot delete {devicelabel} because it has {count} mounted partitions."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:325
+#, python-brace-format
+msgid "Cannot delete {devicelabel} because it has 1 mounted partition."
+msgstr ""
+
+#: ../subiquity/common/filesystem/actions.py:334
+msgid ""
+"Cannot delete a single logical volume from a volume group that already has "
+"logical volumes."
+msgstr ""
+
+#. A pre-existing device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:34
+msgid "existing"
+msgstr ""
+
+#. A newly created device such as a partition or RAID
+#: ../subiquity/common/filesystem/labels.py:37
+msgid "new"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:60
+msgid "PReP"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:64
+#: ../subiquity/common/filesystem/labels.py:78
+msgid "configured"
+msgstr ""
+
+#. boot loader partition
+#: ../subiquity/common/filesystem/labels.py:67
+#: ../subiquity/common/filesystem/labels.py:80
+msgid "unconfigured"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:70
+msgid "primary ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:72
+msgid "backup ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:74
+msgid "unused ESP"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:81
+msgid "BIOS grub spacer"
+msgstr ""
+
+#. extended partition
+#: ../subiquity/common/filesystem/labels.py:84
+msgid "extended"
+msgstr ""
+
+#. logical partition
+#: ../subiquity/common/filesystem/labels.py:87
+msgid "logical"
+msgstr ""
+
+#. Flag for a LVM volume group
+#: ../subiquity/common/filesystem/labels.py:97
+msgid "encrypted"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:113
+msgid "multipath device"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:114
+msgid "local disk"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:119
+#, python-brace-format
+msgid "partition of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:124
+#, python-brace-format
+msgid "software RAID {level}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:129
+msgid "LVM volume group"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:134
+msgid "LVM logical volume"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:168
+#: ../subiquity/ui/views/filesystem/guided.py:95
+#, python-brace-format
+msgid "partition {number}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:170
+#, python-brace-format
+msgid "partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:178
+#, python-brace-format
+msgid "{component_name} of {desc} {name}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:186
+#, python-brace-format
+msgid "already formatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:188
+#, python-brace-format
+msgid "to be reformatted as {fstype}"
+msgstr ""
+
+#: ../subiquity/common/filesystem/labels.py:190
+#, python-brace-format
+msgid "to be formatted as {fstype}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:196
+#, python-brace-format
+msgid "mounted at {path}"
+msgstr ""
+
+#. A filesytem
+#: ../subiquity/common/filesystem/labels.py:199
+msgid "not mounted"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:204
+#: ../subiquity/common/filesystem/labels.py:211
+msgid "unused"
+msgstr ""
+
+#. A filesytem that cannot be mounted (i.e. swap)
+#. is used or unused
+#: ../subiquity/common/filesystem/labels.py:208
+msgid "used"
+msgstr ""
+
+#: ../subiquity/common/types.py:37
+msgid "Block device probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:38
+msgid "Disk probe failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:39
+msgid "Install failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:40
+msgid "Installer crash"
+msgstr ""
+
+#: ../subiquity/common/types.py:41
+msgid "Network error"
+msgstr ""
+
+#: ../subiquity/common/types.py:42
+msgid "Network client error"
+msgstr ""
+
+#: ../subiquity/common/types.py:43
+msgid "Server request failure"
+msgstr ""
+
+#: ../subiquity/common/types.py:44
+msgid "Unknown error"
+msgstr ""
+
+#: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
 msgstr ""
 
 #. Information about a network interface
-#: ../subiquitycore/models/network.py:39
+#: ../subiquitycore/models/network.py:43
 msgctxt "NetDevAction"
 msgid "Info"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:40
+#: ../subiquitycore/models/network.py:44
 msgctxt "NetDevAction"
 msgid "Edit Wifi"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:41
+#: ../subiquitycore/models/network.py:45
 msgctxt "NetDevAction"
 msgid "Edit IPv4"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:42
+#: ../subiquitycore/models/network.py:46
 msgctxt "NetDevAction"
 msgid "Edit IPv6"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:43
+#: ../subiquitycore/models/network.py:47
 msgctxt "NetDevAction"
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:44
+#: ../subiquitycore/models/network.py:48
 msgctxt "NetDevAction"
 msgid "Add a VLAN tag"
 msgstr ""
 
-#: ../subiquitycore/models/network.py:45
+#: ../subiquitycore/models/network.py:49
 msgctxt "NetDevAction"
 msgid "Delete"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:50
+#: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
 msgstr ""
 
-#: ../subiquitycore/ssh.py:57
+#: ../subiquitycore/ssh.py:66
 #, python-brace-format
 msgid ""
-"The {keytype} host key fingerprints is:\n"
+"The {keytype} host key fingerprint is:\n"
 "    {fingerprint}\n"
-msgstr ""
-
-#: ../subiquitycore/ui/utils.py:340
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:334
-#: ../subiquity/ui/views/filesystem/disk_info.py:53
-#: ../subiquity/ui/views/filesystem/filesystem.py:229
-#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/snaplist.py:330
-#: ../subiquity/ui/views/installprogress.py:80
-#: ../subiquity/ui/views/error.py:59
-msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
@@ -92,30 +420,51 @@ msgstr ""
 msgid "This field must be a {schemes} URL."
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:151
-#: ../subiquity/ui/views/filesystem/filesystem.py:491
-#: ../subiquity/ui/views/snaplist.py:481
+#: ../subiquitycore/ui/form.py:451 ../subiquitycore/ui/views/network.py:308
+#: ../subiquity/ui/views/filesystem/filesystem.py:494
+#: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
 msgstr ""
 
-#: ../subiquitycore/ui/form.py:452
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:32
-#: ../subiquity/ui/views/filesystem/delete.py:87
-#: ../subiquity/ui/views/filesystem/delete.py:153
-#: ../subiquity/ui/views/ssh.py:161 ../subiquity/ui/views/snaplist.py:260
-#: ../subiquity/ui/views/snaplist.py:287 ../subiquity/ui/views/keyboard.py:96
-#: ../subiquity/ui/views/keyboard.py:359
+#: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
+#: ../subiquity/ui/views/filesystem/delete.py:89
+#: ../subiquity/ui/views/filesystem/delete.py:155
+#: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
+#: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
+#: ../subiquity/ui/views/ssh.py:185
+msgid "Yes"
+msgstr ""
+
+#: ../subiquitycore/ui/interactive.py:109
+#: ../subiquity/ui/views/installprogress.py:247
+#: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
+#: ../subiquity/ui/views/ssh.py:186
+msgid "No"
+msgstr ""
+
+#: ../subiquitycore/ui/utils.py:349
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
+#: ../subiquity/ui/views/error.py:60
+#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquity/ui/views/filesystem/filesystem.py:232
+#: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
+#: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
+msgid "Close"
 msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:439
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:50
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:382
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:51
+#: ../subiquity/ui/views/filesystem/lvm.py:158
+#: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
-#: ../subiquity/ui/views/filesystem/partition.py:386
-#: ../subiquity/ui/views/filesystem/lvm.py:151
 msgid "Save"
 msgstr ""
 
@@ -177,1101 +526,633 @@ msgstr ""
 msgid "IPv{v} Method: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:269
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:426
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
+#: ../subiquity/ui/views/filesystem/lvm.py:143
+#: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
-#: ../subiquity/ui/views/filesystem/partition.py:374
-#: ../subiquity/ui/views/filesystem/lvm.py:136
 msgid "Create"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:276
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:292
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
 msgid "{netdev} already exists"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:304
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
 msgstr ""
 
 #. {device} is the name of a network device
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:337
-#: ../subiquity/ui/views/filesystem/disk_info.py:55
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
+#: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:391
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
+#: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
-#: ../subiquity/ui/views/filesystem/lvm.py:87
 msgid "Name:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:392
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:393
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:395
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:396
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:412
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:414
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:425
-#: ../subiquitycore/ui/views/network.py:97
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
+#: ../subiquitycore/ui/views/network.py:244
 msgid "Create bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network_configure_manual_interface.py:438
+#: ../subiquitycore/ui/views/network_configure_manual_interface.py:424
 msgid "Edit bond"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:76
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
+msgid "Select a network"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
+#, python-brace-format
+msgid "Network interface {nic} WIFI configuration"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:118
+#, python-brace-format
+msgid "VLAN {id} on interface {link}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:121
+#, python-brace-format
+msgid "bond master for {interfaces}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:141
+#, python-brace-format
+msgid "ssid: {ssid}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:143
+#: ../subiquitycore/ui/views/network.py:145
+msgid "not connected"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:148
+#, python-brace-format
+msgid "enslaved to {device}"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:175
+msgid "timed out"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:180
+msgid "static"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:187
+msgid "disabled"
+msgstr ""
+
+#: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:77
+#: ../subiquitycore/ui/views/network.py:213
 msgid ""
 "Configure at least one interface this server can use to talk to other "
 "machines, and which preferably provides sufficient access for updates."
 msgstr ""
 
 #. See _route_watcher
-#: ../subiquitycore/ui/views/network.py:108
-#: ../subiquity/ui/views/filesystem/guided.py:123
-#: ../subiquity/ui/views/filesystem/filesystem.py:496
+#: ../subiquitycore/ui/views/network.py:255
+#: ../subiquity/ui/views/filesystem/filesystem.py:499
+#: ../subiquity/ui/views/filesystem/guided.py:147
 #: ../subiquity/ui/views/filesystem/probing.py:53
-#: ../subiquity/ui/views/filesystem/probing.py:78
-#: ../subiquity/ui/views/refresh.py:157 ../subiquity/ui/views/refresh.py:184
-#: ../subiquity/ui/views/refresh.py:214 ../subiquity/ui/views/refresh.py:280
-#: ../subiquity/ui/views/mirror.py:38 ../subiquity/ui/views/ssh.py:107
-#: ../subiquity/ui/views/snaplist.py:482 ../subiquity/ui/views/keyboard.py:379
-#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/zdev.py:148
+#: ../subiquity/ui/views/filesystem/probing.py:79
+#: ../subiquity/ui/views/keyboard.py:353 ../subiquity/ui/views/mirror.py:38
+#: ../subiquity/ui/views/proxy.py:41 ../subiquity/ui/views/refresh.py:157
+#: ../subiquity/ui/views/refresh.py:184 ../subiquity/ui/views/refresh.py:214
+#: ../subiquity/ui/views/refresh.py:276 ../subiquity/ui/views/snaplist.py:455
+#: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
+#: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:153
+#: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:166
+#: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
 msgstr ""
 
-#: ../subiquitycore/ui/views/network.py:182
-msgid "not connected"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:188
-#, python-brace-format
-msgid "enslaved to {device}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:212
-msgid "timed out"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:219
-#, python-brace-format
-msgid "unknown state {state}"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:230
-msgid "static"
-msgstr ""
-
-#. Network addressing mode (static/dhcp/disabled)
-#: ../subiquitycore/ui/views/network.py:239
-msgid "disabled"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:357
-#, python-brace-format
-msgid "VLAN {id} on interface {link}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network.py:360
-#, python-brace-format
-msgid "bond master for {interfaces}"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:37
-msgid "Select a network"
-msgstr ""
-
-#: ../subiquitycore/ui/views/network_configure_wlan_interface.py:69
-#, python-brace-format
-msgid "Network interface {nic} WIFI configuration"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:186
-#: ../subiquity/ui/views/keyboard.py:227
-msgid "Yes"
-msgstr ""
-
-#: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/ssh.py:97
-#: ../subiquity/ui/views/ssh.py:187 ../subiquity/ui/views/keyboard.py:228
-#: ../subiquity/ui/views/installprogress.py:213
-msgid "No"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:107
-msgid "Importing keys failed:"
-msgstr ""
-
-#: ../subiquity/controllers/ssh.py:116
-msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:154
-msgid "An error has occurred"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:313
-msgid "Installation complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:314
-msgid "Finished install!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:448
-msgid "Installing system"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:450
-msgid "Install complete!"
-msgstr ""
-
-#: ../subiquity/controllers/installprogress.py:453
-msgid "An error occurred during installation"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:54
-msgid "Block device probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:55
-msgid "Disk probe failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:56
-msgid "Install failure"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:57
-msgid "Installer crash"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:58
-msgid "Network error"
-msgstr ""
-
-#: ../subiquity/controllers/error.py:59
-msgid "Unknown error"
-msgstr ""
-
-#. for translator: failed is a zdev device status
-#: ../subiquity/controllers/zdev.py:618
-msgid "failed"
-msgstr ""
-
-#. for translator: auto is a zdev device status
-#: ../subiquity/controllers/zdev.py:621
-msgid "auto"
-msgstr ""
-
-#. for translator: online is a zdev device status
-#: ../subiquity/controllers/zdev.py:624
-msgid "online"
-msgstr ""
-
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:152
+#: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
 msgstr ""
 
 #. for translators: this is a description of a RAID level
-#: ../subiquity/models/filesystem.py:154
+#: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:155
+#: ../subiquity/models/filesystem.py:173
 msgid "5"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:156
+#: ../subiquity/models/filesystem.py:174
 msgid "6"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:157
+#: ../subiquity/models/filesystem.py:175
 msgid "10"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:192
+#: ../subiquity/models/filesystem.py:210
 msgid "input cannot be empty"
 msgstr ""
 
 #. Attempting to convert input to a size
-#: ../subiquity/models/filesystem.py:204 ../subiquity/models/filesystem.py:216
+#: ../subiquity/models/filesystem.py:222 ../subiquity/models/filesystem.py:234
 msgid "{input!r} is not valid input"
 msgstr ""
 
-#. Information about a drive
-#: ../subiquity/models/filesystem.py:417
-msgctxt "DeviceAction"
-msgid "Info"
+#: ../subiquity/ui/mount.py:71
+msgid "Other"
 msgstr ""
 
-#. Edit a device (partition, logical volume, RAID, etc)
-#: ../subiquity/models/filesystem.py:419
-msgctxt "DeviceAction"
-msgid "Edit"
+#: ../subiquity/ui/mount.py:73
+msgid "Leave unmounted"
 msgstr ""
 
-#: ../subiquity/models/filesystem.py:420
-msgctxt "DeviceAction"
-msgid "Reformat"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:421
-msgctxt "DeviceAction"
-msgid "Add Partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:422
-msgctxt "DeviceAction"
-msgid "Create Logical Volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:423
-msgctxt "DeviceAction"
-msgid "Format"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:424
-msgctxt "DeviceAction"
-msgid "Remove from RAID/LVM"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:425
-msgctxt "DeviceAction"
-msgid "Delete"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:426
-msgctxt "DeviceAction"
-msgid "Make Boot Device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:437
-#, python-brace-format
-msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:449
-#, python-brace-format
-msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:460
-#, python-brace-format
+#: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
-"{min_devices} devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:469
-#, python-brace-format
-msgid ""
-"Removing {selflabel} would leave the {cdtype} {cdlabel} with no devices."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:482
-#, python-brace-format
-msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
-
-#. A pre-existing device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:506
-msgid "existing"
-msgstr ""
-
-#. A newly created device such as a partition or RAID
-#: ../subiquity/models/filesystem.py:509
-msgid "new"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:520
-#, python-brace-format
-msgid "{component_name} of {desc} {name}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:528
-#, python-brace-format
-msgid "already formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:530
-#, python-brace-format
-msgid "to be reformatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:532
-#, python-brace-format
-msgid "to be formatted as {fstype}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:538
-#, python-brace-format
-msgid "mounted at {path}"
-msgstr ""
-
-#. A filesytem
-#: ../subiquity/models/filesystem.py:541
-msgid "not mounted"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:546 ../subiquity/models/filesystem.py:553
-msgid "unused"
-msgstr ""
-
-#. A filesytem that cannot be mounted (i.e. swap)
-#. is used or unused
-#: ../subiquity/models/filesystem.py:550
-msgid "used"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:704
-#, python-brace-format
-msgid ""
-"Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
-"{cdname}."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:713
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:719
-#, python-brace-format
-msgid "Cannot delete {selflabel} because it has 1 mounted partition."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:793
-msgid "multipath device"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:794
-msgid "local disk"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:919 ../subiquity/models/filesystem.py:933
-msgid "configured"
-msgstr ""
-
-#. boot loader partition
-#: ../subiquity/models/filesystem.py:922 ../subiquity/models/filesystem.py:935
-msgid "unconfigured"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:925
-msgid "primary ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:927
-msgid "backup ESP"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:929
-msgid "unused ESP"
-msgstr ""
-
-#. extended partition
-#: ../subiquity/models/filesystem.py:939
-msgid "extended"
-msgstr ""
-
-#. logical partition
-#: ../subiquity/models/filesystem.py:942
-msgid "logical"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:951
-#, python-brace-format
-msgid "partition of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:955
-#, python-brace-format
-msgid "partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:960
-#, python-brace-format
-msgid "partition {number}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:994
-msgid ""
-"Cannot delete a single partition from a device that already has partitions."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:997
-msgid "Cannot delete required bootloader partition"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1049
-#, python-brace-format
-msgid "software RAID {level}"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1063
-msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1066
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has partitions."
-msgstr ""
-
-#. Flag for a LVM volume group
-#: ../subiquity/models/filesystem.py:1118
-msgid "encrypted"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1126
-msgid "LVM volume group"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1137
-msgid "Cannot edit pre-existing volume groups."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1140
-#, python-brace-format
-msgid "Cannot edit {selflabel} because it has logical volumes."
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1179
-msgid "LVM logical volume"
-msgstr ""
-
-#: ../subiquity/models/filesystem.py:1197
-msgid ""
-"Cannot delete a single logical volume from a volume group that already has "
-"logical volumes."
-msgstr ""
-
-#: ../subiquity/core.py:59
-msgid ""
-"Installer shell session activated.\n"
 "\n"
-"This shell session is running inside the installer environment.  You\n"
-"will be returned to the installer when this shell is exited, for\n"
-"example by typing Control-D or 'exit'.\n"
-"\n"
-"Be aware that this is an ephemeral environment.  Changes to this\n"
-"environment will not survive a reboot. If the install has started, the\n"
-"installed system will be mounted at /target."
+"Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
 
-#: ../subiquity/core.py:224
-#, python-brace-format
-msgid "the installer running on {tty} will perform the autoinstall"
-msgstr ""
-
-#: ../subiquity/core.py:237
-#, python-brace-format
-msgid "waiting for installer running on {tty} to run early commands"
-msgstr ""
-
-#: ../subiquity/core.py:328
-msgid "yes"
-msgstr ""
-
-#: ../subiquity/core.py:329
-msgid "no"
-msgstr ""
-
-#: ../subiquity/core.py:334
-msgid "Confirmation is required to continue."
-msgstr ""
-
-#: ../subiquity/core.py:335
-msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
-
-#: ../subiquity/core.py:339
-msgid "Continue with autoinstall?"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:50
-msgid "The characters : , and = are not permitted in this field"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:60
-msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:84
-msgid "Your name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:86
-msgid "Your server's name:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:87
-msgid "The name it uses when it talks to other computers."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:88
-msgid "Pick a username:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:89
-msgid "Choose a password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:90
-msgid "Confirm your password:"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:95
-#, python-brace-format
-msgid "Name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:100
-msgid "Server name must not be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:104
-#, python-brace-format
-msgid "Server name too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:108
-msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:113
-msgid "Username missing"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:117
-#, python-brace-format
-msgid "Username too long, must be less than {limit}"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:121
-msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:125
-#, python-brace-format
-msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:130
-#: ../subiquity/ui/views/filesystem/guided.py:61
-msgid "Password must be set"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:134
-#: ../subiquity/ui/views/filesystem/guided.py:65
-msgid "Passwords do not match"
-msgstr ""
-
-#. desc is "passwords" or "passphrases"
-#: ../subiquity/ui/views/identity.py:143
-#, python-brace-format
-msgid "{desc} do not match"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:151
-msgid "Profile setup"
-msgstr ""
-
-#: ../subiquity/ui/views/identity.py:152
+#: ../subiquity/ui/views/error.py:73
 msgid ""
-"Enter the username and password you will use to log in to the system. You "
-"can configure SSH access on the next screen but a password is still needed "
-"for sudo."
+"\n"
+"Sorry, there was a problem completing the installation.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/identity.py:186
-msgid "passwords"
+#: ../subiquity/ui/views/error.py:76
+msgid ""
+"\n"
+"Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:129
+#: ../subiquity/ui/views/error.py:79
+msgid ""
+"\n"
+"Sorry, the installer has encountered an internal error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:82
+msgid ""
+"\n"
+"Sorry, the installer has restarted because of an error.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:85
+msgid ""
+"\n"
+"Sorry, an unknown error occurred.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:91
+msgid ""
+"\n"
+"Information is being collected from the system that will help the\n"
+"developers diagnose the report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:95
+msgid ""
+"\n"
+"Loading report...\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:98
+msgid ""
+"\n"
+"Collecting information from the system failed. See the files in\n"
+"/var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:102
+msgid ""
+"\n"
+"Loading the report failed. See the files in /var/log/installer for more.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:108
+msgid ""
+"\n"
+"You can continue and the installer will just present the disks present\n"
+"in the system and not other block devices, or you may be able to fix\n"
+"the issue by switching to a shell and reconfiguring the system's block\n"
+"devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:114
+msgid ""
+"\n"
+"You may be able to fix the issue by switching to a shell and\n"
+"reconfiguring the system's block devices manually.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:118
+msgid ""
+"\n"
+"You can continue with the installation but it will be assumed the network\n"
+"is not functional.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:122
+msgid ""
+"\n"
+"You can continue or restart the installer.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:125
+msgid ""
+"\n"
+"Do you want to try starting the installation again?\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:129
+msgid "Select continue to try the installation again."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:134
+msgid ""
+"\n"
+"If you want to help improve the installer, you can send an error report.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:156
+msgid "Cancel upload"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:157
+msgid "Close report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:158
+#: ../subiquity/ui/views/installprogress.py:65
+#: ../subiquity/ui/views/installprogress.py:248
+#: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
+#: ../subiquity/ui/views/zdev.py:162
+msgid "Continue"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:160
+#: ../subiquity/ui/views/installprogress.py:282
+#: ../subiquity/ui/views/welcome.py:113
+msgid "Switch to a shell"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:162
+msgid "Restart the installer"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:164
+msgid "Send to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:165
+msgid "Sent to Canonical"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:167
+msgid "View full report"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:235
+msgid ""
+"The error report has been saved to\n"
+"\n"
+"  {loc}\n"
+"\n"
+"on the filesystem with label {label!r}."
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:317
+msgid "DATE"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:318
+msgid "KIND"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:319
+msgid "STATUS"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:330
+msgid "Select an error report to view:"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:344
+msgid "VIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/error.py:345
+msgid "UNVIEWED"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
 msgid "formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:131
+#: ../subiquity/ui/views/filesystem/compound.py:132
 #, python-brace-format
 msgid ", mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:133
+#: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:135
+#: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
 msgid "unused {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/compound.py:215
+#: ../subiquity/ui/views/filesystem/compound.py:217
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/raid.py:67
-msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:73
-msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:91
-msgid "RAID Level:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:92
-#: ../subiquity/ui/views/filesystem/lvm.py:88
-msgid "Devices:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:93
-#: ../subiquity/ui/views/filesystem/lvm.py:89
-msgid "Size:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:104
-#, python-brace-format
-msgid "There is already a RAID named '{name}'"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:107
-msgid ". and .. are not valid names for RAID devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:113
-#, python-brace-format
-msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:126
-msgid "Create software RAID (\"MD\") disk"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/raid.py:142
-#, python-brace-format
-msgid "Edit software RAID disk \"{name}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:75
-msgid "Leave unformatted"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:78
-#, python-brace-format
-msgid "Leave formatted as {fstype}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:111
-#, python-brace-format
-msgid "Capped partition size at {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:118
-#, python-brace-format
-msgid "Rounded size up to {size}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:130
-msgid ""
-"The only characters permitted in the name of a logical volume are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:164
-#, python-brace-format
-msgid "Size (max {size}):"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:201
-msgid "Name: "
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:203
-msgid "Format:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:204
-msgid "Mount:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:206
-msgid "Use as swap"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:207
-msgid "Use this swap partition in the installed system."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:231
-msgid "The name of a logical volume cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:233
-msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:236
-#, python-brace-format
-msgid "A logical volume may not be called {name}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:243
-#, python-brace-format
-msgid "The name of a logical volume may not contain \"{substring}\""
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:248
-#, python-brace-format
-msgid "There is already a logical volume named {name}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:257
-msgid "Path exceeds PATH_MAX"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:260
-#, python-brace-format
-msgid "{device} is already mounted at {path}."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:268
-#, python-brace-format
-msgid ""
-"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
-"proceed only with caution."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:284
-#, python-brace-format
-msgid ""
-"Bootloader partition\n"
-"\n"
-"{middle}\n"
-"\n"
-"However, on a disk with a GPT partition table, there is not enough\n"
-"space after the MBR for GRUB to store its second-stage core.img, so a\n"
-"small unformatted partition is needed at the start of the disk. It\n"
-"will not contain a filesystem and will not be mounted, and cannot be\n"
-"edited here.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:296
-msgid ""
-"If this disk is selected as a boot device, GRUB will be installed onto\n"
-"the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:300
-msgid ""
-"As this disk has been selected as a boot device, GRUB will be\n"
-"installed onto the target disk's MBR."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:304
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
-"disk is selected as a boot device, Grub will be installed onto this\n"
-"partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:312
-msgid ""
-"Bootloader partition\n"
-"\n"
-"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
-"disk has been selected as a boot device, Grub will be installed onto\n"
-"this partition, which must be formatted as fat32.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:320
-msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:324
-msgid ""
-"You can choose whether to use the existing filesystem on this\n"
-"partition or reformat it.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:329
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. If this disk is\n"
-"selected as a boot device, Grub will be installed onto this partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:336
-msgid ""
-"Required bootloader partition\n"
-"\n"
-"This is the PReP partion which is required on POWER. As this disk has\n"
-"been selected as a boot device, Grub will be installed onto this\n"
-"partition.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:421
-#: ../subiquity/ui/views/filesystem/guided.py:203
-#: ../subiquity/ui/views/keyboard.py:95 ../subiquity/ui/views/keyboard.py:145
-#: ../subiquity/ui/views/keyboard.py:358
-msgid "OK"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:428
-msgid "Use existing fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:434
-msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:512
-#, python-brace-format
-msgid "Adding logical volume to {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:515
-#, python-brace-format
-msgid "Adding {ptype} partition to {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:521
-#, python-brace-format
-msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:526
-#, python-brace-format
-msgid "Editing partition {number} of {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:579
-msgid ""
-"Formatting and mounting a disk directly is unusual. You probably want to add "
-"a partition instead."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/partition.py:591
-#, python-brace-format
-msgid "Format and/or mount {device}"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/delete.py:41
+#: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:51
-#: ../subiquity/ui/views/filesystem/delete.py:122
+#: ../subiquity/ui/views/filesystem/delete.py:53
+#: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:57
-#: ../subiquity/ui/views/filesystem/delete.py:128
+#: ../subiquity/ui/views/filesystem/delete.py:59
+#: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:63
+#: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
 msgid "It contains 1 logical volume"
 msgid_plural "It contains {n} logical volumes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:68
+#: ../subiquity/ui/views/filesystem/delete.py:70
 #, python-brace-format
 msgid "It contains 1 partition"
 msgid_plural "It contains {n} partitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:80
+#: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:82
+#: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:110
+#: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
 msgid "Remove filesystem from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:114
+#: ../subiquity/ui/views/filesystem/delete.py:116
 #, python-brace-format
 msgid "Do you really want to remove the existing filesystem from {device}?"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:132
+#: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:134
+#: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
 msgstr ""
 
 #. things is either "logical volumes" or "partitions"
-#: ../subiquity/ui/views/filesystem/delete.py:136
+#: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/delete.py:140
+#: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
 msgstr ""
 
 #. XXX summarize partitions here?
-#: ../subiquity/ui/views/filesystem/delete.py:147
+#: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:61
-msgid ""
-"The only characters permitted in the name of a volume group are a-z, A-Z, "
-"0-9, +, _, . and -"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:84
-msgid "passphrases"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:90
-msgid "Create encrypted volume"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:91
-#: ../subiquity/ui/views/filesystem/guided.py:56
-msgid "Passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:92
-#: ../subiquity/ui/views/filesystem/guided.py:57
-msgid "Confirm passphrase:"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:103
-msgid "Select at least one device to be part of the volume group."
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:109
-msgid "The name of a volume group cannot be empty"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:111
-msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/lvm.py:113
+#: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
-msgid "{name} is not a valid name for a volume group"
+msgid "existing {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:116
+#: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
-msgid "There is already a volume group named '{name}'"
+msgid "new {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:121
-msgid "Passphrase must be set"
+#: ../subiquity/ui/views/filesystem/filesystem.py:135
+msgid "No disks or partitions mounted."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:126
-msgid "Passphrases do not match"
+#: ../subiquity/ui/views/filesystem/filesystem.py:160
+msgid "MOUNT POINT"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:135
-msgid "Create LVM volume group"
+#: ../subiquity/ui/views/filesystem/filesystem.py:161
+#: ../subiquity/ui/views/filesystem/filesystem.py:385
+#: ../subiquity/ui/views/snaplist.py:162
+msgid "SIZE"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/lvm.py:150
+#: ../subiquity/ui/views/filesystem/filesystem.py:162
+#: ../subiquity/ui/views/filesystem/filesystem.py:384
+msgid "TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:163
+msgid "DEVICE TYPE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:186
+msgid "Unmount"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:260
+msgid "No available devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:262
+msgid "No used devices"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
-msgid "Edit volume group \"{name}\""
+msgid "Remove from {device}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:51
+#: ../subiquity/ui/views/filesystem/filesystem.py:328
+#, python-brace-format
+msgid "Add {ptype} Partition"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:333
+msgid "Stop Using As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:338
+msgid "Add As Another Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:339
+msgid "Use As Boot Device"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:383
+msgid "DEVICE"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:412
+msgid "free space"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:426
+msgid "Storage configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:437
+msgid "Create software RAID (md)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:440
+msgid "Create volume group (LVM)"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:447
+msgid "FILE SYSTEM SUMMARY"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:452
+msgid "AVAILABLE DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:459
+msgid "USED DEVICES"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:477
+msgid "Mount a filesystem at /"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:479
+msgid "Select a boot disk"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:484
+msgid "To continue you need to:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/filesystem.py:498
+msgid "Reset"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:78
+#: ../subiquity/ui/views/filesystem/guided.py:58
+#: ../subiquity/ui/views/filesystem/lvm.py:93
+msgid "Passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:59
+#: ../subiquity/ui/views/filesystem/lvm.py:94
+msgid "Confirm passphrase:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:63
+#: ../subiquity/ui/views/identity.py:137
+msgid "Password must be set"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:67
+#: ../subiquity/ui/views/identity.py:141
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:85
+#: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:119
+#: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:121
+#: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:134
+#: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
 "\n"
 "\n"
@@ -1305,7 +1186,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:164
+#: ../subiquity/ui/views/filesystem/guided.py:188
 msgid ""
 "\n"
 "Block probing did not discover any disks big enough to support guided "
@@ -1313,134 +1194,288 @@ msgid ""
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:170
+#: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
 "\n"
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:178
+#: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/guided.py:211
+#: ../subiquity/ui/views/filesystem/guided.py:221
+#: ../subiquity/ui/views/filesystem/partition.py:422
+#: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
+#: ../subiquity/ui/views/keyboard.py:332
+msgid "OK"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:98
+#: ../subiquity/ui/views/filesystem/lvm.py:61
+msgid ""
+"The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
+"9, +, _, . and -"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:86
+msgid "passphrases"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:90
+#: ../subiquity/ui/views/filesystem/raid.py:92
+msgid "Devices:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:91
+#: ../subiquity/ui/views/filesystem/raid.py:93
+msgid "Size:"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:92
+msgid "Create encrypted volume"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:105
+msgid "Select at least one device to be part of the volume group."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:111
+msgid "The name of a volume group cannot be empty"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:113
+msgid "The name of a volume group cannot start with a hyphen"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
-msgid "existing {fstype}"
+msgid "There is already a volume group named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:100
+#: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
-msgid "new {fstype}"
+msgid "{name} is not a valid name for a volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:132
-msgid "No disks or partitions mounted."
+#: ../subiquity/ui/views/filesystem/lvm.py:124
+msgid "Passphrase must be set"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:157
-msgid "MOUNT POINT"
+#: ../subiquity/ui/views/filesystem/lvm.py:129
+msgid "Passphrases do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:158
-#: ../subiquity/ui/views/filesystem/filesystem.py:382
-#: ../subiquity/ui/views/snaplist.py:156
-msgid "SIZE"
+#: ../subiquity/ui/views/filesystem/lvm.py:142
+msgid "Create LVM volume group"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:159
-#: ../subiquity/ui/views/filesystem/filesystem.py:381
-msgid "TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:160
-msgid "DEVICE TYPE"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:183
-msgid "Unmount"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:257
-msgid "No available devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:259
-msgid "No used devices"
-msgstr ""
-
-#: ../subiquity/ui/views/filesystem/filesystem.py:320
+#: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
-msgid "Remove from {device}"
+msgid "Edit volume group \"{name}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:325
+#: ../subiquity/ui/views/filesystem/partition.py:76
+msgid "Leave unformatted"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
-msgid "Add {ptype} Partition"
+msgid "Leave formatted as {fstype}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:330
-msgid "Stop Using As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:112
+#, python-brace-format
+msgid "Capped partition size at {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:335
-msgid "Add As Another Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:119
+#, python-brace-format
+msgid "Rounded size up to {size}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:336
-msgid "Use As Boot Device"
+#: ../subiquity/ui/views/filesystem/partition.py:131
+msgid ""
+"The only characters permitted in the name of a logical volume are a-z, A-Z, "
+"0-9, +, _, . and -"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:380
-msgid "DEVICE"
+#: ../subiquity/ui/views/filesystem/partition.py:165
+#, python-brace-format
+msgid "Size (max {size}):"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:409
-msgid "free space"
+#: ../subiquity/ui/views/filesystem/partition.py:202
+msgid "Name: "
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:423
-msgid "Storage configuration"
+#: ../subiquity/ui/views/filesystem/partition.py:204
+msgid "Format:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:434
-msgid "Create software RAID (md)"
+#: ../subiquity/ui/views/filesystem/partition.py:205
+msgid "Mount:"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:437
-msgid "Create volume group (LVM)"
+#: ../subiquity/ui/views/filesystem/partition.py:207
+msgid "Use as swap"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:444
-msgid "FILE SYSTEM SUMMARY"
+#: ../subiquity/ui/views/filesystem/partition.py:208
+msgid "Use this swap partition in the installed system."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:449
-msgid "AVAILABLE DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:232
+msgid "The name of a logical volume cannot be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:456
-msgid "USED DEVICES"
+#: ../subiquity/ui/views/filesystem/partition.py:234
+msgid "The name of a logical volume cannot start with a hyphen"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:474
-msgid "Mount a filesystem at /"
+#: ../subiquity/ui/views/filesystem/partition.py:237
+#, python-brace-format
+msgid "A logical volume may not be called {name}"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:476
-msgid "Select a boot disk"
+#: ../subiquity/ui/views/filesystem/partition.py:244
+#, python-brace-format
+msgid "The name of a logical volume may not contain \"{substring}\""
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:481
-msgid "To continue you need to:"
+#: ../subiquity/ui/views/filesystem/partition.py:249
+#, python-brace-format
+msgid "There is already a logical volume named {name}."
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/filesystem.py:495
-msgid "Reset"
+#: ../subiquity/ui/views/filesystem/partition.py:258
+msgid "Path exceeds PATH_MAX"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:261
+#, python-brace-format
+msgid "{device} is already mounted at {path}."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:269
+#, python-brace-format
+msgid ""
+"Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
+"proceed only with caution."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:285
+#, python-brace-format
+msgid ""
+"Bootloader partition\n"
+"\n"
+"{middle}\n"
+"\n"
+"However, on a disk with a GPT partition table, there is not enough\n"
+"space after the MBR for GRUB to store its second-stage core.img, so a\n"
+"small unformatted partition is needed at the start of the disk. It\n"
+"will not contain a filesystem and will not be mounted, and cannot be\n"
+"edited here.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:297
+msgid ""
+"If this disk is selected as a boot device, GRUB will be installed onto\n"
+"the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:301
+msgid ""
+"As this disk has been selected as a boot device, GRUB will be\n"
+"installed onto the target disk's MBR."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:305
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. If this\n"
+"disk is selected as a boot device, Grub will be installed onto this\n"
+"partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:313
+msgid ""
+"Bootloader partition\n"
+"\n"
+"This is an ESP / \"EFI system partition\" as required by UEFI. As this\n"
+"disk has been selected as a boot device, Grub will be installed onto\n"
+"this partition, which must be formatted as fat32.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:321
+msgid "The only aspect of this partition that can be edited is the size.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:325
+msgid ""
+"You can choose whether to use the existing filesystem on this\n"
+"partition or reformat it.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:330
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. If this disk is\n"
+"selected as a boot device, Grub will be installed onto this partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:337
+msgid ""
+"Required bootloader partition\n"
+"\n"
+"This is the PReP partion which is required on POWER. As this disk has\n"
+"been selected as a boot device, Grub will be installed onto this\n"
+"partition.\n"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:429
+msgid "Use existing fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:435
+msgid "Reformat as fresh fat32 filesystem"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:513
+#, python-brace-format
+msgid "Adding logical volume to {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:516
+#, python-brace-format
+msgid "Adding {ptype} partition to {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:522
+#, python-brace-format
+msgid "Editing logical volume {lvname} of {vgname}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:527
+#, python-brace-format
+msgid "Editing partition {number} of {device}"
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:580
+msgid ""
+"Formatting and mounting a disk directly is unusual. You probably want to add "
+"a partition instead."
+msgstr ""
+
+#: ../subiquity/ui/views/filesystem/partition.py:592
+#, python-brace-format
+msgid "Format and/or mount {device}"
 msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
@@ -1464,100 +1499,43 @@ msgstr ""
 msgid "Probing for devices to install to failed"
 msgstr ""
 
-#: ../subiquity/ui/views/filesystem/probing.py:76
+#: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:111
-msgid "Checking for installer update..."
+#: ../subiquity/ui/views/filesystem/raid.py:67
+msgid "/ is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:113
-msgid ""
-"Contacting the snap store to check if a new version of the installer is "
-"available."
+#: ../subiquity/ui/views/filesystem/raid.py:73
+msgid "Whitespace is not permitted in the name of a RAID device"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:117
-msgid "Contacting the snap store failed"
+#: ../subiquity/ui/views/filesystem/raid.py:91
+msgid "RAID Level:"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:119
-msgid "Contacting the snap store failed:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:122
-msgid "Installer update available"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:124
+#: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
-msgid ""
-"Version {new} of the installer is now available ({current} is currently "
-"running)."
+msgid "There is already a RAID named '{name}'"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:128
-msgid "Downloading update..."
+#: ../subiquity/ui/views/filesystem/raid.py:107
+msgid ". and .. are not valid names for RAID devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:130
-msgid ""
-"Please wait while the updated installer is being downloaded. The installer "
-"will restart automatically when the download is complete."
+#: ../subiquity/ui/views/filesystem/raid.py:113
+#, python-brace-format
+msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:134
-msgid "Update failed"
+#: ../subiquity/ui/views/filesystem/raid.py:126
+msgid "Create software RAID (\"MD\") disk"
 msgstr ""
 
-#: ../subiquity/ui/views/refresh.py:136
-msgid "Downloading and applying the update:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
-#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:279
-msgid "Continue without updating"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:278
-#: ../subiquity/ui/views/snaplist.py:286 ../subiquity/ui/views/snaplist.py:406
-msgid "Try again"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:199
-msgid "You can read the release notes for each version at:"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:206
-msgid ""
-"If you choose to update, the update will be downloaded and the installation "
-"will continue from here."
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:212
-msgid "Update to the new installer"
-msgstr ""
-
-#: ../subiquity/ui/views/refresh.py:238
-msgid "Cancel update"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:32
-msgid ""
-"You may provide an archive mirror that will be used instead of the default."
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:40
-msgid "Mirror address:"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:45
-msgid "Configure Ubuntu archive mirror"
-msgstr ""
-
-#: ../subiquity/ui/views/mirror.py:46
-msgid "If you use an alternative mirror for Ubuntu, enter its details here."
+#: ../subiquity/ui/views/filesystem/raid.py:142
+#, python-brace-format
+msgid "Edit software RAID disk \"{name}\""
 msgstr ""
 
 #: ../subiquity/ui/views/help.py:70
@@ -1614,576 +1592,324 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "\n"
-"To connect, SSH to installer@{ip}.\n"
+"To connect, SSH to {username}@{ip}."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:115
+#: ../subiquity/ui/views/help.py:114
+#, python-brace-format
+msgid "The password you should use is \"{password}\"."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:117
+msgid "You should use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:120
+#, python-brace-format
+msgid ""
+"You can log in with the {keytype} key with fingerprint:\n"
+"\n"
+"    {fingerprint}\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:126
+msgid "You can log in with one of the following keys:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:130
 #, python-brace-format
 msgid ""
 "\n"
-"The password you should use is \"{password}\".\n"
+"Or you can use the password \"{password}\"."
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:119
+#: ../subiquity/ui/views/help.py:133
+msgid ""
+"\n"
+"Or you can use the preconfigured password passed to cloud-init."
+msgstr ""
+
+#: ../subiquity/ui/views/help.py:136
 msgid ""
 "\n"
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:124
+#: ../subiquity/ui/views/help.py:141
 msgid ""
 "\n"
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:174
+#: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "ESC"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:178
+#: ../subiquity/ui/views/help.py:221
 msgid "go back"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "F1"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:179
+#: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:180
+#: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:181
+#: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:185
+#: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:189
+#: ../subiquity/ui/views/help.py:232
 msgid "quit"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:190
+#: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:191
+#: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:192
+#: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:193
+#: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:207
+#: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:223
+#: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:274
+#: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:276
+#: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:278
+#: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:287 ../subiquity/ui/views/help.py:443
+#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:291
+#: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:301
+#: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:310
+#: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:378
+#: ../subiquity/ui/views/help.py:399
 msgid "Help"
 msgstr ""
 
-#: ../subiquity/ui/views/help.py:432
+#: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:38
-msgid ""
-"\n"
-"Select the language to use for the installer and to be configured in the\n"
-"installed system.\n"
+#: ../subiquity/ui/views/identity.py:55
+msgid "The characters : , and = are not permitted in this field"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:98
-msgid "Use UP, DOWN and ENTER keys to select your language."
+#: ../subiquity/ui/views/identity.py:65
+msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
 msgstr ""
 
-#: ../subiquity/ui/views/welcome.py:146
-msgid "Help choosing a language"
+#: ../subiquity/ui/views/identity.py:89
+msgid "Your name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:66
-msgid "Import Username:"
+#: ../subiquity/ui/views/identity.py:91
+msgid "Your server's name:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:73
-msgid "GitHub Username:"
+#: ../subiquity/ui/views/identity.py:92
+msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:74
-msgid "Enter your GitHub username."
+#: ../subiquity/ui/views/identity.py:93
+msgid "Pick a username:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:76
-msgid "A GitHub username may only contain alphanumeric characters or hyphens."
+#: ../subiquity/ui/views/identity.py:94
+msgid "Choose a password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:80
-msgid "Launchpad Username:"
+#: ../subiquity/ui/views/identity.py:95
+msgid "Confirm your password:"
 msgstr ""
 
-#: ../subiquity/ui/views/ssh.py:83
-msgid ""
-"A Launchpad username may only contain lower-case alphanumeric characters, "
-"hyphens, plus, or periods."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:92
-msgid "Install OpenSSH server"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:95
-msgid "Import SSH identity:"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:98
-msgid "from GitHub"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:99
-msgid "from Launchpad"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from GitHub or Launchpad."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:105
-msgid "Allow password authentication over SSH"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:138
-msgid "This field must not be blank."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:140
-msgid "SSH id too long, must be < "
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:144
-msgid ""
-"A Launchpad username must start with a letter or number. All letters must be "
-"lower-case. The characters +, - and . are also allowed after the first "
-"character."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:150
-msgid ""
-"A GitHub username may only contain alphanumeric characters or single "
-"hyphens, and cannot begin or end with a hyphen."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:160
-msgid "Fetching SSH keys..."
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:190
-msgid "Confirm SSH keys"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:191
-msgid ""
-"Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:194
-msgid "Confirm SSH key"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:195
-msgid ""
-"A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:222
-msgid "SSH Setup"
-msgstr ""
-
-#: ../subiquity/ui/views/ssh.py:223
-msgid ""
-"You can choose to install the OpenSSH server package to enable secure remote "
-"access to your server."
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:79
-msgid "just now"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:83
-msgid "minute"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:85
-msgid "minutes"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:89
-msgid "hour"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:91
-msgid "hours"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:95
-msgid "day"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:97
-msgid "days"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:100
+#: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
-msgid "{amount:2} {unit} ago"
+msgid "Name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:144
-msgid "LICENSE: "
+#: ../subiquity/ui/views/identity.py:105
+msgid "Server name must not be empty"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:149
-msgid "LAST UPDATED: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:154
-msgid "CHANNEL"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:155
-msgid "VERSION"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:157
-msgid "PUBLISHED"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:158
-msgid "CONFINEMENT"
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:176
-msgid "by: "
-msgstr ""
-
-#: ../subiquity/ui/views/snaplist.py:256
+#: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
-msgid "Fetching info for {snap}"
+msgid "Server name too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:282
+#: ../subiquity/ui/views/identity.py:114
+msgid "Hostname must match HOSTNAME_REGEX: "
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:119
+msgid "Username missing"
+msgstr ""
+
+#: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
-msgid "Fetching info for {snap} failed"
+msgid "Username too long, must be less than {limit}"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:369
-msgid "Featured Server Snaps"
+#: ../subiquity/ui/views/identity.py:128
+msgid "Username must match USERNAME_REGEX: "
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:398 ../subiquity/ui/views/snaplist.py:407
-#: ../subiquity/ui/views/installprogress.py:63
-#: ../subiquity/ui/views/installprogress.py:214
-#: ../subiquity/ui/views/error.py:143 ../subiquity/ui/views/zdev.py:147
-msgid "Continue"
+#: ../subiquity/ui/views/identity.py:132
+#, python-brace-format
+msgid "The username \"{username}\" is reserved for use by the system."
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:399
-msgid "Loading server snaps from store, please wait..."
+#. desc is "passwords" or "passphrases"
+#: ../subiquity/ui/views/identity.py:150
+#, python-brace-format
+msgid "{desc} do not match"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:404
-msgid "Sorry, loading snaps from the store failed."
+#: ../subiquity/ui/views/identity.py:158
+msgid "Profile setup"
 msgstr ""
 
-#: ../subiquity/ui/views/snaplist.py:487
+#: ../subiquity/ui/views/identity.py:159
 msgid ""
-"These are popular snaps in server environments. Select or deselect with "
-"SPACE, press ENTER to see more details of the package, publisher and "
-"versions available."
+"Enter the username and password you will use to log in to the system. You "
+"can configure SSH access on the next screen but a password is still needed "
+"for sudo."
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:64
-msgid "Keyboard auto-detection"
+#: ../subiquity/ui/views/identity.py:188
+msgid "passwords"
 msgstr ""
 
-#: ../subiquity/ui/views/keyboard.py:90
-msgid ""
-"Keyboard detection starting. You will be asked a series of questions about "
-"your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:108
-msgid "Keyboard auto detection failed, sorry"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:116
-msgid ""
-"Keyboard auto detection completed.\n"
-"\n"
-"Your keyboard was detected as:\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:121
-msgid ""
-"\n"
-"If this is correct, select Done on the next screen. If not you can select "
-"another layout or run the automated detection again.\n"
-"\n"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:135
-msgid "Layout"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:136
-msgid "Variant"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:161
-msgid "Please press one of the following keys:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:197 ../subiquity/ui/views/keyboard.py:205
-msgid "Input was not recognized, try again"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:222
-msgid "Is the following key present on your keyboard?"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:291
-msgid "Applying config"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:303
-msgid ""
-"You will need a way to toggle the keyboard between the national layout and "
-"the standard Latin layout.\n"
-"\n"
-"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
-"latter case, use the combination Shift+Caps Lock for normal Caps toggle). Alt"
-"+Shift is also a popular combination; it will however lose its usual "
-"behavior in Emacs and other programs that use it for specific needs.\n"
-"\n"
-"Not all listed keys are present on all keyboards. "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:316
-msgid "Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:317
-msgid "Right Alt (AltGr)"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:318
-msgid "Right Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:319
-msgid "Right Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:320
-msgid "Right Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:321
-msgid "Menu key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:322
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:323
-msgid "Control+Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:324
-msgid "Control+Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:325
-msgid "Alt+Caps Lock"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:326
-msgid "Left Control+Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:327
-msgid "Left Alt"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:328
-msgid "Left Control"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:329
-msgid "Left Shift"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:330
-msgid "Left Logo key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:331
-msgid "Scroll Lock key"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:332
-msgid "No toggling"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:353
-msgid "Shortcut: "
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:363
-msgid "Select layout toggle"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:381
-msgid "Layout:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:382
-msgid "Variant:"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:387
-msgid "Keyboard configuration"
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:417
-msgid ""
-"Please select the layout of the keyboard directly attached to the system, if "
-"any."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:420
-msgid ""
-"Please select your keyboard layout below, or select \"Identify keyboard\" to "
-"detect your layout automatically."
-msgstr ""
-
-#: ../subiquity/ui/views/keyboard.py:429
-msgid "Identify keyboard"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:50
+#: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:57
+#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:174
+#: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:59
+#: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:61
+#: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:77
+#: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
 msgstr ""
 
 #: ../subiquity/ui/views/installprogress.py:142
+#: ../subiquity/ui/views/installprogress.py:145
+#: ../subiquity/ui/views/installprogress.py:148
+#: ../subiquity/ui/views/installprogress.py:151
+#: ../subiquity/ui/views/installprogress.py:154
+msgid "Installing system"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:157
+#: ../subiquity/ui/views/installprogress.py:165
+#: ../subiquity/ui/views/installprogress.py:173
+msgid "Install complete!"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:146
-msgid "Reboot"
-msgstr ""
-
-#: ../subiquity/ui/views/installprogress.py:179
+#: ../subiquity/ui/views/installprogress.py:166
+#: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:195
+#: ../subiquity/ui/views/installprogress.py:180
+msgid "An error occurred during installation"
+msgstr ""
+
+#: ../subiquity/ui/views/installprogress.py:230
 msgid ""
 "Selecting Continue below will begin the installation process and\n"
 "result in the loss of data on the disks selected to be formatted.\n"
@@ -2194,11 +1920,11 @@ msgid ""
 "Are you sure you want to continue?"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:217
+#: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:235
+#: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
 msgid ""
 "The installer running on {tty} is currently installing the system.\n"
@@ -2206,9 +1932,187 @@ msgid ""
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/installprogress.py:247
-#: ../subiquity/ui/views/error.py:145
-msgid "Switch to a shell"
+#: ../subiquity/ui/views/keyboard.py:67
+msgid "Keyboard auto-detection"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:93
+msgid ""
+"Keyboard detection starting. You will be asked a series of questions about "
+"your keyboard. Press escape at any time to go back to the previous screen."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:106
+msgid ""
+"Keyboard auto detection completed.\n"
+"\n"
+"Your keyboard was detected as:\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:111
+msgid ""
+"\n"
+"If this is correct, select Done on the next screen. If not you can select "
+"another layout or run the automated detection again.\n"
+"\n"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:128
+msgid "Layout"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:129
+msgid "Variant"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:152
+msgid "Please press one of the following keys:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
+msgid "Input was not recognized, try again"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:213
+msgid "Is the following key present on your keyboard?"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:277
+msgid ""
+"You will need a way to toggle the keyboard between the national layout and "
+"the standard Latin layout.\n"
+"\n"
+"Right Alt or Caps Lock keys are often chosen for ergonomic reasons (in the "
+"latter case, use the combination Shift+Caps Lock for normal Caps toggle). "
+"Alt+Shift is also a popular combination; it will however lose its usual "
+"behavior in Emacs and other programs that use it for specific needs.\n"
+"\n"
+"Not all listed keys are present on all keyboards. "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:290
+msgid "Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:291
+msgid "Right Alt (AltGr)"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:292
+msgid "Right Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:293
+msgid "Right Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:294
+msgid "Right Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:295
+msgid "Menu key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:296
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:297
+msgid "Control+Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:298
+msgid "Control+Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:299
+msgid "Alt+Caps Lock"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:300
+msgid "Left Control+Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:301
+msgid "Left Alt"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:302
+msgid "Left Control"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:303
+msgid "Left Shift"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:304
+msgid "Left Logo key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:305
+msgid "Scroll Lock key"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:306
+msgid "No toggling"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:327
+msgid "Shortcut: "
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:337
+msgid "Select layout toggle"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:355
+msgid "Layout:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:356
+msgid "Variant:"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:361
+msgid "Keyboard configuration"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:382
+msgid ""
+"Please select the layout of the keyboard directly attached to the system, if "
+"any."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:385
+msgid ""
+"Please select your keyboard layout below, or select \"Identify keyboard\" to "
+"detect your layout automatically."
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:394
+msgid "Identify keyboard"
+msgstr ""
+
+#: ../subiquity/ui/views/keyboard.py:429
+msgid "Applying config"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:32
+msgid ""
+"You may provide an archive mirror that will be used instead of the default."
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:40
+msgid "Mirror address:"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:45
+msgid "Configure Ubuntu archive mirror"
+msgstr ""
+
+#: ../subiquity/ui/views/mirror.py:46
+msgid "If you use an alternative mirror for Ubuntu, enter its details here."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:33
@@ -2216,8 +2120,8 @@ msgid ""
 "If you need to use a HTTP proxy to access the outside world, enter the proxy "
 "information here. Otherwise, leave this blank.\n"
 "\n"
-"The proxy information should be given in the standard form of \"http://"
-"[[user][:pass]@]host[:port]/\"."
+"The proxy information should be given in the standard form of "
+"\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
 
 #: ../subiquity/ui/views/proxy.py:43
@@ -2234,190 +2138,329 @@ msgid ""
 "details here."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:66 ../subiquity/ui/views/error.py:69
+#: ../subiquity/ui/views/refresh.py:111
+msgid "Checking for installer update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:113
+msgid ""
+"Contacting the snap store to check if a new version of the installer is "
+"available."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:117
+msgid "Contacting the snap store failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:119
+msgid "Contacting the snap store failed:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:122
+msgid "Installer update available"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:124
+#, python-brace-format
+msgid ""
+"Version {new} of the installer is now available ({current} is currently "
+"running)."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:128
+msgid "Downloading update..."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:130
+msgid ""
+"Please wait while the updated installer is being downloaded. The installer "
+"will restart automatically when the download is complete."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:134
+msgid "Update failed"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:136
+msgid "Downloading and applying the update:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
+#: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
+msgid "Continue without updating"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
+#: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
+msgid "Try again"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:199
+msgid "You can read the release notes for each version at:"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:206
+msgid ""
+"If you choose to update, the update will be downloaded and the installation "
+"will continue from here."
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:212
+msgid "Update to the new installer"
+msgstr ""
+
+#: ../subiquity/ui/views/refresh.py:238
+msgid "Cancel update"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:83
+msgid "just now"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:87
+msgid "minute"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:89
+msgid "minutes"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:93
+msgid "hour"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:95
+msgid "hours"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:99
+msgid "day"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:101
+msgid "days"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:104
+#, python-brace-format
+msgid "{amount:2} {unit} ago"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:150
+msgid "LICENSE: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:155
+msgid "LAST UPDATED: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:160
+msgid "CHANNEL"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:161
+msgid "VERSION"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:163
+msgid "PUBLISHED"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:164
+msgid "CONFINEMENT"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:182
+msgid "by: "
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:260
+#, python-brace-format
+msgid "Fetching info for {snap} failed"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:301
+#, python-brace-format
+msgid "Fetching info for {snap}"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:339
+msgid "Featured Server Snaps"
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:353
+msgid "Loading server snaps from store, please wait..."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:374
+msgid "Sorry, loading snaps from the store failed."
+msgstr ""
+
+#: ../subiquity/ui/views/snaplist.py:460
+msgid ""
+"These are popular snaps in server environments. Select or deselect with "
+"SPACE, press ENTER to see more details of the package, publisher and "
+"versions available."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:67
+msgid "Import Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:74
+msgid "Github Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:75
+msgid "Enter your Github username."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:77
+msgid ""
+"A Github username may only contain alphanumeric characters or hyphens."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:81
+msgid "Launchpad Username:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:84
+msgid ""
+"A Launchpad username may only contain lower-case alphanumeric characters, "
+"hyphens, plus, or periods."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:93
+msgid "Install OpenSSH server"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:96
+msgid "Import SSH identity:"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:99
+msgid "from Github"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:100
+msgid "from Launchpad"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:102
+msgid "You can import your SSH keys from Github or Launchpad."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:106
+msgid "Allow password authentication over SSH"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:139
+msgid "This field must not be blank."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:141
+msgid "SSH id too long, must be < "
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:145
+msgid ""
+"A Launchpad username must start with a letter or number. All letters must be "
+"lower-case. The characters +, - and . are also allowed after the first "
+"character."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:151
+msgid ""
+"A Github username may only contain alphanumeric characters or single "
+"hyphens, and cannot begin or end with a hyphen."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:161
+msgid "Fetching SSH keys..."
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:189
+msgid "Confirm SSH keys"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:190
+msgid ""
+"Keys with the following fingerprints were fetched. Do you want to use them?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:193
+msgid "Confirm SSH key"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:194
+msgid ""
+"A key with the following fingerprint was fetched. Do you want to use it?"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:220
+msgid "SSH Setup"
+msgstr ""
+
+#: ../subiquity/ui/views/ssh.py:221
+msgid ""
+"You can choose to install the OpenSSH server package to enable secure remote "
+"access to your server."
+msgstr ""
+
+#: ../subiquity/ui/views/welcome.py:36
 msgid ""
 "\n"
-"Sorry, there was a problem examining the storage devices on this system.\n"
+"Select the language to use for the installer and to be configured in the\n"
+"installed system.\n"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:72
-msgid ""
-"\n"
-"Sorry, there was a problem completing the installation.\n"
+#: ../subiquity/ui/views/welcome.py:99
+msgid "Use UP, DOWN and ENTER keys to select your language."
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:75
-msgid ""
-"\n"
-"Sorry, there was a problem applying the network configuration.\n"
+#: ../subiquity/ui/views/welcome.py:106
+msgid "Help choosing a language"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:78
-msgid ""
-"\n"
-"Sorry, the installer has restarted because of an error.\n"
+#. for translator: failed is a zdev device status
+#: ../subiquity/ui/views/zdev.py:56
+msgid "failed"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:81
-msgid ""
-"\n"
-"Sorry, an unknown error occurred.\n"
+#. for translator: auto is a zdev device status
+#: ../subiquity/ui/views/zdev.py:59
+msgid "auto"
 msgstr ""
 
-#: ../subiquity/ui/views/error.py:87
-msgid ""
-"\n"
-"Information is being collected from the system that will help the\n"
-"developers diagnose the report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:91
-msgid ""
-"\n"
-"Loading report...\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:94
-msgid ""
-"\n"
-"Collecting information from the system failed. See the files in\n"
-"/var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:98
-msgid ""
-"\n"
-"Loading the report failed. See the files in /var/log/installer for more.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:104
-msgid ""
-"\n"
-"You can continue and the installer will just present the disks present\n"
-"in the system and not other block devices, or you may be able to fix\n"
-"the issue by switching to a shell and reconfiguring the system's block\n"
-"devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:110
-msgid ""
-"\n"
-"You may be able to fix the issue by switching to a shell and\n"
-"reconfiguring the system's block devices manually.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:114
-msgid ""
-"\n"
-"You can continue with the installation but it will be assumed the network\n"
-"is not functional.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:118
-msgid ""
-"\n"
-"Do you want to try starting the installation again?\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:122
-msgid "Select continue to try the installation again."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:127
-msgid ""
-"\n"
-"If you want to help improve the installer, you can send an error report.\n"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:141
-msgid "Cancel upload"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:142
-msgid "Close report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:147
-msgid "Restart the installer"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:149
-msgid "Send to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:150
-msgid "Sent to Canonical"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:152
-msgid "View full report"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:210
-msgid ""
-"The error report has been saved to\n"
-"\n"
-"  {loc}\n"
-"\n"
-"on the filesystem with label {label!r}."
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:282
-msgid "DATE"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:283
-msgid "KIND"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:284
-msgid "STATUS"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:294
-msgid "Select an error report to view:"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:308
-msgid "VIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/error.py:309
-msgid "UNVIEWED"
-msgstr ""
-
-#: ../subiquity/ui/views/zdev.py:64
-msgid "No zdev devices found."
+#. for translator: online is a zdev device status
+#: ../subiquity/ui/views/zdev.py:62
+msgid "online"
 msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
+msgid "No zdev devices found."
+msgstr ""
+
+#: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:78
+#: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:79
+#: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:103
+#: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:104
+#: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
 msgstr ""
 
-#: ../subiquity/ui/views/zdev.py:129
+#: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:71
-msgid "Other"
-msgstr ""
-
-#: ../subiquity/ui/mount.py:73
-msgid "Leave unmounted"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,23 +1,22 @@
-# Latvian translation for subiquity
-# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
+# Chinese (Traditional) translation for subiquity
+# Copyright (c) 2021 Rosetta Contributors and Canonical Ltd 2021
 # This file is distributed under the same license as the subiquity package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: subiquity\n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2021-06-04 13:18+1200\n"
-"PO-Revision-Date: 2017-09-17 14:15+0000\n"
-"Last-Translator: Dimitri John Ledkov <dimitri.ledkov+lp@canonical.com>\n"
-"Language-Team: Latvian <lv@li.org>\n"
+"PO-Revision-Date: 2021-02-18 02:14+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Chinese (Traditional) <zh_TW@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "X-Launchpad-Export-Date: 2021-06-05 04:52+0000\n"
 "X-Generator: Launchpad (build b45bdbe3a00b6b668fa7f2069bd545c35c41f7f4)\n"
-"Language: lv\n"
 
 #: ../subiquity/client/client.py:70
 msgid ""
@@ -34,31 +33,31 @@ msgstr ""
 
 #: ../subiquity/client/client.py:212
 msgid "yes"
-msgstr ""
+msgstr "是"
 
 #: ../subiquity/client/client.py:213
 msgid "no"
-msgstr ""
+msgstr "否"
 
 #: ../subiquity/client/client.py:215
 msgid "Confirmation is required to continue."
-msgstr ""
+msgstr "必須確認以繼續。"
 
 #: ../subiquity/client/client.py:216
 msgid "Add 'autoinstall' to your kernel command line to avoid this"
-msgstr ""
+msgstr "為內核指令列加入 autoinstall 以避免此情況"
 
 #: ../subiquity/client/client.py:219
 msgid "Continue with autoinstall?"
-msgstr ""
+msgstr "是否以 autoinstall 繼續？"
 
 #: ../subiquity/client/controllers/ssh.py:91
 msgid "Importing keys failed:"
-msgstr ""
+msgstr "金鑰匯入失敗："
 
 #: ../subiquity/client/controllers/ssh.py:100
 msgid "ssh-keygen failed to show fingerprint of downloaded keys:"
-msgstr ""
+msgstr "ssh-keygen 無法顯示下載的金鑰指紋："
 
 #. Information about a drive
 #: ../subiquity/common/filesystem/actions.py:48
@@ -110,11 +109,11 @@ msgstr ""
 #: ../subiquity/common/filesystem/actions.py:151
 #, python-brace-format
 msgid "Cannot edit {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
+msgstr "無法編輯 {selflabel} 因為它是 {cdtype} {cdname} 的一部分。"
 
 #: ../subiquity/common/filesystem/actions.py:165
 msgid "Cannot edit pre-existing RAIDs."
-msgstr ""
+msgstr "無法編輯現存的 RAID。"
 
 #: ../subiquity/common/filesystem/actions.py:168
 #, python-brace-format
@@ -123,7 +122,7 @@ msgstr ""
 
 #: ../subiquity/common/filesystem/actions.py:177
 msgid "Cannot edit pre-existing volume groups."
-msgstr ""
+msgstr "無法編輯預先存在的卷宗群組。"
 
 #: ../subiquity/common/filesystem/actions.py:180
 #, python-brace-format
@@ -133,14 +132,14 @@ msgstr ""
 #: ../subiquity/common/filesystem/actions.py:247
 #, python-brace-format
 msgid "Cannot remove {selflabel} from pre-existing {cdtype} {cdlabel}."
-msgstr ""
+msgstr "無法從現存的 {cdtype} {cdlabel} 移除 {selflabel}。"
 
 #: ../subiquity/common/filesystem/actions.py:258
 #, python-brace-format
 msgid ""
 "Removing {selflabel} would leave the {cdtype} {cdlabel} with less than "
 "{min_devices} devices."
-msgstr ""
+msgstr "移除 {selflabel} 會使 {cdtype} {cdlabel} 少於 {min_devices} 個裝置。"
 
 #: ../subiquity/common/filesystem/actions.py:267
 #, python-brace-format
@@ -151,16 +150,16 @@ msgstr ""
 #: ../subiquity/common/filesystem/actions.py:283
 #, python-brace-format
 msgid "Cannot delete {selflabel} as it is part of the {cdtype} {cdname}."
-msgstr ""
+msgstr "無法移除 {selflabel} 因為它是 {cdtype} {cdname} 的一部分。"
 
 #: ../subiquity/common/filesystem/actions.py:293
 msgid ""
 "Cannot delete a single partition from a device that already has partitions."
-msgstr ""
+msgstr "無法自已經有分割區的裝置移除單一個分割區。"
 
 #: ../subiquity/common/filesystem/actions.py:296
 msgid "Cannot delete required bootloader partition"
-msgstr ""
+msgstr "無法刪除必要的開機載入程式分割區"
 
 #: ../subiquity/common/filesystem/actions.py:310
 #, python-brace-format
@@ -184,17 +183,17 @@ msgstr ""
 msgid ""
 "Cannot delete a single logical volume from a volume group that already has "
 "logical volumes."
-msgstr ""
+msgstr "無法自已有邏輯卷宗的卷宗群組移除單一個邏輯卷宗。"
 
 #. A pre-existing device such as a partition or RAID
 #: ../subiquity/common/filesystem/labels.py:34
 msgid "existing"
-msgstr ""
+msgstr "現有"
 
 #. A newly created device such as a partition or RAID
 #: ../subiquity/common/filesystem/labels.py:37
 msgid "new"
-msgstr ""
+msgstr "新增"
 
 #: ../subiquity/common/filesystem/labels.py:60
 msgid "PReP"
@@ -204,25 +203,25 @@ msgstr ""
 #: ../subiquity/common/filesystem/labels.py:64
 #: ../subiquity/common/filesystem/labels.py:78
 msgid "configured"
-msgstr ""
+msgstr "已設定"
 
 #. boot loader partition
 #: ../subiquity/common/filesystem/labels.py:67
 #: ../subiquity/common/filesystem/labels.py:80
 msgid "unconfigured"
-msgstr ""
+msgstr "未設定"
 
 #: ../subiquity/common/filesystem/labels.py:70
 msgid "primary ESP"
-msgstr ""
+msgstr "主要的 ESP"
 
 #: ../subiquity/common/filesystem/labels.py:72
 msgid "backup ESP"
-msgstr ""
+msgstr "備援的 ESP"
 
 #: ../subiquity/common/filesystem/labels.py:74
 msgid "unused ESP"
-msgstr ""
+msgstr "未使用的 ESP"
 
 #: ../subiquity/common/filesystem/labels.py:81
 msgid "BIOS grub spacer"
@@ -231,17 +230,17 @@ msgstr ""
 #. extended partition
 #: ../subiquity/common/filesystem/labels.py:84
 msgid "extended"
-msgstr ""
+msgstr "擴充分割區"
 
 #. logical partition
 #: ../subiquity/common/filesystem/labels.py:87
 msgid "logical"
-msgstr ""
+msgstr "邏輯分割區"
 
 #. Flag for a LVM volume group
 #: ../subiquity/common/filesystem/labels.py:97
 msgid "encrypted"
-msgstr ""
+msgstr "已加密"
 
 #: ../subiquity/common/filesystem/labels.py:113
 msgid "multipath device"
@@ -249,36 +248,36 @@ msgstr ""
 
 #: ../subiquity/common/filesystem/labels.py:114
 msgid "local disk"
-msgstr ""
+msgstr "本機磁碟"
 
 #: ../subiquity/common/filesystem/labels.py:119
 #, python-brace-format
 msgid "partition of {device}"
-msgstr ""
+msgstr "{device} 的分割區"
 
 #: ../subiquity/common/filesystem/labels.py:124
 #, python-brace-format
 msgid "software RAID {level}"
-msgstr ""
+msgstr "軟體 RAID {level}"
 
 #: ../subiquity/common/filesystem/labels.py:129
 msgid "LVM volume group"
-msgstr ""
+msgstr "LVM 卷宗群組"
 
 #: ../subiquity/common/filesystem/labels.py:134
 msgid "LVM logical volume"
-msgstr ""
+msgstr "LVM 邏輯卷宗"
 
 #: ../subiquity/common/filesystem/labels.py:168
 #: ../subiquity/ui/views/filesystem/guided.py:95
 #, python-brace-format
 msgid "partition {number}"
-msgstr ""
+msgstr "分割區 {number}"
 
 #: ../subiquity/common/filesystem/labels.py:170
 #, python-brace-format
 msgid "partition {number} of {device}"
-msgstr ""
+msgstr "{device} 的分割區 {number}"
 
 #: ../subiquity/common/filesystem/labels.py:178
 #, python-brace-format
@@ -288,61 +287,61 @@ msgstr ""
 #: ../subiquity/common/filesystem/labels.py:186
 #, python-brace-format
 msgid "already formatted as {fstype}"
-msgstr ""
+msgstr "已格式化為 {fstype}"
 
 #: ../subiquity/common/filesystem/labels.py:188
 #, python-brace-format
 msgid "to be reformatted as {fstype}"
-msgstr ""
+msgstr "要重新格式化為 {fstype}"
 
 #: ../subiquity/common/filesystem/labels.py:190
 #, python-brace-format
 msgid "to be formatted as {fstype}"
-msgstr ""
+msgstr "要格式化為 {fstype}"
 
 #. A filesytem
 #: ../subiquity/common/filesystem/labels.py:196
 #, python-brace-format
 msgid "mounted at {path}"
-msgstr ""
+msgstr "掛載於 {path}"
 
 #. A filesytem
 #: ../subiquity/common/filesystem/labels.py:199
 msgid "not mounted"
-msgstr ""
+msgstr "未掛載"
 
 #. A filesytem that cannot be mounted (i.e. swap)
 #. is used or unused
 #: ../subiquity/common/filesystem/labels.py:204
 #: ../subiquity/common/filesystem/labels.py:211
 msgid "unused"
-msgstr ""
+msgstr "未使用"
 
 #. A filesytem that cannot be mounted (i.e. swap)
 #. is used or unused
 #: ../subiquity/common/filesystem/labels.py:208
 msgid "used"
-msgstr ""
+msgstr "已用"
 
 #: ../subiquity/common/types.py:37
 msgid "Block device probe failure"
-msgstr ""
+msgstr "系統區塊裝置探測失敗"
 
 #: ../subiquity/common/types.py:38
 msgid "Disk probe failure"
-msgstr ""
+msgstr "磁碟探測失敗"
 
 #: ../subiquity/common/types.py:39
 msgid "Install failure"
-msgstr ""
+msgstr "安裝失敗"
 
 #: ../subiquity/common/types.py:40
 msgid "Installer crash"
-msgstr ""
+msgstr "安裝程式崩潰"
 
 #: ../subiquity/common/types.py:41
 msgid "Network error"
-msgstr ""
+msgstr "網路錯誤"
 
 #: ../subiquity/common/types.py:42
 msgid "Network client error"
@@ -354,11 +353,11 @@ msgstr ""
 
 #: ../subiquity/common/types.py:44
 msgid "Unknown error"
-msgstr ""
+msgstr "未知的錯誤"
 
 #: ../subiquitycore/controllers/network.py:202
 msgid "autoconfiguration failed"
-msgstr ""
+msgstr "自動設定失敗"
 
 #. Information about a network interface
 #: ../subiquitycore/models/network.py:43
@@ -398,7 +397,7 @@ msgstr ""
 
 #: ../subiquitycore/ssh.py:59
 msgid "The host key fingerprints are:\n"
-msgstr ""
+msgstr "主機金鑰指紋為：\n"
 
 #: ../subiquitycore/ssh.py:66
 #, python-brace-format
@@ -409,11 +408,11 @@ msgstr ""
 
 #: ../subiquitycore/ui/form.py:365
 msgid ", or "
-msgstr ""
+msgstr "，或 "
 
 #: ../subiquitycore/ui/form.py:367
 msgid " or "
-msgstr ""
+msgstr " 或 "
 
 #: ../subiquitycore/ui/form.py:371
 #, python-brace-format
@@ -424,7 +423,7 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/filesystem.py:494
 #: ../subiquity/ui/views/snaplist.py:454
 msgid "Done"
-msgstr "Gatavs"
+msgstr "完成"
 
 #: ../subiquitycore/ui/form.py:452 ../subiquitycore/ui/utils.py:382
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:33
@@ -433,19 +432,19 @@ msgstr "Gatavs"
 #: ../subiquity/ui/views/keyboard.py:99 ../subiquity/ui/views/keyboard.py:333
 #: ../subiquity/ui/views/snaplist.py:265 ../subiquity/ui/views/ssh.py:162
 msgid "Cancel"
-msgstr "Atcelt"
+msgstr "取消"
 
 #: ../subiquitycore/ui/interactive.py:109 ../subiquity/ui/views/keyboard.py:218
 #: ../subiquity/ui/views/ssh.py:185
 msgid "Yes"
-msgstr "Jā"
+msgstr "是"
 
 #: ../subiquitycore/ui/interactive.py:109
 #: ../subiquity/ui/views/installprogress.py:247
 #: ../subiquity/ui/views/keyboard.py:219 ../subiquity/ui/views/ssh.py:98
 #: ../subiquity/ui/views/ssh.py:186
 msgid "No"
-msgstr "Nē"
+msgstr "否"
 
 #: ../subiquitycore/ui/utils.py:349
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:319
@@ -455,7 +454,7 @@ msgstr "Nē"
 #: ../subiquity/ui/views/help.py:66 ../subiquity/ui/views/installprogress.py:82
 #: ../subiquity/ui/views/snaplist.py:315 ../subiquity/ui/views/welcome.py:115
 msgid "Close"
-msgstr "Aizvērt"
+msgstr "關閉"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:86
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:152
@@ -466,40 +465,40 @@ msgstr "Aizvērt"
 #: ../subiquity/ui/views/filesystem/partition.py:387
 #: ../subiquity/ui/views/filesystem/raid.py:144
 msgid "Save"
-msgstr "Saglabāt"
+msgstr "儲存"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:88
 msgid "Subnet:"
-msgstr ""
+msgstr "子網路："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:89
 msgid "Address:"
-msgstr "Adrese:"
+msgstr "位址："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:90
 msgid "Gateway:"
-msgstr "Vārteja:"
+msgstr "閘道："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:91
 msgid "Name servers:"
-msgstr ""
+msgstr "名稱伺服器："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:92
 msgid "IP addresses, comma separated"
-msgstr ""
+msgstr "IP 位址，以逗號分隔"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:93
 msgid "Search domains:"
-msgstr ""
+msgstr "搜尋網域："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:94
 msgid "Domains, comma separated"
-msgstr ""
+msgstr "網域，以逗號分隔"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:102
 #, python-brace-format
 msgid "should be in CIDR form ({example})"
-msgstr ""
+msgstr "須為 CIDR 形式（{example}）"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:114
 #, python-brace-format
@@ -509,22 +508,22 @@ msgstr ""
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:143
 msgid "Automatic (DHCP)"
-msgstr ""
+msgstr "自動 (DHCP)"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:145
 msgid "Manual"
-msgstr "Manuālā"
+msgstr "手動"
 
 #. A choice for how to configure a network interface
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:147
 msgid "Disabled"
-msgstr ""
+msgstr "停用"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:165
 #, python-brace-format
 msgid "IPv{v} Method: "
-msgstr ""
+msgstr "IPv{v} 方法： "
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:263
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:410
@@ -532,15 +531,15 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/partition.py:375
 #: ../subiquity/ui/views/filesystem/raid.py:127
 msgid "Create"
-msgstr ""
+msgstr "建立"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:270
 msgid "VLAN ID:"
-msgstr ""
+msgstr "VLAN ID:"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:279
 msgid "VLAN ID must be between 1 and 4095"
-msgstr ""
+msgstr "VLAN ID 必須介於 1 及 4095"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:285
 #, python-brace-format
@@ -549,49 +548,49 @@ msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:297
 msgid "Add a VLAN tag"
-msgstr ""
+msgstr "加入 VLAN 標記"
 
 #. {device} is the name of a network device
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:322
 #: ../subiquity/ui/views/filesystem/disk_info.py:57
 #, python-brace-format
 msgid "Info for {device}"
-msgstr ""
+msgstr "{device} 的資訊"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:376
 #: ../subiquity/ui/views/filesystem/lvm.py:89
 #: ../subiquity/ui/views/filesystem/raid.py:90
 msgid "Name:"
-msgstr ""
+msgstr "名稱："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:377
 msgid "Devices: "
-msgstr ""
+msgstr "裝置： "
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:378
 msgid "Bond mode:"
-msgstr ""
+msgstr "綁定模式："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:380
 msgid "XMIT hash policy:"
-msgstr ""
+msgstr "XMIT 排序邏輯："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:381
 msgid "LACP rate:"
-msgstr ""
+msgstr "LACP 交換間隔："
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:394
 #, python-brace-format
 msgid "There is already a network device named \"{netdev}\""
-msgstr ""
+msgstr "已有名為「{netdev}」的網路裝置"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:397
 msgid "Name cannot be empty"
-msgstr ""
+msgstr "名稱不能空白"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:399
 msgid "Name cannot be more than 16 characters long"
-msgstr ""
+msgstr "名稱不能超過 16 個字元"
 
 #: ../subiquitycore/ui/views/network_configure_manual_interface.py:409
 #: ../subiquitycore/ui/views/network.py:244
@@ -604,17 +603,17 @@ msgstr ""
 
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:38
 msgid "Select a network"
-msgstr ""
+msgstr "選取網路"
 
 #: ../subiquitycore/ui/views/network_configure_wlan_interface.py:70
 #, python-brace-format
 msgid "Network interface {nic} WIFI configuration"
-msgstr ""
+msgstr "網路介面 {nic} WIFI 設定"
 
 #: ../subiquitycore/ui/views/network.py:118
 #, python-brace-format
 msgid "VLAN {id} on interface {link}"
-msgstr ""
+msgstr "VLAN {id} 在介面 {link} 上"
 
 #: ../subiquitycore/ui/views/network.py:121
 #, python-brace-format
@@ -629,28 +628,28 @@ msgstr ""
 #: ../subiquitycore/ui/views/network.py:143
 #: ../subiquitycore/ui/views/network.py:145
 msgid "not connected"
-msgstr ""
+msgstr "未連線"
 
 #: ../subiquitycore/ui/views/network.py:148
 #, python-brace-format
 msgid "enslaved to {device}"
-msgstr ""
+msgstr "附屬於 {device} 之下"
 
 #: ../subiquitycore/ui/views/network.py:175
 msgid "timed out"
-msgstr ""
+msgstr "已逾時"
 
 #: ../subiquitycore/ui/views/network.py:180
 msgid "static"
-msgstr ""
+msgstr "靜態"
 
 #: ../subiquitycore/ui/views/network.py:187
 msgid "disabled"
-msgstr ""
+msgstr "停用"
 
 #: ../subiquitycore/ui/views/network.py:212
 msgid "Network connections"
-msgstr ""
+msgstr "網路連線"
 
 #: ../subiquitycore/ui/views/network.py:213
 msgid ""
@@ -671,37 +670,37 @@ msgstr ""
 #: ../subiquity/ui/views/ssh.py:108 ../subiquity/ui/views/welcome.py:93
 #: ../subiquity/ui/views/zdev.py:163
 msgid "Back"
-msgstr "Atpakaļ"
+msgstr "返回"
 
 #: ../subiquitycore/ui/views/network.py:310
 msgid "Continue without network"
-msgstr ""
+msgstr "以無網路連線繼續"
 
 #: ../subiquitycore/ui/views/network.py:323
 msgid "Applying changes"
-msgstr ""
+msgstr "正在套用變更"
 
 #. for translators: this is a description of a RAID level
 #: ../subiquity/models/filesystem.py:170
 msgid "0 (striped)"
-msgstr ""
+msgstr "0（條帶化）"
 
 #. for translators: this is a description of a RAID level
 #: ../subiquity/models/filesystem.py:172
 msgid "1 (mirrored)"
-msgstr ""
+msgstr "1（鏡像）"
 
 #: ../subiquity/models/filesystem.py:173
 msgid "5"
-msgstr ""
+msgstr "5"
 
 #: ../subiquity/models/filesystem.py:174
 msgid "6"
-msgstr ""
+msgstr "6"
 
 #: ../subiquity/models/filesystem.py:175
 msgid "10"
-msgstr ""
+msgstr "10"
 
 #. Attempting to convert input to a size
 #: ../subiquity/models/filesystem.py:210
@@ -715,29 +714,35 @@ msgstr ""
 
 #: ../subiquity/ui/mount.py:71
 msgid "Other"
-msgstr ""
+msgstr "其他"
 
 #: ../subiquity/ui/mount.py:73
 msgid "Leave unmounted"
-msgstr ""
+msgstr "維持未掛載狀態"
 
 #: ../subiquity/ui/views/error.py:67 ../subiquity/ui/views/error.py:70
 msgid ""
 "\n"
 "Sorry, there was a problem examining the storage devices on this system.\n"
 msgstr ""
+"\n"
+"抱歉，在檢查本系統上的儲存裝置時發生了一點問題。\n"
 
 #: ../subiquity/ui/views/error.py:73
 msgid ""
 "\n"
 "Sorry, there was a problem completing the installation.\n"
 msgstr ""
+"\n"
+"抱歉，因為發生了問題所以無法完成安裝。\n"
 
 #: ../subiquity/ui/views/error.py:76
 msgid ""
 "\n"
 "Sorry, there was a problem applying the network configuration.\n"
 msgstr ""
+"\n"
+"抱歉，套用網路設定時發生了一點問題。\n"
 
 #: ../subiquity/ui/views/error.py:79
 msgid ""
@@ -750,12 +755,16 @@ msgid ""
 "\n"
 "Sorry, the installer has restarted because of an error.\n"
 msgstr ""
+"\n"
+"抱歉，安裝程式已因為錯誤而重新啟動。\n"
 
 #: ../subiquity/ui/views/error.py:85
 msgid ""
 "\n"
 "Sorry, an unknown error occurred.\n"
 msgstr ""
+"\n"
+"抱歉，發生了未知的錯誤。\n"
 
 #: ../subiquity/ui/views/error.py:91
 msgid ""
@@ -763,12 +772,17 @@ msgid ""
 "Information is being collected from the system that will help the\n"
 "developers diagnose the report.\n"
 msgstr ""
+"\n"
+"從系統上蒐集的資訊將會協助\n"
+"開發者診斷報告。\n"
 
 #: ../subiquity/ui/views/error.py:95
 msgid ""
 "\n"
 "Loading report...\n"
 msgstr ""
+"\n"
+"載入報告中...\n"
 
 #: ../subiquity/ui/views/error.py:98
 msgid ""
@@ -776,12 +790,17 @@ msgid ""
 "Collecting information from the system failed. See the files in\n"
 "/var/log/installer for more.\n"
 msgstr ""
+"\n"
+"蒐集系統資訊失敗。更多資訊請查閱位在\n"
+"/var/log/installer 的檔案。\n"
 
 #: ../subiquity/ui/views/error.py:102
 msgid ""
 "\n"
 "Loading the report failed. See the files in /var/log/installer for more.\n"
 msgstr ""
+"\n"
+"載入報告失敗。更多資訊請查閱位在 /var/log/installer 的檔案。\n"
 
 #: ../subiquity/ui/views/error.py:108
 msgid ""
@@ -798,6 +817,9 @@ msgid ""
 "You may be able to fix the issue by switching to a shell and\n"
 "reconfiguring the system's block devices manually.\n"
 msgstr ""
+"\n"
+"您可能可以透過切換至 shell 並手動重新設定\n"
+"系統區塊裝置的來修正這個問題。\n"
 
 #: ../subiquity/ui/views/error.py:118
 msgid ""
@@ -805,6 +827,9 @@ msgid ""
 "You can continue with the installation but it will be assumed the network\n"
 "is not functional.\n"
 msgstr ""
+"\n"
+"您可以繼續安裝但它將會假定網路功能\n"
+"不能用。\n"
 
 #: ../subiquity/ui/views/error.py:122
 msgid ""
@@ -817,24 +842,28 @@ msgid ""
 "\n"
 "Do you want to try starting the installation again?\n"
 msgstr ""
+"\n"
+"您是否想要試著再次執行安裝？\n"
 
 #: ../subiquity/ui/views/error.py:129
 msgid "Select continue to try the installation again."
-msgstr ""
+msgstr "選擇繼續來再次嘗試安裝。"
 
 #: ../subiquity/ui/views/error.py:134
 msgid ""
 "\n"
 "If you want to help improve the installer, you can send an error report.\n"
 msgstr ""
+"\n"
+"若您想協助改善安裝程式，您可以傳送一份錯誤報告。\n"
 
 #: ../subiquity/ui/views/error.py:156
 msgid "Cancel upload"
-msgstr ""
+msgstr "取消上傳"
 
 #: ../subiquity/ui/views/error.py:157
 msgid "Close report"
-msgstr ""
+msgstr "關閉報告"
 
 #: ../subiquity/ui/views/error.py:158
 #: ../subiquity/ui/views/installprogress.py:65
@@ -842,29 +871,29 @@ msgstr ""
 #: ../subiquity/ui/views/snaplist.py:352 ../subiquity/ui/views/snaplist.py:377
 #: ../subiquity/ui/views/zdev.py:162
 msgid "Continue"
-msgstr "Turpināt"
+msgstr "繼續"
 
 #: ../subiquity/ui/views/error.py:160
 #: ../subiquity/ui/views/installprogress.py:282
 #: ../subiquity/ui/views/welcome.py:113
 msgid "Switch to a shell"
-msgstr ""
+msgstr "切換至 shell"
 
 #: ../subiquity/ui/views/error.py:162
 msgid "Restart the installer"
-msgstr ""
+msgstr "重新啟動安裝程式"
 
 #: ../subiquity/ui/views/error.py:164
 msgid "Send to Canonical"
-msgstr ""
+msgstr "傳送至 Canonical"
 
 #: ../subiquity/ui/views/error.py:165
 msgid "Sent to Canonical"
-msgstr ""
+msgstr "已傳送至 Canonical"
 
 #: ../subiquity/ui/views/error.py:167
 msgid "View full report"
-msgstr ""
+msgstr "檢視完整報告"
 
 #: ../subiquity/ui/views/error.py:235
 msgid ""
@@ -874,30 +903,35 @@ msgid ""
 "\n"
 "on the filesystem with label {label!r}."
 msgstr ""
+"錯誤報告已被儲存至\n"
+"\n"
+"  {loc}\n"
+"\n"
+"在標籤為 {label!r} 的檔案系統上。"
 
 #: ../subiquity/ui/views/error.py:317
 msgid "DATE"
-msgstr ""
+msgstr "日期"
 
 #: ../subiquity/ui/views/error.py:318
 msgid "KIND"
-msgstr ""
+msgstr "類別"
 
 #: ../subiquity/ui/views/error.py:319
 msgid "STATUS"
-msgstr ""
+msgstr "狀態"
 
 #: ../subiquity/ui/views/error.py:330
 msgid "Select an error report to view:"
-msgstr ""
+msgstr "選擇要檢視的錯誤報告："
 
 #: ../subiquity/ui/views/error.py:344
 msgid "VIEWED"
-msgstr ""
+msgstr "已檢視"
 
 #: ../subiquity/ui/views/error.py:345
 msgid "UNVIEWED"
-msgstr ""
+msgstr "未檢視"
 
 #: ../subiquity/ui/views/filesystem/compound.py:130
 #, python-brace-format
@@ -911,7 +945,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/compound.py:134
 msgid ", not mounted"
-msgstr ""
+msgstr "，未掛載"
 
 #: ../subiquity/ui/views/filesystem/compound.py:136
 #, python-brace-format
@@ -922,24 +956,24 @@ msgstr ""
 msgid ""
 "If you put all disks into RAIDs or LVM VGs, there will be nowhere to put the "
 "boot partition."
-msgstr ""
+msgstr "若您將所有的磁碟加入 RAID 或 LVM VG，這樣將會沒有地方可以放開機磁區。"
 
 #: ../subiquity/ui/views/filesystem/delete.py:43
 #, python-brace-format
 msgid "Do you really want to delete the {desc} {label}?"
-msgstr ""
+msgstr "是否真的要刪除 {desc} {label}？"
 
 #: ../subiquity/ui/views/filesystem/delete.py:53
 #: ../subiquity/ui/views/filesystem/delete.py:124
 #, python-brace-format
 msgid "It is formatted as {fstype} and mounted at {path}"
-msgstr ""
+msgstr "它已被格式化為 {fstype} 且掛載於 {path}"
 
 #: ../subiquity/ui/views/filesystem/delete.py:59
 #: ../subiquity/ui/views/filesystem/delete.py:130
 #, python-brace-format
 msgid "It is formatted as {fstype} and not mounted."
-msgstr ""
+msgstr "它已被格式化為 {fstype} 但尚未掛載。"
 
 #: ../subiquity/ui/views/filesystem/delete.py:65
 #, python-brace-format
@@ -957,11 +991,11 @@ msgstr[1] ""
 
 #: ../subiquity/ui/views/filesystem/delete.py:82
 msgid "It is not formatted or mounted."
-msgstr ""
+msgstr "它尚未被格式化或掛載。"
 
 #: ../subiquity/ui/views/filesystem/delete.py:84
 msgid "Delete"
-msgstr ""
+msgstr "刪除"
 
 #: ../subiquity/ui/views/filesystem/delete.py:112
 #, python-brace-format
@@ -975,182 +1009,182 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/delete.py:134
 msgid "logical volumes"
-msgstr ""
+msgstr "邏輯卷宗"
 
 #: ../subiquity/ui/views/filesystem/delete.py:136
 msgid "partitions"
-msgstr ""
+msgstr "硬碟分割區"
 
 #. things is either "logical volumes" or "partitions"
 #: ../subiquity/ui/views/filesystem/delete.py:138
 #, python-brace-format
 msgid "Remove all {things} from {obj}"
-msgstr ""
+msgstr "刪除 {obj} 的所有 {things}"
 
 #: ../subiquity/ui/views/filesystem/delete.py:142
 #, python-brace-format
 msgid "Do you really want to remove all {things} from {obj}?"
-msgstr ""
+msgstr "是否真的要由 {obj} 移除所有 {things}？"
 
 #. XXX summarize partitions here?
 #: ../subiquity/ui/views/filesystem/delete.py:149
 msgid "Reformat"
-msgstr ""
+msgstr "重新格式化"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:101
 #, python-brace-format
 msgid "existing {fstype}"
-msgstr ""
+msgstr "現有 {fstype}"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:103
 #, python-brace-format
 msgid "new {fstype}"
-msgstr ""
+msgstr "新增 {fstype}"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:135
 msgid "No disks or partitions mounted."
-msgstr ""
+msgstr "未有掛載的磁碟或分割區。"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:160
 msgid "MOUNT POINT"
-msgstr ""
+msgstr "掛載點"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:161
 #: ../subiquity/ui/views/filesystem/filesystem.py:385
 #: ../subiquity/ui/views/snaplist.py:162
 msgid "SIZE"
-msgstr ""
+msgstr "大小"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:162
 #: ../subiquity/ui/views/filesystem/filesystem.py:384
 msgid "TYPE"
-msgstr ""
+msgstr "類型"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:163
 msgid "DEVICE TYPE"
-msgstr ""
+msgstr "裝置類型"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:186
 msgid "Unmount"
-msgstr ""
+msgstr "卸載"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:260
 msgid "No available devices"
-msgstr ""
+msgstr "無可用的裝置"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:262
 msgid "No used devices"
-msgstr ""
+msgstr "無使用的裝置"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:323
 #, python-brace-format
 msgid "Remove from {device}"
-msgstr ""
+msgstr "自 {device} 中移除"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:328
 #, python-brace-format
 msgid "Add {ptype} Partition"
-msgstr ""
+msgstr "加入 {ptype} 分割區"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:333
 msgid "Stop Using As Boot Device"
-msgstr ""
+msgstr "不再將其用作開機裝置"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:338
 msgid "Add As Another Boot Device"
-msgstr ""
+msgstr "新增為另一個開機裝置"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:339
 msgid "Use As Boot Device"
-msgstr ""
+msgstr "用作開機裝置"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:383
 msgid "DEVICE"
-msgstr ""
+msgstr "裝置"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:412
 msgid "free space"
-msgstr ""
+msgstr "可用空間"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:426
 msgid "Storage configuration"
-msgstr ""
+msgstr "儲存空間設定"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:437
 msgid "Create software RAID (md)"
-msgstr ""
+msgstr "建立軟體 RAID (md)"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:440
 msgid "Create volume group (LVM)"
-msgstr ""
+msgstr "建立卷宗群組 (LVM)"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:447
 msgid "FILE SYSTEM SUMMARY"
-msgstr ""
+msgstr "檔案系統彙整"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:452
 msgid "AVAILABLE DEVICES"
-msgstr ""
+msgstr "可用裝置"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:459
 msgid "USED DEVICES"
-msgstr ""
+msgstr "使用的裝置"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:477
 msgid "Mount a filesystem at /"
-msgstr ""
+msgstr "將檔案系統掛載於 /"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:479
 msgid "Select a boot disk"
-msgstr ""
+msgstr "選擇開機磁碟"
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:484
 msgid "To continue you need to:"
-msgstr ""
+msgstr "為了繼續，您需要："
 
 #: ../subiquity/ui/views/filesystem/filesystem.py:498
 msgid "Reset"
-msgstr "Atstatīt"
+msgstr "重設"
 
 #: ../subiquity/ui/views/filesystem/guided.py:53
 msgid "Configure a guided storage layout, or create a custom one:"
-msgstr ""
+msgstr "設定一個引導式儲存空間配置，或是建立自訂的配置："
 
 #: ../subiquity/ui/views/filesystem/guided.py:58
 #: ../subiquity/ui/views/filesystem/lvm.py:93
 msgid "Passphrase:"
-msgstr ""
+msgstr "通關密語："
 
 #: ../subiquity/ui/views/filesystem/guided.py:59
 #: ../subiquity/ui/views/filesystem/lvm.py:94
 msgid "Confirm passphrase:"
-msgstr ""
+msgstr "確認通關密語："
 
 #: ../subiquity/ui/views/filesystem/guided.py:63
 #: ../subiquity/ui/views/identity.py:137
 msgid "Password must be set"
-msgstr ""
+msgstr "必須設定密碼"
 
 #: ../subiquity/ui/views/filesystem/guided.py:67
 #: ../subiquity/ui/views/identity.py:141
 msgid "Passwords do not match"
-msgstr "Paroles nesakrīt"
+msgstr "密碼不符"
 
 #: ../subiquity/ui/views/filesystem/guided.py:80
 msgid "Encrypt the LVM group with LUKS"
-msgstr ""
+msgstr "用 LUKS 加密 LVM 群組"
 
 #: ../subiquity/ui/views/filesystem/guided.py:109
 msgid "Set up this disk as an LVM group"
-msgstr ""
+msgstr "將此磁碟設定為 LVM 群組"
 
 #: ../subiquity/ui/views/filesystem/guided.py:143
 msgid "Use an entire disk"
-msgstr ""
+msgstr "使用整個磁碟"
 
 #: ../subiquity/ui/views/filesystem/guided.py:145
 msgid "Custom storage layout"
-msgstr ""
+msgstr "自訂儲存配置"
 
 #: ../subiquity/ui/views/filesystem/guided.py:158
 msgid ""
@@ -1193,6 +1227,9 @@ msgid ""
 "storage\n"
 "configuration. Manual configuration may still be possible.\n"
 msgstr ""
+"\n"
+"系統區塊裝置探測沒有找到任何空間夠大可進行引導式儲存空間設定的磁碟。\n"
+"可能可以進行手動設定。\n"
 
 #: ../subiquity/ui/views/filesystem/guided.py:194
 msgid ""
@@ -1200,27 +1237,30 @@ msgid ""
 "Block probing did not discover any disks. Unfortunately this means that\n"
 "installation will not be possible.\n"
 msgstr ""
+"\n"
+"系統區塊裝置探測沒有找到任何磁碟。很不幸的這代表\n"
+"安裝將不可能完成。\n"
 
 #: ../subiquity/ui/views/filesystem/guided.py:202
 msgid "Guided storage configuration"
-msgstr ""
+msgstr "引導式儲存空間設定"
 
 #: ../subiquity/ui/views/filesystem/guided.py:221
 #: ../subiquity/ui/views/filesystem/partition.py:422
 #: ../subiquity/ui/views/keyboard.py:98 ../subiquity/ui/views/keyboard.py:136
 #: ../subiquity/ui/views/keyboard.py:332
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../subiquity/ui/views/filesystem/guided.py:229
 msgid "Help on guided storage configuration"
-msgstr ""
+msgstr "關於引導式儲存空間設定的說明"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:61
 msgid ""
 "The only characters permitted in the name of a volume group are a-z, A-Z, 0-"
 "9, +, _, . and -"
-msgstr ""
+msgstr "邏輯卷宗群組名稱可用的字元為 a-z、A-Z、0-9、+、_、. 和 -"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:86
 msgid "passphrases"
@@ -1229,69 +1269,69 @@ msgstr ""
 #: ../subiquity/ui/views/filesystem/lvm.py:90
 #: ../subiquity/ui/views/filesystem/raid.py:92
 msgid "Devices:"
-msgstr ""
+msgstr "裝置："
 
 #: ../subiquity/ui/views/filesystem/lvm.py:91
 #: ../subiquity/ui/views/filesystem/raid.py:93
 msgid "Size:"
-msgstr ""
+msgstr "大小："
 
 #: ../subiquity/ui/views/filesystem/lvm.py:92
 msgid "Create encrypted volume"
-msgstr ""
+msgstr "建立加密卷宗"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:105
 msgid "Select at least one device to be part of the volume group."
-msgstr ""
+msgstr "選擇至少一裝置，以組成卷宗群組。"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:111
 msgid "The name of a volume group cannot be empty"
-msgstr ""
+msgstr "卷宗群組的名稱不得為空"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:113
 msgid "The name of a volume group cannot start with a hyphen"
-msgstr ""
+msgstr "卷宗群組的名稱不得以連字號開頭"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:115
 #, python-brace-format
 msgid "There is already a volume group named '{name}'"
-msgstr ""
+msgstr "已有名為「{name}」的卷宗群組"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:119
 #, python-brace-format
 msgid "{name} is not a valid name for a volume group"
-msgstr ""
+msgstr "{name} 並非有效的卷宗群組名稱"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:124
 msgid "Passphrase must be set"
-msgstr ""
+msgstr "必須設定通關密語"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:129
 msgid "Passphrases do not match"
-msgstr ""
+msgstr "通關密語不相符"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:142
 msgid "Create LVM volume group"
-msgstr ""
+msgstr "建立 LVM 卷宗群組"
 
 #: ../subiquity/ui/views/filesystem/lvm.py:157
 #, python-brace-format
 msgid "Edit volume group \"{name}\""
-msgstr ""
+msgstr "編輯卷宗群組「{name}」"
 
 #: ../subiquity/ui/views/filesystem/partition.py:76
 msgid "Leave unformatted"
-msgstr ""
+msgstr "保持未格式化狀態"
 
 #: ../subiquity/ui/views/filesystem/partition.py:79
 #, python-brace-format
 msgid "Leave formatted as {fstype}"
-msgstr ""
+msgstr "保持格式化為 {fstype} 狀態"
 
 #: ../subiquity/ui/views/filesystem/partition.py:112
 #, python-brace-format
 msgid "Capped partition size at {size}"
-msgstr ""
+msgstr "設定分割區大小上限於 {size}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:119
 #, python-brace-format
@@ -1302,40 +1342,40 @@ msgstr ""
 msgid ""
 "The only characters permitted in the name of a logical volume are a-z, A-Z, "
 "0-9, +, _, . and -"
-msgstr ""
+msgstr "邏輯卷宗名稱可用的字元為 a-z、A-Z、0-9、+、_、. 和 -"
 
 #: ../subiquity/ui/views/filesystem/partition.py:165
 #, python-brace-format
 msgid "Size (max {size}):"
-msgstr ""
+msgstr "大小（最大 {size}）："
 
 #: ../subiquity/ui/views/filesystem/partition.py:202
 msgid "Name: "
-msgstr ""
+msgstr "名稱： "
 
 #: ../subiquity/ui/views/filesystem/partition.py:204
 msgid "Format:"
-msgstr ""
+msgstr "格式："
 
 #: ../subiquity/ui/views/filesystem/partition.py:205
 msgid "Mount:"
-msgstr ""
+msgstr "掛載點："
 
 #: ../subiquity/ui/views/filesystem/partition.py:207
 msgid "Use as swap"
-msgstr ""
+msgstr "用作置換空間"
 
 #: ../subiquity/ui/views/filesystem/partition.py:208
 msgid "Use this swap partition in the installed system."
-msgstr ""
+msgstr "在安裝的系統使用此置換分割區"
 
 #: ../subiquity/ui/views/filesystem/partition.py:232
 msgid "The name of a logical volume cannot be empty"
-msgstr ""
+msgstr "邏輯卷宗的名稱不可為空"
 
 #: ../subiquity/ui/views/filesystem/partition.py:234
 msgid "The name of a logical volume cannot start with a hyphen"
-msgstr ""
+msgstr "邏輯卷宗的名稱不可以連字號開頭"
 
 #: ../subiquity/ui/views/filesystem/partition.py:237
 #, python-brace-format
@@ -1354,19 +1394,19 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/partition.py:258
 msgid "Path exceeds PATH_MAX"
-msgstr ""
+msgstr "路徑長度超越 PATH_MAX"
 
 #: ../subiquity/ui/views/filesystem/partition.py:261
 #, python-brace-format
 msgid "{device} is already mounted at {path}."
-msgstr ""
+msgstr "{device} 已掛載於 {path}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:269
 #, python-brace-format
 msgid ""
 "Mounting an existing filesystem at {mountpoint} is usually a bad idea, "
 "proceed only with caution."
-msgstr ""
+msgstr "將現存的檔案系統掛載於 {mountpoint} 通常不是個好主意，請謹慎進行。"
 
 #: ../subiquity/ui/views/filesystem/partition.py:285
 #, python-brace-format
@@ -1387,12 +1427,16 @@ msgid ""
 "If this disk is selected as a boot device, GRUB will be installed onto\n"
 "the target disk's MBR."
 msgstr ""
+"若此磁碟被選為開機裝置，GRUB 將被安裝於\n"
+"目標磁碟的主開機紀錄上。"
 
 #: ../subiquity/ui/views/filesystem/partition.py:301
 msgid ""
 "As this disk has been selected as a boot device, GRUB will be\n"
 "installed onto the target disk's MBR."
 msgstr ""
+"因為磁碟被選為開機裝置，GRUB 將被安裝於\n"
+"目標磁碟的主開機紀錄上。"
 
 #: ../subiquity/ui/views/filesystem/partition.py:305
 msgid ""
@@ -1402,6 +1446,11 @@ msgid ""
 "disk is selected as a boot device, Grub will be installed onto this\n"
 "partition, which must be formatted as fat32.\n"
 msgstr ""
+"開機載入程式分割區\n"
+"\n"
+"此為 UEFI 必需的 ESP（EFI 系統分割區）。\n"
+"若本磁碟被選為開機裝置，GRUB 將被安裝於此分割區，\n"
+"且必須格式化為 FAT32。\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:313
 msgid ""
@@ -1411,16 +1460,23 @@ msgid ""
 "disk has been selected as a boot device, Grub will be installed onto\n"
 "this partition, which must be formatted as fat32.\n"
 msgstr ""
+"開機載入程式分割區\n"
+"\n"
+"此為 UEFI 必需的 ESP（EFI 系統分割區）。\n"
+"因本磁碟被選為開機裝置，GRUB 將被安裝於此分割區，\n"
+"且必須格式化為 FAT32。\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:321
 msgid "The only aspect of this partition that can be edited is the size.\n"
-msgstr ""
+msgstr "此分割區只有大小能被調整。\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:325
 msgid ""
 "You can choose whether to use the existing filesystem on this\n"
 "partition or reformat it.\n"
 msgstr ""
+"您可以選擇使用此分割區上的現有檔案系統，\n"
+"或者將其重新格式化。\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:330
 msgid ""
@@ -1429,6 +1485,10 @@ msgid ""
 "This is the PReP partion which is required on POWER. If this disk is\n"
 "selected as a boot device, Grub will be installed onto this partition.\n"
 msgstr ""
+"需要開機載入程式分割區\n"
+"\n"
+"此為開機時必要的 PReP 分割區。若本磁碟\n"
+"被選為開機裝置，GRUB 將被安裝於此分割區。\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:337
 msgid ""
@@ -1438,40 +1498,44 @@ msgid ""
 "been selected as a boot device, Grub will be installed onto this\n"
 "partition.\n"
 msgstr ""
+"需要開機載入程式分割區\n"
+"\n"
+"此為開機時必要的 PReP 分割區。因為本磁碟\n"
+"被選為開機裝置，GRUB 將被安裝於此分割區。\n"
 
 #: ../subiquity/ui/views/filesystem/partition.py:429
 msgid "Use existing fat32 filesystem"
-msgstr ""
+msgstr "使用現有 fat32 檔案系統"
 
 #: ../subiquity/ui/views/filesystem/partition.py:435
 msgid "Reformat as fresh fat32 filesystem"
-msgstr ""
+msgstr "重新格式化為新的 fat32 檔案系統"
 
 #: ../subiquity/ui/views/filesystem/partition.py:513
 #, python-brace-format
 msgid "Adding logical volume to {vgname}"
-msgstr ""
+msgstr "在 {vgname} 加入邏輯卷宗"
 
 #: ../subiquity/ui/views/filesystem/partition.py:516
 #, python-brace-format
 msgid "Adding {ptype} partition to {device}"
-msgstr ""
+msgstr "在 {device} 加入 {ptype} 分割區"
 
 #: ../subiquity/ui/views/filesystem/partition.py:522
 #, python-brace-format
 msgid "Editing logical volume {lvname} of {vgname}"
-msgstr ""
+msgstr "正在編輯 {vgname} 的 {lvname} 邏輯卷宗"
 
 #: ../subiquity/ui/views/filesystem/partition.py:527
 #, python-brace-format
 msgid "Editing partition {number} of {device}"
-msgstr ""
+msgstr "正在編輯 {device} 上的分割區 {number}"
 
 #: ../subiquity/ui/views/filesystem/partition.py:580
 msgid ""
 "Formatting and mounting a disk directly is unusual. You probably want to add "
 "a partition instead."
-msgstr ""
+msgstr "直接格式化並掛載磁碟是很罕見的，您或許會想先新增分割區。"
 
 #: ../subiquity/ui/views/filesystem/partition.py:592
 #, python-brace-format
@@ -1480,13 +1544,13 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/probing.py:40
 msgid "Waiting for storage probing to complete"
-msgstr ""
+msgstr "等待儲存裝置探測工作完成中"
 
 #: ../subiquity/ui/views/filesystem/probing.py:48
 msgid ""
 "The installer is probing for block devices to install to. Please wait until "
 "it completes."
-msgstr ""
+msgstr "安裝程式正在探測要安裝至哪個系統區塊裝置。請稍待它完成。"
 
 #: ../subiquity/ui/views/filesystem/probing.py:61
 msgid ""
@@ -1494,26 +1558,28 @@ msgid ""
 "on Launchpad, and if possible include the contents of the /var/log/installer "
 "directory."
 msgstr ""
+"很不幸的探測要安裝至哪個系統區塊裝置的工作失敗。請至 Launchpad 回報錯誤，若可能的話請附上 /var/log/installer "
+"資料夾內的內容。"
 
 #: ../subiquity/ui/views/filesystem/probing.py:68
 msgid "Probing for devices to install to failed"
-msgstr ""
+msgstr "探測要安裝至哪個裝置的工作失敗"
 
 #: ../subiquity/ui/views/filesystem/probing.py:77
 msgid "Show Error Report"
-msgstr ""
+msgstr "顯示錯誤報告"
 
 #: ../subiquity/ui/views/filesystem/raid.py:67
 msgid "/ is not permitted in the name of a RAID device"
-msgstr ""
+msgstr "/ 不可出現在 RAID 裝置名稱中"
 
 #: ../subiquity/ui/views/filesystem/raid.py:73
 msgid "Whitespace is not permitted in the name of a RAID device"
-msgstr ""
+msgstr "空白不可出現在 RAID 裝置名稱中"
 
 #: ../subiquity/ui/views/filesystem/raid.py:91
 msgid "RAID Level:"
-msgstr ""
+msgstr "RAID 等級："
 
 #: ../subiquity/ui/views/filesystem/raid.py:104
 #, python-brace-format
@@ -1522,21 +1588,21 @@ msgstr ""
 
 #: ../subiquity/ui/views/filesystem/raid.py:107
 msgid ". and .. are not valid names for RAID devices"
-msgstr ""
+msgstr ". 及 .. 並非有效的 RAID 裝置名稱"
 
 #: ../subiquity/ui/views/filesystem/raid.py:113
 #, python-brace-format
 msgid "RAID Level \"{level}\" requires at least {min_active} active devices"
-msgstr ""
+msgstr "RAID {level} 需要至少 {min_active} 部連線的磁碟"
 
 #: ../subiquity/ui/views/filesystem/raid.py:126
 msgid "Create software RAID (\"MD\") disk"
-msgstr ""
+msgstr "建立軟體 RAID (\"MD\") 磁碟"
 
 #: ../subiquity/ui/views/filesystem/raid.py:142
 #, python-brace-format
 msgid "Edit software RAID disk \"{name}\""
-msgstr ""
+msgstr "編輯軟體 RAID 磁碟 {name}"
 
 #: ../subiquity/ui/views/help.py:70
 #, python-brace-format
@@ -1555,6 +1621,18 @@ msgid ""
 "\n"
 "This is version {snap_version} of the installer.\n"
 msgstr ""
+"\n"
+"歡迎使用 Ubuntu Server 安裝程式\n"
+"\n"
+"Ubuntu Server 乃雲端及資料中心裡最熱門的伺服器 Linux 作業系統，\n"
+"此版本的 Ubuntu 在釋出後的九個月內都可以持續取得更新。\n"
+"\n"
+"本安裝程式將帶您安裝 Ubuntu Server {release}。\n"
+"\n"
+"本安裝程式僅需使用上下鍵、空白鍵（或 Enter / Return 鍵），\n"
+"並輸入一些資料。\n"
+"\n"
+"此為 {snap_version} 版的安裝程式。\n"
 
 #: ../subiquity/ui/views/help.py:86
 #, python-brace-format
@@ -1573,6 +1651,18 @@ msgid ""
 "\n"
 "This is version {snap_version} of the installer.\n"
 msgstr ""
+"\n"
+"歡迎使用 Ubuntu Server 安裝程式\n"
+"\n"
+"Ubuntu Server 乃雲端及資料中心裡最熱門的伺服器 Linux 作業系統，\n"
+"您可以仰賴其保證的五年免費升級。\n"
+"\n"
+"本安裝程式將帶您安裝 Ubuntu Server {release} LTS。\n"
+"\n"
+"本安裝程式僅需使用上下鍵、空白鍵（或 Enter/Return 鍵），\n"
+"並輸入一些資料。\n"
+"\n"
+"此為 {snap_version} 版的安裝程式。\n"
 
 #: ../subiquity/ui/views/help.py:102
 msgid ""
@@ -1587,6 +1677,8 @@ msgid ""
 "\n"
 "To connect, SSH to any of these addresses:\n"
 msgstr ""
+"\n"
+"若要連線請以 SSH 建立連線至以下其一位址：\n"
 
 #: ../subiquity/ui/views/help.py:111
 #, python-brace-format
@@ -1635,6 +1727,8 @@ msgid ""
 "Unfortunately this system seems to have no global IP addresses at this\n"
 "time.\n"
 msgstr ""
+"\n"
+"很抱歉，此系統目前沒有全域的 IP 位址。\n"
 
 #: ../subiquity/ui/views/help.py:141
 msgid ""
@@ -1642,46 +1736,48 @@ msgid ""
 "Unfortunately the installer was unable to detect the password that has\n"
 "been set.\n"
 msgstr ""
+"\n"
+"很抱歉，安裝程式無法偵測設定的密碼。\n"
 
 #: ../subiquity/ui/views/help.py:217
 msgid "The following keys can be used at any time:"
-msgstr ""
+msgstr "下列金鑰可隨時被使用："
 
 #: ../subiquity/ui/views/help.py:221
 msgid "ESC"
-msgstr ""
+msgstr "ESC"
 
 #: ../subiquity/ui/views/help.py:221
 msgid "go back"
-msgstr ""
+msgstr "後退"
 
 #: ../subiquity/ui/views/help.py:222
 msgid "F1"
-msgstr ""
+msgstr "F1 鍵"
 
 #: ../subiquity/ui/views/help.py:222
 msgid "open help menu"
-msgstr ""
+msgstr "打開說明選單"
 
 #: ../subiquity/ui/views/help.py:223
 msgid "Control-Z, F2"
-msgstr ""
+msgstr "Control-Z, F2"
 
 #: ../subiquity/ui/views/help.py:223
 msgid "switch to shell"
-msgstr ""
+msgstr "切換至 shell"
 
 #: ../subiquity/ui/views/help.py:224
 msgid "Control-L, F3"
-msgstr ""
+msgstr "Control-L, F3"
 
 #: ../subiquity/ui/views/help.py:224
 msgid "redraw screen"
-msgstr ""
+msgstr "重繪畫面"
 
 #: ../subiquity/ui/views/help.py:228
 msgid "Control-T, F4"
-msgstr ""
+msgstr "Control-T, F4"
 
 #: ../subiquity/ui/views/help.py:228
 msgid "toggle rich mode (colour, unicode) on and off"
@@ -1689,39 +1785,39 @@ msgstr ""
 
 #: ../subiquity/ui/views/help.py:232
 msgid "Control-X"
-msgstr ""
+msgstr "Control-X"
 
 #: ../subiquity/ui/views/help.py:232
 msgid "quit"
-msgstr ""
+msgstr "結束"
 
 #: ../subiquity/ui/views/help.py:233
 msgid "Control-E"
-msgstr ""
+msgstr "Control-E"
 
 #: ../subiquity/ui/views/help.py:233
 msgid "generate noisy error report"
-msgstr ""
+msgstr "產生較為詳盡的錯誤報告"
 
 #: ../subiquity/ui/views/help.py:234
 msgid "Control-R"
-msgstr ""
+msgstr "Control-R"
 
 #: ../subiquity/ui/views/help.py:234
 msgid "generate quiet error report"
-msgstr ""
+msgstr "產生較為簡略的錯誤報告"
 
 #: ../subiquity/ui/views/help.py:235
 msgid "Control-G"
-msgstr ""
+msgstr "Control-G"
 
 #: ../subiquity/ui/views/help.py:235
 msgid "pretend to run an install"
-msgstr ""
+msgstr "假裝要執行安裝"
 
 #: ../subiquity/ui/views/help.py:236
 msgid "Control-U"
-msgstr ""
+msgstr "Control-U"
 
 #: ../subiquity/ui/views/help.py:236
 msgid "crash the ui"
@@ -1729,27 +1825,27 @@ msgstr ""
 
 #: ../subiquity/ui/views/help.py:250
 msgid "(dry-run only)"
-msgstr ""
+msgstr "（僅乾運行）"
 
 #: ../subiquity/ui/views/help.py:266
 msgid "Shortcut Keys"
-msgstr ""
+msgstr "快捷鍵"
 
 #: ../subiquity/ui/views/help.py:292
 msgid "About this installer"
-msgstr ""
+msgstr "關於此安裝程式"
 
 #: ../subiquity/ui/views/help.py:294
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "鍵盤快捷鍵"
 
 #: ../subiquity/ui/views/help.py:296
 msgid "Enter shell"
-msgstr ""
+msgstr "進入 shell"
 
 #: ../subiquity/ui/views/help.py:305 ../subiquity/ui/views/help.py:465
 msgid "Help on SSH access"
-msgstr ""
+msgstr "SSH 存取的說明"
 
 #: ../subiquity/ui/views/help.py:309
 msgid "Toggle rich mode"
@@ -1757,51 +1853,51 @@ msgstr ""
 
 #: ../subiquity/ui/views/help.py:321
 msgid "Help on this screen"
-msgstr ""
+msgstr "關於此頁面的說明"
 
 #: ../subiquity/ui/views/help.py:326 ../subiquity/ui/views/help.py:331
 msgid "View error reports"
-msgstr ""
+msgstr "檢視錯誤報告"
 
 #: ../subiquity/ui/views/help.py:399
 msgid "Help"
-msgstr ""
+msgstr "說明"
 
 #: ../subiquity/ui/views/help.py:456
 msgid "About the installer"
-msgstr ""
+msgstr "關於此安裝程式"
 
 #: ../subiquity/ui/views/identity.py:55
 msgid "The characters : , and = are not permitted in this field"
-msgstr ""
+msgstr "此欄位不允許 : , = 的字元"
 
 #: ../subiquity/ui/views/identity.py:65
 msgid "The only characters permitted in this field are a-z, 0-9, _ and -"
-msgstr ""
+msgstr "此欄位僅允許使用的字元為 a-z、0-9、_ 和 -"
 
 #: ../subiquity/ui/views/identity.py:89
 msgid "Your name:"
-msgstr "Jūsu vārds:"
+msgstr "您的名字："
 
 #: ../subiquity/ui/views/identity.py:91
 msgid "Your server's name:"
-msgstr ""
+msgstr "您的伺服器名稱："
 
 #: ../subiquity/ui/views/identity.py:92
 msgid "The name it uses when it talks to other computers."
-msgstr "Šo nosaukumu izmanto saziņā ar citiem datoriem."
+msgstr "當它與其它電腦溝通時所使用的名稱。"
 
 #: ../subiquity/ui/views/identity.py:93
 msgid "Pick a username:"
-msgstr "Izvēlieties lietotājvārdu:"
+msgstr "使用者名稱："
 
 #: ../subiquity/ui/views/identity.py:94
 msgid "Choose a password:"
-msgstr "Izvēlieties paroli:"
+msgstr "請設定一組密碼："
 
 #: ../subiquity/ui/views/identity.py:95
 msgid "Confirm your password:"
-msgstr "Apstipriniet paroli:"
+msgstr "確認您的密碼："
 
 #: ../subiquity/ui/views/identity.py:100
 #, python-brace-format
@@ -1810,7 +1906,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:105
 msgid "Server name must not be empty"
-msgstr ""
+msgstr "伺服器名稱不得為空白"
 
 #: ../subiquity/ui/views/identity.py:109
 #, python-brace-format
@@ -1823,7 +1919,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/identity.py:119
 msgid "Username missing"
-msgstr ""
+msgstr "缺少使用者名稱"
 
 #: ../subiquity/ui/views/identity.py:123
 #, python-brace-format
@@ -1837,50 +1933,50 @@ msgstr ""
 #: ../subiquity/ui/views/identity.py:132
 #, python-brace-format
 msgid "The username \"{username}\" is reserved for use by the system."
-msgstr ""
+msgstr "使用者名稱「{username}」保留供系統使用。"
 
 #. desc is "passwords" or "passphrases"
 #: ../subiquity/ui/views/identity.py:150
 #, python-brace-format
 msgid "{desc} do not match"
-msgstr ""
+msgstr "{desc} 不相符"
 
 #: ../subiquity/ui/views/identity.py:158
 msgid "Profile setup"
-msgstr ""
+msgstr "設置設定組合"
 
 #: ../subiquity/ui/views/identity.py:159
 msgid ""
 "Enter the username and password you will use to log in to the system. You "
 "can configure SSH access on the next screen but a password is still needed "
 "for sudo."
-msgstr ""
+msgstr "輸入您用來登入系統的帳號及密碼。您可以在下個畫面設定 SSH 存取，但 sudo 的密碼是必要的。"
 
 #: ../subiquity/ui/views/identity.py:188
 msgid "passwords"
-msgstr ""
+msgstr "密碼"
 
 #: ../subiquity/ui/views/installprogress.py:52
 msgid "Install progress"
-msgstr ""
+msgstr "安裝進度"
 
 #: ../subiquity/ui/views/installprogress.py:59
 #: ../subiquity/ui/views/installprogress.py:174
 #: ../subiquity/ui/views/installprogress.py:181
 msgid "Reboot Now"
-msgstr ""
+msgstr "馬上重新開機"
 
 #: ../subiquity/ui/views/installprogress.py:61
 msgid "View error report"
-msgstr ""
+msgstr "檢視錯誤報告"
 
 #: ../subiquity/ui/views/installprogress.py:63
 msgid "View full log"
-msgstr ""
+msgstr "檢視完整記錄檔"
 
 #: ../subiquity/ui/views/installprogress.py:79
 msgid "Full installer output"
-msgstr ""
+msgstr "完整的安裝程式輸出"
 
 #: ../subiquity/ui/views/installprogress.py:142
 #: ../subiquity/ui/views/installprogress.py:145
@@ -1888,26 +1984,26 @@ msgstr ""
 #: ../subiquity/ui/views/installprogress.py:151
 #: ../subiquity/ui/views/installprogress.py:154
 msgid "Installing system"
-msgstr "Instalēju sistēmu"
+msgstr "正在安裝系統"
 
 #: ../subiquity/ui/views/installprogress.py:157
 #: ../subiquity/ui/views/installprogress.py:165
 #: ../subiquity/ui/views/installprogress.py:173
 msgid "Install complete!"
-msgstr ""
+msgstr "安裝完成！"
 
 #: ../subiquity/ui/views/installprogress.py:159
 msgid "Cancel update and reboot"
-msgstr ""
+msgstr "取消更新並重新開機"
 
 #: ../subiquity/ui/views/installprogress.py:166
 #: ../subiquity/ui/views/installprogress.py:214
 msgid "Rebooting..."
-msgstr ""
+msgstr "正在重新開機..."
 
 #: ../subiquity/ui/views/installprogress.py:180
 msgid "An error occurred during installation"
-msgstr ""
+msgstr "安裝過程中發生錯誤"
 
 #: ../subiquity/ui/views/installprogress.py:230
 msgid ""
@@ -1919,10 +2015,16 @@ msgid ""
 "\n"
 "Are you sure you want to continue?"
 msgstr ""
+"選擇下方的繼續將會開始進行安裝，而要被格式化\n"
+"的磁碟上原有的檔案將會消失。\n"
+"\n"
+"一旦安裝開始，您將會無法回到此頁面或上一頁。\n"
+"\n"
+"您是否想要繼續？"
 
 #: ../subiquity/ui/views/installprogress.py:251
 msgid "Confirm destructive action"
-msgstr ""
+msgstr "確認執行不可逆的破壞性操作"
 
 #: ../subiquity/ui/views/installprogress.py:271
 #, python-brace-format
@@ -1931,16 +2033,19 @@ msgid ""
 "\n"
 "You can wait for this to complete or switch to a shell.\n"
 msgstr ""
+"在 {tty} 上執行的安裝程式正在安裝作業系統。\n"
+"\n"
+"您可以等它執行完畢或切換至 shell。\n"
 
 #: ../subiquity/ui/views/keyboard.py:67
 msgid "Keyboard auto-detection"
-msgstr ""
+msgstr "鍵盤配置自動偵測"
 
 #: ../subiquity/ui/views/keyboard.py:93
 msgid ""
 "Keyboard detection starting. You will be asked a series of questions about "
 "your keyboard. Press escape at any time to go back to the previous screen."
-msgstr ""
+msgstr "開始偵測鍵盤配置，您將會被問幾個與您鍵盤有關的問題。您可以隨時按下 Esc 鍵回到上一個畫面。"
 
 #: ../subiquity/ui/views/keyboard.py:106
 msgid ""
@@ -1948,6 +2053,9 @@ msgid ""
 "\n"
 "Your keyboard was detected as:\n"
 msgstr ""
+"鍵盤配置自動偵測已完成。\n"
+"\n"
+"您的鍵盤配置為：\n"
 
 #: ../subiquity/ui/views/keyboard.py:111
 msgid ""
@@ -1956,10 +2064,13 @@ msgid ""
 "another layout or run the automated detection again.\n"
 "\n"
 msgstr ""
+"\n"
+"若正確，請在下個畫面選擇「完成」。若不正確您可以選擇其他配置或重新執行自動偵測。\n"
+"\n"
 
 #: ../subiquity/ui/views/keyboard.py:128
 msgid "Layout"
-msgstr ""
+msgstr "配置"
 
 #: ../subiquity/ui/views/keyboard.py:129
 msgid "Variant"
@@ -1967,15 +2078,15 @@ msgstr ""
 
 #: ../subiquity/ui/views/keyboard.py:152
 msgid "Please press one of the following keys:"
-msgstr ""
+msgstr "請按以下其中一個鍵："
 
 #: ../subiquity/ui/views/keyboard.py:188 ../subiquity/ui/views/keyboard.py:196
 msgid "Input was not recognized, try again"
-msgstr ""
+msgstr "無法辨識輸入，請重試"
 
 #: ../subiquity/ui/views/keyboard.py:213
 msgid "Is the following key present on your keyboard?"
-msgstr ""
+msgstr "以下按鍵有出現在您的鍵盤上嗎？"
 
 #: ../subiquity/ui/views/keyboard.py:277
 msgid ""
@@ -1989,86 +2100,92 @@ msgid ""
 "\n"
 "Not all listed keys are present on all keyboards. "
 msgstr ""
+"您將會需要一個能夠在鍵盤的國際配置以及標準拉丁配置間切換的方法。\n"
+"\n"
+"右 Alt 或 Caps Lock 鍵通常是個較符合人體工學的選擇（或採用後者，請用 Shift+Caps Lock "
+"鍵的組合來切換大小寫）。Alt+Shift 也是個很受歡迎的組合；不過這將會使這組合鍵在 Emacs 與其他程式中無法使用原本該有的特定功能。\n"
+"\n"
+"不是在所有鍵盤上都可找到所有列出來的按鍵。 "
 
 #: ../subiquity/ui/views/keyboard.py:290
 msgid "Caps Lock"
-msgstr ""
+msgstr "Caps Lock 鍵"
 
 #: ../subiquity/ui/views/keyboard.py:291
 msgid "Right Alt (AltGr)"
-msgstr ""
+msgstr "右 Alt (AltGr)"
 
 #: ../subiquity/ui/views/keyboard.py:292
 msgid "Right Control"
-msgstr ""
+msgstr "右 Control"
 
 #: ../subiquity/ui/views/keyboard.py:293
 msgid "Right Shift"
-msgstr ""
+msgstr "右 Shift"
 
 #: ../subiquity/ui/views/keyboard.py:294
 msgid "Right Logo key"
-msgstr ""
+msgstr "右 Logo 鍵"
 
 #: ../subiquity/ui/views/keyboard.py:295
 msgid "Menu key"
-msgstr ""
+msgstr "選單鍵"
 
 #: ../subiquity/ui/views/keyboard.py:296
 msgid "Alt+Shift"
-msgstr ""
+msgstr "Alt+Shift"
 
 #: ../subiquity/ui/views/keyboard.py:297
 msgid "Control+Shift"
-msgstr ""
+msgstr "Control+Shift"
 
 #: ../subiquity/ui/views/keyboard.py:298
 msgid "Control+Alt"
-msgstr ""
+msgstr "Control+Alt"
 
 #: ../subiquity/ui/views/keyboard.py:299
 msgid "Alt+Caps Lock"
-msgstr ""
+msgstr "Alt+Caps Lock"
 
 #: ../subiquity/ui/views/keyboard.py:300
 msgid "Left Control+Left Shift"
-msgstr ""
+msgstr "左 Ctrl + 左 Shift"
 
 #: ../subiquity/ui/views/keyboard.py:301
 msgid "Left Alt"
-msgstr ""
+msgstr "左 Alt"
 
 #: ../subiquity/ui/views/keyboard.py:302
 msgid "Left Control"
-msgstr ""
+msgstr "左 Control"
 
 #: ../subiquity/ui/views/keyboard.py:303
 msgid "Left Shift"
-msgstr ""
+msgstr "左 Shift"
 
 #: ../subiquity/ui/views/keyboard.py:304
 msgid "Left Logo key"
-msgstr ""
+msgstr "左 Logo 鍵"
 
 #: ../subiquity/ui/views/keyboard.py:305
 msgid "Scroll Lock key"
-msgstr ""
+msgstr "Scroll Lock 鍵"
 
 #: ../subiquity/ui/views/keyboard.py:306
 msgid "No toggling"
-msgstr ""
+msgstr "不切換"
 
 #: ../subiquity/ui/views/keyboard.py:327
 msgid "Shortcut: "
-msgstr ""
+msgstr "快捷鍵： "
 
 #: ../subiquity/ui/views/keyboard.py:337
 msgid "Select layout toggle"
-msgstr ""
+msgstr "選擇配置切換鍵"
 
 #: ../subiquity/ui/views/keyboard.py:355
 msgid "Layout:"
-msgstr ""
+msgstr "鍵盤配置："
 
 #: ../subiquity/ui/views/keyboard.py:356
 msgid "Variant:"
@@ -2076,44 +2193,44 @@ msgstr ""
 
 #: ../subiquity/ui/views/keyboard.py:361
 msgid "Keyboard configuration"
-msgstr ""
+msgstr "鍵盤設定"
 
 #: ../subiquity/ui/views/keyboard.py:382
 msgid ""
 "Please select the layout of the keyboard directly attached to the system, if "
 "any."
-msgstr ""
+msgstr "若有鍵盤連接到本系統，請選擇它的鍵盤配置。"
 
 #: ../subiquity/ui/views/keyboard.py:385
 msgid ""
 "Please select your keyboard layout below, or select \"Identify keyboard\" to "
 "detect your layout automatically."
-msgstr ""
+msgstr "請在下方選擇您的鍵盤配置，或選擇「辨認鍵盤配置」來自動偵測您的配置。"
 
 #: ../subiquity/ui/views/keyboard.py:394
 msgid "Identify keyboard"
-msgstr ""
+msgstr "辨認鍵盤配置"
 
 #: ../subiquity/ui/views/keyboard.py:429
 msgid "Applying config"
-msgstr ""
+msgstr "套用設定中"
 
 #: ../subiquity/ui/views/mirror.py:32
 msgid ""
 "You may provide an archive mirror that will be used instead of the default."
-msgstr ""
+msgstr "您可以設定鏡像站以替代預設的伺服器。"
 
 #: ../subiquity/ui/views/mirror.py:40
 msgid "Mirror address:"
-msgstr ""
+msgstr "鏡像站位址："
 
 #: ../subiquity/ui/views/mirror.py:45
 msgid "Configure Ubuntu archive mirror"
-msgstr ""
+msgstr "設定 Ubuntu 鏡像站"
 
 #: ../subiquity/ui/views/mirror.py:46
 msgid "If you use an alternative mirror for Ubuntu, enter its details here."
-msgstr ""
+msgstr "若您要使用 Ubuntu 的替代鏡像站，請在此輸入它的資訊。"
 
 #: ../subiquity/ui/views/proxy.py:33
 msgid ""
@@ -2123,156 +2240,159 @@ msgid ""
 "The proxy information should be given in the standard form of "
 "\"http://[[user][:pass]@]host[:port]/\"."
 msgstr ""
+"若您需要使用 HTTP 代理伺服器來存取網際網路，請在此輸入代理伺服器資訊。否則請將此處留白。\n"
+"\n"
+"代理伺服器資訊應該符合後列標準格式「http://[[user][:pass]@]host[:port]/」。"
 
 #: ../subiquity/ui/views/proxy.py:43
 msgid "Proxy address:"
-msgstr ""
+msgstr "代理伺服器位址："
 
 #: ../subiquity/ui/views/proxy.py:48
 msgid "Configure proxy"
-msgstr ""
+msgstr "設定代理伺服器"
 
 #: ../subiquity/ui/views/proxy.py:49
 msgid ""
 "If this system requires a proxy to connect to the internet, enter its "
 "details here."
-msgstr ""
+msgstr "若此系統需要透過代理伺服器來連接網際網路，請在此輸入詳細資料。"
 
 #: ../subiquity/ui/views/refresh.py:111
 msgid "Checking for installer update..."
-msgstr ""
+msgstr "檢查有否安裝程式更新..."
 
 #: ../subiquity/ui/views/refresh.py:113
 msgid ""
 "Contacting the snap store to check if a new version of the installer is "
 "available."
-msgstr ""
+msgstr "正在與 Snap 商店檢查是否有新版安裝程式。"
 
 #: ../subiquity/ui/views/refresh.py:117
 msgid "Contacting the snap store failed"
-msgstr ""
+msgstr "與 Snap 商店連線失敗"
 
 #: ../subiquity/ui/views/refresh.py:119
 msgid "Contacting the snap store failed:"
-msgstr ""
+msgstr "與 Snap 商店連線失敗："
 
 #: ../subiquity/ui/views/refresh.py:122
 msgid "Installer update available"
-msgstr ""
+msgstr "有新版的安裝程式"
 
 #: ../subiquity/ui/views/refresh.py:124
 #, python-brace-format
 msgid ""
 "Version {new} of the installer is now available ({current} is currently "
 "running)."
-msgstr ""
+msgstr "{new} 版的安裝程式已可供使用（目前使用的是 {current} 版）。"
 
 #: ../subiquity/ui/views/refresh.py:128
 msgid "Downloading update..."
-msgstr ""
+msgstr "正在下載更新..."
 
 #: ../subiquity/ui/views/refresh.py:130
 msgid ""
 "Please wait while the updated installer is being downloaded. The installer "
 "will restart automatically when the download is complete."
-msgstr ""
+msgstr "正在下載新版安裝程式，請稍候，安裝程式將在下載完成後自動重新啟動。"
 
 #: ../subiquity/ui/views/refresh.py:134
 msgid "Update failed"
-msgstr ""
+msgstr "更新失敗"
 
 #: ../subiquity/ui/views/refresh.py:136
 msgid "Downloading and applying the update:"
-msgstr ""
+msgstr "正在下載並套用更新："
 
 #: ../subiquity/ui/views/refresh.py:156 ../subiquity/ui/views/refresh.py:183
 #: ../subiquity/ui/views/refresh.py:213 ../subiquity/ui/views/refresh.py:275
 msgid "Continue without updating"
-msgstr ""
+msgstr "以目前版本繼續"
 
 #: ../subiquity/ui/views/refresh.py:182 ../subiquity/ui/views/refresh.py:274
 #: ../subiquity/ui/views/snaplist.py:264 ../subiquity/ui/views/snaplist.py:376
 msgid "Try again"
-msgstr ""
+msgstr "重試"
 
 #: ../subiquity/ui/views/refresh.py:199
 msgid "You can read the release notes for each version at:"
-msgstr ""
+msgstr "您可在這裡閱讀每個版本的發行備註："
 
 #: ../subiquity/ui/views/refresh.py:206
 msgid ""
 "If you choose to update, the update will be downloaded and the installation "
 "will continue from here."
-msgstr ""
+msgstr "若您選擇更新，將下載更新檔，且安裝進度將從此步驟繼續。"
 
 #: ../subiquity/ui/views/refresh.py:212
 msgid "Update to the new installer"
-msgstr ""
+msgstr "更新到新版安裝程式"
 
 #: ../subiquity/ui/views/refresh.py:238
 msgid "Cancel update"
-msgstr ""
+msgstr "取消更新"
 
 #: ../subiquity/ui/views/snaplist.py:83
 msgid "just now"
-msgstr ""
+msgstr "剛剛"
 
 #: ../subiquity/ui/views/snaplist.py:87
 msgid "minute"
-msgstr ""
+msgstr "分鐘"
 
 #: ../subiquity/ui/views/snaplist.py:89
 msgid "minutes"
-msgstr ""
+msgstr "分鐘"
 
 #: ../subiquity/ui/views/snaplist.py:93
 msgid "hour"
-msgstr ""
+msgstr "小時"
 
 #: ../subiquity/ui/views/snaplist.py:95
 msgid "hours"
-msgstr ""
+msgstr "小時"
 
 #: ../subiquity/ui/views/snaplist.py:99
 msgid "day"
-msgstr ""
+msgstr "天"
 
 #: ../subiquity/ui/views/snaplist.py:101
 msgid "days"
-msgstr ""
+msgstr "天"
 
 #: ../subiquity/ui/views/snaplist.py:104
 #, python-brace-format
 msgid "{amount:2} {unit} ago"
-msgstr ""
+msgstr "{amount:2} {unit}之前"
 
 #: ../subiquity/ui/views/snaplist.py:150
 msgid "LICENSE: "
-msgstr ""
+msgstr "授權： "
 
 #: ../subiquity/ui/views/snaplist.py:155
 msgid "LAST UPDATED: "
-msgstr ""
+msgstr "最後更新： "
 
 #: ../subiquity/ui/views/snaplist.py:160
 msgid "CHANNEL"
-msgstr ""
+msgstr "CHANNEL"
 
 #: ../subiquity/ui/views/snaplist.py:161
 msgid "VERSION"
-msgstr ""
+msgstr "版本"
 
 #: ../subiquity/ui/views/snaplist.py:163
 msgid "PUBLISHED"
-msgstr ""
+msgstr "發布"
 
 #: ../subiquity/ui/views/snaplist.py:164
 msgid "CONFINEMENT"
-msgstr ""
+msgstr "限制"
 
 #: ../subiquity/ui/views/snaplist.py:182
 msgid "by: "
-msgstr ""
+msgstr "由： "
 
 #: ../subiquity/ui/views/snaplist.py:260
 #, python-brace-format
@@ -2286,15 +2406,15 @@ msgstr ""
 
 #: ../subiquity/ui/views/snaplist.py:339
 msgid "Featured Server Snaps"
-msgstr ""
+msgstr "精選伺服器 Snaps"
 
 #: ../subiquity/ui/views/snaplist.py:353
 msgid "Loading server snaps from store, please wait..."
-msgstr ""
+msgstr "自商店載入伺服器 snaps 中，請稍候..."
 
 #: ../subiquity/ui/views/snaplist.py:374
 msgid "Sorry, loading snaps from the store failed."
-msgstr ""
+msgstr "抱歉，從商店載入 snaps 失敗。"
 
 #: ../subiquity/ui/views/snaplist.py:460
 msgid ""
@@ -2302,110 +2422,111 @@ msgid ""
 "SPACE, press ENTER to see more details of the package, publisher and "
 "versions available."
 msgstr ""
+"這些是在伺服器環境下受歡迎的 snaps。用空白鍵來選擇或取消選擇，按下 ENTER 鍵來查閱關於此套件的更多詳細訊、發布者以及可用的版本。"
 
 #: ../subiquity/ui/views/ssh.py:67
 msgid "Import Username:"
-msgstr ""
+msgstr "匯入使用者名稱："
 
 #: ../subiquity/ui/views/ssh.py:74
 msgid "Github Username:"
-msgstr ""
+msgstr "Github 使用者名稱："
 
 #: ../subiquity/ui/views/ssh.py:75
 msgid "Enter your Github username."
-msgstr ""
+msgstr "輸入您的 Github 使用者名稱。"
 
 #: ../subiquity/ui/views/ssh.py:77
 msgid ""
 "A Github username may only contain alphanumeric characters or hyphens."
-msgstr ""
+msgstr "Github 使用者名稱只能由字母、數字或連字號組成。"
 
 #: ../subiquity/ui/views/ssh.py:81
 msgid "Launchpad Username:"
-msgstr ""
+msgstr "Launchpad 使用者名稱："
 
 #: ../subiquity/ui/views/ssh.py:84
 msgid ""
 "A Launchpad username may only contain lower-case alphanumeric characters, "
 "hyphens, plus, or periods."
-msgstr ""
+msgstr "Launchpad 使用者名稱只能由小寫字母、數字、連字號、加號或句點組成。"
 
 #: ../subiquity/ui/views/ssh.py:93
 msgid "Install OpenSSH server"
-msgstr ""
+msgstr "安裝 OpenSSH 伺服器"
 
 #: ../subiquity/ui/views/ssh.py:96
 msgid "Import SSH identity:"
-msgstr ""
+msgstr "匯入 SSH 身份："
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Github"
-msgstr ""
+msgstr "由 Github"
 
 #: ../subiquity/ui/views/ssh.py:100
 msgid "from Launchpad"
-msgstr ""
+msgstr "由 Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:102
 msgid "You can import your SSH keys from Github or Launchpad."
-msgstr ""
+msgstr "您可以由 Github 或 Launchpad 匯入 SSH 金鑰。"
 
 #: ../subiquity/ui/views/ssh.py:106
 msgid "Allow password authentication over SSH"
-msgstr ""
+msgstr "允許 SSH 使用密碼來登入"
 
 #: ../subiquity/ui/views/ssh.py:139
 msgid "This field must not be blank."
-msgstr ""
+msgstr "此欄位不得為空。"
 
 #: ../subiquity/ui/views/ssh.py:141
 msgid "SSH id too long, must be < "
-msgstr ""
+msgstr "SSH id 過長，須小於 "
 
 #: ../subiquity/ui/views/ssh.py:145
 msgid ""
 "A Launchpad username must start with a letter or number. All letters must be "
 "lower-case. The characters +, - and . are also allowed after the first "
 "character."
-msgstr ""
+msgstr "Launchpad 使用者名稱必須由字母或數字開頭。所有字母必須是小寫。特殊符號 +、- 以及 . 可以在第一個字元後使用。"
 
 #: ../subiquity/ui/views/ssh.py:151
 msgid ""
 "A Github username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
-msgstr ""
+msgstr "Github 使用者名稱只能由字母、數字、或連字號組成，而且頭尾不能是連字號。"
 
 #: ../subiquity/ui/views/ssh.py:161
 msgid "Fetching SSH keys..."
-msgstr ""
+msgstr "取得 SSH 金鑰中..."
 
 #: ../subiquity/ui/views/ssh.py:189
 msgid "Confirm SSH keys"
-msgstr ""
+msgstr "確認 SSH 金鑰"
 
 #: ../subiquity/ui/views/ssh.py:190
 msgid ""
 "Keys with the following fingerprints were fetched. Do you want to use them?"
-msgstr ""
+msgstr "已下載有著以下指紋的金鑰。您是否想要使用它們？"
 
 #: ../subiquity/ui/views/ssh.py:193
 msgid "Confirm SSH key"
-msgstr ""
+msgstr "確認 SSH 金鑰"
 
 #: ../subiquity/ui/views/ssh.py:194
 msgid ""
 "A key with the following fingerprint was fetched. Do you want to use it?"
-msgstr ""
+msgstr "已下載有著以下指紋的金鑰。您是否想要使用它？"
 
 #: ../subiquity/ui/views/ssh.py:220
 msgid "SSH Setup"
-msgstr ""
+msgstr "SSH 設置"
 
 #: ../subiquity/ui/views/ssh.py:221
 msgid ""
 "You can choose to install the OpenSSH server package to enable secure remote "
 "access to your server."
-msgstr ""
+msgstr "您可以選擇安裝 OpenSSH server 套件來啟用對您伺服器的安全遠端連線功能。"
 
 #: ../subiquity/ui/views/welcome.py:36
 msgid ""
@@ -2413,24 +2534,26 @@ msgid ""
 "Select the language to use for the installer and to be configured in the\n"
 "installed system.\n"
 msgstr ""
+"\n"
+"請選擇安裝過程及在安裝好的系統上想使用的語言。\n"
 
 #: ../subiquity/ui/views/welcome.py:99
 msgid "Use UP, DOWN and ENTER keys to select your language."
-msgstr ""
+msgstr "使用上、下和 ENTER 鍵選擇您的語言。"
 
 #: ../subiquity/ui/views/welcome.py:106
 msgid "Help choosing a language"
-msgstr ""
+msgstr "協助選擇語言"
 
 #. for translator: failed is a zdev device status
 #: ../subiquity/ui/views/zdev.py:56
 msgid "failed"
-msgstr ""
+msgstr "失敗"
 
 #. for translator: auto is a zdev device status
 #: ../subiquity/ui/views/zdev.py:59
 msgid "auto"
-msgstr ""
+msgstr "自動"
 
 #. for translator: online is a zdev device status
 #: ../subiquity/ui/views/zdev.py:62
@@ -2439,11 +2562,11 @@ msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:77
 msgid "No zdev devices found."
-msgstr ""
+msgstr "沒有找到 zdev 裝置。"
 
 #: ../subiquity/ui/views/zdev.py:92
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #: ../subiquity/ui/views/zdev.py:93
 msgid "ONLINE"
@@ -2451,16 +2574,155 @@ msgstr ""
 
 #: ../subiquity/ui/views/zdev.py:94
 msgid "NAMES"
-msgstr ""
+msgstr "名稱"
 
 #: ../subiquity/ui/views/zdev.py:118
 msgid "Enable"
-msgstr ""
+msgstr "啟用"
 
 #: ../subiquity/ui/views/zdev.py:119
 msgid "Disable"
-msgstr ""
+msgstr "停用"
 
 #: ../subiquity/ui/views/zdev.py:144
 msgid "Zdev setup"
-msgstr ""
+msgstr "Zdev 設置"
+
+#~ msgid "Edit IPv6"
+#~ msgstr "編輯 IPv6"
+
+#~ msgid "Edit IPv4"
+#~ msgstr "編輯 IPv4"
+
+#~ msgid "Edit Wifi"
+#~ msgstr "編輯 Wifi"
+
+#~ msgid "Info"
+#~ msgstr "資訊"
+
+#~ msgid "Finished install!"
+#~ msgstr "完成安裝！"
+
+#~ msgid "Installation complete!"
+#~ msgstr "安裝完成！"
+
+#~ msgid "Edit"
+#~ msgstr "編輯"
+
+#~ msgid "Format"
+#~ msgstr "格式化"
+
+#~ msgid ", mounted at {}"
+#~ msgstr "，已掛載於 {}"
+
+#~ msgid "formatted as {}"
+#~ msgstr "已格式化為 {}"
+
+#~ msgid "There is already a RAID named '{}'"
+#~ msgstr "已有名為 {} 的 RAID"
+
+#~ msgid "Reboot"
+#~ msgstr "重新開機"
+
+#~ msgid "An error has occurred"
+#~ msgstr "發生錯誤"
+
+#~ msgid "{!r} is not valid input"
+#~ msgstr "{!r} 為無效的輸入"
+
+#~ msgid "Remove from RAID/LVM"
+#~ msgstr "自 RAID/LVM 中移除"
+
+#~ msgid "Add Partition"
+#~ msgstr "新增分割區"
+
+#~ msgid "Make Boot Device"
+#~ msgstr "製作開機磁碟"
+
+#~ msgid "Realname too long, must be < "
+#~ msgstr "名稱過長，需少於 "
+
+#~ msgid "Server name too long, must be < "
+#~ msgstr "伺服器名稱過長，需少於 "
+
+#~ msgid "Username too long, must be < "
+#~ msgstr "使用者名稱過長，需少於 "
+
+#~ msgid "Do you really want to remove the existing filesystem from {}?"
+#~ msgstr "確定要自 {} 刪除現有的檔案系統嗎？"
+
+#~ msgid "Remove filesystem from {}"
+#~ msgstr "自 {} 刪除檔案系統"
+
+#~ msgid "Passphrases"
+#~ msgstr "通關密語"
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has {count} mounted partitions."
+#~ msgstr "{selflabel} 已有 {count} 個已掛載的分割區，因此無法將其刪除。"
+
+#, python-brace-format
+#~ msgid "Cannot delete {selflabel} because it has 1 mounted partition."
+#~ msgstr "{selflabel} 已有 1 個已掛載的分割區，因此無法將其刪除。"
+
+#, python-format
+#~ msgid "%s already exists"
+#~ msgstr "%s 已經存在"
+
+#, python-format
+#~ msgid "This field must be a %s URL."
+#~ msgstr "此欄位必須是 %s URL。"
+
+#, python-format
+#~ msgid "'%s' is not contained in '%s'"
+#~ msgstr "「%s」不包含在「%s」之中"
+
+#, python-brace-format
+#~ msgid ""
+#~ "Cannot delete {selflabel} as partition {partnum} is part of the {cdtype} "
+#~ "{cdname}."
+#~ msgstr "無法刪除 {selflabel} 因為分割區 {partnum} 為 {cdtype} {cdname} 的一部分。"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has partitions."
+#~ msgstr "無法編輯 {selflabel} 因其已有分割區。"
+
+#~ msgid "Hostname must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "主機名稱必須符合 NAME_REGEX，即 [a-z_][a-z0-9_-]*"
+
+#~ msgid "Username must match NAME_REGEX, i.e. [a-z_][a-z0-9_-]*"
+#~ msgstr "使用者名稱必須符合 NAME_REGEX，即 [a-z_][a-z0-9_-]*"
+
+#~ msgid "Info for {}"
+#~ msgstr "{} 的資訊"
+
+#~ msgid "unused {}"
+#~ msgstr "未使用 {}"
+
+#~ msgid "Format and/or mount {}"
+#~ msgstr "格式化並且/或者掛載 {}"
+
+#~ msgid "There is already a logical volume named {}."
+#~ msgstr "已經有叫做 {} 的邏輯卷宗。"
+
+#~ msgid "The name of a logical volume may not contain \"{}\""
+#~ msgstr "邏輯卷宗的名稱不可包含「{}」"
+
+#~ msgid "A logical volume may not be called {}"
+#~ msgstr "邏輯卷宗不可取名為 {}"
+
+#, python-brace-format
+#~ msgid "Cannot edit {selflabel} because it has logical volumes."
+#~ msgstr "無法編輯 {selflabel} 因其有邏輯卷宗。"
+
+#~ msgid "Create Logical Volume"
+#~ msgstr "建立邏輯卷宗"
+
+#~ msgid "Keyboard auto detection failed, sorry"
+#~ msgstr "鍵盤配置自動偵測失敗，抱歉"
+
+#~ msgid "Fetching info for {}"
+#~ msgstr "取得 {} 的資訊中"
+
+#~ msgid "Fetching info for {} failed"
+#~ msgstr "取得 {} 的資訊失敗"


### PR DESCRIPTION
A while ago I set up subiquity for translations at
https://translations.launchpad.net/subiquity by uploading the pot and po
files that were current at the time and set it to export translations to
lp:~canonical-foundations/subiquity/translations-export (unfortunately,
launchpad translations only support exporting to bzr).  This commit
contains the po files from that branch. The diff is noisy but I don't
think there are many actual changes (although there are a few so some
people must have found this).

I haven't publicized this or asked the ubuntu-translators team to work
on the translations because I am still uncertain about what the best way
to manage translations for subiquity is. But this still seems better
than nothing.