### PR TITLE
Validate UA token & list available services

### DIFF
--- a/examples/uaclient-status-expired.json
+++ b/examples/uaclient-status-expired.json
@@ -1,0 +1,49 @@
+{
+    "version": "27.4.2~21.10.1",
+    "effective": null,
+    "expires": "2010-12-31T00:00:00+00:00",
+    "services": [
+        {
+            "name": "cis",
+            "description": "Center for Internet Security Audit Tools",
+            "entitled": "yes",
+            "auto_enabled": "no",
+            "available": "yes"
+        },
+        {
+            "name": "esm-apps",
+            "description": "UA Apps: Extended Security Maintenance (ESM)",
+            "entitled": "yes",
+            "auto_enabled": "yes",
+            "available": "yes"
+        },
+        {
+            "name": "esm-infra",
+            "description": "UA Infra: Extended Security Maintenance (ESM)",
+            "entitled": "yes",
+            "auto_enabled": "yes",
+            "available": "yes"
+        },
+        {
+            "name": "fips",
+            "description": "NIST-certified core packages",
+            "entitled": "yes",
+            "auto_enabled": "no",
+            "available": "yes"
+        },
+        {
+            "name": "fips-updates",
+            "description": "NIST-certified core packages with priority security updates",
+            "entitled": "yes",
+            "auto_enabled": "no",
+            "available": "yes"
+        },
+        {
+            "name": "livepatch",
+            "description": "Canonical Livepatch service",
+            "entitled": "yes",
+            "auto_enabled": "yes",
+            "available": "yes"
+        }
+    ]
+}

--- a/examples/uaclient-status-valid.json
+++ b/examples/uaclient-status-valid.json
@@ -1,0 +1,49 @@
+{
+    "version": "27.4.2~21.10.1",
+    "effective": null,
+    "expires": "2035-12-31T00:00:00+00:00",
+    "services": [
+        {
+            "name": "cis",
+            "description": "Center for Internet Security Audit Tools",
+            "entitled": "yes",
+            "auto_enabled": "no",
+            "available": "yes"
+        },
+        {
+            "name": "esm-apps",
+            "description": "UA Apps: Extended Security Maintenance (ESM)",
+            "entitled": "yes",
+            "auto_enabled": "yes",
+            "available": "yes"
+        },
+        {
+            "name": "esm-infra",
+            "description": "UA Infra: Extended Security Maintenance (ESM)",
+            "entitled": "yes",
+            "auto_enabled": "yes",
+            "available": "yes"
+        },
+        {
+            "name": "fips",
+            "description": "NIST-certified core packages",
+            "entitled": "yes",
+            "auto_enabled": "no",
+            "available": "yes"
+        },
+        {
+            "name": "fips-updates",
+            "description": "NIST-certified core packages with priority security updates",
+            "entitled": "yes",
+            "auto_enabled": "no",
+            "available": "yes"
+        },
+        {
+            "name": "livepatch",
+            "description": "Canonical Livepatch service",
+            "entitled": "yes",
+            "auto_enabled": "yes",
+            "available": "yes"
+        }
+    ]
+}

--- a/subiquity/client/controllers/ubuntu_advantage.py
+++ b/subiquity/client/controllers/ubuntu_advantage.py
@@ -18,7 +18,18 @@
 import logging
 from typing import Optional
 
+from subiquitycore.async_helpers import schedule_task
+
 from subiquity.client.controller import SubiquityTuiController
+from subiquity.common.ubuntu_advantage import (
+    InvalidUATokenError,
+    ExpiredUATokenError,
+    CheckSubscriptionError,
+    UAInterface,
+    UAInterfaceStrategy,
+    MockedUAInterfaceStrategy,
+    UAClientUAInterfaceStrategy,
+)
 from subiquity.common.types import UbuntuAdvantageInfo
 from subiquity.ui.views.ubuntu_advantage import UbuntuAdvantageView
 
@@ -32,6 +43,16 @@ class UbuntuAdvantageController(SubiquityTuiController):
     """ Client-side controller for Ubuntu Advantage configuration. """
 
     endpoint_name = "ubuntu_advantage"
+
+    def __init__(self, app):
+        """ Initializer for client-side UA controller. """
+        strategy: UAInterfaceStrategy
+        if app.opts.dry_run:
+            strategy = MockedUAInterfaceStrategy()
+        else:
+            strategy = UAClientUAInterfaceStrategy()
+        self.ua_interface = UAInterface(strategy)
+        super().__init__(app)
 
     async def make_ui(self) -> UbuntuAdvantageView:
         """ Generate the UI, based on the data provided by the model. """
