### PR TITLE
pubsub: Obsolete EventCallback

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -25,7 +25,6 @@ from typing import Dict, List, Optional, Union
 import attr
 
 from subiquitycore.models.network import NetDevInfo
-from subiquitycore.pubsub import CoreChannels
 
 
 class ErrorReportState(enum.Enum):
@@ -336,12 +335,6 @@ class TimeZoneInfo:
 class ShutdownMode(enum.Enum):
     REBOOT = enum.auto()
     POWEROFF = enum.auto()
-
-
-class InstallerChannels(CoreChannels):
-    NETWORK_PROXY_SET = 'network-proxy-set'
-    SNAPD_NETWORK_CHANGE = 'snapd-network-change'
-    GEOIP = 'geoip'
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -25,6 +25,7 @@ from typing import Dict, List, Optional, Union
 import attr
 
 from subiquitycore.models.network import NetDevInfo
+from subiquitycore.pubsub import CoreChannels
 
 
 class ErrorReportState(enum.Enum):
@@ -335,6 +336,12 @@ class TimeZoneInfo:
 class ShutdownMode(enum.Enum):
     REBOOT = enum.auto()
     POWEROFF = enum.auto()
+
+
+class InstallerChannels(CoreChannels):
+    NETWORK_PROXY_SET = 'network-proxy-set'
+    SNAPD_NETWORK_CHANGE = 'snapd-network-change'
+    GEOIP = 'geoip'
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -65,9 +65,9 @@ class MirrorController(SubiquityController):
         except asyncio.TimeoutError:
             pass
 
-    def on_countrycode(self, cc):
+    def on_countrycode(self, unused):
         if self.geoip_enabled:
-            self.model.set_country(cc)
+            self.model.set_country(self.app.geoip.countrycode)
         self.cc_event.set()
 
     def serialize(self):

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -19,9 +19,9 @@ import logging
 from curtin.config import merge_config
 
 from subiquitycore.context import with_context
-from subiquitycore.pubsub import MessageChannels
 
 from subiquity.common.apidef import API
+from subiquity.common.types import InstallerChannels
 from subiquity.server.controller import SubiquityController
 
 log = logging.getLogger('subiquity.server.controllers.mirror')
@@ -46,7 +46,7 @@ class MirrorController(SubiquityController):
     def __init__(self, app):
         super().__init__(app)
         self.geoip_enabled = True
-        self.app.hub.subscribe(MessageChannels.GEOIP, self.on_geoip)
+        self.app.hub.subscribe(InstallerChannels.GEOIP, self.on_geoip)
         self.cc_event = asyncio.Event()
 
     def load_autoinstall_data(self, data):

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -19,6 +19,7 @@ import logging
 from curtin.config import merge_config
 
 from subiquitycore.context import with_context
+from subiquitycore.pubsub import MessageChannels
 
 from subiquity.common.apidef import API
 from subiquity.server.controller import SubiquityController
@@ -45,7 +46,7 @@ class MirrorController(SubiquityController):
     def __init__(self, app):
         super().__init__(app)
         self.geoip_enabled = True
-        self.app.geoip.on_countrycode.subscribe(self.on_countrycode)
+        self.app.hub.subscribe(MessageChannels.GEOIP, self.on_geoip)
         self.cc_event = asyncio.Event()
 
     def load_autoinstall_data(self, data):
@@ -65,7 +66,7 @@ class MirrorController(SubiquityController):
         except asyncio.TimeoutError:
             pass
 
-    def on_countrycode(self, unused):
+    def on_geoip(self):
         if self.geoip_enabled:
             self.model.set_country(self.app.geoip.countrycode)
         self.cc_event.set()

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -21,8 +21,8 @@ from curtin.config import merge_config
 from subiquitycore.context import with_context
 
 from subiquity.common.apidef import API
-from subiquity.common.types import InstallerChannels
 from subiquity.server.controller import SubiquityController
+from subiquity.server.types import InstallerChannels
 
 log = logging.getLogger('subiquity.server.controllers.mirror')
 

--- a/subiquity/server/controllers/proxy.py
+++ b/subiquity/server/controllers/proxy.py
@@ -17,9 +17,9 @@ import logging
 import os
 
 from subiquitycore.context import with_context
-from subiquitycore.pubsub import MessageChannels
 
 from subiquity.common.apidef import API
