### PR TITLE
Make progress controller optional.

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -506,7 +506,8 @@ class SubiquityClient(TuiApplication):
         return view
 
     def show_progress(self):
-        self.ui.set_body(self.controllers.Progress.progress_view)
+        if hasattr(self.controllers, 'Progress'):
+            self.ui.set_body(self.controllers.Progress.progress_view)
 
     def unhandled_input(self, key):
         if key == 'f1':


### PR DESCRIPTION
The progress controller was already optional in
subiquity/server/controllers/cmdlist.py. However, there was one missing
place in show_progress(). Use a similar getattr strategy.

This is part 1 on getting the `make integration` fix (subiquity side).