### PR TITLE
workflows: skip impish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         image:
           - ubuntu-daily:bionic


### PR DESCRIPTION
Impish systemd-resolved seems unhappy and it's interfering with the
other test runs.