+from subiquity.common.types import InstallerChannels
 from subiquity.server.controller import SubiquityController
 
 log = logging.getLogger('subiquity.server.controllers.proxy')
@@ -46,7 +46,7 @@ class ProxyController(SubiquityController):
             os.environ['http_proxy'] = os.environ['https_proxy'] = \
               self.model.proxy
             self._set_task = self.app.hub.broadcast(
-                MessageChannels.NETWORK_PROXY_SET)
+                InstallerChannels.NETWORK_PROXY_SET)
 
     @with_context()
     async def apply_autoinstall_config(self, context=None):
@@ -68,5 +68,5 @@ class ProxyController(SubiquityController):
     async def POST(self, data: str):
         self.model.proxy = data
         os.environ['http_proxy'] = os.environ['https_proxy'] = data
-        self.app.hub.broadcast(MessageChannels.NETWORK_PROXY_SET)
+        self.app.hub.broadcast(InstallerChannels.NETWORK_PROXY_SET)
         self.configured()

--- a/subiquity/server/controllers/proxy.py
+++ b/subiquity/server/controllers/proxy.py
@@ -17,6 +17,7 @@ import logging
 import os
 
 from subiquitycore.context import with_context
+from subiquitycore.pubsub import MessageChannels
 
 from subiquity.common.apidef import API
 from subiquity.server.controller import SubiquityController
@@ -44,7 +45,8 @@ class ProxyController(SubiquityController):
         if self.model.proxy:
             os.environ['http_proxy'] = os.environ['https_proxy'] = \
               self.model.proxy
-            self._set_task = self.app.hub.broadcast('network-proxy-set')
+            self._set_task = self.app.hub.broadcast(
+                MessageChannels.NETWORK_PROXY_SET)
 
     @with_context()
     async def apply_autoinstall_config(self, context=None):
@@ -66,5 +68,5 @@ class ProxyController(SubiquityController):
     async def POST(self, data: str):
         self.model.proxy = data
         os.environ['http_proxy'] = os.environ['https_proxy'] = data
-        self.app.hub.broadcast('network-proxy-set')
+        self.app.hub.broadcast(MessageChannels.NETWORK_PROXY_SET)
         self.configured()

--- a/subiquity/server/controllers/proxy.py
+++ b/subiquity/server/controllers/proxy.py
@@ -19,8 +19,8 @@ import os
 from subiquitycore.context import with_context
 
 from subiquity.common.apidef import API
-from subiquity.common.types import InstallerChannels
 from subiquity.server.controller import SubiquityController
+from subiquity.server.types import InstallerChannels
 
 log = logging.getLogger('subiquity.server.controllers.proxy')
 

--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -27,13 +27,13 @@ from subiquitycore.context import with_context
 
 from subiquity.common.apidef import API
 from subiquity.common.types import (
-    InstallerChannels,
     RefreshCheckState,
     RefreshStatus,
     )
 from subiquity.server.controller import (
     SubiquityController,
     )
+from subiquity.server.types import InstallerChannels
 
 
 log = logging.getLogger('subiquity.server.controllers.refresh')

--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -24,10 +24,10 @@ from subiquitycore.async_helpers import (
     SingleInstanceTask,
     )
 from subiquitycore.context import with_context
-from subiquitycore.pubsub import MessageChannels
 
 from subiquity.common.apidef import API
 from subiquity.common.types import (
+    InstallerChannels,
     RefreshCheckState,
     RefreshStatus,
     )
@@ -60,7 +60,7 @@ class RefreshController(SubiquityController):
         self.configure_task = None
         self.check_task = None
         self.status = RefreshStatus(availability=RefreshCheckState.UNKNOWN)
