### PR TITLE
check-language-support: fix empty pkg list

### DIFF
--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -142,7 +142,7 @@ class ConfigureController(SubiquityController):
                       cp.args, cp.returncode)
             return False
 
-        packages = cp.stdout.strip('\n').split(' ')
+        packages = [pkg for pkg in cp.stdout.strip().split(' ') if pkg]
         if len(packages) == 0:
             log.debug("%s didn't recommend any packages. Nothing to do.",
                       clsCommand)


### PR DESCRIPTION
The check-language-support on my machine was providing a single empty
newline as output, and the length check isn't catching that as the
resulting packages array has a value of `['']`.
Drop empty values from the list to avoid a `KeyError: ''` exception.