### PR TITLE
Complementary to 1127 on integration side

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -82,7 +82,7 @@ validate () {
                 echo "expected not empty directory var/cache/apt/archives/"
                 exit 1
             fi
-            if [ -z "$( diff -Nup .subiquity/etc/locale.gen .subiquity/etc/locale.gen-)" ] ; then
+            if [ -z "$( diff -Nup .subiquity/etc/locale.gen .subiquity/etc/locale.gen.test)" ] ; then
                 echo "expected changes in etc/locale.gen"
                 exit 1
             fi

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -78,8 +78,9 @@ validate () {
                 echo "user not assigned with the expected group sudo"
                 exit 1
             fi
-            if [ -z "$( ls .subiquity/var/cache/apt/archives/)" ] ; then
-                echo "expected not empty directory var/cache/apt/archives/"
+            lang="$(grep -Eo 'LANG="([^.@ _]+)' .subiquity/etc/default/locale | cut -d \" -f 2)"
+            if [ -z "$( ls .subiquity/var/cache/apt/archives/) | grep $lang" ] ; then
+                echo "expected $lang language packs in directory var/cache/apt/archives/"
                 exit 1
             fi
             if [ -z "$( diff -Nup .subiquity/etc/locale.gen .subiquity/etc/locale.gen.test)" ] ; then
@@ -99,6 +100,7 @@ clean () {
     rm -rf .subiquity/run/
     rm -rf .subiquity/home/
     rm -rf .subiquity/etc/.pwd.lock
+    rm -rf .subiquity/etc/default/locale
     rm -rf .subiquity/etc/{locale*,passwd*,shadow*,group*,gshadow*,subgid*,subuid*}
     rm -rf .subiquity/etc/*.conf
     rm -rf .subiquity/etc/cloud/cloud.cfg.d/99-installer.cfg


### PR DESCRIPTION
Hi, @dbungert !

This fix avoids integration tests to fail even if `check-language-support` returns an empty list of packages, which would be the case when all packages needed by one specific configuration of locale are already installed.

This complements #1127 .