@@ -49,6 +70,31 @@ class UbuntuAdvantageController(SubiquityTuiController):
     def run_answers(self) -> None:
         if "token" in self.answers:
             self.done(self.answers["token"])
+
+    def check_token(self, token: str):
+        """ Asynchronously check the token passed as an argument. """
+        async def inner() -> None:
+            try:
+                svcs = await self.ua_interface.get_avail_services(token=token)
+            except InvalidUATokenError:
+                if isinstance(self.ui.body, UbuntuAdvantageView):
+                    self.ui.body.show_invalid_token()
+            except ExpiredUATokenError:
+                if isinstance(self.ui.body, UbuntuAdvantageView):
+                    self.ui.body.show_expired_token()
+            except CheckSubscriptionError:
+                if isinstance(self.ui.body, UbuntuAdvantageView):
+                    self.ui.body.show_unknown_error()
+            else:
+                if isinstance(self.ui.body, UbuntuAdvantageView):
+                    self.ui.body.show_available_services(svcs)
+
+        self._check_task = schedule_task(inner())
+
+    def cancel_check_token(self) -> None:
+        """ Cancel the asynchronous token check (if started). """
+        if self._check_task is not None:
+            self._check_task.cancel()
 
     def cancel(self) -> None:
         self.app.prev_screen()

--- a/subiquity/client/controllers/ubuntu_advantage.py
+++ b/subiquity/client/controllers/ubuntu_advantage.py
@@ -35,11 +35,6 @@ class UbuntuAdvantageController(SubiquityTuiController):
 
     async def make_ui(self) -> UbuntuAdvantageView:
         """ Generate the UI, based on the data provided by the model. """
-
-        # TODO remove these two lines to enable this screen
-        await self.endpoint.skip.POST()
-        raise Skip("Hiding the screen until we can validate the token.")
-
         path_lsb_release: Optional[str] = None
         if self.app.opts.dry_run:
             # In dry-run mode, always pretend to be on LTS

