### PR TITLE
Validate output autoinstall data in integration tests

### DIFF
--- a/examples/answers-bond.yaml
+++ b/examples/answers-bond.yaml
@@ -46,7 +46,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: ""
 SSH:
   install_server: false
 SnapList:

--- a/examples/answers-guided-lvm.yaml
+++ b/examples/answers-guided-lvm.yaml
@@ -21,7 +21,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: C1NWcZTHLteJXGVMM6YhvHDpGrhyy7
 SSH:
   install_server: false
 SnapList:

--- a/examples/answers-imsm.yaml
+++ b/examples/answers-imsm.yaml
@@ -21,7 +21,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: C1NWcZTHLteJXGVMM6YhvHDpGrhyy7
 SSH:
   install_server: true
   pwauth: false

--- a/examples/answers-lvm-dmcrypt.yaml
+++ b/examples/answers-lvm-dmcrypt.yaml
@@ -65,7 +65,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: C1NWcZTHLteJXGVMM6YhvHDpGrhyy7
 SSH:
   install_server: true
   pwauth: false

--- a/examples/answers-lvm.yaml
+++ b/examples/answers-lvm.yaml
@@ -46,7 +46,7 @@ Filesystem:
         mount: /
     - action: done
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: C1NWcZTHLteJXGVMM6YhvHDpGrhyy7
 Identity:
   realname: Ubuntu
   username: ubuntu

--- a/examples/answers-preserve.yaml
+++ b/examples/answers-preserve.yaml
@@ -26,7 +26,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: ""
 SSH:
   install_server: true
   pwauth: false

--- a/examples/answers-raid-lvm.yaml
+++ b/examples/answers-raid-lvm.yaml
@@ -97,7 +97,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: C1NWcZTHLteJXGVMM6YhvHDpGrhyy7
 SSH:
   install_server: false
 SnapList:

--- a/examples/answers-raid.yaml
+++ b/examples/answers-raid.yaml
@@ -56,7 +56,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: C1NWcZTHLteJXGVMM6YhvHDpGrhyy7
 SSH:
   install_server: false
 SnapList:

--- a/examples/answers-serial.yaml
+++ b/examples/answers-serial.yaml
@@ -25,7 +25,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: ""
 SSH:
   install_server: true
   pwauth: false

--- a/examples/answers-swap.yaml
+++ b/examples/answers-swap.yaml
@@ -29,7 +29,7 @@ Identity:
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: C1NWcZTHLteJXGVMM6YhvHDpGrhyy7
 SSH:
   install_server: false
 SnapList:

--- a/examples/answers.yaml
+++ b/examples/answers.yaml
@@ -23,7 +23,7 @@ Identity:
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
   ssh-import-id: gh:mwhudson
 UbuntuAdvantage:
-  token: "a1b2c3d4"
+  token: ""
 SnapList:
   snaps:
     hello:

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -21,6 +21,7 @@ validate () {
             echo "log file not created"
             exit 1
         fi
+        python3 scripts/validate-autoinstall-user-data.py < .subiquity/var/log/installer/autoinstall-user-data
         if grep passw0rd .subiquity/subiquity-client-debug.log .subiquity/subiquity-server-debug.log | grep -v "Loaded answers" | grep -v "answers_action"; then
             echo "password leaked into log file"
             exit 1
@@ -118,6 +119,7 @@ clean () {
     rm -rf .subiquity/etc/cloud/cloud.cfg.d/99-installer.cfg
     rm -rf .subiquity/var/crash
     rm -rf .subiquity/var/cache
+    rm -rf .subiquity/run/subiquity/states
 }
 
 error () {

--- a/scripts/validate-autoinstall-user-data.py
+++ b/scripts/validate-autoinstall-user-data.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Entry-point to validate autoinstall-user-data against schema.
+By default, we are expecting the autoinstall user-data to be wrapped in a cloud
+config format:
+
+#cloud-config
+autoinstall:
+  <user data comes here>
+
+To validate the user-data directly, you can pass the --no-expect-cloudconfig
+switch.
+"""
+
+import argparse
+import json
+
+import jsonschema
+import yaml
+
+
+def main() -> None:
+    """ Entry point. """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--json-schema",
+                        help="Path to the JSON schema",
+                        type=argparse.FileType("r"),
+                        default="autoinstall-schema.json")
+    parser.add_argument("input", nargs="?",
+                        help="Path to the user data instead of stdin",
+                        type=argparse.FileType("r"),
+                        default="-")
+    parser.add_argument("--no-expect-cloudconfig", dest="expect-cloudconfig",
+                        action="store_false",
+                        help="Assume the data is not wrapped in cloud-config.",
+                        default=True)
+
+    args = vars(parser.parse_args())
+
+    if args["expect-cloudconfig"]:
+        assert args["input"].readline() == "#cloud-config\n"
+        get_autoinstall_data = lambda data: data["autoinstall"]
+    else:
+        get_autoinstall_data = lambda data: data
+
+    data = yaml.safe_load(args["input"])
+
+    jsonschema.validate(get_autoinstall_data(data),
+                        json.load(args["json_schema"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/subiquity/models/ssh.py
+++ b/subiquity/models/ssh.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import List
 
 log = logging.getLogger("subiquity.models.ssh")
 
@@ -22,7 +23,7 @@ class SSHModel:
 
     def __init__(self):
         self.install_server = False
-        self.authorized_keys = None
+        self.authorized_keys: List[str] = []
         self.pwauth = True
         # Although the generated config just contains the key above,
         # we store the imported id so that we can re-fill the form if

--- a/subiquity/server/controllers/ubuntu_advantage.py
+++ b/subiquity/server/controllers/ubuntu_advantage.py
@@ -57,6 +57,8 @@ class UbuntuAdvantageController(SubiquityController):
         """ Return a dictionary that can be used as an autoinstall snippet for
         Ubuntu Advantage.
         """
+        if not self.model.token:
+            return {}
         return {
             "token": self.model.token
         }


### PR DESCRIPTION
When running integration tests, we now automatically validate the generated autoinstall data (i.e., `.subiquity/var/log/installer/autoinstall-user-data`) against the JSON schema.

I added a script that does the validation: `scripts/validate-autoinstall-user-data.py`.
The script can be used for autoinstall files that have data enclosed inside the cloud-config header:
```bash
$ head -n 3 .subiquity/var/log/installer/autoinstall-user-data 
#cloud-config
autoinstall:
  apt:
$ scripts/validate-autoinstall-user-data.py .subiquity/var/log/installer/autoinstall-user-data
```
or it can be used with the `--no-expect-cloudconfig` for our example files:
```bash
$ head -n 3 examples/autoinstall.yaml 
version: 1
early-commands:
  - echo a
$ scripts/validate-autoinstall-user-data.py --no-expect-cloudconfig examples/autoinstall.yaml 
```

It showed me two existing errors that I fixed on the way:

The following output was generated during an autoinstall with no ssh: key in the input. Having null for authorized-keys is not accepted by the JSON schema.
```yaml
  ssh:
    authorized-keys: null
```

When skipping the Ubuntu Advantage screen (for whatever reason) or leaving the field blank, we would end up with:
```yaml
  ubuntu-advantage:
    token: ""
```
Having an empty string is not accepted by the schema ; although having no token at all is valid.

It also points out that passing an invalid UA token (which can be forced today) will subsequently generate an autoinstall file that is not valid according to the schema. But this PR does not address that part.