### PR TITLE
autoinstall: fix issues in autoinstall roundtrip

### DIFF
--- a/autoinstall-schema.json
+++ b/autoinstall-schema.json
@@ -340,25 +340,8 @@
                     },
                     "classic": {
                         "type": "boolean"
-                    },
-                    "is_classic": {
-                        "type": "boolean"
                     }
                 },
-                "oneOf": [
-                    {
-                        "type": "object",
-                        "required": [
-                            "classic"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "is_classic"
-                        ]
-                    }
-                ],
                 "required": [
                     "name"
                 ],

--- a/autoinstall-schema.json
+++ b/autoinstall-schema.json
@@ -340,8 +340,25 @@
                     },
                     "classic": {
                         "type": "boolean"
+                    },
+                    "is_classic": {
+                        "type": "boolean"
                     }
                 },
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "required": [
+                            "classic"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "is_classic"
+                        ]
+                    }
+                ],
                 "required": [
                     "name"
                 ],

--- a/examples/answers-bond.yaml
+++ b/examples/answers-bond.yaml
@@ -51,7 +51,7 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes
 

--- a/examples/answers-guided-lvm.yaml
+++ b/examples/answers-guided-lvm.yaml
@@ -26,7 +26,7 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes
 

--- a/examples/answers-imsm.yaml
+++ b/examples/answers-imsm.yaml
@@ -30,6 +30,6 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes

--- a/examples/answers-lvm-dmcrypt.yaml
+++ b/examples/answers-lvm-dmcrypt.yaml
@@ -74,6 +74,6 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes

--- a/examples/answers-lvm.yaml
+++ b/examples/answers-lvm.yaml
@@ -61,6 +61,6 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes

--- a/examples/answers-preserve.yaml
+++ b/examples/answers-preserve.yaml
@@ -35,6 +35,6 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes

--- a/examples/answers-raid-lvm.yaml
+++ b/examples/answers-raid-lvm.yaml
@@ -102,6 +102,6 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes

--- a/examples/answers-raid.yaml
+++ b/examples/answers-raid.yaml
@@ -61,6 +61,6 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes

--- a/examples/answers-serial.yaml
+++ b/examples/answers-serial.yaml
@@ -34,7 +34,7 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes
 

--- a/examples/answers-swap.yaml
+++ b/examples/answers-swap.yaml
@@ -34,7 +34,7 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes
 

--- a/examples/answers.yaml
+++ b/examples/answers.yaml
@@ -26,7 +26,7 @@ SnapList:
   snaps:
     hello:
       channel: stable
-      is_classic: false
+      classic: false
 InstallProgress:
   reboot: yes
 

--- a/subiquity/client/controllers/snaplist.py
+++ b/subiquity/client/controllers/snaplist.py
@@ -48,6 +48,8 @@ class SnapListController(SubiquityTuiController):
         if 'snaps' in self.answers:
             selections = []
             for snap_name, selection in self.answers['snaps'].items():
+                if 'is_classic' in selection:
+                    selection['classic'] = selection.pop('is_classic')
                 selections.append(SnapSelection(name=snap_name, **selection))
             self.done(selections)
 

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -332,7 +332,7 @@ class SnapInfo:
 class SnapSelection:
     name: str
     channel: str
-    is_classic: bool = False
+    classic: bool = False
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/models/snaplist.py
+++ b/subiquity/models/snaplist.py
@@ -100,7 +100,7 @@ class SnapListModel:
         cmds = []
         for selection in self.selections:
             cmd = ['snap', 'install', '--channel=' + selection.channel]
-            if selection.is_classic:
+            if selection.classic:
                 cmd.append('--classic')
             cmd.append(selection.name)
             cmds.append(' '.join(cmd))

--- a/subiquity/server/controllers/kernel.py
+++ b/subiquity/server/controllers/kernel.py
@@ -75,8 +75,4 @@ class KernelController(NonInteractiveController):
         self.model.metapkg_name = package
 
     def make_autoinstall(self):
-        return {
-            'kernel': {
-                'package': self.model.metapkg_name,
-                },
-            }
+        return {'package': self.model.metapkg_name}

--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -124,18 +124,7 @@ class SnapListController(SubiquityController):
                 'name': {'type': 'string'},
                 'channel': {'type': 'string'},
                 'classic': {'type': 'boolean'},
-                'is_classic': {'type': 'boolean'},
-            },
-            'oneOf': [
-                {
-                    'type': 'object',
-                    'required': ['classic'],
                 },
-                {
-                    'type': 'object',
-                    'required': ['is_classic'],
-                }
-            ],
             'required': ['name'],
             'additionalProperties': False,
             },
@@ -159,7 +148,7 @@ class SnapListController(SubiquityController):
             to_install.append(SnapSelection(
                 name=snap['name'],
                 channel=snap.get('channel', 'stable'),
-                is_classic=snap.get('classic', snap.get('is_classic', False))))
+                classic=snap.get('classic', False)))
         self.model.set_installed_list(to_install)
 
     def snapd_network_changed(self):

--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -124,7 +124,18 @@ class SnapListController(SubiquityController):
                 'name': {'type': 'string'},
                 'channel': {'type': 'string'},
                 'classic': {'type': 'boolean'},
+                'is_classic': {'type': 'boolean'},
+            },
+            'oneOf': [
+                {
+                    'type': 'object',
+                    'required': ['classic'],
                 },
+                {
+                    'type': 'object',
+                    'required': ['is_classic'],
+                }
+            ],
             'required': ['name'],
             'additionalProperties': False,
             },
@@ -148,7 +159,7 @@ class SnapListController(SubiquityController):
             to_install.append(SnapSelection(
                 name=snap['name'],
                 channel=snap.get('channel', 'stable'),
-                is_classic=snap.get('classic', False)))
+                is_classic=snap.get('classic', snap.get('is_classic', False))))
         self.model.set_installed_list(to_install)
 
     def snapd_network_changed(self):

--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -128,7 +128,7 @@ class SnapInfoView(WidgetWrap):
             selection = SnapSelection(
                 name=self.snap.name,
                 channel=csi.channel_name,
-                is_classic=csi.confinement == "classic")
+                classic=csi.confinement == "classic")
             btn = StarRadioButton(
                 radio_group,
                 csi.channel_name,
@@ -328,7 +328,7 @@ class SnapCheckBox(CheckBox):
             self.parent.selections_by_name[self.snap.name] = SnapSelection(
                 name=self.snap.name,
                 channel='stable',
-                is_classic=self.snap.confinement == "classic")
+                classic=self.snap.confinement == "classic")
         else:
             log.debug("unselecting %s", self.snap.name)
             self.parent.selections_by_name.pop(self.snap.name, None)


### PR DESCRIPTION
Fix autoinstall output for kernel & snaplist.
This is necessary but not sufficient to roundtrip an autoinstall file.