### PR TITLE
Make api tests less flaky

### DIFF
--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -111,12 +111,11 @@ class Server(Client):
               + ' --machine-config ' + machine_config
         cmd = cmd.split(' ')
         self.proc = await astart_command(cmd, env=env)
-        self.server_task = asyncio.create_task(self.proc.communicate())
 
     async def close(self):
         try:
             await asyncio.wait_for(self.server_shutdown(), timeout=5.0)
-            await asyncio.wait_for(self.server_task, timeout=5.0)
+            await asyncio.wait_for(self.proc.communicate(), timeout=5.0)
         except asyncio.exceptions.TimeoutError:
             pass
         finally:


### PR DESCRIPTION
* Fix misuse of process communicate which resulted in a race condition
* Observe server state at startup to wait longer for a happy state
* Improve how timeouts are specified