### PR TITLE
system_setup: Many fixes for ci

### DIFF
--- a/system_setup/cmd/tui.py
+++ b/system_setup/cmd/tui.py
@@ -72,7 +72,7 @@ def main():
         opts, unknown = parser.parse_known_args(args)
         if opts.socket is None:
             need_start_server = True
-            server_output_dir = '/tmp/.subiquity'
+            server_output_dir = '.subiquity'
             sock_path = os.path.join(server_output_dir, 'socket')
             if os.path.exists('.subiquity/run/subiquity/server-state'):
                 os.unlink('.subiquity/run/subiquity/server-state')

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -59,7 +59,6 @@ class SystemSetupServer(SubiquityServer):
 
     def __init__(self, opts, block_log_dir):
         super().__init__(opts, block_log_dir)
-        self.echo_syslog_id = ""
         self.event_syslog_id = ""
         self.log_syslog_id = ""
         if is_reconfigure(opts.dry_run):

--- a/system_setup/ui/views/summary.py
+++ b/system_setup/ui/views/summary.py
@@ -65,8 +65,6 @@ class SummaryView(BaseView):
                 self.view_error_btn,
                 self.reboot_btn,
                 ]
-        else:
-            raise Exception(state)
         if self.controller.showing:
             self.controller.app.ui.set_header(self.title)
         self._set_buttons(btns)


### PR DESCRIPTION
Avoid a crash due to in progress state when summary is displayed.
Fixes on non systemd machines on output printing.
Use correct path in dry-run for socket.

This is part 2 (over 3) on fixing `make integration`.