### PR TITLE
WSL OOBE - no dry mode

### DIFF
--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -57,3 +57,8 @@ class SystemSetupServer(SubiquityServer):
             root = os.path.abspath('.subiquity')
         return SystemSetupModel(root, INSTALL_MODEL_NAMES,
                                 POSTINSTALL_MODEL_NAMES)
+
+    # We don’t have cloudinit in system_setup.
+    async def wait_for_cloudinit(self):
+        self.cloud_init_ok = True
+        return


### PR DESCRIPTION
2 fixes after running in real mode (no dry run) on a WSL system:
1. The server must be started by the client when it is not socket activated
2. When there is no cloud init, the client was waiting on it forever