### PR TITLE
Make consistent calls to lsb_release

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -217,7 +217,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         if self.model.bootloader == Bootloader.PREP:
             self.supports_resilient_boot = False
         else:
-            release = lsb_release()['release']
+            release = lsb_release(dry_run=self.app.opts.dry_run)['release']
             self.supports_resilient_boot = release >= '20.04'
         self.ui.set_body(FilesystemView(self.model, self))
 

--- a/subiquity/client/controllers/ubuntu_advantage.py
+++ b/subiquity/client/controllers/ubuntu_advantage.py
@@ -16,7 +16,6 @@
 """
 
 import logging
-from typing import Optional
 
 from subiquity.client.controller import SubiquityTuiController
 from subiquity.common.types import UbuntuAdvantageInfo
@@ -40,11 +39,8 @@ class UbuntuAdvantageController(SubiquityTuiController):
         await self.endpoint.skip.POST()
         raise Skip("Hiding the screen until we can validate the token.")
 
-        path_lsb_release: Optional[str] = None
-        if self.app.opts.dry_run:
-            # In dry-run mode, always pretend to be on LTS
-            path_lsb_release = "examples/lsb-release-focal"
-        if "LTS" not in lsb_release(path_lsb_release)["description"]:
+        dry_run: bool = self.app.opts.dry_run
+        if "LTS" not in lsb_release(dry_run=dry_run)["description"]:
             await self.endpoint.skip.POST()
             raise Skip("Not running LTS version")
 

--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -207,7 +207,7 @@ class AptConfigurer:
             if os.path.exists(proxy_path):
                 os.unlink(proxy_path)
 
-        codename = lsb_release()['codename']
+        codename = lsb_release(dry_run=self.app.opts.dry_run)['codename']
 
         write_file(
             self.install_tree.p('etc/apt/sources.list'),

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -448,7 +448,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if self.model.bootloader == Bootloader.PREP:
             self.supports_resilient_boot = False
         else:
-            release = lsb_release()['release']
+            release = lsb_release(dry_run=self.app.opts.dry_run)['release']
             self.supports_resilient_boot = release >= '20.04'
         self._start_task = schedule_task(self._start())
 

--- a/subiquity/server/controllers/kernel.py
+++ b/subiquity/server/controllers/kernel.py
@@ -70,8 +70,10 @@ class KernelController(NonInteractiveController):
                     # Should check this package exists really but
                     # that's a bit tricky until we get cleverer about
                     # the apt config in general.
+                    dry_run: bool = self.app.opts.dry_run
                     package = 'linux-{flavor}-{release}'.format(
-                        flavor=flavor, release=lsb_release()['release'])
+                        flavor=flavor,
+                        release=lsb_release(dry_run=dry_run)['release'])
         self.model.metapkg_name = package
 
     def make_autoinstall(self):

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -441,7 +441,7 @@ class HelpMenu(PopUpLauncher):
         self.app.add_global_overlay(stretchy)
 
     def about(self, sender=None):
-        info = lsb_release()
+        info = lsb_release(dry_run=self.app.opts.dry_run)
         if 'LTS' in info['description']:
             template = _(ABOUT_INSTALLER_LTS)
         else:

--- a/subiquitycore/lsb_release.py
+++ b/subiquitycore/lsb_release.py
@@ -2,13 +2,17 @@
 import shlex
 
 LSB_RELEASE_FILE = "/etc/lsb-release"
+LSB_RELEASE_EXAMPLE = "examples/lsb-release-focal"
 
 
-def lsb_release(path=None):
+def lsb_release(path=None, dry_run: bool = False):
     """return a dictionary of values from /etc/lsb-release.
     keys are lower case with DISTRIB_ prefix removed."""
+    if dry_run and path is not None:
+        raise ValueError("Both dry_run and path are specified.")
+
     if path is None:
-        path = LSB_RELEASE_FILE
+        path = LSB_RELEASE_EXAMPLE if dry_run else LSB_RELEASE_FILE
 
     ret = {}
     try:

--- a/subiquitycore/tests/test_lsb_release.py
+++ b/subiquitycore/tests/test_lsb_release.py
@@ -1,0 +1,58 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import patch, mock_open
+
+from subiquitycore.lsb_release import lsb_release
+
+
+class TestLSBRelease(unittest.TestCase):
+    def setUp(self):
+        self.target = "subiquitycore.lsb_release.open"
+
+    def test_lsb_release(self):
+        lsb_str = """
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=21.10
+DISTRIB_CODENAME=impish
+DISTRIB_DESCRIPTION="Ubuntu 21.10"
+        """
+
+        with patch(self.target, mock_open(read_data=lsb_str)) as patched:
+            distro = lsb_release(path="dummy")
+            patched.assert_called_once_with("dummy", "r")
+            self.assertEqual(distro["id"], "Ubuntu")
+            self.assertEqual(distro["release"], "21.10")
+            self.assertEqual(distro["codename"], "impish")
+            self.assertEqual(distro["description"], "Ubuntu 21.10")
+
+    def test_lsb_release_inexistent(self):
+        with patch(self.target, side_effect=FileNotFoundError):
+            self.assertEqual(lsb_release("/inexistent"), {})
+
+    def test_lsb_release_default(self):
+        with patch(self.target, side_effect=FileNotFoundError) as patched:
+            lsb_release(path=None)
+            patched.assert_called_once_with("/etc/lsb-release", "r")
+
+    def test_lsb_release_dry_run(self):
+        with patch(self.target, side_effect=FileNotFoundError) as patched:
+            lsb_release(dry_run=True)
+            patched.assert_called_once_with("examples/lsb-release-focal", "r")
+
+    def test_lsb_release_mutually_exclusive(self):
+        with self.assertRaises(ValueError):
+            lsb_release(path="dummy", dry_run=True)


### PR DESCRIPTION
Hello,

This PR introduces a new parameter `dry_run` to `lsb_release`.

When this parameter evaluates to true, we will load the file `examples/lsb-release-focal` instead of the default `/etc/lsb-release`.

```python
# will try to parse examples/lsb-release-focal:
lsb_release(dry_run=True)

# will try to parse /dummy:
lsb_release(path="/dummy")

# will try to parse /etc/lsb-release
lsb_release()
lsb_release(dry_run=False)

# path and dry_run are mutually exclusive: the following raises a ValueError
lsb_release(path="/dummy", dry_run=True)
```
All calls to `lsb_release` from Subiquity now explicitly pass the application-wide `dry_run` variable. Therefore, the returned value is consistent.

Also added unit tests to cover the `lsb_release` module / function.

This change was requested at https://github.com/canonical/subiquity/pull/1140#discussion_r770999254

Thanks,
Olivier