### PR TITLE
Summary page to show immediately and update once the setup is done

### DIFF
--- a/system_setup/client/controllers/identity.py
+++ b/system_setup/client/controllers/identity.py
@@ -46,4 +46,5 @@ class WSLIdentityController(SubiquityTuiController):
         log.debug(
             "IdentityController.done next_screen user_spec=%s",
             identity_data)
+        self.app.identity = identity_data
         self.app.next_screen(self.endpoint.POST(identity_data))

--- a/system_setup/client/controllers/summary.py
+++ b/system_setup/client/controllers/summary.py
@@ -83,10 +83,8 @@ class SummaryController(SubiquityTuiController):
 
     async def make_ui(self):
         real_name = ""
-        identity = getattr(self.app.client, "identity")
-        if identity is not None:
-            data = await identity.GET()
-            real_name = data.realname
+        if hasattr(self.app, "identity"):
+            real_name = self.app.identity.realname
         self.summary_view = SummaryView(self, real_name)
         # We may reach the DONE or ERROR state even before we had a chance
         # to show the UI.

--- a/system_setup/ui/views/summary.py
+++ b/system_setup/ui/views/summary.py
@@ -16,6 +16,8 @@ from subiquitycore.ui.buttons import (
 from subiquitycore.ui.width import widget_width
 from subiquity.common.types import ApplicationState
 
+from subiquitycore.ui.container import ListBox
+from urwid import Text
 
 log = logging.getLogger("ubuntu_wsl_oobe.ui.views.summary")
 
@@ -25,18 +27,19 @@ class SummaryView(BaseView):
 
     def __init__(self, controller, real_name):
         self.controller = controller
-        complete_text = _("You have completed the setup!\n\n"
-                          "All settings will take effect after next "
-                          "restart of Ubuntu.")
+        completed = _("You have completed the setup!\n\n"
+                      "All settings will take effect after next "
+                      "restart of Ubuntu.")
         if real_name != '':
-            complete_text = _("Hi {real_name},\n\n"
-                              "You have completed the setup!\n\n"
-                              "It is suggested to run the following commands"
-                              " to update your Ubuntu to the latest version:"
-                              "\n\n\n"
-                              "  $ sudo apt update\n  $ sudo apt upgrade\n\n\n"
-                              "All settings will take effect after next "
-                              "restart of Ubuntu.").format(real_name=real_name)
+            completed = _("Hi {real_name},\n\n"
+                          "You have completed the setup!\n\n"
+                          "It is suggested to run the following commands"
+                          " to update your Ubuntu to the latest version:"
+                          "\n\n\n"
+                          "  $ sudo apt update\n  $ sudo apt upgrade\n\n\n"
+                          "All settings will take effect after next "
+                          "restart of Ubuntu.").format(real_name=real_name)
+        self.completed = completed
 
         self.reboot_btn = Toggleable(ok_btn(
             _("Reboot Now"), on_press=self.reboot))
@@ -44,12 +47,13 @@ class SummaryView(BaseView):
             _("View error report"), on_press=self.view_error)
 
         self.event_buttons = button_pile([])
+        self.body = ListBox([Text(_("Applying changes…"))])
         super().__init__(
             screen(
-                rows=[],
+                rows=self.body,
                 buttons=self.event_buttons,
                 focus_buttons=True,
-                excerpt=complete_text,
+                excerpt=None,
             )
         )
 
@@ -57,6 +61,7 @@ class SummaryView(BaseView):
         btns = []
         if state == ApplicationState.DONE:
             btns = [self.reboot_btn]
+            self.body.base_widget.body = [Text(self.completed)]
         elif state == ApplicationState.ERROR:
             self.title = _('An error occurred during installation')
             self.reboot_btn.base_widget.set_label(_("Reboot Now"))


### PR DESCRIPTION
Shows immediately the summary page. Before, this one was making a GET
request to the server, which was stuck on any long running command in
the controller.
Now, affect correctly the identity in memory and reuse it if needed.

Show a progress message while the configuration is happening and replace
it with a "completed" text on success.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>