### PR TITLE
snapcraft: ssh-import-id lsb_release from live

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -94,8 +94,6 @@ parts:
       - cloud-init
       - libsystemd0
       - iso-codes
-      - lsb-release
-      - ssh-import-id
       - libpython3.8-minimal
       - libpython3.8-stdlib
       - libpython3-stdlib
@@ -121,6 +119,9 @@ parts:
       'bin/subiquity-service': usr/bin/subiquity-service
       'bin/subiquity-server': usr/bin/subiquity-server
       'bin/subiquity-cmd': usr/bin/subiquity-cmd
+    stage:
+      - '*'
+      - '-usr/bin/lsb_release'
   users-and-groups:
     plugin: nil
     build-packages:


### PR DESCRIPTION
ssh-import-id in the snap has python loading problems due to trying to
load stuff from the live system instead.  If you mangle that hard enough
your reward is the same result for lsb_release.

In draft until I test this to my liking.  I also now mistrust every single external program we interact with and want to ensure we have tested all such paths.