### PR TITLE
Add '--quiet' to 'lszdev' to omit additional progress msg - lp1944516

### DIFF
--- a/scripts/zdev-generate.py
+++ b/scripts/zdev-generate.py
@@ -12,6 +12,6 @@ for row in rows:
     record = dict([k.split('=',1) for k in row])
     if record['COLUMN'] not in ('TYPE', 'ATTR:', 'ATTRPATH:'):
         desired_columns.append(record['COLUMN'].lower())
-cmd = ['lszdev','--pairs','--columns',','.join(desired_columns)]
+cmd = ['lszdev', '--quiet', '--pairs','--columns',','.join(desired_columns)]
 print(cmd)
 print(' '.join(cmd))

--- a/scripts/zdev-generate.py
+++ b/scripts/zdev-generate.py
@@ -12,6 +12,6 @@ for row in rows:
     record = dict([k.split('=',1) for k in row])
     if record['COLUMN'] not in ('TYPE', 'ATTR:', 'ATTRPATH:'):
         desired_columns.append(record['COLUMN'].lower())
-cmd = ['lszdev', '--quiet', '--pairs','--columns',','.join(desired_columns)]
+cmd = ['lszdev','--quiet','--pairs','--columns',','.join(desired_columns)]
 print(cmd)
 print(' '.join(cmd))

--- a/subiquity/server/controllers/zdev.py
+++ b/subiquity/server/controllers/zdev.py
@@ -30,7 +30,7 @@ from subiquity.server.controller import SubiquityController
 
 log = logging.getLogger("subiquity.server.controller.zdev")
 
-lszdev_cmd = ['lszdev', '--pairs', '--columns',
+lszdev_cmd = ['lszdev', '--quiet', '--pairs', '--columns',
               'id,type,on,exists,pers,auto,failed,names']
 
 lszdev_stock = '''id="0.0.1500" type="dasd-eckd" on="no" exists="yes" pers="no" auto="no" failed="no" names=""


### PR DESCRIPTION
Adding "--quiet" as additional option to "lszdev" omits additional progress status messages that "lszdev" might produce in case a significant amount of ccw devices are present (in the range of thousands of devices), since such progress messages will eventually cause parsing issues, like mentioned in LP#1944516.