### PR TITLE
Add support for APT preferences through autoinstall in Subiquity

### DIFF
--- a/autoinstall-schema.json
+++ b/autoinstall-schema.json
@@ -306,6 +306,28 @@
                             "non-free"
                         ]
                     }
+                },
+                "preferences": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "package": {
+                                "type": "string"
+                            },
+                            "pin": {
+                                "type": "string"
+                            },
+                            "pin-priority": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "package",
+                            "pin",
+                            "pin-priority"
+                        ]
+                    }
                 }
             }
         },

--- a/examples/autoinstall.yaml
+++ b/examples/autoinstall.yaml
@@ -22,6 +22,9 @@ apt:
   disable_components:
     - non-free
     - restricted
+  preferences:
+    - {package: "python3-*", pin: "origin *ubuntu.com*", pin-priority: 200}
+    - {package: "python-*", pin: "origin *ubuntu.com*", pin-priority: -1}
 packages:
   - package1
   - package2

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -168,7 +168,11 @@ timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoi
                                --source-catalog=examples/install-sources.yaml"
 validate
 python3 scripts/check-yaml-fields.py .subiquity/var/log/installer/subiquity-curtin-apt.conf \
-        apt.disable_components='[non-free, restricted]'
+        apt.disable_components='[non-free, restricted]' \
+        apt.preferences[0].pin-priority=200 \
+        apt.preferences[0].pin='"origin *ubuntu.com*"' \
+        apt.preferences[1].package='"python-*"' \
+        apt.preferences[1].pin-priority=-1
 python3 scripts/check-yaml-fields.py .subiquity/var/log/installer/subiquity-curtin-install.conf \
         debconf_selections.subiquity='"eek"' \
         storage.config[-1].options='"errors=remount-ro"'

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: ce811db127fe1ce46498b83615f8faed8c7dfeb6
+    source-commit: 36c0035843d6ccf7632735a130bd83a3c464616c
     build-packages:
       - shared-mime-info
       - zlib1g-dev

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -50,6 +50,28 @@ class MirrorController(SubiquityController):
                     'enum': ['universe', 'multiverse', 'restricted',
                              'contrib', 'non-free']
                 }
+            },
+            "preferences": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "package": {
+                            "type": "string",
+                        },
+                        "pin": {
+                            "type": "string",
+                        },
+                        "pin-priority": {
+                            "type": "integer",
+                        },
+                    },
+                    "required": [
+                        "package",
+                        "pin",
+                        "pin-priority",
+                    ],
+                }
             }
         }
     }


### PR DESCRIPTION
Hello,

This PR adds partial support to Subiquity for apt preferences (aka. pinning / priorities) when using autoinstall.

The autoinstall schema for "apt" now supports the "preferences" configuration. Each preference element should contain the properties described below, that 1:1 map with the keywords from apt_preferences(5):

```
  * package      <-> Package:
  * pin          <-> Pin:
  * pin-priority <-> Pin-Priority:
```

These preferences are forwarded to curtin through subiquity-curtin-apt.conf. Another PR will need to be done in curtin to have full support for this feature.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>