### PR TITLE
fixing swap path + support partition size units

### DIFF
--- a/scripts/validate-yaml.py
+++ b/scripts/validate-yaml.py
@@ -14,7 +14,10 @@ class StorageChecker:
     def _check_partition(self, action):
         assert 'device' in action
         assert 'size' in action
-        assert action['size'] % 512 == 0
+        size = str(action['size'])
+        size_units = ['B', 'KB', 'K', 'MB', 'M', 'GB', 'G', 'TB', 'T', '%']
+        valid_unit = any(unit in size for unit in size_units)
+        assert size == '-1' or valid_unit or int(size) % 512 == 0
         assert 'number' in action
         assert action['device'] in self.actions
         assert 'ptable' in self.actions[action['device']]
@@ -30,7 +33,7 @@ class StorageChecker:
     def _check_mount(self, action):
         assert 'device' in action
         assert action['device'] in self.actions
-        if not action.get('path'):
+        if not action.get('path') or action.get('path') == 'none':
             assert self.actions[action['device']]['fstype'] == "swap"
             self.unmounted_swap_ids.remove(action['device'])
         else:


### PR DESCRIPTION
- The 20.04 autoinstaller expects a swap path of 'none'
- Added support for the working units for partition sizes

Both changes where needed for my customized partition layout to be valid. The installation afterwards was successful.
Opening this PR because the script otherwise helped finding errors in my customized partition layout :slightly_smiling_face:.

```
    config:
    - {ptable: msdos, size: "largest", preserve: false, name: '', grub_device: true, type: disk, id: bootdrive}
    - {device: bootdrive, size: 1MB, flag: bios_grub, number: 1, preserve: false, grub_device: false, type: partition, id: bios_boot_partition}

    - {device: bootdrive, size: '512M', wipe: superblock, flag: 'boot', number: 2, preserve: false, grub_device: false, type: partition, id: bootpart}
    - {fstype: ext4, volume: bootpart, preserve: false, type: format, id: bootloader}

    - {device: bootdrive, size: '2%', wipe: superblock, flag: swap, number: 3, preserve: false, grub_device: false, type: partition, id: swappart}
    - {fstype: swap, volume: swappart, preserve: false, type: format, id: swap}

    - {device: bootdrive, size: -1, wipe: superblock, flag: linux, number: 4, preserve: false, grub_device: false, type: partition, id: rootpart}
    - {fstype: btrfs, volume: rootpart, preserve: false, type: format, id: root}

    - {device: root, path: /, type: mount, id: rootmount}
    - {device: swap, path: none, type: mount, id: swapmount}
```