### PR TITLE
make the snaps produced by slimy-update-snap.sh pass review

### DIFF
--- a/scripts/slimy-update-snap.sh
+++ b/scripts/slimy-update-snap.sh
@@ -58,6 +58,6 @@ rm -rf new/lib/python3.6/site-packages/subiquitycore
 
 (cd "${src}" && ./scripts/update-part.py curtin)
 
-rsync -a $src/subiquity $src/subiquitycore $src/curtin/curtin new/lib/python3.6/site-packages
+rsync -a --chown 0:0 $src/subiquity $src/subiquitycore $src/curtin/curtin new/lib/python3.6/site-packages
 
-mksquashfs new $new -comp gzip -Xcompression-level 3
+snapcraft pack new --output $new


### PR DESCRIPTION
I mean we /probably/ shouldn't be using the snaps this makes for
anything serious but it can be useful for testing emergency fixes...