### PR TITLE
add an object to represent a gap between partitions

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -19,6 +19,7 @@ import logging
 from subiquitycore.lsb_release import lsb_release
 
 from subiquity.client.controller import SubiquityTuiController
+from subiquity.common.filesystem import gaps
 from subiquity.common.filesystem.manipulator import FilesystemManipulator
 from subiquity.common.types import ProbeStatus
 from subiquity.models.filesystem import (
@@ -159,6 +160,10 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
             action_name = action['action']
             if action_name == "MAKE_BOOT":
                 action_name = "TOGGLE_BOOT"
+            if action_name == "CREATE_LV":
+                action_name = "PARTITION"
+            if action_name == "PARTITION":
+                obj = gaps.largest_gap(obj)
             meth = getattr(
                 self.ui.body.avail_list,
                 "_{}_{}".format(obj.type, action_name))

--- a/subiquity/common/filesystem/actions.py
+++ b/subiquity/common/filesystem/actions.py
@@ -17,7 +17,7 @@ import enum
 import functools
 from gettext import pgettext
 
-from subiquity.common.filesystem import boot, labels
+from subiquity.common.filesystem import boot, gaps, labels
 from subiquity.models.filesystem import (
     Bootloader,
     Disk,
@@ -139,6 +139,11 @@ def _lv_actions(lv):
         DeviceAction.EDIT,
         DeviceAction.DELETE,
         ]
+
+
+@_supported_actions.register(gaps.Gap)
+def _gap_actions(lv):
+    return []
 
 
 _can_info = make_checker(DeviceAction.INFO)

--- a/subiquity/common/filesystem/actions.py
+++ b/subiquity/common/filesystem/actions.py
@@ -84,7 +84,6 @@ def _disk_actions(disk):
     actions = [
         DeviceAction.INFO,
         DeviceAction.REFORMAT,
-        DeviceAction.PARTITION,
         DeviceAction.FORMAT,
         DeviceAction.REMOVE,
         ]
@@ -112,7 +111,6 @@ def _raid_actions(raid):
     else:
         actions = [
             DeviceAction.EDIT,
-            DeviceAction.PARTITION,
             DeviceAction.FORMAT,
             DeviceAction.REMOVE,
             DeviceAction.DELETE,
@@ -128,7 +126,6 @@ def _raid_actions(raid):
 def _vg_actions(vg):
     return [
         DeviceAction.EDIT,
-        DeviceAction.CREATE_LV,
         DeviceAction.DELETE,
         ]
 
@@ -143,7 +140,9 @@ def _lv_actions(lv):
 
 @_supported_actions.register(gaps.Gap)
 def _gap_actions(lv):
-    return []
+    return [
+        DeviceAction.PARTITION,
+        ]
 
 
 _can_info = make_checker(DeviceAction.INFO)
@@ -215,18 +214,8 @@ def _can_reformat_device(device):
 _can_partition = make_checker(DeviceAction.PARTITION)
 
 
-@_can_partition.register(Disk)
-@_can_partition.register(Raid)
-def _can_partition_device(device):
-    if device._has_preexisting_partition():
-        return False
-    if device.free_for_partitions <= 0:
-        return False
-    # We only create msdos partition tables with FBA dasds, which
-    # only support 3 partitions. As and when we support editing
-    # partition msdos tables we'll need to be more clever here.
-    if device.ptable in ['vtoc', 'msdos'] and len(device._partitions) >= 3:
-        return False
+@_can_partition.register(gaps.Gap)
+def _can_partition_gap(gap):
     return True
 
 

--- a/subiquity/common/filesystem/actions.py
+++ b/subiquity/common/filesystem/actions.py
@@ -49,7 +49,6 @@ class DeviceAction(enum.Enum):
     EDIT = pgettext("DeviceAction", "Edit")
     REFORMAT = pgettext("DeviceAction", "Reformat")
     PARTITION = pgettext("DeviceAction", "Add Partition")
-    CREATE_LV = pgettext("DeviceAction", "Create Logical Volume")
     FORMAT = pgettext("DeviceAction", "Format")
     REMOVE = pgettext("DeviceAction", "Remove from RAID/LVM")
     DELETE = pgettext("DeviceAction", "Delete")
@@ -217,14 +216,6 @@ _can_partition = make_checker(DeviceAction.PARTITION)
 @_can_partition.register(gaps.Gap)
 def _can_partition_gap(gap):
     return True
-
-
-_can_create_lv = make_checker(DeviceAction.CREATE_LV)
-
-
-@_can_create_lv.register(LVM_VolGroup)
-def _can_create_lv_vg(vg):
-    return not vg.preserve and vg.free_for_partitions > 0
 
 
 _can_format = make_checker(DeviceAction.FORMAT)

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import functools
+
+import attr
+
+from subiquity.models.filesystem import (
+    align_up,
+    align_down,
+    Disk,
+    LVM_CHUNK_SIZE,
+    LVM_VolGroup,
+    GPT_OVERHEAD,
+    Raid,
+    )
+
+
+@attr.s(auto_attribs=True)
+class Gap:
+    size: int
+
+
+@functools.singledispatch
+def parts_and_gaps(device):
+    raise NotImplementedError(device)
+
+
+@parts_and_gaps.register(Disk)
+@parts_and_gaps.register(Raid)
+def parts_and_gaps_disk(device):
+    if device._fs is not None:
+        return []
+    r = []
+    used = 0
+    for p in device._partitions:
+        used = align_up(used + p.size, 1 << 20)
+        r.append(p)
+    if device._has_preexisting_partition():
+        return r
+    if device.ptable == 'vtoc' and len(device._partitions) >= 3:
+        return r
+    end = align_down(device.size, 1 << 20) - GPT_OVERHEAD
+    if end - used >= (1 << 20):
+        r.append(Gap(end - used))
+    return r
+
+
+@parts_and_gaps.register(LVM_VolGroup)
+def _parts_and_gaps_vg(device):
+    used = 0
+    r = []
+    for lv in device._partitions:
+        r.append(lv)
+        used += lv.size
+    if device.preserve:
+        return r
+    remaining = align_down(device.size - used, LVM_CHUNK_SIZE)
+    if remaining >= LVM_CHUNK_SIZE:
+        r.append(Gap(remaining))
+    return r

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -88,3 +88,10 @@ def largest_gap(device):
                 largest = pg
                 largest_size = pg.size
     return largest
+
+
+def largest_gap_size(device):
+    largest = largest_gap(device)
+    if largest is not None:
+        return largest.size
+    return 0

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -292,7 +292,7 @@ def _for_client_disk(disk, *, min_size=0):
         preserve=disk.preserve,
         usage_labels=usage_labels(disk),
         partitions=[for_client(p) for p in disk._partitions],
-        free_for_partitions=disk.free_for_partitions,
+        free_for_partitions=gaps.largest_gap_size(disk),
         boot_device=boot.is_boot_device(disk),
         ok_for_guided=disk.size >= min_size,
         model=getattr(disk, 'model', None),

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -15,7 +15,7 @@
 
 import logging
 
-from subiquity.common.filesystem import boot
+from subiquity.common.filesystem import boot, gaps
 from subiquity.common.types import Bootloader
 from subiquity.models.filesystem import (
     align_up,
@@ -199,12 +199,12 @@ class FilesystemManipulator:
 
     def partition_disk_handler(self, disk, partition, spec):
         log.debug('partition_disk_handler: %s %s %s', disk, partition, spec)
-        log.debug('disk.freespace: {}'.format(disk.free_for_partitions))
+        log.debug('disk.freespace: {}'.format(gaps.largest_gap_size(disk)))
 
         if partition is not None:
             if 'size' in spec:
                 partition.size = align_up(spec['size'])
-                if disk.free_for_partitions < 0:
+                if gaps.largest_gap_size(disk) < 0:
                     raise Exception("partition size too large")
             self.delete_filesystem(partition.fs())
             self.create_filesystem(partition, spec)
@@ -225,11 +225,11 @@ class FilesystemManipulator:
 
             # adjust downward the partition size (if necessary) to accommodate
             # bios/grub partition
-            if spec['size'] > disk.free_for_partitions:
+            if spec['size'] > gaps.largest_gap_size(disk):
                 log.debug(
                     "Adjusting request down: %s - %s = %s",
-                    spec['size'], part.size, disk.free_for_partitions)
-                spec['size'] = disk.free_for_partitions
+                    spec['size'], part.size, gaps.largest_gap_size(disk))
+                spec['size'] = gaps.largest_gap_size(disk)
 
         self.create_partition(disk, spec)
 
@@ -237,14 +237,14 @@ class FilesystemManipulator:
 
     def logical_volume_handler(self, vg, lv, spec):
         log.debug('logical_volume_handler: %s %s %s', vg, lv, spec)
-        log.debug('vg.freespace: {}'.format(vg.free_for_partitions))
+        log.debug('vg.freespace: {}'.format(gaps.largest_gap_size(vg)))
 
         if lv is not None:
             if 'name' in spec:
                 lv.name = spec['name']
             if 'size' in spec:
                 lv.size = align_up(spec['size'])
-                if vg.free_for_partitions < 0:
+                if gaps.largest_gap_size(vg) < 0:
                     raise Exception("lv size too large")
             self.delete_filesystem(lv.fs())
             self.create_filesystem(lv, spec)
@@ -322,7 +322,7 @@ class FilesystemManipulator:
                             self.model.add_filesystem(
                                 p, p.original_fstype(), preserve=True)
         else:
-            full = boot_disk.free_for_partitions == 0
+            full = gaps.largest_gap_size(boot_disk) == 0
             tot_size = 0
             for p in partitions:
                 tot_size += p.size
@@ -371,9 +371,9 @@ class FilesystemManipulator:
             elif bootloader == Bootloader.BIOS:
                 part_size = BIOS_GRUB_SIZE_BYTES
             log.debug("bootloader %s", bootloader)
-            if part_size > new_boot_disk.free_for_partitions:
+            if part_size > gaps.largest_gap_size(new_boot_disk):
                 largest_part = max(
                     new_boot_disk.partitions(), key=lambda p: p.size)
                 largest_part.size -= (
-                    part_size - new_boot_disk.free_for_partitions)
+                    part_size - gaps.largest_gap_size(new_boot_disk))
             self._create_boot_partition(new_boot_disk)

--- a/subiquity/common/filesystem/tests/test_actions.py
+++ b/subiquity/common/filesystem/tests/test_actions.py
@@ -142,7 +142,8 @@ class TestActions(unittest.TestCase):
         self.assertActionPossible(dos_disk, DeviceAction.TOGGLE_BOOT)
         # Even if they have existing partitions
         make_partition(
-            model, dos_disk, size=dos_disk.free_for_partitions, preserve=True)
+            model, dos_disk, size=gaps.largest_gap_size(dos_disk),
+            preserve=True)
         self.assertActionPossible(dos_disk, DeviceAction.TOGGLE_BOOT)
         # (we never create dos partition tables so no need to test
         # preserve=False case).
