### PR TITLE
Fix advancing from snap list screen before snaps have loaded

### DIFF
--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -116,6 +116,7 @@ class SnapInfoView(WidgetWrap):
         self.parent = parent
         self.snap = snap
         self.needs_focus = True
+        self.selections_by_name = {}
 
         self.description = Text(snap.description.replace('\r', '').strip())
         self.lb_description = ListBox([self.description])
@@ -462,10 +463,6 @@ class SnapListView(BaseView):
                 "package, publisher and versions available."))
 
     def done(self, sender=None):
-        if not hasattr(self, 'selections_by_name'):
-            log.warning('failed to obtain a snaps selection')
-            return self.offer_retry()
-        
         log.debug("snaps to install %s", self.selections_by_name)
         self.controller.done(sorted(
             self.selections_by_name.values(),

--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -462,6 +462,10 @@ class SnapListView(BaseView):
                 "package, publisher and versions available."))
 
     def done(self, sender=None):
+        if not hasattr(self, 'selections_by_name'):
+            log.warning('failed to obtain a snaps selection')
+            return self.offer_retry()
+        
         log.debug("snaps to install %s", self.selections_by_name)
         self.controller.done(sorted(
             self.selections_by_name.values(),


### PR DESCRIPTION
when done() is called before the snap has loaded this causes an attribute error on the following line

'log.debug("snaps to install %s", self.selections_by_name)'

