### PR TITLE
autoinstall: skip autoinstall on empty arg

### DIFF
--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -41,7 +41,11 @@ def make_server_args_parser():
     parser.add_argument('--bootloader',
                         choices=['none', 'bios', 'prep', 'uefi'],
                         help='Override style of bootloader to use')
-    parser.add_argument('--autoinstall', action='store')
+    parser.add_argument(
+        '--autoinstall', action='store',
+        help=('Path to autoinstall file. Empty value disables autoinstall. '
+              'By default tries to load /autoinstall.yaml, '
+              'or autoinstall data from cloud-init.'))
     with open('/proc/cmdline') as fp:
         cmdline = fp.read()
     parser.add_argument('--kernel-cmdline', action='store', default=cmdline)


### PR DESCRIPTION
If autoinstall is set on the command line, don't override that with a
pre-baked file or from cloud-init.  The intent here is to allow
ubuntu-desktop-installer to temporarily say --autoinstall="" to disable
autoinstall until UI support for autoinstall is in place.