@@ -151,7 +152,7 @@ class TestActions(unittest.TestCase):
         gpt_disk = make_disk(model, ptable='gpt', preserve=False)
         self.assertActionPossible(gpt_disk, DeviceAction.TOGGLE_BOOT)
         # Even if they are filled with partitions (we resize partitions to fit)
-        make_partition(model, gpt_disk, size=dos_disk.free_for_partitions)
+        make_partition(model, gpt_disk, size=gaps.largest_gap_size(dos_disk))
         self.assertActionPossible(gpt_disk, DeviceAction.TOGGLE_BOOT)
 
         # GPT disks with existing partition tables but no partitions can be the
@@ -187,7 +188,8 @@ class TestActions(unittest.TestCase):
         new_disk = make_disk(model, preserve=False)
         self.assertActionPossible(new_disk, DeviceAction.TOGGLE_BOOT)
         # Even if they are filled with partitions (we resize partitions to fit)
-        make_partition(model, new_disk, size=new_disk.free_for_partitions)
+        make_partition(
+            model, new_disk, size=gaps.largest_gap_size(new_disk))
         self.assertActionPossible(new_disk, DeviceAction.TOGGLE_BOOT)
 
         # A disk with an existing but empty partitions can also be the
@@ -363,7 +365,7 @@ class TestActions(unittest.TestCase):
     def test_vg_action_EDIT(self):
         model, vg = make_model_and_vg()
         self.assertActionPossible(vg, DeviceAction.EDIT)
