### PR TITLE
invoke lsb_release from /target when configuring cdrom source for apt

### DIFF
--- a/bin/subiquity-configure-apt
+++ b/bin/subiquity-configure-apt
@@ -61,7 +61,7 @@ else
 fi
 
 cat > "$TARGET_MOUNT_POINT/etc/apt/sources.list" <<EOF
-deb [check-date=no] file:///cdrom $(lsb_release -sc) main restricted
+deb [check-date=no] file:///cdrom $(chroot $TARGET_MOUNT_POINT lsb_release -sc) main restricted
 EOF
 
 $PY -m curtin in-target -- apt-get update


### PR DESCRIPTION
for some reason lsb_release in the snap is a bit busted.

For https://bugs.launchpad.net/subiquity/+bug/1946790