### PR TITLE
Enables preserving existing container instances.

### DIFF
--- a/scripts/test-in-lxd.sh
+++ b/scripts/test-in-lxd.sh
@@ -2,7 +2,7 @@
 set -eux
 IMAGE=$1
 SCRIPT=$2
-TESTER=${IMAGE##*:}
+TESTER=subiquity-${IMAGE##*:}
 
 lxd init --auto
 

--- a/scripts/test-in-lxd.sh
+++ b/scripts/test-in-lxd.sh
@@ -6,7 +6,7 @@ TESTER=${IMAGE##*:}
 
 lxd init --auto
 
-if [ -z "$(lxc list -f csv | grep $TESTER)" ]
+if [ -z "$(lxc list -f csv -c n ^${TESTER}\$)" ]
 then
     lxc launch $IMAGE $TESTER
     lxc config device add $TESTER code disk source=`pwd` path=/subiquity

--- a/scripts/test-in-lxd.sh
+++ b/scripts/test-in-lxd.sh
@@ -2,34 +2,40 @@
 set -eux
 IMAGE=$1
 SCRIPT=$2
+TESTER=${IMAGE##*:}
 
 lxd init --auto
 
-lxc launch $IMAGE tester
-lxc config device add tester code disk source=`pwd` path=/subiquity
+if [ -z "$(lxc list -f csv | grep $TESTER)" ]
+then
+    lxc launch $IMAGE $TESTER
+    lxc config device add $TESTER code disk source=`pwd` path=/subiquity
+else
+    lxc start $TESTER
+fi
 # copy is allowed to fail, in case the subiquity directory being tested
 # includes some uncopyable stuff
-lxc exec tester -- sh -ec "
+lxc exec $TESTER -- sh -ec "
     cd ~
     sudo cp -a /subiquity . || true
     [ -d ~/subiquity ]
     "
 
 attempts=0
-while ! lxc file pull tester/etc/resolv.conf - 2> /dev/null | grep -q ^nameserver; do
+while ! lxc file pull $TESTER/etc/resolv.conf - 2> /dev/null | grep -q ^nameserver; do
     sleep 1
     attempts=$((attempts+1))
     if [ $attempts -gt 30 ]; then
-        lxc file pull tester/etc/resolv.conf
-        lxc exec tester -- ps aux
+        lxc file pull $TESTER/etc/resolv.conf
+        lxc exec $TESTER -- ps aux
         echo "Network failed to come up after 30 seconds"
         exit 1
     fi
 done
-if ! lxc file pull tester/etc/resolv.conf - 2> /dev/null | grep ^nameserver | grep -qv 127.0.0.53
+if ! lxc file pull $TESTER/etc/resolv.conf - 2> /dev/null | grep ^nameserver | grep -qv 127.0.0.53
 then
     echo "systemd-resolved"
-    while ! lxc file pull tester/run/systemd/resolve/resolv.conf - 2> /dev/null | grep -v fe80 | grep -q ^nameserver; do
+    while ! lxc file pull $TESTER/run/systemd/resolve/resolv.conf - 2> /dev/null | grep -v fe80 | grep -q ^nameserver; do
         sleep 1
         attempts=$((attempts+1))
         if [ $attempts -gt 30 ]; then
@@ -39,9 +45,11 @@ then
     done
 fi
 
-lxc exec tester -- cloud-init status --wait
+lxc exec $TESTER -- cloud-init status --wait
 
-lxc exec tester -- sh -ec "
+lxc exec $TESTER -- sh -ec "
     cd ~/subiquity
     ./scripts/installdeps.sh
     $SCRIPT"
+
+lxc stop $TESTER


### PR DESCRIPTION
Hi @dbungert !

I hope you guys find this one useful and nothing breaks GitHub side. I changed the `test-in-lxd` script to preserve existing instances and starting then, which is useful for develop environment. I used that in debugging one issue preventing the server to start on Focal only.

The name of the instance changes from `tester` to the adjective of the Ubuntu Release (extracted from the image name). That enables preserving instances from different releases while doing matrix builds. That makes the dev environment closer to the CI.

Feel free to discard or modify that in case it doesn't fit well for everybody working on Subiquity.