-        model.add_logical_volume(vg, 'lv1', size=vg.free_for_partitions//2)
+        model.add_logical_volume(vg, 'lv1', size=gaps.largest_gap_size(vg))
         self.assertActionNotPossible(vg, DeviceAction.EDIT)
 
         vg2 = make_vg(model)
@@ -391,7 +393,7 @@ class TestActions(unittest.TestCase):
         self.assertActionPossible(vg, DeviceAction.DELETE)
         self.assertActionPossible(vg, DeviceAction.DELETE)
         lv = model.add_logical_volume(
-            vg, 'lv0', size=vg.free_for_partitions//2)
+            vg, 'lv0', size=gaps.largest_gap_size(vg)//2)
         self.assertActionPossible(vg, DeviceAction.DELETE)
         fs = model.add_filesystem(lv, 'ext4')
         self.assertActionPossible(vg, DeviceAction.DELETE)

--- a/subiquity/common/filesystem/tests/test_actions.py
+++ b/subiquity/common/filesystem/tests/test_actions.py
@@ -18,6 +18,7 @@ import unittest
 from subiquity.common.filesystem.actions import (
     DeviceAction,
     )
+from subiquity.common.filesystem import gaps
 from subiquity.models.filesystem import Bootloader
 from subiquity.models.tests.test_filesystem import (
     make_disk,
@@ -110,23 +111,7 @@ class TestActions(unittest.TestCase):
 
     def test_disk_action_PARTITION(self):
         model, disk = make_model_and_disk()
-        self.assertActionPossible(disk, DeviceAction.PARTITION)
-        make_partition(model, disk, size=disk.free_for_partitions//2)
-        self.assertActionPossible(disk, DeviceAction.PARTITION)
-        make_partition(model, disk, size=disk.free_for_partitions)
-        self.assertActionNotPossible(disk, DeviceAction.PARTITION)
-
-        # Can partition a disk with .preserve=True
-        disk2 = make_disk(model)
-        disk2.preserve = True
-        self.assertActionPossible(disk2, DeviceAction.PARTITION)
-        # But not if it has a partition.
-        make_partition(model, disk2, preserve=True)
-        self.assertActionNotPossible(disk2, DeviceAction.PARTITION)
-
-    def test_disk_action_CREATE_LV(self):
-        model, disk = make_model_and_disk()
-        self.assertActionNotSupported(disk, DeviceAction.CREATE_LV)
+        self.assertActionNotSupported(disk, DeviceAction.PARTITION)
 
     def test_disk_action_FORMAT(self):
         model, disk = make_model_and_disk()
@@ -240,10 +225,6 @@ class TestActions(unittest.TestCase):
         model, part = make_model_and_partition()
         self.assertActionNotSupported(part, DeviceAction.PARTITION)
 
-    def test_partition_action_CREATE_LV(self):
-        model, part = make_model_and_partition()
-        self.assertActionNotSupported(part, DeviceAction.CREATE_LV)
-
     def test_partition_action_FORMAT(self):
         model, part = make_model_and_partition()
         self.assertActionNotSupported(part, DeviceAction.FORMAT)
@@ -332,23 +313,7 @@ class TestActions(unittest.TestCase):
 
     def test_raid_action_PARTITION(self):
         model, raid = make_model_and_raid()
-        self.assertActionPossible(raid, DeviceAction.PARTITION)
-        make_partition(model, raid, size=raid.free_for_partitions//2)
-        self.assertActionPossible(raid, DeviceAction.PARTITION)
-        make_partition(model, raid, size=raid.free_for_partitions)
-        self.assertActionNotPossible(raid, DeviceAction.PARTITION)
-
-        # Can partition a raid with .preserve=True
-        raid2 = make_raid(model)
-        raid2.preserve = True
-        self.assertActionPossible(raid2, DeviceAction.PARTITION)
-        # But not if it has a partition.
-        make_partition(model, raid2, preserve=True)
-        self.assertActionNotPossible(raid2, DeviceAction.PARTITION)
-
-    def test_raid_action_CREATE_LV(self):
-        model, raid = make_model_and_raid()
-        self.assertActionNotSupported(raid, DeviceAction.CREATE_LV)
+        self.assertActionNotSupported(raid, DeviceAction.PARTITION)
 
     def test_raid_action_FORMAT(self):
         model, raid = make_model_and_raid()
@@ -413,17 +378,6 @@ class TestActions(unittest.TestCase):
         model, vg = make_model_and_vg()
         self.assertActionNotSupported(vg, DeviceAction.PARTITION)
 
-    def test_vg_action_CREATE_LV(self):
-        model, vg = make_model_and_vg()
-        self.assertActionPossible(vg, DeviceAction.CREATE_LV)
-        model.add_logical_volume(vg, 'lv1', size=vg.free_for_partitions//2)
-        self.assertActionPossible(vg, DeviceAction.CREATE_LV)
-        model.add_logical_volume(vg, 'lv2', size=vg.free_for_partitions)
-        self.assertActionNotPossible(vg, DeviceAction.CREATE_LV)
-        vg2 = make_vg(model)
-        vg2.preserve = True
-        self.assertActionNotPossible(vg2, DeviceAction.CREATE_LV)
-
     def test_vg_action_FORMAT(self):
         model, vg = make_model_and_vg()
         self.assertActionNotSupported(vg, DeviceAction.FORMAT)
@@ -464,10 +418,6 @@ class TestActions(unittest.TestCase):
         model, lv = make_model_and_lv()
         self.assertActionNotSupported(lv, DeviceAction.PARTITION)
 
-    def test_lv_action_CREATE_LV(self):
-        model, lv = make_model_and_lv()
-        self.assertActionNotSupported(lv, DeviceAction.CREATE_LV)
-
     def test_lv_action_FORMAT(self):
         model, lv = make_model_and_lv()
         self.assertActionNotSupported(lv, DeviceAction.FORMAT)
@@ -491,3 +441,6 @@ class TestActions(unittest.TestCase):
     def test_lv_action_TOGGLE_BOOT(self):
         model, lv = make_model_and_lv()
         self.assertActionNotSupported(lv, DeviceAction.TOGGLE_BOOT)
+
+    def test_gap_PARTITION(self):
+        self.assertActionPossible(gaps.Gap(None, 0), DeviceAction.PARTITION)

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -18,6 +18,7 @@ import unittest
 from subiquity.common.filesystem.actions import (
     DeviceAction,
     )
+from subiquity.common.filesystem import gaps
 from subiquity.common.filesystem.manipulator import (
     FilesystemManipulator,
     )
@@ -130,7 +131,7 @@ class TestFilesystemManipulator(unittest.TestCase):
             disk1 = make_disk(manipulator.model, preserve=False)
             disk2 = make_disk(manipulator.model, preserve=False)
             disk2p1 = manipulator.model.add_partition(
-                disk2, size=disk2.free_for_partitions)
+                disk2, size=gaps.largest_gap_size(disk2))
 
             manipulator.add_boot_disk(disk1)
             self.assertIsBootDisk(manipulator, disk1)
@@ -171,7 +172,7 @@ class TestFilesystemManipulator(unittest.TestCase):
             disk1 = make_disk(manipulator.model, preserve=False)
             disk2 = make_disk(manipulator.model, preserve=False)
             disk2p1 = manipulator.model.add_partition(
-                disk2, size=disk2.free_for_partitions)
+                disk2, size=gaps.largest_gap_size(disk2))
 
             manipulator.add_boot_disk(disk1)
             self.assertIsBootDisk(manipulator, disk1)
@@ -218,7 +219,7 @@ class TestFilesystemManipulator(unittest.TestCase):
             disk1, size=512 << 20, flag="boot")
         disk1p1.preserve = True
         disk1p2 = manipulator.model.add_partition(
-            disk1, size=disk1.free_for_partitions)
+            disk1, size=gaps.largest_gap_size(disk1))
         disk1p2.preserve = True
         manipulator.partition_disk_handler(
             disk1, disk1p2, {'fstype': 'ext4', 'mount': '/'})

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -522,7 +522,7 @@ class _Device(_Formattable, ABC):
 
     @property
     def available_for_partitions(self):
-        return self.size - GPT_OVERHEAD
+        return align_down(self.size, 1 << 20) - GPT_OVERHEAD
 
     @property
     def free_for_partitions(self):
@@ -622,7 +622,7 @@ class Disk(_Device):
 
     @property
     def size(self):
-        return align_down(self._info.size)
+        return self._info.size
 
     def dasd(self):
         return self._m._one(type='dasd', device_id=self.device_id)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -524,10 +524,6 @@ class _Device(_Formattable, ABC):
     def available_for_partitions(self):
         return align_down(self.size, 1 << 20) - GPT_OVERHEAD
 
-    @property
-    def free_for_partitions(self):
-        return self.available_for_partitions - self.used
-
     def available(self):
         # A _Device is available if:
         # 1) it is not part of a device like a RAID or LVM or zpool or ...
@@ -540,9 +536,11 @@ class _Device(_Formattable, ABC):
             return False
         if self._fs is not None:
             return self._fs._available()
-        if self.free_for_partitions > 0:
-            if not self._has_preexisting_partition():
-                return True
+        from subiquity.common.filesystem.gaps import (
+            largest_gap_size,
+            )
+        if largest_gap_size(self) > 0:
+            return True
         return any(p.available() for p in self._partitions)
 
     def has_unavailable_partition(self):
@@ -802,11 +800,6 @@ class LVM_VolGroup(_Device):
     @property
     def available_for_partitions(self):
         return self.size
-
-    @property
-    def free_for_partitions(self):
-        return align_down(
-            self.available_for_partitions - self.used, LVM_CHUNK_SIZE)
 
     ok_for_raid = False
     ok_for_lvm_vg = False
@@ -1083,10 +1076,10 @@ class FilesystemModel(object):
                         raise Exception(
                             "{} has negative size but is not final partition "
                             "of {}".format(p, parent))
-                    p.size = 0
-                    p.size = parent.free_for_partitions
-                    if p.type == 'lvm_partition':
-                        p.size = align_down(p.size, LVM_CHUNK_SIZE)
+                    from subiquity.common.filesystem.gaps import (
+                        largest_gap_size,
+                        )
+                    p.size = largest_gap_size(parent)
             elif isinstance(p.size, str):
                 if p.size.endswith("%"):
                     percentage = int(p.size[:-1])
@@ -1346,8 +1339,6 @@ class FilesystemModel(object):
     def add_partition(self, device, size, flag="", wipe=None,
                       grub_device=None):
         from subiquity.common.filesystem import boot
-        if size > device.free_for_partitions:
-            raise Exception("%s > %s", size, device.free_for_partitions)
         real_size = align_up(size)
         log.debug("add_partition: rounded size from %s to %s", size, real_size)
         if device._fs is not None:

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -28,6 +28,7 @@ from subiquity.models.filesystem import (
     align_down,
     LVM_CHUNK_SIZE,
     )
+from subiquity.common.filesystem import gaps
 
 
 class TestHumanizeSize(unittest.TestCase):
@@ -164,7 +165,7 @@ def make_partition(model, device=None, *, preserve=False, size=None, **kw):
     if device is None:
         device = make_disk(model)
     if size is None:
-        size = device.free_for_partitions//2
+        size = gaps.largest_gap_size(device)//2
     partition = Partition(
         m=model, device=device, size=size, preserve=preserve, **kw)
     if preserve:
@@ -203,7 +204,7 @@ def make_model_and_vg(bootloader=None):
 def make_lv(model):
     vg = make_vg(model)
     name = 'lv%s' % len(model._actions)
-    return model.add_logical_volume(vg, name, vg.free_for_partitions//2)
+    return model.add_logical_volume(vg, name, gaps.largest_gap_size(vg))
 
 
 def make_model_and_lv(bootloader=None):

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -40,7 +40,7 @@ from subiquity.common.errorreport import ErrorReportKind
 from subiquity.common.filesystem.actions import (
     DeviceAction,
     )
-from subiquity.common.filesystem import boot, labels
+from subiquity.common.filesystem import boot, gaps, labels
 from subiquity.common.filesystem.manipulator import FilesystemManipulator
 from subiquity.common.types import (
     Bootloader,
@@ -126,7 +126,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     def guided_direct(self, disk):
         self.reformat(disk)
         result = {
-            "size": disk.free_for_partitions,
+            "size": gaps.largest_gap_size(disk),
             "fstype": "ext4",
             "mount": "/",
             }
@@ -144,7 +144,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 ))
         part = self.create_partition(
             device=disk, spec=dict(
-                size=disk.free_for_partitions,
+                size=gaps.largest_gap_size(disk),
                 fstype=None,
                 ))
         vg_name = 'ubuntu-vg'
@@ -348,7 +348,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         disk = self.model._one(id=data.disk_id)
         size = data.partition.size
         if size is None or size < 0:
-            size = disk.free_for_partitions
+            size = gaps.largest_gap_size(disk)
         spec = {
             'size': size,
             'fstype': data.partition.format,

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -265,7 +265,6 @@ class DeviceList(WidgetWrap):
 
     _disk_INFO = _stretchy_shower(DiskInfoStretchy)
     _disk_REFORMAT = _stretchy_shower(ConfirmReformatStretchy)
-    _disk_PARTITION = _stretchy_shower(PartitionStretchy)
     _disk_FORMAT = _stretchy_shower(FormatEntireStretchy)
 
     def _disk_REMOVE(self, disk):
@@ -298,7 +297,6 @@ class DeviceList(WidgetWrap):
     _partition_DELETE = _stretchy_shower(ConfirmDeleteStretchy)
 
     _raid_EDIT = _stretchy_shower(RaidStretchy)
-    _raid_PARTITION = _disk_PARTITION
     _raid_FORMAT = _disk_FORMAT
     _raid_REFORMAT = _disk_REFORMAT
     _raid_REMOVE = _disk_REMOVE
@@ -306,12 +304,14 @@ class DeviceList(WidgetWrap):
     _raid_TOGGLE_BOOT = _disk_TOGGLE_BOOT
 
     _lvm_volgroup_EDIT = _stretchy_shower(VolGroupStretchy)
-    _lvm_volgroup_CREATE_LV = _disk_PARTITION
     _lvm_volgroup_DELETE = _partition_DELETE
 
     _lvm_partition_EDIT = _stretchy_shower(
         lambda parent, part: PartitionStretchy(parent, part.volgroup, part))
     _lvm_partition_DELETE = _partition_DELETE
+
+    _gap_PARTITION = _stretchy_shower(
+        lambda parent, gap: PartitionStretchy(parent, gap.device))
 
     def _action(self, sender, value, device):
         action, meth = value
@@ -325,9 +325,13 @@ class DeviceList(WidgetWrap):
         else:
             return action.str()
 
-    def _label_PARTITION(self, action, device):
-        return _("Add {ptype} Partition").format(
-            ptype=device.ptable_for_new_partition().upper())
+    def _label_PARTITION(self, action, gap):
+        device = gap.device
+        if device.type == 'lvm_volgroup':
+            return _("Create Logical Volume")
+        else:
+            return _("Add {ptype} Partition").format(
+                ptype=device.ptable_for_new_partition().upper())
 
     def _label_TOGGLE_BOOT(self, action, device):
         if boot.is_boot_device(device):

--- a/subiquity/ui/views/filesystem/helpers.py
+++ b/subiquity/ui/views/filesystem/helpers.py
@@ -15,11 +15,7 @@
 
 from urwid import Text
 
-from subiquitycore.ui.utils import (
-    Color,
-    )
-
-from subiquity.common.filesystem import labels
+from subiquity.common.filesystem import gaps, labels
 from subiquity.models.filesystem import (
     humanize_size,
     )
@@ -35,7 +31,7 @@ def summarize_device(device, part_filter=lambda p: True):
     out by looking at the uses of this function.
     """
     label = labels.label(device)
-    anns = labels.annotations(device)
+    anns = labels.annotations(device) + labels.usage_labels(device)
     if anns:
         label = "{} ({})".format(label, ", ".join(anns))
     rows = [(device, [
@@ -43,20 +39,15 @@ def summarize_device(device, part_filter=lambda p: True):
         Text(labels.desc(device)),
         Text(humanize_size(device.size), align="right"),
         ])]
-    partitions = device.partitions()
-    if partitions:
-        for part in device.partitions():
-            if not part_filter(part):
-                continue
-            details = ", ".join(
-                labels.annotations(part) + labels.usage_labels(part))
-            rows.append((part, [
-                Text(labels.label(part, short=True)),
-                (2, Text(details)),
-                Text(humanize_size(part.size), align="right"),
-                ]))
-    else:
-        rows.append((None, [
-            (4, Color.info_minor(Text(", ".join(labels.usage_labels(device)))))
+    partitions = gaps.parts_and_gaps(device)
+    for part in partitions:
+        if not part_filter(part):
+            continue
+        details = ", ".join(
+            labels.annotations(part) + labels.usage_labels(part))
+        rows.append((part, [
+            Text(labels.label(part, short=True)),
+            (2, Text(details)),
+            Text(humanize_size(part.size), align="right"),
             ]))
     return rows

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -37,7 +37,7 @@ from subiquitycore.ui.container import Pile
 from subiquitycore.ui.stretchy import Stretchy
 from subiquitycore.ui.utils import rewrap
 
-from subiquity.common.filesystem import boot, labels
+from subiquity.common.filesystem import boot, gaps, labels
 from subiquity.models.filesystem import (
     align_up,
     Disk,
@@ -375,7 +375,7 @@ class PartitionStretchy(Stretchy):
         self.model = parent.model
         self.controller = parent.controller
         self.parent = parent
-        max_size = disk.free_for_partitions
+        max_size = gaps.largest_gap_size(disk)
 
         initial = {}
         label = _("Create")


### PR DESCRIPTION
Currently this just puts a gap at the end of the list of partitions if it's possible to add a partition (or logical volume) to a disk. And then you can select the gap in the ui to add a partition.

The idea of course is that when it comes to editing partitions, there may be more than one gap to put a partition in.

I should probably write some tests for this version of the parts_and_gaps function (I do have a batch of tests written for the more interesting 'partition editing supporting' version).