### PR TITLE
Fix language packs detection in integration tests

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -90,7 +90,7 @@ validate () {
                 exit 1
             fi
             lang="$(grep -Eo 'LANG="([^.@ _]+)' .subiquity/etc/default/locale | cut -d \" -f 2)"
-            if [ -z "$( ls .subiquity/var/cache/apt/archives/) | grep $lang" ] ; then
+            if ! ls .subiquity/var/cache/apt/archives/ | grep --fixed-strings --quiet -- "$lang"; then
                 echo "expected $lang language packs in directory var/cache/apt/archives/"
                 exit 1
             fi

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -89,7 +89,8 @@ validate () {
                 echo "user not assigned with the expected group sudo"
                 exit 1
             fi
-            lang="$(grep -Eo 'LANG="([^.@ _]+)' .subiquity/etc/default/locale | cut -d \" -f 2)"
+            # Extract value of the LANG variable from etc/default/locale (with or without quotes)
+            lang="$(grep -Eo 'LANG=([^.@ _]+)' .subiquity/etc/default/locale | cut -d= -f 2- | cut -d\" -f 2-)"
             if ! ls .subiquity/var/cache/apt/archives/ | grep --fixed-strings --quiet -- "$lang"; then
                 echo "expected $lang language packs in directory var/cache/apt/archives/"
                 exit 1


### PR DESCRIPTION
Hello,

While looking at the logs from the integration tests, I observed some weird behavior:
```bash
      ++ ls .subiquity/var/cache/apt/archives/
      + '[' -z 'language-pack-en:amd64
      wamerican:amd64
      wbritish:amd64 | grep ' ']'
```

this comes from this instruction:

```bash
            if [ -z "$( ls .subiquity/var/cache/apt/archives/) | grep $lang" ] ; then
```

One issue is that the `grep` is not being executed. It is used as a string literal and therefore causes the `-z` check to always be false. I rewrote the test and dropped the use of the subshell since we don't need it.

The other issue is that the lang variable is empty. I figured out it's empty because etc/default/locale contains:

```bash
LANG=en_US
```

and we expect it to contain:

```bash
LANG="en_US"
```

I changed the pattern matching to not expect the quotes.

Thanks,
Olivier