### PR TITLE
unittest: use pytest-3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ aptdeps:
 		libnl-route-3-dev python3-attr python3-distutils-extra python3-requests \
 		python3-requests-unixsocket python3-jsonschema python3-apport \
 		python3-bson xorriso isolinux python3-aiohttp cloud-init ssh-import-id \
-		curl jq build-essential
+		curl jq build-essential python3-pytest
 
 install_deps: aptdeps gitdeps
 
@@ -68,7 +68,7 @@ flake8:
 	$(PYTHON) -m flake8 $(CHECK_DIRS) --exclude gettext38.py,contextlib38.py
 
 unit: gitdeps
-	python3 -m unittest discover
+	python3 -m pytest --ignore curtin --ignore probert
 
 integration: gitdeps
 	echo "Running integration tests..."

--- a/scripts/installdeps.sh
+++ b/scripts/installdeps.sh
@@ -11,7 +11,7 @@ ConditionPathExists=/dev/zfs
 EOF
 cp -r /etc/systemd/system/zfs-mount.service.d/ /etc/systemd/system/zfs-share.service.d/
 systemctl daemon-reload
-apt-get install -o APT::Get::Always-Include-Phased-Updates=true -y --no-install-recommends libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libsystemd-dev python3-distutils-extra pkg-config python3.5 python3-pip git lsb-release python3-setuptools gcc python3-dev python3-wheel pep8 python3-pyflakes python3-bson make curl jq build-essential
+apt-get install -o APT::Get::Always-Include-Phased-Updates=true -y --no-install-recommends libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libsystemd-dev python3-distutils-extra pkg-config python3.5 python3-pip git lsb-release python3-setuptools gcc python3-dev python3-wheel pep8 python3-pyflakes python3-bson make curl jq build-essential python3-pytest
 pip3 install -r requirements.txt
 
 make gitdeps


### PR DESCRIPTION
pytest-3 lets us set exclude directories, which is helpful with the
desired API testing to seperate them from 'unittest discover' so that we
can keep unit test runtime short.