### PR TITLE
Fix exception messages not interpolated properly

### DIFF
--- a/subiquity/common/serialize.py
+++ b/subiquity/common/serialize.py
@@ -164,7 +164,7 @@ class Serializer:
             serializer = self.type_serializers[annotation]
         except KeyError:
             raise Exception(
-                "do not know how to handle %s at %s", annotation, path)
+                f"do not know how to handle {annotation} at {path}")
         else:
             return serializer(annotation, value, metadata, path)
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1417,7 +1417,7 @@ class FilesystemModel(object):
                         volume.flag == 'bios_grub' and fstype == 'fat32')):
                     raise Exception("{} is not available".format(volume))
         if volume._fs is not None:
-            raise Exception("%s is already formatted", volume)
+            raise Exception(f"{volume} is already formatted")
         fs = Filesystem(
             m=self, volume=volume, fstype=fstype, preserve=preserve)
         self._actions.append(fs)
@@ -1430,7 +1430,7 @@ class FilesystemModel(object):
 
     def add_mount(self, fs, path):
         if fs._mount is not None:
-            raise Exception("%s is already mounted", fs)
+            raise Exception(f"{fs} is already mounted")
         m = Mount(m=self, device=fs, path=path)
         self._actions.append(m)
         return m

--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -100,7 +100,7 @@ class RefreshController(SubiquityController):
         while True:
             change = await self.get_progress(change_id)
             if change['status'] not in ['Do', 'Doing', 'Done']:
-                raise Exception("update failed: %s", change['status'])
+                raise Exception(f"update failed: {change['status']}")
             await asyncio.sleep(0.1)
 
     @with_context()

--- a/subiquity/ui/mount.py
+++ b/subiquity/ui/mount.py
@@ -129,7 +129,7 @@ class MountSelector(WidgetWrap):
             self._selector.value = OTHER
             self._showhide_other(True)
             if not val.startswith('/'):
-                raise ValueError("%s does not start with /", val)
+                raise ValueError(f"{val} does not start with /")
             self._other.value = val[1:]
 
 

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -125,7 +125,7 @@ class Option:
                 self.enabled = True
                 self.value = val
             else:
-                raise SelectorError("invalid option %r", val)
+                raise SelectorError(f"invalid option {val!r}")
         elif len(val) == 1:
             self.label = val[0]
             self.enabled = True

--- a/subiquitycore/ui/width.py
+++ b/subiquitycore/ui/width.py
@@ -57,4 +57,4 @@ def widget_width(w):
                 r += widget_width(w1)
         r += (len(w.contents) - 1) * w.dividechars
         return r
-    raise Exception("don't know how to find width of %r", w)
+    raise Exception(f"don't know how to find width of {w!r}")


### PR DESCRIPTION
Hello,
While working on `UbuntuAdvantageView`, I got the following exception (because I was doing something wrong):

```python
----> 1 raise Exception("don't know how to find width of %r", w)

Exception: ("don't know how to find width of %r", None)
```

I think the expected output would be:
```python
Exception: "don't know how to find width of None"
```

This happens because, unlike the functions from the `logging.*` family, `Exceptions` don't perform string interpolation. If we want string interpolation, we need to do it ourselves, either using f-string, `.format` or the old string modulo operator: `%`.

Fixed by using f-string to do the interpolation.
I also fixed other occurrences across the tree.

Thanks,
Olivier