### PR TITLE
Fix crash with autoinstall on non-systemd env

### DIFF
--- a/subiquity/server/controllers/cmdlist.py
+++ b/subiquity/server/controllers/cmdlist.py
@@ -60,7 +60,7 @@ class CmdListController(NonInteractiveController):
             with context.child("command_{}".format(i), desc):
                 if isinstance(cmd, str):
                     cmd = ['sh', '-c', cmd]
-                if self.syslog_id is not None:
+                if self.syslog_id:
                     journal.send(
                         "  running " + desc, SYSLOG_IDENTIFIER=self.syslog_id)
                     cmd = [

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -55,6 +55,9 @@ class SystemSetupServer(SubiquityServer):
 
     def __init__(self, opts, block_log_dir):
         super().__init__(opts, block_log_dir)
+        self.echo_syslog_id = ""
+        self.event_syslog_id = ""
+        self.log_syslog_id = ""
         if is_reconfigure(opts.dry_run):
             self.set_source_variant("wsl_configuration")
 


### PR DESCRIPTION
DEENG-29 

On WSL and any system without systemd the server crashes because the syslog id is always set (and never None) and `systemd-cat` cannot connect to the journal.
We can't set the id to None because the API expects a string, so the check `is not None` is always true.

```2021-10-04 20:05:11,992 INFO root:39 start: subiquity/Meta/status_GET: 
2021-10-04 20:05:12,883 DEBUG root:39 start: subiquity/Early/run: 
2021-10-04 20:05:12,883 DEBUG root:39 start: subiquity/Early/run/command_0: echo a
2021-10-04 20:05:12,884 DEBUG subiquitycore.utils:74 arun_command called: ['systemd-cat', '--level-prefix=false', '--identifier=', 'sh', '-c', 'echo a']
2021-10-04 20:05:12,890 DEBUG subiquitycore.utils:83 arun_command ['systemd-cat', '--level-prefix=false', '--identifier=', 'sh', '-c', 'echo a'] exited with code 1
2021-10-04 20:05:12,891 ERROR root:39 finish: subiquity/Early/run/command_0: FAIL: Command '['systemd-cat', '--level-prefix=false', '--identifier=', 'sh', '-c', 'echo a']' returned non-zero exit status 1.
2021-10-04 20:05:12,891 ERROR root:39 finish: subiquity/Early/run: FAIL: Command '['systemd-cat', '--level-prefix=false', '--identifier=', 'sh', '-c', 'echo a']' returned non-zero exit status 1.
2021-10-04 20:05:12,891 ERROR subiquity.server.server:391 top level error
Traceback (most recent call last):
  File "/home/u/subiquity/subiquity/server/server.py", line 588, in start
    await self.controllers.Early.run()
  File "/home/u/subiquity/subiquitycore/context.py", line 148, in decorated_async
    return await meth(self, **kw)
  File "/home/u/subiquity/subiquity/server/controllers/cmdlist.py", line 70, in run
    await arun_command(
  File "/home/u/subiquity/subiquitycore/utils.py", line 85, in arun_command
    raise subprocess.CalledProcessError(proc.returncode, cmd)
subprocess.CalledProcessError: Command '['systemd-cat', '--level-prefix=false', '--identifier=', 'sh', '-c', 'echo a']' returned non-zero exit status 1.
2021-10-04 20:05:12,892 DEBUG subiquitycore.common.errorreport:384 generating crash report
```