-        self.app.hub.subscribe(MessageChannels.SNAPD_NETWORK_CHANGE,
+        self.app.hub.subscribe(InstallerChannels.SNAPD_NETWORK_CHANGE,
                                self.snapd_network_changed)
 
     def load_autoinstall_data(self, data):

--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -24,6 +24,7 @@ from subiquitycore.async_helpers import (
     SingleInstanceTask,
     )
 from subiquitycore.context import with_context
+from subiquitycore.pubsub import MessageChannels
 
 from subiquity.common.apidef import API
 from subiquity.common.types import (
@@ -59,8 +60,8 @@ class RefreshController(SubiquityController):
         self.configure_task = None
         self.check_task = None
         self.status = RefreshStatus(availability=RefreshCheckState.UNKNOWN)
-        self.app.hub.subscribe(
-            'snapd-network-change', self.snapd_network_changed)
+        self.app.hub.subscribe(MessageChannels.SNAPD_NETWORK_CHANGE,
+                               self.snapd_network_changed)
 
     def load_autoinstall_data(self, data):
         if data is not None:

--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -24,10 +24,10 @@ from subiquitycore.async_helpers import (
     schedule_task,
     )
 from subiquitycore.context import with_context
-from subiquitycore.pubsub import MessageChannels
 
 from subiquity.common.apidef import API
 from subiquity.common.types import (
+    InstallerChannels,
     SnapCheckState,
     SnapInfo,
     SnapListResponse,
@@ -139,7 +139,7 @@ class SnapListController(SubiquityController):
     def __init__(self, app):
         super().__init__(app)
         self.loader = self._make_loader()
-        self.app.hub.subscribe(MessageChannels.SNAPD_NETWORK_CHANGE,
+        self.app.hub.subscribe(InstallerChannels.SNAPD_NETWORK_CHANGE,
                                self.snapd_network_changed)
 
     def load_autoinstall_data(self, ai_data):

--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -24,6 +24,7 @@ from subiquitycore.async_helpers import (
     schedule_task,
     )
 from subiquitycore.context import with_context
+from subiquitycore.pubsub import MessageChannels
 
 from subiquity.common.apidef import API
 from subiquity.common.types import (
@@ -138,8 +139,8 @@ class SnapListController(SubiquityController):
     def __init__(self, app):
         super().__init__(app)
         self.loader = self._make_loader()
-        self.app.hub.subscribe(
-            'snapd-network-change', self.snapd_network_changed)
+        self.app.hub.subscribe(MessageChannels.SNAPD_NETWORK_CHANGE,
+                               self.snapd_network_changed)
 
     def load_autoinstall_data(self, ai_data):
         to_install = []

--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -27,7 +27,6 @@ from subiquitycore.context import with_context
 
 from subiquity.common.apidef import API
 from subiquity.common.types import (
-    InstallerChannels,
     SnapCheckState,
     SnapInfo,
     SnapListResponse,
@@ -36,6 +35,7 @@ from subiquity.common.types import (
 from subiquity.server.controller import (
     SubiquityController,
     )
+from subiquity.server.types import InstallerChannels
 
 
 log = logging.getLogger('subiquity.server.controllers.snaplist')

--- a/subiquity/server/geoip.py
+++ b/subiquity/server/geoip.py
@@ -22,7 +22,7 @@ from subiquitycore.async_helpers import (
     run_in_thread,
     SingleInstanceTask,
 )
-from subiquitycore.pubsub import EventCallback
+from subiquitycore.pubsub import (EventCallback, MessageChannels)
 
 log = logging.getLogger('subiquity.common.geoip')
 
@@ -44,8 +44,10 @@ class GeoIP:
         self.on_countrycode = EventCallback()
         self.on_timezone = EventCallback()
         self.lookup_task = SingleInstanceTask(self.lookup)
-        self.app.hub.subscribe('network-up', self.maybe_start_check)
-        self.app.hub.subscribe('network-proxy-set', self.maybe_start_check)
+        self.app.hub.subscribe(MessageChannels.NETWORK_UP,
+                               self.maybe_start_check)
+        self.app.hub.subscribe(MessageChannels.NETWORK_PROXY_SET,
+                               self.maybe_start_check)
 
     def maybe_start_check(self):
         if self.check_state != CheckState.DONE:

--- a/subiquity/server/geoip.py
+++ b/subiquity/server/geoip.py
@@ -22,7 +22,8 @@ from subiquitycore.async_helpers import (
     run_in_thread,
     SingleInstanceTask,
 )
-from subiquitycore.pubsub import MessageChannels
+
+from subiquity.common.types import InstallerChannels
 
 log = logging.getLogger('subiquity.common.geoip')
 
@@ -42,9 +43,9 @@ class GeoIP:
         self.tz = None
         self.check_state = CheckState.NOT_STARTED
         self.lookup_task = SingleInstanceTask(self.lookup)
-        self.app.hub.subscribe(MessageChannels.NETWORK_UP,
+        self.app.hub.subscribe(InstallerChannels.NETWORK_UP,
                                self.maybe_start_check)
-        self.app.hub.subscribe(MessageChannels.NETWORK_PROXY_SET,
+        self.app.hub.subscribe(InstallerChannels.NETWORK_PROXY_SET,
                                self.maybe_start_check)
 
     def maybe_start_check(self):
@@ -97,7 +98,7 @@ class GeoIP:
             self.tz = tz.text
 
         if changed:
-            self.app.hub.broadcast(MessageChannels.GEOIP)
+            self.app.hub.broadcast(InstallerChannels.GEOIP)
 
         return True
 

--- a/subiquity/server/geoip.py
+++ b/subiquity/server/geoip.py
@@ -23,7 +23,7 @@ from subiquitycore.async_helpers import (
     SingleInstanceTask,
 )
 
-from subiquity.common.types import InstallerChannels
+from subiquity.server.types import InstallerChannels
 
 log = logging.getLogger('subiquity.common.geoip')
 

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -57,7 +57,6 @@ from subiquity.common.types import (
     ApplicationState,
     ApplicationStatus,
     ErrorReportRef,
-    InstallerChannels,
     KeyFingerprint,
     LiveSessionSSHInfo,
     PasswordKind,
@@ -69,6 +68,7 @@ from subiquity.models.subiquity import (
 from subiquity.server.controller import SubiquityController
 from subiquity.server.geoip import GeoIP
 from subiquity.server.errors import ErrorController
+from subiquity.server.types import InstallerChannels
 from subiquitycore.snapd import (
     AsyncSnapd,
     FakeSnapdConnection,

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -37,6 +37,7 @@ from subiquitycore.async_helpers import run_in_thread
 from subiquitycore.context import with_context
 from subiquitycore.core import Application
 from subiquitycore.prober import Prober
+from subiquitycore.pubsub import MessageChannels
 from subiquitycore.ssh import (
     host_key_fingerprints,
     user_key_fingerprints,
@@ -280,8 +281,8 @@ class SubiquityServer(Application):
         self.note_data_for_apport("SnapUpdated", str(self.updated))
         self.event_listeners = []
         self.autoinstall_config = None
-        self.hub.subscribe('network-up', self._network_change)
-        self.hub.subscribe('network-proxy-set', self._proxy_set)
+        self.hub.subscribe(MessageChannels.NETWORK_UP, self._network_change)
+        self.hub.subscribe(MessageChannels.NETWORK_PROXY_SET, self._proxy_set)
         self.geoip = GeoIP(self)
 
     def load_serialized_state(self):
@@ -580,14 +581,14 @@ class SubiquityServer(Application):
     def _network_change(self):
         if not self.snapd:
             return
-        self.hub.broadcast('snapd-network-change')
+        self.hub.broadcast(MessageChannels.SNAPD_NETWORK_CHANGE)
 
     async def _proxy_set(self):
         if not self.snapd:
             return
         await run_in_thread(
             self.snapd.connection.configure_proxy, self.base_model.proxy)
-        self.hub.broadcast('snapd-network-change')
+        self.hub.broadcast(MessageChannels.SNAPD_NETWORK_CHANGE)
 
     def restart(self):
         if not self.snapd:

--- a/subiquity/server/types.py
+++ b/subiquity/server/types.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from subiquitycore.pubsub import CoreChannels
+
+
+class InstallerChannels(CoreChannels):
+    NETWORK_PROXY_SET = 'network-proxy-set'
+    SNAPD_NETWORK_CHANGE = 'snapd-network-change'
+    GEOIP = 'geoip'

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -36,7 +36,7 @@ from subiquitycore.models.network import (
     )
 from subiquitycore import netplan
 from subiquitycore.controller import BaseController
-from subiquitycore.pubsub import MessageChannels
+from subiquitycore.pubsub import CoreChannels
 from subiquitycore.tuicontroller import TuiController
 from subiquitycore.ui.stretchy import StretchyOverlay
 from subiquitycore.ui.views.network import (
@@ -480,7 +480,7 @@ class BaseNetworkController(BaseController):
     @abc.abstractmethod
     def update_default_routes(self, routes):
         if routes:
-            self.app.hub.broadcast(MessageChannels.NETWORK_UP)
+            self.app.hub.broadcast(CoreChannels.NETWORK_UP)
 
     @abc.abstractmethod
     def new_link(self, netdev):

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -36,6 +36,7 @@ from subiquitycore.models.network import (
     )
 from subiquitycore import netplan
 from subiquitycore.controller import BaseController
+from subiquitycore.pubsub import MessageChannels
 from subiquitycore.tuicontroller import TuiController
 from subiquitycore.ui.stretchy import StretchyOverlay
 from subiquitycore.ui.views.network import (
@@ -479,7 +480,7 @@ class BaseNetworkController(BaseController):
     @abc.abstractmethod
     def update_default_routes(self, routes):
         if routes:
-            self.app.hub.broadcast('network-up')
+            self.app.hub.broadcast(MessageChannels.NETWORK_UP)
 
     @abc.abstractmethod
     def new_link(self, netdev):

--- a/subiquitycore/pubsub.py
+++ b/subiquitycore/pubsub.py
@@ -14,15 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-import enum
 import inspect
 
 
-class MessageChannels(enum.IntEnum):
-    NETWORK_UP = enum.auto()
-    NETWORK_PROXY_SET = enum.auto()
-    SNAPD_NETWORK_CHANGE = enum.auto()
-    GEOIP = enum.auto()
+class CoreChannels:
+    NETWORK_UP = 'network-up'
 
 
 class MessageHub:

--- a/subiquitycore/pubsub.py
+++ b/subiquitycore/pubsub.py
@@ -41,21 +41,3 @@ class MessageHub:
 
     def broadcast(self, channel):
         return asyncio.get_event_loop().create_task(self.abroadcast(channel))
-
-
-class EventCallback:
-
-    def __init__(self):
-        self.subscriptions = []
-
-    def subscribe(self, method, *args):
-        self.subscriptions.append((method, args))
-
-    async def abroadcast(self, cbdata):
-        for m, args in self.subscriptions:
-            v = m(cbdata, *args)
-            if inspect.iscoroutine(v):
-                await v
-
-    def broadcast(self, cbdata):
-        return asyncio.get_event_loop().create_task(self.abroadcast(cbdata))

--- a/subiquitycore/pubsub.py
+++ b/subiquitycore/pubsub.py
@@ -14,7 +14,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import enum
 import inspect
+
+
+class MessageChannels(enum.IntEnum):
+    NETWORK_UP = enum.auto()
+    NETWORK_PROXY_SET = enum.auto()
+    SNAPD_NETWORK_CHANGE = enum.auto()
 
 
 class MessageHub:

--- a/subiquitycore/pubsub.py
+++ b/subiquitycore/pubsub.py
@@ -22,6 +22,7 @@ class MessageChannels(enum.IntEnum):
     NETWORK_UP = enum.auto()
     NETWORK_PROXY_SET = enum.auto()
     SNAPD_NETWORK_CHANGE = enum.auto()
+    GEOIP = enum.auto()
 
 
 class MessageHub:

--- a/subiquitycore/tests/test_pubsub.py
+++ b/subiquitycore/tests/test_pubsub.py
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
-
 from subiquitycore.tests import SubiTestCase
-from subiquitycore.pubsub import (MessageHub, EventCallback)
+from subiquitycore.pubsub import MessageHub
 from subiquitycore.tests.util import run_coro
 
 
@@ -37,26 +35,4 @@ class TestMessageHub(SubiTestCase):
         channel_id = 1234
         private_data = 42
         self.hub = MessageHub()
-        run_coro(fn())
-
-
-class TestEventCallback(SubiTestCase):
-    def test_basic(self):
-        def job():
-            self.thething.broadcast(42)
-
-        def cb(val, mydata):
-            self.assertEqual(42, val)
-            self.assertEqual('bacon', mydata)
-            self.called += 1
-
-        async def fn():
-            self.called = 0
-            self.thething = EventCallback()
-            calls_expected = 3
-            for _ in range(calls_expected):
-                self.thething.subscribe(cb, 'bacon')
-            await self.thething.broadcast(42)
-            self.assertEqual(calls_expected, self.called)
-
         run_coro(fn())


### PR DESCRIPTION
* Adjust existing usage of EventCallback to use MessageHub instead.
* Add constants for use with MessageHub.
* Adapt EventCallback test for MessageHub instead.