### PR TITLE
Fix some typing issues reported by mypy, including potential crash when comparing snap versions

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -21,6 +21,7 @@ import os
 import signal
 import sys
 import traceback
+from typing import Optional
 
 import aiohttp
 
@@ -82,9 +83,9 @@ installed system will be mounted at /target.""")
 
 class SubiquityClient(TuiApplication):
 
-    snapd_socket_path = '/run/snapd.socket'
+    snapd_socket_path: Optional[str] = '/run/snapd.socket'
 
-    variant = None
+    variant: Optional[str] = None
     cmdline = ['snap', 'run', 'subiquity']
     dryrun_cmdline_module = 'subiquity.cmd.tui'
 

--- a/subiquity/client/controller.py
+++ b/subiquity/client/controller.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import Optional
 
 from subiquitycore.tuicontroller import (
     TuiController,
@@ -28,7 +29,7 @@ class Confirm(Exception):
 
 class SubiquityTuiController(TuiController):
 
-    endpoint_name = None
+    endpoint_name: Optional[str] = None
 
     def __init__(self, app):
         super().__init__(app)

--- a/subiquity/common/snap.py
+++ b/subiquity/common/snap.py
@@ -76,9 +76,9 @@ class SnapVersion:
         elif self.patch < other.patch:
             return False
 
-        if self.git_build_id is not None and other.git_build_id is None:
-            return True
-        elif self.git_build_id is None and other.git_build_id is not None:
-            return False
+        build_id_self = \
+            float("-inf") if self.git_build_id is None else self.git_build_id
+        build_id_other = \
+            float("-inf") if other.git_build_id is None else other.git_build_id
 
-        return self.git_build_id > other.git_build_id
+        return build_id_self > build_id_other

--- a/subiquity/common/tests/test_snap.py
+++ b/subiquity/common/tests/test_snap.py
@@ -43,3 +43,7 @@ class TestSnapVersion(unittest.TestCase):
         # Make sure we ignore the build ID when the patch version is different
         self.assertLess(SnapVersion.from_string("21.10.2+git255.deadbeef"),
                         SnapVersion.from_string("21.10.3+git135.deadbeef"))
+
+        snap_version = SnapVersion.from_string("21.10.02")
+        self.assertFalse(snap_version < snap_version)
+        self.assertFalse(snap_version > snap_version)

--- a/subiquity/common/ubuntu_advantage.py
+++ b/subiquity/common/ubuntu_advantage.py
@@ -58,7 +58,7 @@ class CheckSubscriptionError(Exception):
 class UAInterfaceStrategy(ABC):
     """ Strategy to query information about a UA subscription. """
     @abstractmethod
-    async def query_info(token: str) -> dict:
+    async def query_info(self, token: str) -> dict:
         """ Return information about the UA subscription based on the token
         provided.  """
 

--- a/subiquity/common/ubuntu_advantage.py
+++ b/subiquity/common/ubuntu_advantage.py
@@ -147,7 +147,7 @@ class UAInterface:
         """ Return a dictionary containing the subscription information. """
         return await self.strategy.query_info(token)
 
-    async def get_avail_services(self, token: str) -> list:
+    async def get_avail_services(self, token: str) -> List[dict]:
         """ Return a list of available services for the subscription
         associated with the token provided.
         """

--- a/subiquity/server/controller.py
+++ b/subiquity/server/controller.py
@@ -16,6 +16,7 @@
 import json
 import logging
 import os
+from typing import Any, Optional
 
 import jsonschema
 
@@ -32,10 +33,10 @@ log = logging.getLogger("subiquity.server.controller")
 
 class SubiquityController(BaseController):
 
-    autoinstall_key = None
-    autoinstall_schema = None
-    autoinstall_default = None
-    endpoint = None
+    autoinstall_key: Optional[str] = None
+    autoinstall_schema: Any = None
+    autoinstall_default: Any = None
+    endpoint: Optional[type] = None
 
     def __init__(self, app):
         super().__init__(app)

--- a/subiquity/ui/views/ubuntu_advantage.py
+++ b/subiquity/ui/views/ubuntu_advantage.py
@@ -189,7 +189,7 @@ class UbuntuAdvantageView(BaseView):
         self.remove_overlay()
         self.show_stretchy_overlay(ContinueAnywayWidget(self))
 
-    def show_available_services(self, services: dict) -> None:
+    def show_available_services(self, services: List[dict]) -> None:
         """ Display an overlay with the list of services that will be enabled
         via Ubuntu Advantage subscription. After the user confirms, the next we
         will quit the current view and move on. """
@@ -199,7 +199,8 @@ class UbuntuAdvantageView(BaseView):
 
 class ShowServicesWidget(Stretchy):
     """ Widget to show the available services for UA subscription. """
-    def __init__(self, parent: UbuntuAdvantageView, services: list):
+    def __init__(self, parent: UbuntuAdvantageView,
+                 services: List[dict]) -> None:
         """ Initializes the widget by including the list of services as a
         bullet-point list. """
         self.parent = parent

--- a/subiquitycore/controller.py
+++ b/subiquitycore/controller.py
@@ -15,6 +15,7 @@
 
 from abc import ABC
 import logging
+from typing import Optional
 
 log = logging.getLogger("subiquitycore.controller")
 
@@ -22,7 +23,7 @@ log = logging.getLogger("subiquitycore.controller")
 class BaseController(ABC):
     """Base class for controllers."""
 
-    model_name = None
+    model_name: Optional[str] = None
 
     def __init__(self, app):
         self.name = type(self).__name__[:-len("Controller")]

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import logging
 import re
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 import apt
 import apt_pkg
 
@@ -117,7 +117,8 @@ class ConfigureController(SubiquityController):
 
         return True
 
-    async def __recommended_language_packs(self, lang, env) -> List[str]:
+    async def __recommended_language_packs(self, lang, env) \
+            -> Optional[List[str]]:
         """ Return a list of package names recommended by
          check-language-support (or a fake list if in dryrun).
          List returned can be empty on success. None for failure.


### PR DESCRIPTION
I ran mypy over the source tree and had a look at some of the most obvious issues reported.

One of the most concerning was this one:
```
subiquity/common/snap.py:84: error: Unsupported operand types for > ("int" and "None")
subiquity/common/snap.py:84: error: Unsupported operand types for < ("int" and "None")
subiquity/common/snap.py:84: error: Unsupported left operand type for > ("None")
subiquity/common/snap.py:84: note: Both left and right operands are union
```
There is a part of a false-positive here. mypy is not able to infer that, but the operands in question can't be a mix of`int` and `None` based on the logic that happens before.
However, there is one scenario that leads to both operands of the comparison being `None`. And this scenario occurs when comparing a snap version to itself  and when there is no git_build_id specified:

```python
SnapVersion.from_string("1.0.0") > SnapVersion.from_string("1.0.0")
TypeError: '>' not supported between instances of 'NoneType' and 'NoneType'
```

Fixed by first converting the build ID to a number before making the comparison. Also added a unit test to cover this scenario.

Also added some type hinting in base classes of controllers to silence some redundant errors.