--- a/subiquity/common/tests/test_ubuntu_advantage.py
+++ b/subiquity/common/tests/test_ubuntu_advantage.py
@@ -1,0 +1,132 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from subprocess import CalledProcessError, CompletedProcess
+import unittest
+from unittest.mock import patch
+
+from subiquity.common.ubuntu_advantage import (
+    InvalidUATokenError,
+    ExpiredUATokenError,
+    CheckSubscriptionError,
+    UAInterface,
+    MockedUAInterfaceStrategy,
+    UAClientUAInterfaceStrategy,
+    )
+from subiquitycore.tests.util import run_coro
+
+
+class TestMockedUAInterfaceStrategy(unittest.TestCase):
+    def setUp(self):
+        self.strategy = MockedUAInterfaceStrategy(scale_factor=1_000_000)
+
+    def test_query_info_invalid(self):
+        # Tokens starting with "i" in dry-run mode cause the token to be
+        # reported as invalid.
+        with self.assertRaises(InvalidUATokenError):
+            run_coro(self.strategy.query_info(token="invalidToken"))
+
+    def test_query_info_failure(self):
+        # Tokens starting with "f" in dry-run mode simulate an "internal"
+        # error.
+        with self.assertRaises(CheckSubscriptionError):
+            run_coro(self.strategy.query_info(token="failure"))
+
+    def test_query_info_expired(self):
+        # Tokens starting with "x" is dry-run mode simulate an expired token.
+        info = run_coro(self.strategy.query_info(token="xpiredToken"))
+        self.assertEqual(info["expires"], "2010-12-31T00:00:00+00:00")
+
+    def test_query_info_valid(self):
+        # Other tokens are considered valid in dry-run mode.
+        info = run_coro(self.strategy.query_info(token="validToken"))
+        self.assertEqual(info["expires"], "2035-12-31T00:00:00+00:00")
+
+
+class TestUAClientUAInterfaceStrategy(unittest.TestCase):
+    arun_command = "subiquity.common.ubuntu_advantage.utils.arun_command"
+
+    def test_query_info_succeeded(self):
+        strategy = UAClientUAInterfaceStrategy()
+        command = (
+            "ubuntu-advantage",
+            "status",
+            "--format", "json",
+            "--simulate-with-token", "123456789",
+        )
+
+        with patch(self.arun_command) as mock_arun:
+            mock_arun.return_value = CompletedProcess([], 0)
+            mock_arun.return_value.stdout = "{}"
+            run_coro(strategy.query_info(token="123456789"))
+            mock_arun.assert_called_once_with(command, check=True)
+
+    def test_query_info_failed(self):
+        strategy = UAClientUAInterfaceStrategy()
+        command = (
+            "ubuntu-advantage",
+            "status",
+            "--format", "json",
+            "--simulate-with-token", "123456789",
+        )
+
+        with patch(self.arun_command) as mock_arun:
+            mock_arun.side_effect = CalledProcessError(returncode=1,
+                                                       cmd=command)
+            mock_arun.return_value.stdout = "{}"
+            with self.assertRaises(CheckSubscriptionError):
+                run_coro(strategy.query_info(token="123456789"))
+            mock_arun.assert_called_once_with(command, check=True)
+
+    def test_query_info_invalid_json(self):
+        strategy = UAClientUAInterfaceStrategy()
+        command = (
+            "ubuntu-advantage",
+            "status",
+            "--format", "json",
+            "--simulate-with-token", "123456789",
+        )
+
+        with patch(self.arun_command) as mock_arun:
+            mock_arun.return_value = CompletedProcess([], 0)
+            mock_arun.return_value.stdout = "invalid-json"
+            with self.assertRaises(CheckSubscriptionError):
+                run_coro(strategy.query_info(token="123456789"))
+            mock_arun.assert_called_once_with(command, check=True)
+
+
+class TestUAInterface(unittest.TestCase):
+
+    def test_mocked_get_avail_services(self):
+        strategy = MockedUAInterfaceStrategy(scale_factor=1_000_000)
+        interface = UAInterface(strategy)
+
+        with self.assertRaises(InvalidUATokenError):
+            run_coro(interface.get_avail_services(token="invalidToken"))
+        # Tokens starting with "f" in dry-run mode simulate an "internal"
+        # error.
+        with self.assertRaises(CheckSubscriptionError):
+            run_coro(interface.get_avail_services(token="failure"))
+
+        # Tokens starting with "x" is dry-run mode simulate an expired token.
+        with self.assertRaises(ExpiredUATokenError):
+            run_coro(interface.get_avail_services(token="xpiredToken"))
+
+        # Other tokens are considered valid in dry-run mode.
+        services = run_coro(interface.get_avail_services(token="validToken"))
+        for service in services:
+            self.assertIn("name", service)
+            self.assertIn("description", service)
+            self.assertTrue(service["available"])

