### PR TITLE
Embed ubuntu-advantage-tools into Subiquity snap and use it

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -114,6 +114,7 @@ parts:
       - python3-requests-unixsocket
       - python3-requests
       - python3-pyudev
+      - ubuntu-advantage-tools
     stage:
       - "*"
       - -bin/python

--- a/subiquity/client/controllers/ubuntu_advantage.py
+++ b/subiquity/client/controllers/ubuntu_advantage.py
@@ -16,6 +16,7 @@
 """
 
 import logging
+import os
 
 from subiquitycore.async_helpers import schedule_task
 
@@ -49,7 +50,12 @@ class UbuntuAdvantageController(SubiquityTuiController):
         if app.opts.dry_run:
             strategy = MockedUAInterfaceStrategy(scale_factor=app.scale_factor)
         else:
-            strategy = UAClientUAInterfaceStrategy()
+            # Make sure we execute `$PYTHON "$SNAP/usr/bin/ubuntu-advantage"`.
+            executable = (
+                os.environ["PYTHON"],
+                os.path.join(os.environ["SNAP"], "usr/bin/ubuntu-advantage"),
+            )
+            strategy = UAClientUAInterfaceStrategy(executable=executable)
         self.ua_interface = UAInterface(strategy)
         super().__init__(app)
 

--- a/subiquity/common/tests/test_ubuntu_advantage.py
+++ b/subiquity/common/tests/test_ubuntu_advantage.py
@@ -58,6 +58,22 @@ class TestMockedUAInterfaceStrategy(unittest.TestCase):
 class TestUAClientUAInterfaceStrategy(unittest.TestCase):
     arun_command = "subiquity.common.ubuntu_advantage.utils.arun_command"
 
+    def test_init(self):
+        # Default initializer.
+        strategy = UAClientUAInterfaceStrategy()
+        self.assertEqual(strategy.executable, ["ubuntu-advantage"])
+
+        # Initialize with a mere path.
+        strategy = UAClientUAInterfaceStrategy("/usr/bin/ubuntu-advantage")
+        self.assertEqual(strategy.executable, ["/usr/bin/ubuntu-advantage"])
+
+        # Initialize with a path + interpreter.
+        strategy = UAClientUAInterfaceStrategy(
+            ("python3", "/usr/bin/ubuntu-advantage")
+        )
+        self.assertEqual(strategy.executable,
+                         ["python3", "/usr/bin/ubuntu-advantage"])
+
     def test_query_info_succeeded(self):
         strategy = UAClientUAInterfaceStrategy()
         command = (

--- a/subiquity/common/ubuntu_advantage.py
+++ b/subiquity/common/ubuntu_advantage.py
@@ -20,6 +20,7 @@ from datetime import datetime as dt
 import json
 import logging
 from subprocess import CalledProcessError, CompletedProcess
+from typing import List, Sequence, Union
 import asyncio
 
 from subiquitycore import utils
@@ -96,12 +97,24 @@ class MockedUAInterfaceStrategy(UAInterfaceStrategy):
 class UAClientUAInterfaceStrategy(UAInterfaceStrategy):
     """ Strategy that relies on UA client script to retrieve the information.
     """
+    Executable = Union[str, Sequence[str]]
+
+    def __init__(self, executable: Executable = "ubuntu-advantage") -> None:
+        """ Initialize the strategy using the path to the ubuntu-advantage
+        executable we want to use. The executable can be specified as a
+        sequence of strings so that we can specify the interpret to use as
+        well.
+        """
+        self.executable: List[str] = \
+            [executable] if isinstance(executable, str) else list(executable)
+        super().__init__()
+
     async def query_info(self, token: str) -> dict:
         """ Return the subscription info associated with the supplied
-        UA token. The information will be queried using UA client.
+        UA token. The information will be queried using the UA client
+        executable passed to the initializer.
         """
-        command = (
-            "ubuntu-advantage",
+        command = tuple(self.executable) + (
             "status",
             "--format", "json",
             "--simulate-with-token", token,


### PR DESCRIPTION
We now embed the package `ubuntu-advantage-tools` in the Subiquity snap.
The goal is to make sure that u-a-c implements the `status --simulate-with-token` option, that might not be present in old ISOs.

We now have two different installations of ubuntu-advantage-tools (one from the ISO and one from the snap).
When invoking `ubuntu-advantage`, we need to make sure we use the Python installation from the snap rather than from base ISO. Similarly, we also need to make sure we use right `ubuntu-advantage` entry point (the one from the snap).

NOTE: the version of `ubuntu-advantage` that we place in the snap is currently too old. The version is picked up from `focal-updates`. We need to wait until 27.5~20.04.1 lands in `focal-updates` to get `--simulate-with-token` to work.