### PR TITLE
DE-97 - system-setup: finished removing duplicated fields

### DIFF
--- a/system_setup/server/controllers/wslconfadvanced.py
+++ b/system_setup/server/controllers/wslconfadvanced.py
@@ -28,7 +28,6 @@ log = logging.getLogger(
     'subiquity.server.controllers.wsl_configuration_advanced')
 
 
-# TODO WSL: remove all duplicates from WSL config base controller
 class WSLConfigurationAdvancedController(SubiquityController):
 
     endpoint = API.wslconfadvanced
@@ -37,10 +36,6 @@ class WSLConfigurationAdvancedController(SubiquityController):
     autoinstall_schema = {
         'type': 'object',
         'properties': {
-            'custom_path': {'type': 'string'},
-            'custom_mount_opt': {'type': 'string'},
-            'gen_host': {'type': 'boolean'},
-            'gen_resolvconf': {'type': 'boolean'},
             'interop_enabled': {'type': 'boolean'},
             'interop_appendwindowspath': {'type': 'boolean'},
             'gui_theme': {'type': 'string'},
@@ -63,12 +58,6 @@ class WSLConfigurationAdvancedController(SubiquityController):
             "automount": {
                 "enabled": "automount",
                 "mountfstab": "mountfstab",
-                "root": "custom_path",
-                "options": "custom_mount_opt",
-            },
-            "network": {
-                "generatehosts": "gen_host",
-                "generateresolvconf": "gen_resolvconf",
             },
             "interop": {
                 "enabled": "interop_enabled",
@@ -118,10 +107,6 @@ class WSLConfigurationAdvancedController(SubiquityController):
             def bool_converter(x):
                 return x == 'true'
             reconf_data = WSLConfigurationAdvanced(
-                custom_path=data['custom_path'],
-                custom_mount_opt=data['custom_mount_opt'],
-                gen_host=bool_converter(data['gen_host']),
-                gen_resolvconf=bool_converter(data['gen_resolvconf']),
                 interop_enabled=bool_converter(data['interop_enabled']),
                 interop_appendwindowspath=bool_converter(
                     data['interop_appendwindowspath']),
@@ -139,10 +124,6 @@ class WSLConfigurationAdvancedController(SubiquityController):
     def load_autoinstall_data(self, data):
         if data is not None:
             reconf_data = WSLConfigurationAdvanced(
-                custom_path=data['custom_path'],
-                custom_mount_opt=data['custom_mount_opt'],
-                gen_host=data['gen_host'],
-                gen_resolvconf=data['gen_resolvconf'],
                 interop_enabled=data['interop_enabled'],
                 interop_appendwindowspath=data['interop_appendwindowspath'],
                 gui_theme=data['gui_theme'],
@@ -167,10 +148,6 @@ class WSLConfigurationAdvancedController(SubiquityController):
     async def GET(self) -> WSLConfigurationAdvanced:
         data = WSLConfigurationAdvanced()
         if self.model.wslconfadvanced is not None:
-            data.custom_path = self.model.wslconfadvanced.custom_path
-            data.custom_mount_opt = self.model.wslconfadvanced.custom_mount_opt
-            data.gen_host = self.model.wslconfadvanced.gen_host
-            data.gen_resolvconf = self.model.wslconfadvanced.gen_resolvconf
             data.interop_enabled = self.model.wslconfadvanced.interop_enabled
             data.interop_appendwindowspath = \
                 self.model.wslconfadvanced.interop_appendwindowspath

--- a/system_setup/ui/views/wslconfadvanced.py
+++ b/system_setup/ui/views/wslconfadvanced.py
@@ -38,9 +38,6 @@ MountField = simple_field(MountEditor)
 StringField = simple_field(StringEditor)
 
 
-# TODO WSL: Advanced should not contain base configuration
-# (it must be in 2 pages).
-
 class WSLConfigurationAdvancedForm(Form):
     def __init__(self, initial):
         super().__init__(initial=initial)
@@ -55,15 +52,6 @@ class WSLConfigurationAdvancedForm(Form):
                                      "contains the necessary information to"
                                      " automate the process of mounting "
                                      "partitions. "))
-    custom_path = MountField(_("Auto-Mount Location"),
-                             help=_("Location for the automount"))
-    custom_mount_opt = StringField(_("Auto-Mount Option"),
-                                   help=_("Mount option passed for "
-                                          "the automount"))
-    gen_host = BooleanField(_("Enable Host Generation"), help=_(
-        "Selecting enables /etc/host re-generation at every start"))
-    gen_resolvconf = BooleanField(_("Enable resolv.conf Generation"), help=_(
-        "Selecting enables /etc/resolv.conf re-generation at every start"))
     interop_enabled = BooleanField(_("Enable Interop"),
                                    help=_("Whether the interoperability is"
                                           " enabled"))
@@ -104,44 +92,6 @@ class WSLConfigurationAdvancedForm(Form):
                                         " your MOTD News. Toggling it on "
                                         "allows you to see the MOTD."))
 
-    def validate_custom_path(self):
-        p = self.custom_path.value
-        if p != "" and (re.fullmatch(r"(/[^/ ]*)+/?", p) is None):
-            return _("Mount location must be a absolute UNIX path"
-                     " without space.")
-
-    def validate_custom_mount_opt(self):
-        o = self.custom_mount_opt.value
-        # filesystem independent mount option
-        fsimo = [r"async", r"(no)?atime", r"(no)?auto",
-                 r"(fs|def|root)?context=\w+", r"(no)?dev", r"(no)?diratime",
-                 r"dirsync", r"(no)?exec", r"group", r"(no)?iversion",
-                 r"(no)?mand", r"_netdev", r"nofail", r"(no)?relatime",
-                 r"(no)?strictatime", r"(no)?suid", r"owner", r"remount",
-                 r"ro", r"rw", r"_rnetdev", r"sync", r"(no)?user", r"users"]
-        # DrvFs filesystem mount option
-        drvfsmo = r"case=(dir|force|off)|metadata|(u|g)id=\d+|(u|f|d)mask=\d+|"
-        fso = "{0}{1}".format(drvfsmo, '|'.join(fsimo))
-
-        if o != "":
-            e_t = ""
-            p = o.split(',')
-            x = True
-            for i in p:
-                if i == "":
-                    e_t += _("an empty entry detected; ")
-                    x = x and False
-                elif re.fullmatch(fso, i) is not None:
-                    x = x and True
-                else:
-                    e_t += _("{} is not a valid mount option; ").format(i)
-                    x = x and False
-            if not x:
-                return _("Invalid Input: {}Please check "
-                         "https://docs.microsoft.com/en-us/windows/wsl/"
-                         "wsl-config#mount-options "
-                         "for correct valid input").format(e_t)
-
 
 class WSLConfigurationAdvancedView(BaseView):
     title = _("WSL advanced options")
@@ -152,10 +102,6 @@ class WSLConfigurationAdvancedView(BaseView):
         self.controller = controller
 
         initial = {
-            'custom_path': configuration_data.custom_path,
-            'custom_mount_opt': configuration_data.custom_mount_opt,
-            'gen_host': configuration_data.gen_host,
-            'gen_resolvconf': configuration_data.gen_resolvconf,
             'interop_enabled': configuration_data.interop_enabled,
             'interop_appendwindowspath':
                 configuration_data.interop_appendwindowspath,
@@ -182,10 +128,6 @@ class WSLConfigurationAdvancedView(BaseView):
 
     def done(self, result):
         self.controller.done(WSLConfigurationAdvanced(
-            custom_path=self.form.custom_path.value,
-            custom_mount_opt=self.form.custom_mount_opt.value,
-            gen_host=self.form.gen_host.value,
-            gen_resolvconf=self.form.gen_resolvconf.value,
             interop_enabled=self.form.interop_enabled.value,
             interop_appendwindowspath=self.form
             .interop_appendwindowspath.value,


### PR DESCRIPTION
There was some remaining duplicated fields in the controllers and models
between base and advanced configuration, which made the code crash.

This is a follow up to PR #1041.

Co-authored-by: Didier Roche <didrocks@ubuntu.com>