### PR TITLE
Make sure test-this-branch.sh exits if distro-info is not installed

### DIFF
--- a/scripts/test-this-branch.sh
+++ b/scripts/test-this-branch.sh
@@ -8,7 +8,8 @@ sudo apt install -y zsync xorriso isolinux
 
 snapcraft snap --output subiquity_test.snap
 urlbase=http://cdimage.ubuntu.com/ubuntu-server/daily-live/current
-isoname=$(distro-info -d)-live-server-$(dpkg --print-architecture).iso
+distroname=$(distro-info -d)
+isoname="${distroname}"-live-server-$(dpkg --print-architecture).iso
 zsync ${urlbase}/${isoname}.zsync
 sudo ./scripts/inject-subiquity-snap.sh ${isoname} subiquity_test.snap custom.iso
 


### PR DESCRIPTION
Although the script is running with `set -e`, having two distinct invocations of a subshell in the same instruction masks failures in the first subshell invocation. It is similar in essence to what the `pipefail` option controls.

As a consequence, the following instruction does not fail if `distro-info` is not installed:

```bash
  isoname=$(distro-info -d)-live-server-$(dpkg --print-architecture).iso
```

And therefore, we end up with something like:

```bash
  isoname=-live-server-amd64.iso
```

Fixed by first assigning the value of `$(distro-info -d)` to a variable.