### PR TITLE
actions: trigger -push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
The push trigger is semi redundant.  It is nice in that someone about to
open a PR can first verify on their own fork that the CI passes, but
other than that it just causes the CI to run twice.  This is
particularly visible on the system_setup branhces, which has double the
number of CI steps expected.