### PR TITLE
actions: +accept-existing-contributors for CLA

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -8,3 +8,5 @@ jobs:
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1
+        with:
+          accept-existing-contributors: true


### PR DESCRIPTION
Canonical employees who have not signed the CLA, and sign commits with
their ubuntu.com alias, fall into a weird gap where their commits are
covered (as employees) but there is no great way for the CLA check to
determine that.
https://github.com/canonical/subiquity/pull/1044#issuecomment-916764603