### PR TITLE
SystemSetupModel now acks the variant at start.

### DIFF
--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -78,8 +78,10 @@ class SystemSetupServer(SubiquityServer):
         root = '/'
         if self.opts.dry_run:
             root = os.path.abspath('.subiquity')
-        return SystemSetupModel(root, self.hub, INSTALL_MODEL_NAMES,
-                                POSTINSTALL_MODEL_NAMES)
+        model = SystemSetupModel(root, self.hub, INSTALL_MODEL_NAMES,
+                                 POSTINSTALL_MODEL_NAMES)
+        model.set_source_variant(self.variant)
+        return model
 
     # We don’t have cloudinit in system_setup.
     async def wait_for_cloudinit(self):


### PR DESCRIPTION
Without this change, `wsl_configuration` variant is not recognized without client_variant.POST. The server is expected to start in that variant if the environment is properly set.
Issue and suggestions of fixes originally reported by @jpnurmi.