### PR TITLE
apt: fix disable_components w/ autoinstall

### DIFF
--- a/examples/autoinstall.yaml
+++ b/examples/autoinstall.yaml
@@ -19,6 +19,9 @@ apt:
   primary:
     - arches: [default]
       uri: "http://mymirror.local/repository/Apt/ubuntu/"
+  disable_components:
+    - non-free
+    - restricted
 packages:
   - package1
   - package2

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -155,6 +155,8 @@ timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoi
                                --kernel-cmdline 'autoinstall' \
                                --source-catalog=examples/install-sources.yaml"
 validate
+python3 scripts/check-yaml-fields.py .subiquity/var/log/installer/subiquity-curtin-apt.conf \
+        apt.disable_components='[non-free, restricted]'
 python3 scripts/check-yaml-fields.py .subiquity/var/log/installer/subiquity-curtin-install.conf \
         debconf_selections.subiquity='"eek"' \
         storage.config[-1].options='"errors=remount-ro"'

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -75,5 +75,14 @@ class MirrorModel(object):
             self.config, "primary", self.architecture)
         config["uri"] = mirror
 
+    def disable_components(self, comps, add):
+        dc = set(self.config.get('disable_components', []))
+        comps = set(comps)
+        if add:
+            dc |= comps
+        else:
+            dc -= comps
+        self.config['disable_components'] = list(dc)
+
     def render(self):
         return {}

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -31,6 +31,7 @@ log = logging.getLogger('subiquitycore.models.mirror')
 
 
 DEFAULT = {
+    "disable_components": [],
     "preserve_sources_list": False,
     "primary": [
         {
@@ -51,12 +52,9 @@ class MirrorModel(object):
         self.config = copy.deepcopy(DEFAULT)
         self.architecture = get_architecture()
         self.default_mirror = self.get_mirror()
-        self.disable_components = set()
 
     def get_apt_config(self):
-        config = copy.deepcopy(self.config)
-        config['disable_components'] = list(self.disable_components)
-        return config
+        return copy.deepcopy(self.config)
 
     def mirror_is_default(self):
         return self.get_mirror() == self.default_mirror

--- a/subiquity/models/tests/test_mirror.py
+++ b/subiquity/models/tests/test_mirror.py
@@ -15,6 +15,8 @@
 
 import unittest
 
+from curtin.config import merge_config
+
 from subiquity.models.mirror import (
     MirrorModel,
     )
@@ -47,8 +49,10 @@ class TestMirrorModel(unittest.TestCase):
         config = MirrorModel().get_apt_config()
         self.assertEqual([], config['disable_components'])
 
-    def test_set_disable_components(self):
+    def test_from_autoinstall(self):
+        # autoinstall loads to the config directly
         model = MirrorModel()
-        model.disable_components = set(['universe'])
+        data = {'disable_components': ['non-free']}
+        merge_config(model.config, data)
         config = model.get_apt_config()
-        self.assertEqual(['universe'], config['disable_components'])
+        self.assertEqual(['non-free'], config['disable_components'])

--- a/subiquity/models/tests/test_mirror.py
+++ b/subiquity/models/tests/test_mirror.py
@@ -23,36 +23,52 @@ from subiquity.models.mirror import (
 
 
 class TestMirrorModel(unittest.TestCase):
+    def setUp(self):
+        self.model = MirrorModel()
 
     def test_set_country(self):
-        model = MirrorModel()
-        model.set_country("CC")
+        self.model.set_country("CC")
         self.assertIn(
-            model.get_mirror(),
+            self.model.get_mirror(),
             [
                 "http://CC.archive.ubuntu.com/ubuntu",
                 "http://CC.ports.ubuntu.com/ubuntu-ports",
             ])
 
     def test_set_mirror(self):
-        model = MirrorModel()
-        model.set_mirror("http://mymirror.invalid/")
-        self.assertEqual(model.get_mirror(), "http://mymirror.invalid/")
+        self.model.set_mirror("http://mymirror.invalid/")
+        self.assertEqual(self.model.get_mirror(), "http://mymirror.invalid/")
 
     def test_set_country_after_set_mirror(self):
-        model = MirrorModel()
-        model.set_mirror("http://mymirror.invalid/")
-        model.set_country("CC")
-        self.assertEqual(model.get_mirror(), "http://mymirror.invalid/")
+        self.model.set_mirror("http://mymirror.invalid/")
+        self.model.set_country("CC")
+        self.assertEqual(self.model.get_mirror(), "http://mymirror.invalid/")
 
     def test_default_disable_components(self):
-        config = MirrorModel().get_apt_config()
+        config = self.model.get_apt_config()
         self.assertEqual([], config['disable_components'])
 
     def test_from_autoinstall(self):
         # autoinstall loads to the config directly
-        model = MirrorModel()
         data = {'disable_components': ['non-free']}
-        merge_config(model.config, data)
-        config = model.get_apt_config()
+        merge_config(self.model.config, data)
+        config = self.model.get_apt_config()
         self.assertEqual(['non-free'], config['disable_components'])
+
+    def test_disable_add(self):
+        expected = ['things', 'stuff']
+        self.model.disable_components(expected.copy(), add=True)
+        actual = self.model.get_apt_config()['disable_components']
+        actual.sort()
+        expected.sort()
+        self.assertEqual(expected, actual)
+
+    def test_disable_remove(self):
+        self.model.config['disable_components'] = ['a', 'b', 'things']
+        to_remove = ['things', 'stuff']
+        expected = ['a', 'b']
+        self.model.disable_components(to_remove, add=False)
+        actual = self.model.get_apt_config()['disable_components']
+        actual.sort()
+        expected.sort()
+        self.assertEqual(expected, actual)

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -129,7 +129,7 @@ class MirrorController(SubiquityController):
         await self.configured()
 
     async def disable_components_GET(self) -> List[str]:
-        return list(self.model.disable_components)
+        return self.model.config.get('disable_components', [])
 
     async def disable_components_POST(self, data: List[str]):
-        self.model.disable_components = set(data)
+        self.model.config['disable_components'] = data

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -165,11 +165,8 @@ class MetaController:
     async def free_only_POST(self, enable: bool) -> None:
         self.free_only = enable
         to_disable = {'restricted', 'multiverse'}
-        if enable:
-            # enabling free only mode means disabling components
-            self.app.base_model.mirror.disable_components |= to_disable
-        else:
-            self.app.base_model.mirror.disable_components -= to_disable
+        # enabling free only mode means disabling components
+        self.app.base_model.mirror.disable_components(to_disable, enable)
 
 
 def get_installer_password_from_cloudinit_log():


### PR DESCRIPTION
* The mixture of storage for disable_components in and out of the config
  dict was confusing and caused bugs, depending on the flow
* disable_components now solely lives in the dict, like other items