### PR TITLE
Compare the snaps versions to avoid suggesting a downgrade

### DIFF
--- a/subiquity/common/snap.py
+++ b/subiquity/common/snap.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+
+class SnapVersionParsingError(Exception):
+    """ Exception raised when a version string does not match the expected
+    format
+    """
+    def __init__(self, message: str = "", version: str = ""):
+        self.message = message
+        self.version = version
+        super().__init__()
+
+
+@dataclass
+class SnapVersion:
+    """ Represent the version of a snap in the form {major}.{minor}.{patch} """
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def from_string(cls, s: str) -> "SnapVersion":
+        """ Construct a SnapVersion object from a string representation """
+        try:
+            major, minor, patch = s.split(".")
+            return cls(int(major), int(minor), int(patch))
+        except (ValueError, TypeError):
+            raise SnapVersionParsingError(version=s)
+
+    def __gt__(self, other: "SnapVersion"):
+        """ Tells whether a SnapVersion object is greater than the other """
+        if self.major > other.major:
+            return True
+        elif self.major < other.major:
+            return False
+
+        if self.minor > other.minor:
+            return True
+        elif self.minor < other.minor:
+            return False
+
+        if self.patch > other.patch:
+            return True
+        elif self.patch < other.patch:
+            return False
+
+        return False

--- a/subiquity/common/tests/test_snap.py
+++ b/subiquity/common/tests/test_snap.py
@@ -10,12 +10,23 @@ class TestSnapSnapVersion(unittest.TestCase):
         self.assertEqual(obj.major, 19)
         self.assertEqual(obj.minor, 4)
         self.assertEqual(obj.patch, 2)
+        self.assertIsNone(obj.git_build_id)
+        self.assertIsNone(obj.git_commit_id)
 
+        obj = SnapVersion.from_string("21.10.3+git136.cde71504")
+
+        self.assertEqual(obj.major, 21)
+        self.assertEqual(obj.minor, 10)
+        self.assertEqual(obj.patch, 3)
+        self.assertEqual(obj.git_build_id, 136)
+        self.assertEqual(obj.git_commit_id, "cde71504")
+
+    def test_snap_version_from_string_invalid(self):
         # Test with no patch number
         with self.assertRaises(SnapVersionParsingError):
             SnapVersion.from_string("19.02")
 
-        # Test unsupported version with RC
+        # Test unsupported version with RC (we support only +git)
         with self.assertRaises(SnapVersionParsingError):
             SnapVersion.from_string("19.02.2-rc1")
 
@@ -23,3 +34,12 @@ class TestSnapSnapVersion(unittest.TestCase):
         self.assertGreater(SnapVersion(20, 4, 2), SnapVersion(19, 4, 2))
         self.assertGreater(SnapVersion(19, 5, 2), SnapVersion(19, 4, 1))
         self.assertLess(SnapVersion(19, 4, 2), SnapVersion(20, 3, 2))
+        # Consider the version is greater if one has a build ID
+        self.assertGreater(SnapVersion.from_string("21.10.3+git136.cde71504"),
+                           SnapVersion.from_string("21.10.3"))
+        # Consider the version is greater if the build ID is greater
+        self.assertGreater(SnapVersion.from_string("21.10.3+git136.cde71504"),
+                           SnapVersion.from_string("21.10.3+git135.deadbeef"))
+        # Make sure we ignore the build ID when the patch version is different
+        self.assertLess(SnapVersion.from_string("21.10.2+git255.deadbeef"),
+                        SnapVersion.from_string("21.10.3+git135.deadbeef"))

--- a/subiquity/common/tests/test_snap.py
+++ b/subiquity/common/tests/test_snap.py
@@ -1,0 +1,25 @@
+import unittest
+
+from subiquity.common.snap import SnapVersion, SnapVersionParsingError
+
+
+class TestSnapSnapVersion(unittest.TestCase):
+    def test_snap_version_from_string(self):
+        obj = SnapVersion.from_string("19.04.2")
+
+        self.assertEqual(obj.major, 19)
+        self.assertEqual(obj.minor, 4)
+        self.assertEqual(obj.patch, 2)
+
+        # Test with no patch number
+        with self.assertRaises(SnapVersionParsingError):
+            SnapVersion.from_string("19.02")
+
+        # Test unsupported version with RC
+        with self.assertRaises(SnapVersionParsingError):
+            SnapVersion.from_string("19.02.2-rc1")
+
+    def test_snap_version_compare(self):
+        self.assertGreater(SnapVersion(20, 4, 2), SnapVersion(19, 4, 2))
+        self.assertGreater(SnapVersion(19, 5, 2), SnapVersion(19, 4, 1))
+        self.assertLess(SnapVersion(19, 4, 2), SnapVersion(20, 3, 2))


### PR DESCRIPTION
Hello,

In specific scenarios, subiquity was suggesting to upgrade to a version that is older to the one currently running ; as in the following example [1]

_Version 21.01.2 of the installer is now available (21.06.01 is currently running)._

### Rationale
- To check if an update is available, subiquity queries the snapd daemon through its HTTP API
- The response sent back by snapd seems to 1:1 correspond to what is returned by `$ snap refresh --list`. I’d assume it’s using the same API call internally
- If snapd response contains a result with the “subiquity” title, then it is considered an new available version ; and the update available screen will effectively be displayed. subiquity does not do any filtering based e.g. on the version name returned.

### Implementation
I implemented basic filtering of the snap versions to avoid suggesting something that would result in a downgrade.
We parse the version number of the currently running version and compare it to the version of the snap returned by snapd.
The following formats are supported:

- `{major}.{minor}.{patch}`
- `{major}.{minor}.{patch}+git{build_id}.{commit_id}`

If a different version format is read, the parsing would fail. Consequently, the version returned by snapd would be suggested as an upgrade to the user. Therefore, the current behavior would not change in this scenario.

Thanks,
Olivier

[1] https://bugs.launchpad.net/subiquity/+bug/1936190