### PR TITLE
Fix -drive option and -append option from kvm-test.sh

### DIFF
--- a/scripts/kvm-test.py
+++ b/scripts/kvm-test.py
@@ -20,6 +20,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+from typing import Tuple
 import yaml
 
 
@@ -307,7 +308,8 @@ def create_seed(cloudconfig, tempdir):
     return seed
 
 
-def drive(path, format='qcow2'):
+def drive(path, format='qcow2') -> Tuple[str, str]:
+    """ Return a tuple (-drive, <options>) that can be passed to kvm """
     kwargs = []
     serial = None
     cparam = 'writethrough'
@@ -318,7 +320,7 @@ def drive(path, format='qcow2'):
     if serial:
         kwargs.append(f'serial={serial}')
 
-    return ['-drive', ','.join(kwargs)]
+    return ('-drive', ','.join(kwargs))
 
 
 class PortFinder:

--- a/scripts/kvm-test.py
+++ b/scripts/kvm-test.py
@@ -431,8 +431,7 @@ def install(ctx):
                 # kernel / initrd
                 kvm.extend(('-kernel', f'{mntdir}/casper/vmlinuz'))
                 kvm.extend(('-initrd', get_initrd(mntdir)))
-                toappend = ' '.join(appends)
-                kvm.extend(('-append', f'"{toappend}"'))
+                kvm.extend(('-append', ' '.join(appends)))
                 run(kvm)
         else:
             run(kvm)


### PR DESCRIPTION
The function `drive()` used to return a string in the following format:

  `"-drive file=/path/to/iso,..."`

However, qemu/kvm expects `"-drive"` to be an argument and`"file=/path/to/iso,..."` to be another argument.

The command was constructed as below since the beginning:

```python
  kvm = [
     "kvm",
     "-cdrom", "custom.iso",          # <- OK
     "-drive file=/path/to/iso,...",  # <- NOK
  ]
```

Before 06ac3f92, we would join all the arguments using spaces before executing the kvm command. Therefore we would luckily end up with a correct command:

  `" ".join(kvm)  ->  "kvm -cdrom custom.iso -drive file=/path/to/iso,..."`

However, now that we supply the command to `subprocess.run` directly, the problem shows up.

Fixed by returning a `tuple("-drive", "file=/path/to/iso,...")` from the `drive()` function.

Update: we also have extra quotes being sent to the kernel command line, as shown below: 

```bash
$ cat /proc/cmdline
"autoinstall subiquity-channel=stable" initrd=initrd
```

These quotes were added before to make sure that the `"autoinstall"` and `"subiquity-channel=stable"` were considered a single argument following `"-append"`. But we need to get them removed now that we don't rely on the shell anymore. Otherwise, they get propagated in the kernel command line.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>