### PR TITLE
fixes around logical volume size

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -763,6 +763,11 @@ class LVM_VolGroup(_Device):
     def available_for_partitions(self):
         return self.size
 
+    @property
+    def free_for_partitions(self):
+        return align_down(
+            self.available_for_partitions - self.used, LVM_CHUNK_SIZE)
+
     ok_for_raid = False
     ok_for_lvm_vg = False
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -51,7 +51,9 @@ from subiquity.common.types import (
     StorageResponse,
     )
 from subiquity.models.filesystem import (
+    align_down,
     dehumanize_size,
+    LVM_CHUNK_SIZE,
     Raid,
     )
 from subiquity.server.controller import (
@@ -168,6 +170,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         else:
             # Use at most 100G of a large disk.
             lv_size = 100 * (2 << 30)
+        lv_size = align_down(lv_size, LVM_CHUNK_SIZE)
         self.create_logical_volume(
             vg=vg, spec=dict(
                 size=lv_size,

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -57,6 +57,9 @@ from subiquity.ui.mount import (
 log = logging.getLogger('subiquity.ui.filesystem.add_partition')
 
 
+DEFAULT_ALIGNMENT = 1 << 20
+
+
 class FSTypeField(FormField):
 
     takes_default_style = False
@@ -380,8 +383,8 @@ class PartitionStretchy(Stretchy):
             alignment = LVM_CHUNK_SIZE
             lvm_names = {p.name for p in disk.partitions()}
         else:
+            alignment = DEFAULT_ALIGNMENT
             lvm_names = None
-            alignment = 1 << 20
         if self.partition:
             if partition.flag in ["bios_grub", "prep"]:
                 label = None
@@ -573,7 +576,7 @@ class FormatEntireStretchy(Stretchy):
         elif not isinstance(device, Disk):
             initial['fstype'] = 'ext4'
         self.form = PartitionForm(
-            self.model, 0, initial, None, device, 1 << 20)
+            self.model, 0, initial, None, device, DEFAULT_ALIGNMENT)
         self.form.remove_field('size')
         self.form.remove_field('name')
 

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -44,6 +44,7 @@ from subiquity.models.filesystem import (
     HUMAN_UNITS,
     dehumanize_size,
     humanize_size,
+    LVM_CHUNK_SIZE,
     LVM_VolGroup,
 )
 from subiquity.ui.mount import (
@@ -111,13 +112,14 @@ class SizeWidget(StringEditor):
                 ('info_minor',
                  _("Capped partition size at {size}").format(
                      size=self.form.size_str)))
-        elif (align_up(sz) != sz and
-              humanize_size(align_up(sz)) != self.form.size.value):
-            sz_str = humanize_size(align_up(sz))
-            self.value = sz_str
-            self.form.size.show_extra(
-                ('info_minor', _("Rounded size up to {size}").format(
-                    size=sz_str)))
+        else:
+            aligned_sz = align_up(sz, self.form.alignment)
+            aligned_sz_str = humanize_size(aligned_sz)
+            if aligned_sz != sz and aligned_sz_str != self.form.size.value:
+                self.value = aligned_sz_str
+                self.form.size.show_extra(
+                    ('info_minor', _("Rounded size up to {size}").format(
+                        size=aligned_sz_str)))
 
 
 class SizeField(FormField):
@@ -147,7 +149,7 @@ LVNameField = simple_field(LVNameEditor)
 
 class PartitionForm(Form):
 
-    def __init__(self, model, max_size, initial, lvm_names, device):
+    def __init__(self, model, max_size, initial, lvm_names, device, alignment):
         self.model = model
         self.device = device
         self.existing_fs_type = None
@@ -165,6 +167,7 @@ class PartitionForm(Form):
             self.size.caption = _("Size (max {size}):").format(
                 size=self.size_str)
         self.lvm_names = lvm_names
+        self.alignment = alignment
         super().__init__(initial)
         if max_size is None:
             self.remove_field('size')
@@ -374,9 +377,11 @@ class PartitionStretchy(Stretchy):
         initial = {}
         label = _("Create")
         if isinstance(disk, LVM_VolGroup):
+            alignment = LVM_CHUNK_SIZE
             lvm_names = {p.name for p in disk.partitions()}
         else:
             lvm_names = None
+            alignment = 1 << 20
         if self.partition:
             if partition.flag in ["bios_grub", "prep"]:
                 label = None
@@ -410,7 +415,7 @@ class PartitionStretchy(Stretchy):
                 initial['name'] = name
 
         self.form = PartitionForm(
-            self.model, max_size, initial, lvm_names, partition)
+            self.model, max_size, initial, lvm_names, partition, alignment)
 
         if not isinstance(disk, LVM_VolGroup):
             self.form.remove_field('name')
@@ -567,7 +572,8 @@ class FormatEntireStretchy(Stretchy):
             initial.update(initial_data_for_fs(fs))
         elif not isinstance(device, Disk):
             initial['fstype'] = 'ext4'
-        self.form = PartitionForm(self.model, 0, initial, None, device)
+        self.form = PartitionForm(
+            self.model, 0, initial, None, device, 1 << 20)
         self.form.remove_field('size')
         self.form.remove_field('name')
 


### PR DESCRIPTION
LVM logical volumes can only be multiples of the VG's extent size, which is 4MiB by default.

https://bugs.launchpad.net/subiquity/+bug/1935969