### PR TITLE
Fix prefill only dryrun

### DIFF
--- a/system_setup/cmd/tui.py
+++ b/system_setup/cmd/tui.py
@@ -51,6 +51,10 @@ def make_client_args_parser():
     parser.add_argument('--socket')
     parser.add_argument('--answers')
     parser.add_argument('--server-pid')
+    parser.add_argument('--prefill',
+                        dest='prefill',
+                        help='Prefills UI models with data provided in'
+                        ' a prefill.yaml file yet allowing overrides.')
     return parser
 
 
@@ -69,8 +73,8 @@ def main():
     server_args = []
     server_output_dir = "/var/log/installer"
     server_state_file = "/run/subiquity/server-state"
+    opts, unknown = parser.parse_known_args(args)
     if '--dry-run' in args:
-        opts, unknown = parser.parse_known_args(args)
         server_state_file = ".subiquity/run/subiquity/server-state"
         if opts.socket is None:
             need_start_server = True
@@ -78,13 +82,13 @@ def main():
             sock_path = os.path.join(server_output_dir, 'socket')
             opts.socket = sock_path
             server_args = ['--dry-run', '--socket=' + sock_path] + unknown
-        else:
-            opts = parser.parse_args(args)
-    else:
-        opts = parser.parse_args(args)
-        if opts.socket is None:
-            need_start_server = True
-            opts.socket = '/run/subiquity/socket'
+
+    elif opts.socket is None:
+        need_start_server = True
+        opts.socket = '/run/subiquity/socket'
+
+    if opts.prefill:
+        server_args += ['--prefill='+opts.prefill]
 
     os.makedirs(server_output_dir, exist_ok=True)
     server_output = open(os.path.join(server_output_dir, 'server-output'), 'w')

--- a/system_setup/server/controllers/locale.py
+++ b/system_setup/server/controllers/locale.py
@@ -14,7 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 from subiquity.server.controllers.locale import LocaleController
+from subiquitycore.utils import arun_command
 
 log = logging.getLogger('system_setup.server.controllers.locale')
 
@@ -30,3 +32,62 @@ class WSLLocaleController(LocaleController):
                           .format(self.model.selected_language))
 
         super().start()
+
+    async def _run_locale_support_cmds(self, lang: str):
+        """ Final commands to be ran when a valid language is POST'ed. """
+
+        env = os.environ.copy()
+        # Ensure minimal console translation is enabled.
+        cmds = (["locale-gen"],
+                ["update-locale", "LANG={}".format(lang)],
+                ["bash", "-c", "\"apt", "install", "$(check-language-support",
+                 "-l", lang[0:2], ")\""])
+        if self.app.opts.dry_run:
+            for cmd in cmds:
+                log.debug('Would run: ' + ' '.join(cmd))
+        else:
+            for cmd in cmds:
+                cp = await arun_command(cmd, env=env)
+                if cp.returncode:
+                    log.debug('Command \"%s\" failed with return code %d',
+                              cp.args, cp.returncode)
+
+    async def POST(self, data: str):
+        if data == self.autoinstall_default or data == os.environ.get("LANG"):
+            await super().POST(data)
+            return
+
+        fileContents: str
+        fname = "locale.gen"
+        env = os.environ.copy()
+        if self.app.opts.dry_run:
+            # For debug purposes.
+            fname = ".subiquity/" + fname
+            await arun_command(['cp', '/etc/locale.gen', '.subiquity/'],
+                               env=env)
+        else:
+            fname = "/etc/" + fname
+
+        pendingWrite = False
+        with open(fname, "r") as localeGen:
+            # locale.gen is not so big.
+            fileContents = localeGen.read()
+            lineFound = fileContents.find(data)
+            if lineFound == -1:
+                # An unsupported locale coming from our UI is a bug.
+                raise AssertionError("Selected language {} not supported."
+                                     " Rolling back.".format(data))
+
+            commented = "# {}".format(data)
+            lineFound = fileContents.find(commented)
+            if lineFound != -1:
+                fileContents = fileContents.replace(commented, data)
+                pendingWrite = True
+
+        if pendingWrite:
+            with open(fname, "wt") as f:
+                f.write(fileContents)
+
+        # If we arrive here, data is a supported language.
+        await self._run_locale_support_cmds(data)
+        await super().POST(data)

--- a/system_setup/server/controllers/locale.py
+++ b/system_setup/server/controllers/locale.py
@@ -14,9 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 from subiquity.server.controllers.locale import LocaleController
-from subiquitycore.utils import arun_command
 
 log = logging.getLogger('system_setup.server.controllers.locale')
 
@@ -32,62 +30,3 @@ class WSLLocaleController(LocaleController):
                           .format(self.model.selected_language))
 
         super().start()
-
-    async def _run_locale_support_cmds(self, lang: str):
-        """ Final commands to be ran when a valid language is POST'ed. """
-
-        env = os.environ.copy()
-        # Ensure minimal console translation is enabled.
-        cmds = (["locale-gen"],
-                ["update-locale", "LANG={}".format(lang)],
-                ["bash", "-c", "\"apt", "install", "$(check-language-support",
-                 "-l", lang[0:2], ")\""])
-        if self.app.opts.dry_run:
-            for cmd in cmds:
-                log.debug('Would run: ' + ' '.join(cmd))
-        else:
-            for cmd in cmds:
-                cp = await arun_command(cmd, env=env)
-                if cp.returncode:
-                    log.debug('Command \"%s\" failed with return code %d',
-                              cp.args, cp.returncode)
-
-    async def POST(self, data: str):
-        if data == self.autoinstall_default or data == os.environ.get("LANG"):
-            await super().POST(data)
-            return
-
-        fileContents: str
-        fname = "locale.gen"
-        env = os.environ.copy()
-        if self.app.opts.dry_run:
-            # For debug purposes.
-            fname = ".subiquity/" + fname
-            await arun_command(['cp', '/etc/locale.gen', '.subiquity/'],
-                               env=env)
-        else:
-            fname = "/etc/" + fname
-
-        pendingWrite = False
-        with open(fname, "r") as localeGen:
-            # locale.gen is not so big.
-            fileContents = localeGen.read()
-            lineFound = fileContents.find(data)
-            if lineFound == -1:
-                # An unsupported locale coming from our UI is a bug.
-                raise AssertionError("Selected language {} not supported."
-                                     " Rolling back.".format(data))
-
-            commented = "# {}".format(data)
-            lineFound = fileContents.find(commented)
-            if lineFound != -1:
-                fileContents = fileContents.replace(commented, data)
-                pendingWrite = True
-
-        if pendingWrite:
-            with open(fname, "wt") as f:
-                f.write(fileContents)
-
-        # If we arrive here, data is a supported language.
-        await self._run_locale_support_cmds(data)
-        await super().POST(data)


### PR DESCRIPTION
Without adding the 'prefill' option to the TUI it would only work if under dry-run mode.
Also lifting up CLI parsing to outside of the if clause enables some simplification of the decision-making.