--- a/subiquity/common/ubuntu_advantage.py
+++ b/subiquity/common/ubuntu_advantage.py
@@ -1,0 +1,151 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+""" This module defines utilities to interface with Ubuntu Advantage
+subscriptions. """
+
+from abc import ABC, abstractmethod
+from datetime import datetime as dt
+import json
+import logging
+from subprocess import CalledProcessError, CompletedProcess
+import asyncio
+
+from subiquitycore import utils
+
+
+log = logging.getLogger("subiquitycore.common.ubuntu_advantage")
+
+
+class InvalidUATokenError(Exception):
+    """ Exception to be raised when the supplied token is invalid. """
+    def __init__(self, token: str, message: str = "") -> None:
+        self.token = token
+        self.message = message
+        super().__init__(message)
+
+
+class ExpiredUATokenError(Exception):
+    """ Exception to be raised when the supplied token has expired. """
+    def __init__(self, token: str, expires: str, message: str = "") -> None:
+        self.token = token
+        self.expires = expires
+        self.message = message
+        super().__init__(message)
+
+
+class CheckSubscriptionError(Exception):
+    """ Exception to be raised when we are unable to fetch information about
+    the Ubuntu Advantage subscription. """
+    def __init__(self, token: str, message: str = "") -> None:
+        self.token = token
+        self.message = message
+        super().__init__(message)
+
+
+class UAInterfaceStrategy(ABC):
+    """ Strategy to query information about a UA subscription. """
+    @abstractmethod
+    async def query_info(token: str) -> dict:
+        """ Return information about the UA subscription based on the token
+        provided.  """
+
+
+class MockedUAInterfaceStrategy(UAInterfaceStrategy):
+    """ Mocked version of the Ubuntu Advantage interface strategy. The info it
+    returns is based on example files and appearance of the UA token. """
+    def __init__(self, scale_factor: int = 1):
+        self.scale_factor = scale_factor
+        super().__init__()
+
+    async def query_info(self, token: str) -> dict:
+        """ Return the subscription info associated with the supplied
+        UA token. No actual query is done to the UA servers in this
+        implementation. Instead, we create a response based on the following
+        rules:
+        * Tokens starting with "x" will be considered expired.
+        * Tokens starting with "i" will be considered invalid.
+        * Tokens starting with "f" will generate an internal error.
+        """
+        await asyncio.sleep(1 / self.scale_factor)
+
+        if token[0] == "x":
+            path = "examples/uaclient-status-expired.json"
+        elif token[0] == "i":
+            raise InvalidUATokenError(token)
+        elif token[0] == "f":
+            raise CheckSubscriptionError(token)
+        else:
+            path = "examples/uaclient-status-valid.json"
+
+        with open(path, encoding="utf-8") as stream:
+            return json.load(stream)
+
+
+class UAClientUAInterfaceStrategy(UAInterfaceStrategy):
+    """ Strategy that relies on UA client script to retrieve the information.
+    """
+    async def query_info(self, token: str) -> dict:
+        """ Return the subscription info associated with the supplied
+        UA token. The information will be queried using UA client.
+        """
+        command = (
+            "ubuntu-advantage",
+            "status",
+            "--format", "json",
+            "--simulate-with-token", token,
+        )
+        try:
+            proc: CompletedProcess = await utils.arun_command(command,
+                                                              check=True)
+            # TODO check if we're not returning a string or a list
+            return json.loads(proc.stdout)
+        except CalledProcessError:
+            log.exception("Failed to execute command %r", command)
+            # TODO Check if the command failed because the token is invalid.
+            # Currently, ubuntu-advantage fails with the following error when
+            # the token is invalid:
+            # * Failed to connect to authentication server
+            # * Check your Internet connection and try again.
+        except json.JSONDecodeError:
+            log.exception("Failed to parse output of command %r", command)
+
+        message = "Unable to retrieve subscription information."
+        raise CheckSubscriptionError(token, message=message)
+
+
+class UAInterface:
+    """ Interface to obtain Ubuntu Advantage subscription information. """
+    def __init__(self, strategy: UAInterfaceStrategy):
+        self.strategy = strategy
+
+    async def get_subscription(self, token: str) -> dict:
+        """ Return a dictionary containing the subscription information. """
+        return await self.strategy.query_info(token)
+
+    async def get_avail_services(self, token: str) -> list:
+        """ Return a list of available services for the subscription
+        associated with the token provided.
+        """
+        info = await self.get_subscription(token)
+
+        expiration = dt.fromisoformat(info["expires"])
+        if expiration.timestamp() <= dt.utcnow().timestamp():
+            raise ExpiredUATokenError(token, expires=info["expires"])
+
+        def is_avail_service(service: dict) -> bool:
+            # TODO do we need to check for service["entitled"] as well?
+            return service["available"] == "yes"
+
+        return [svc for svc in info["services"] if is_avail_service(svc)]


### PR DESCRIPTION
Hello,

This PR adds a mechanism to check the supplied token and list the available services associated with the subscription.

We rely on the following command to check the token and retrieve the list of services associated. The support for this command is a work in progress.

```bash
$ ubuntu-advantage enable --simulate-with-token "${token}" --format json
```

In case of error, the “$ ubuntu-advantage” command will exit with a non-zero status. When that happens, we will ask the user if he wants to go back or continue anyway. Unfortunately, in case of an invalid token, the “$ ubuntu-advantage” command also exits with a non-zero status. Therefore, we cannot easily differentiate between a network/internal error and an invalid token provided.

### Screen captures:
valid token:
https://user-images.githubusercontent.com/4038023/146580276-9b7964ce-d3dd-4a73-83fb-7e0fe7b8bff8.png

expired token:
https://user-images.githubusercontent.com/4038023/146579696-d986320d-91e6-4323-b503-3fbd46593995.png

invalid token (only shown in dry-run mode currently): 
https://user-images.githubusercontent.com/4038023/146579530-b9c4b2ff-a04d-4222-86e2-f28a1a4b19bd.png

internal / network error:
https://user-images.githubusercontent.com/4038023/146580380-6c4954ff-784f-4280-81ee-e2137bd69631.png

To test the flow in dry run mode, the following rules have been put in place:
* a token starting with "x" will be considered expired
* a token starting with "i" will be considered invalid
* a token starting with "f" will cause an internal error / network error to be reported
* any other token will be considered valid

Thanks,
Olivier