### PR TITLE
Don't list UA services that are not entitled

### DIFF
--- a/examples/uaclient-status-valid.json
+++ b/examples/uaclient-status-valid.json
@@ -6,7 +6,7 @@
         {
             "name": "cis",
             "description": "Center for Internet Security Audit Tools",
-            "entitled": "yes",
+            "entitled": "no",
             "auto_enabled": "no",
             "available": "yes"
         },
@@ -15,7 +15,7 @@
             "description": "UA Apps: Extended Security Maintenance (ESM)",
             "entitled": "yes",
             "auto_enabled": "yes",
-            "available": "yes"
+            "available": "no"
         },
         {
             "name": "esm-infra",

--- a/subiquity/client/controllers/ubuntu_advantage.py
+++ b/subiquity/client/controllers/ubuntu_advantage.py
@@ -78,7 +78,8 @@ class UbuntuAdvantageController(SubiquityTuiController):
         """ Asynchronously check the token passed as an argument. """
         async def inner() -> None:
             try:
-                svcs = await self.ua_interface.get_avail_services(token=token)
+                svcs = await \
+                        self.ua_interface.get_activable_services(token=token)
             except InvalidUATokenError:
                 if isinstance(self.ui.body, UbuntuAdvantageView):
                     self.ui.body.show_invalid_token()
@@ -90,7 +91,7 @@ class UbuntuAdvantageController(SubiquityTuiController):
                     self.ui.body.show_unknown_error()
             else:
                 if isinstance(self.ui.body, UbuntuAdvantageView):
-                    self.ui.body.show_available_services(svcs)
+                    self.ui.body.show_activable_services(svcs)
 
         self._check_task = schedule_task(inner())
 

--- a/subiquity/common/tests/test_ubuntu_advantage.py
+++ b/subiquity/common/tests/test_ubuntu_advantage.py
@@ -125,24 +125,26 @@ class TestUAClientUAInterfaceStrategy(unittest.TestCase):
 
 class TestUAInterface(unittest.TestCase):
 
-    def test_mocked_get_avail_services(self):
+    def test_mocked_get_activable_services(self):
         strategy = MockedUAInterfaceStrategy(scale_factor=1_000_000)
         interface = UAInterface(strategy)
 
         with self.assertRaises(InvalidUATokenError):
-            run_coro(interface.get_avail_services(token="invalidToken"))
+            run_coro(interface.get_activable_services(token="invalidToken"))
         # Tokens starting with "f" in dry-run mode simulate an "internal"
         # error.
         with self.assertRaises(CheckSubscriptionError):
-            run_coro(interface.get_avail_services(token="failure"))
+            run_coro(interface.get_activable_services(token="failure"))
 
         # Tokens starting with "x" is dry-run mode simulate an expired token.
         with self.assertRaises(ExpiredUATokenError):
-            run_coro(interface.get_avail_services(token="xpiredToken"))
+            run_coro(interface.get_activable_services(token="xpiredToken"))
 
         # Other tokens are considered valid in dry-run mode.
-        services = run_coro(interface.get_avail_services(token="validToken"))
+        services = run_coro(
+                interface.get_activable_services(token="validToken"))
         for service in services:
             self.assertIn("name", service)
             self.assertIn("description", service)
-            self.assertTrue(service["available"])
+            self.assertEqual(service["available"], "yes")
+            self.assertEqual(service["entitled"], "yes")

--- a/subiquity/ui/views/ubuntu_advantage.py
+++ b/subiquity/ui/views/ubuntu_advantage.py
@@ -189,16 +189,16 @@ class UbuntuAdvantageView(BaseView):
         self.remove_overlay()
         self.show_stretchy_overlay(ContinueAnywayWidget(self))
 
-    def show_available_services(self, services: List[dict]) -> None:
-        """ Display an overlay with the list of services that will be enabled
-        via Ubuntu Advantage subscription. After the user confirms, the next we
-        will quit the current view and move on. """
+    def show_activable_services(self, services: List[dict]) -> None:
+        """ Display an overlay with the list of services that can be enabled
+        via Ubuntu Advantage subscription. After the user confirms, we will
+        quit the current view and move on. """
         self.remove_overlay()
         self.show_stretchy_overlay(ShowServicesWidget(self, services))
 
 
 class ShowServicesWidget(Stretchy):
-    """ Widget to show the available services for UA subscription. """
+    """ Widget to show the activable services for UA subscription. """
     def __init__(self, parent: UbuntuAdvantageView,
                  services: List[dict]) -> None:
         """ Initializes the widget by including the list of services as a
@@ -207,8 +207,8 @@ class ShowServicesWidget(Stretchy):
 
         ok = ok_btn(label=_("OK"), on_press=self.ok)
 
-        title = _("Available Services")
-        header = _("List of services that are available through your "
+        title = _("Activable Services")
+        header = _("List of services that are activable through your "
                    "Ubuntu Advantage subscription:")
 
         widgets: List[Widget] = [


### PR DESCRIPTION
Hello,

So far, for a valid contract token, we would list all the UA services that are marked "available".

After discussing with @alnvdl, it turns out that we also want to make sure these services are marked "entitled":

_available_ means it is available for the current machine type (e.g., fips may be available for a x86_64 machine running focal). This is irrespective of the contract; whereas
_entitled_ means that your contract gives you access to the service

Instead of only checking if a given UA service is available, we now also check if it is entitled.

Also fixed the unit test that expected "entitled" to be a boolean field ; but is actually a "yes" or a "no" string.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>