### PR TITLE
never match a disk with 0 size when converting autoinstall config

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -990,6 +990,8 @@ class FilesystemModel(object):
         matchers = self._make_matchers(match)
         candidates = []
         for candidate in disks:
+            if candidate.size == 0:
+                continue
             for matcher in matchers:
                 if not matcher(candidate):
                     break

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -334,6 +334,41 @@ class TestAutoInstallConfig(unittest.TestCase):
         new_disk = model._one(type="disk", id="disk0")
         self.assertEqual(new_disk.serial, "larger")
 
+    def test_smallest(self):
+        model = make_model()
+        make_disk(model, serial='smaller', size=10*(2**30))
+        make_disk(model, serial='larger', size=11*(2**30))
+        fake_up_blockdata(model)
+        model.apply_autoinstall_config([
+            {
+                'type': 'disk',
+                'id': 'disk0',
+                'match': {
+                    'size': 'smallest',
+                    },
+            },
+            ])
+        new_disk = model._one(type="disk", id="disk0")
+        self.assertEqual(new_disk.serial, "smaller")
+
+    def test_smallest_skips_zero_size(self):
+        model = make_model()
+        make_disk(model, serial='smallest', size=0)
+        make_disk(model, serial='smaller', size=10*(2**30))
+        make_disk(model, serial='larger', size=11*(2**30))
+        fake_up_blockdata(model)
+        model.apply_autoinstall_config([
+            {
+                'type': 'disk',
+                'id': 'disk0',
+                'match': {
+                    'size': 'smallest',
+                    },
+            },
+            ])
+        new_disk = model._one(type="disk", id="disk0")
+        self.assertEqual(new_disk.serial, "smaller")
+
     def test_serial_exact(self):
         model = make_model()
         make_disk(model, serial='aaaa', path='/dev/aaa')


### PR DESCRIPTION
Sometimes empty CD drives or SD card readers show up as block devices
with 0 size. It never makes sense to select these when converting
autoinstall config to curtin config (and size: smallest is quite likely
to do so!)

For https://bugs.launchpad.net/subiquity/+bug/1943609