### PR TITLE
LocaleController.start() check model language

### DIFF
--- a/subiquity/server/controllers/locale.py
+++ b/subiquity/server/controllers/locale.py
@@ -37,11 +37,11 @@ class LocaleController(SubiquityController):
 
     def start(self):
         # Language model may have been initialized before start() is called.
-        # But for autoinstall (not interactive)
-        # Someone else initializing to a different value would be unexpected behavior.
-        if (not self.interactive()) or (self.model.selected_language is None):
-                self.model.selected_language = os.environ.get("LANG") \
-                        or self.autoinstall_default
+        # But for autoinstall (not interactive), someone else
+        # initializing to a different value would be unexpected behavior.
+        if not self.interactive() or (self.model.selected_language is None):
+            self.model.selected_language = os.environ.get("LANG") \
+                or self.autoinstall_default
 
         self.app.aio_loop.create_task(self.configured())
         self.app.hub.subscribe(


### PR DESCRIPTION
Hi @dbungert!

As we discussed internally, this very little change in subiquity.server.controllers.locale becomes handy for the feature I'm working on and should not affect any other part of Subiquity.

My feature will affect system_setup, only, but since this piece lies outside of the system_setup folder, I believe I should proposed it in a dedicated PR.

The proposed change enables locale controller to respect the model selected_language if initialized before LocaleController.start().

The feature I'm working on will allow prefilling installation UI screens during WSL installation with information acquired from Windows environment, thus having the controller not overriding that information set during model construction is beneficial.