### PR TITLE
storage/v2: add os-prober data

### DIFF
--- a/examples/win10.json
+++ b/examples/win10.json
@@ -1034,6 +1034,14 @@
             }
         ],
         "multipath": {},
+        "os": {
+            "/dev/sda1": {
+                "label": "Windows",
+                "long": "Windows Boot Manager",
+                "subpath": "/efi/Microsoft/Boot/bootmgfw.efi",
+                "type": "efi"
+            }
+        },
         "raid": {},
         "zfs": {
             "zpools": {}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -180,7 +180,7 @@ parts:
       - libnl-route-3-dev
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: 2bb505172b5f97372eb1abd12ced4629e852504b
+    source-commit: 488fd1fd2a1d26699c7484f17653cd4f23978a25
     requirements: [requirements.txt]
     stage:
       - "*"

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -285,5 +285,6 @@ def _for_client_partition(partition, *, min_size=0):
         grub_device=partition.grub_device,
         boot=partition.boot,
         annotations=annotations(partition) + usage_labels(partition),
+        os=partition.os,
         mount=partition.mount,
         format=partition.format)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -243,6 +243,15 @@ class Bootloader(enum.Enum):
 
 
 @attr.s(auto_attribs=True)
+class OsProber:
+    long: str
+    label: str
+    type: str
+    subpath: Optional[str] = None
+    version: Optional[str] = None
+
+
+@attr.s(auto_attribs=True)
 class Partition:
     size: Optional[int] = None
     number: Optional[int] = None
@@ -256,6 +265,7 @@ class Partition:
     grub_device: Optional[bool] = None
     # does this partition represent the actual boot partition for this device?
     boot: Optional[bool] = None
+    os: Optional[OsProber] = None
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -31,7 +31,7 @@ from curtin.util import human2bytes
 
 from probert.storage import StorageInfo
 
-from subiquity.common.types import Bootloader
+from subiquity.common.types import Bootloader, OsProber
 
 
 log = logging.getLogger('subiquity.models.filesystem')
@@ -707,6 +707,17 @@ class Partition(_Formattable):
         if self._constructed_device is not None:
             return False
         return True
+
+    @property
+    def os(self):
+        # This path calculation is overly simplistic and doesn't handle RAID or
+        # multipath.  Don't take it seriously.
+        path = self.device.path + str(self.number)
+
+        os_data = self._m._probe_data.get('os', {}).get(path)
+        if not os_data:
+            return None
+        return OsProber(**os_data)
 
     ok_for_lvm_vg = ok_for_raid
 

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -693,7 +693,7 @@ class TestInfo(TestAPI):
 
 
 class TestFree(TestAPI):
-    @timeout(5)
+    @timeout()
     async def test_free_only(self):
         async with start_server('examples/simple.json') as inst:
             await inst.post('/meta/free_only', enable=True)
@@ -701,7 +701,7 @@ class TestFree(TestAPI):
             components.sort()
             self.assertEqual(['multiverse', 'restricted'], components)
 
-    @timeout(5)
+    @timeout()
     async def test_not_free_only(self):
         async with start_server('examples/simple.json') as inst:
             comps = ['universe', 'multiverse']
@@ -709,6 +709,24 @@ class TestFree(TestAPI):
             await inst.post('/meta/free_only', enable=False)
             components = await inst.get('/mirror/disable_components')
             self.assertEqual(['universe'], components)
+
+
+class TestOSProbe(TestAPI):
+    @timeout()
+    async def test_win10(self):
+        async with start_server('examples/win10.json') as inst:
+            resp = await inst.get('/storage/v2')
+            sda = first(resp['disks'], 'id', 'disk-sda')
+            sda1 = first(sda['partitions'], 'number', 1)
+            expected = {
+                'label': 'Windows',
+                'long': 'Windows Boot Manager',
+                'subpath': '/efi/Microsoft/Boot/bootmgfw.efi',
+                'type': 'efi',
+                'version': None
+            }
+
+            self.assertEqual(expected, sda1['os'])
 
 
 class TestRegression(TestAPI):


### PR DESCRIPTION
On the Partition objects, add a 'os' field.
This contains os-prober results for that partition.