### PR TITLE
DE-91 - System Setup autoinstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ gitdeps: curtin probert
 
 schema: gitdeps
 	@$(PYTHON) -m subiquity.cmd.schema > autoinstall-schema.json
+	@$(PYTHON) -m system_setup.cmd.schema > autoinstall-system-setup-schema.json
 
 clean:
 	./debian/rules clean

--- a/autoinstall-system-setup-schema.json
+++ b/autoinstall-system-setup-schema.json
@@ -83,7 +83,6 @@
                     "type": "boolean"
                 }
             },
-            "required": [],
             "additionalProperties": false
         },
         "wslconfadvanced": {
@@ -120,7 +119,6 @@
                     "type": "boolean"
                 }
             },
-            "required": [],
             "additionalProperties": false
         },
         "late-commands": {

--- a/autoinstall-system-setup-schema.json
+++ b/autoinstall-system-setup-schema.json
@@ -1,0 +1,150 @@
+{
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1
+        },
+        "early-commands": {
+            "type": "array",
+            "items": {
+                "type": [
+                    "string",
+                    "array"
+                ],
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "reporting": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type"
+                ],
+                "additionalProperties": true
+            }
+        },
+        "error-commands": {
+            "type": "array",
+            "items": {
+                "type": [
+                    "string",
+                    "array"
+                ],
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "locale": {
+            "type": "string"
+        },
+        "identity": {
+            "type": "object",
+            "properties": {
+                "realname": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "username",
+                "password"
+            ],
+            "additionalProperties": false
+        },
+        "wslconfbase": {
+            "type": "object",
+            "properties": {
+                "custom_path": {
+                    "type": "string"
+                },
+                "custom_mount_opt": {
+                    "type": "string"
+                },
+                "gen_host": {
+                    "type": "boolean"
+                },
+                "gen_resolvconf": {
+                    "type": "boolean"
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        },
+        "wslconfadvanced": {
+            "type": "object",
+            "properties": {
+                "interop_enabled": {
+                    "type": "boolean"
+                },
+                "interop_appendwindowspath": {
+                    "type": "boolean"
+                },
+                "gui_theme": {
+                    "type": "string"
+                },
+                "gui_followwintheme": {
+                    "type": "boolean"
+                },
+                "legacy_gui": {
+                    "type": "boolean"
+                },
+                "legacy_audio": {
+                    "type": "boolean"
+                },
+                "adv_ip_detect": {
+                    "type": "boolean"
+                },
+                "wsl_motd_news": {
+                    "type": "boolean"
+                },
+                "automount": {
+                    "type": "boolean"
+                },
+                "mountfstab": {
+                    "type": "boolean"
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        },
+        "late-commands": {
+            "type": "array",
+            "items": {
+                "type": [
+                    "string",
+                    "array"
+                ],
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "shutdown": {
+            "type": "string",
+            "enum": [
+                "reboot",
+                "poweroff"
+            ]
+        }
+    },
+    "required": [
+        "version"
+    ],
+    "additionalProperties": true
+}

--- a/examples/autoinstall-system-setup.yaml
+++ b/examples/autoinstall-system-setup.yaml
@@ -1,0 +1,19 @@
+version: 1
+early-commands:
+        - echo a
+        - ["sleep", "1"]
+        - echo a
+Welcome:
+  lang: en_US
+identity:
+  realname: Ubuntu
+  username: ubuntu
+  # ubuntu
+  password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+WSLConfigurationBase:
+  custom_path: '/custom_mnt_path'
+  custom_mount_opt: 'opt1 opt2 opt3'
+  gen_host: false
+  gen_resolvconf: false
+Summary:
+  reboot: yes

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -107,8 +107,17 @@ while ! scurl a/meta/status >& /dev/null ; do
 done
 scurl a/storage/has_bitlocker | jq -M '. [0].partitions[2]' | grep -q BitLocker
 
+# NOTE:
+# This test doesnt do much ATM but it will be useful when we have more complex scenarios to test with the server and client code.
+# Like generating a wsl.conf file and comparing it to the oracle.
+clean
+timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m system_setup.cmd.tui --autoinstall examples/autoinstall-system-setup.yaml --dry-run"
+
 python3 -m subiquity.cmd.schema > "$testschema"
 scripts/schema-cmp.py "autoinstall-schema.json" "$testschema"
+
+python3 -m system_setup.cmd.schema > "$testschema"
+scripts/schema-cmp.py "autoinstall-system-setup-schema.json" "$testschema" --ignore-tz
 
 set +x  # show PASS/FAIL as the last line of output
 echo 'Runtests all PASSED'

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -4,6 +4,8 @@ set -eux
 testschema=.subiquity/test-autoinstall-schema.json
 export PYTHONPATH=$PWD:$PWD/probert:$PWD/curtin
 
+RELEASE=$(lsb_release -rs)
+
 validate () {
     mode="install"
     [ $# -gt 0 ] && mode="$1"
@@ -70,8 +72,11 @@ for answers in examples/answers*.yaml; do
         validate
         grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' .subiquity/subiquity-server-debug.log
     else
-        timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m system_setup.cmd.tui --answers $answers --dry-run " < $tty
-        validate "system_setup"
+        # The OOBE doesn't exist in WSL < 20.04
+        if [ "${RELEASE%.*}" -ge 20 ]; then
+            timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m system_setup.cmd.tui --answers $answers --dry-run " < $tty
+            validate "system_setup"
+        fi
     fi
 done
 
@@ -107,17 +112,21 @@ while ! scurl a/meta/status >& /dev/null ; do
 done
 scurl a/storage/has_bitlocker | jq -M '. [0].partitions[2]' | grep -q BitLocker
 
-# NOTE:
-# This test doesnt do much ATM but it will be useful when we have more complex scenarios to test with the server and client code.
-# Like generating a wsl.conf file and comparing it to the oracle.
-clean
-timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m system_setup.cmd.tui --autoinstall examples/autoinstall-system-setup.yaml --dry-run"
+# The OOBE doesn't exist in WSL < 20.04
+if [ "${RELEASE%.*}" -ge 20 ]; then
+    # NOTE:
+    # This test doesnt do much ATM but it will be useful when we have more complex scenarios to test with the server and client code.
+    # Like generating a wsl.conf file and comparing it to the oracle.
+    clean
+    timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m system_setup.cmd.tui --autoinstall examples/autoinstall-system-setup.yaml --dry-run"
+
+    python3 -m system_setup.cmd.schema > "$testschema"
+    scripts/schema-cmp.py "autoinstall-system-setup-schema.json" "$testschema" --ignore-tz
+fi
 
 python3 -m subiquity.cmd.schema > "$testschema"
 scripts/schema-cmp.py "autoinstall-schema.json" "$testschema"
 
-python3 -m system_setup.cmd.schema > "$testschema"
-scripts/schema-cmp.py "autoinstall-system-setup-schema.json" "$testschema" --ignore-tz
 
 set +x  # show PASS/FAIL as the last line of output
 echo 'Runtests all PASSED'

--- a/scripts/schema-cmp.py
+++ b/scripts/schema-cmp.py
@@ -6,14 +6,20 @@
 import json
 import sys
 
-def load(filename):
+def load(filename, ignore_tz):
     with open(filename, 'r') as f:
         data = json.load(f)
-    tz = data['properties']['timezone'].pop('enum')
+    tz = None
+    if not ignore_tz:
+        tz = data['properties']['timezone'].pop('enum')
     return data, tz
 
-expected, _ = load(sys.argv[1])
-actual, actual_tz = load(sys.argv[2])
+ignore_tz = False
+if len(sys.argv) > 3 and sys.argv[3].lower() == "--ignore-tz":
+    ignore_tz = True
+
+expected, _ = load(sys.argv[1], ignore_tz)
+actual, actual_tz = load(sys.argv[2], ignore_tz)
 
 if expected != actual:
     print('schema mismatch')
@@ -22,6 +28,9 @@ if expected != actual:
     print('actual:')
     print(actual)
     sys.exit(1)
+
+if ignore_tz:
+    sys.exit(0)
 
 expected_tz = [
     '',

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -187,9 +187,13 @@ class SubiquityModel:
             event.set()
 
     async def wait_install(self):
+        if len(self._cur_install_model_names) == 0:
+            self._install_event.set()
         await self._install_event.wait()
 
     async def wait_postinstall(self):
+        if len(self._cur_postinstall_model_names) == 0:
+            self._postinstall_event.set()
         await self._postinstall_event.wait()
 
     async def wait_confirmation(self):

--- a/system_setup/cmd/schema.py
+++ b/system_setup/cmd/schema.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import sys
+
+import jsonschema
+
+from system_setup.cmd.server import make_server_args_parser
+from system_setup.server.server import SystemSetupServer
+from subiquity.cmd.schema import make_schema
+from subiquity.server.server import NOPROBERARG
+
+
+def make_app():
+    parser = make_server_args_parser()
+    opts, unknown = parser.parse_known_args(['--dry-run'])
+    opts.machine_config = NOPROBERARG
+    opts.kernel_cmdline = ""
+    opts.snaps_from_examples = False
+    app = SystemSetupServer(opts, '')
+    app.base_model = app.make_model()
+    app.controllers.load_all()
+    return app
+
+
+def main():
+    schema = make_schema(make_app())
+    jsonschema.validate({"version": 1}, schema)
+    print(json.dumps(schema, indent=4))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/system_setup/server/controllers/__init__.py
+++ b/system_setup/server/controllers/__init__.py
@@ -20,7 +20,7 @@ from subiquity.server.controllers.cmdlist import (
     )
 from subiquity.server.controllers.reporting import ReportingController
 from subiquity.server.controllers.userdata import UserdataController
-from .identity import IdentityController
+from .identity import WSLIdentityController
 from .locale import WSLLocaleController
 from .wslconfbase import WSLConfigurationBaseController
 from .wslconfadvanced import WSLConfigurationAdvancedController
@@ -30,7 +30,7 @@ from .shutdown import SetupShutdownController
 __all__ = [
     'EarlyController',
     'ErrorController',
-    'IdentityController',
+    'WSLIdentityController',
     'LateController',
     'WSLLocaleController',
     'ReportingController',

--- a/system_setup/server/controllers/identity.py
+++ b/system_setup/server/controllers/identity.py
@@ -41,7 +41,6 @@ class WSLIdentityController(IdentityController):
             identity_data = IdentityData(
                 realname=data.get('realname', ''),
                 username=data['username'],
-                hostname='',
                 crypted_password=data['password'],
                 )
             self.model.add_user(identity_data)

--- a/system_setup/server/controllers/wslconfadvanced.py
+++ b/system_setup/server/controllers/wslconfadvanced.py
@@ -49,7 +49,6 @@ class WSLConfigurationAdvancedController(SubiquityController):
             'automount': {'type': 'boolean'},
             'mountfstab': {'type': 'boolean'}
         },
-        'required': [],
         'additionalProperties': False,
     }
 

--- a/system_setup/server/controllers/wslconfbase.py
+++ b/system_setup/server/controllers/wslconfbase.py
@@ -44,7 +44,6 @@ class WSLConfigurationBaseController(SubiquityController):
             'gen_host': {'type': 'boolean'},
             'gen_resolvconf': {'type': 'boolean'},
             },
-        'required': [],
         'additionalProperties': False,
         }
 

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -39,6 +39,7 @@ class SystemSetupServer(SubiquityServer):
 
     from system_setup.server import controllers as controllers_mod
     controllers = [
+        "Early",
         "Reporting",
         "Error",
         "WSLLocale",

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -42,7 +42,7 @@ class SystemSetupServer(SubiquityServer):
         "Reporting",
         "Error",
         "WSLLocale",
-        "Identity",
+        "WSLIdentity",
         "WSLConfigurationBase",
         "WSLConfigurationAdvanced",
         "Configure",


### PR DESCRIPTION
This is the auto configuration of system-setup on first boot based on the autoinstall feature of subiquity.

The most noticeable change is the support of non-systemd systems (like WSL). This systems cannot rely on journald for communication. In this case we fallback to a file based mechanism. 
This is covered by answer and autoinstall tests.

There are also few fixes for the controllers that are not available in all the modes, the schema for WSL, and loading the right controller for identify.