### PR TITLE
Bump curtin version to fix APT preferences being discarded

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: 36c0035843d6ccf7632735a130bd83a3c464616c
+    source-commit: bfbba202e2cc3b02e4e3953081effb6768da41a8
     build-packages:
       - shared-mime-info
       - zlib1g-dev


### PR DESCRIPTION
The previous version of curtin that we were using would discard the APT preferences when running curthooks. Therefore, the APT preferences would not apply when installation packages from the "packages" autoinstall section.

Bump the version to fix the issue.