### PR TITLE
api test: run in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ aptdeps:
 		python3-requests-unixsocket python3-jsonschema python3-apport \
 		python3-bson xorriso isolinux python3-aiohttp cloud-init ssh-import-id \
 		curl jq build-essential python3-pytest python3-async-timeout \
-	        language-selector-common fuseiso
+	        language-selector-common fuseiso python3-pytest-xdist
 
 .PHONY: install_deps
 install_deps: aptdeps gitdeps
@@ -88,7 +88,7 @@ unit: gitdeps
 
 .PHONY: api
 api: gitdeps
-	$(PYTHON) -m pytest subiquity/tests/api
+	$(PYTHON) -m pytest -n auto subiquity/tests/api
 
 .PHONY: integration
 integration: gitdeps

--- a/console_conf/cmd/tui.py
+++ b/console_conf/cmd/tui.py
@@ -59,6 +59,9 @@ def parse_options(argv):
                         dest='chooser_systems',
                         help=('Run as a recovery chooser interacting with the '
                               'calling process over stdin/stdout streams'))
+    parser.add_argument('--output-base', action='store', dest='output_base',
+                        default='.subiquity',
+                        help='in dryrun, control basedir of files')
     return parser.parse_args(argv)
 
 
@@ -69,7 +72,7 @@ def main():
     opts = parse_options(sys.argv[1:])
     global LOGDIR
     if opts.dry_run:
-        LOGDIR = ".subiquity"
+        LOGDIR = opts.output_base
     setup_logger(dir=LOGDIR)
     logger = logging.getLogger('console_conf')
     logger.info("Starting console-conf v{}".format(VERSION))

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -168,7 +168,7 @@ class IdentityController(TuiController):
                 'username': email,
                 }
             self.model.add_user(result)
-            login_details_path = '.subiquity/login-details.txt'
+            login_details_path = self.opts.output_base + '/login-details.txt'
         else:
             self.app.urwid_loop.draw_screen()
             cp = run_command(

--- a/scripts/installdeps.sh
+++ b/scripts/installdeps.sh
@@ -11,7 +11,7 @@ ConditionPathExists=/dev/zfs
 EOF
 cp -r /etc/systemd/system/zfs-mount.service.d/ /etc/systemd/system/zfs-share.service.d/
 systemctl daemon-reload
-apt-get install -o APT::Get::Always-Include-Phased-Updates=true -y --no-install-recommends libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libsystemd-dev python3-distutils-extra pkg-config python3.5 python3-pip git lsb-release python3-setuptools gcc python3-dev python3-wheel pep8 python3-pyflakes python3-bson make curl jq build-essential python3-pytest python3-async-timeout language-selector-common
+apt-get install -o APT::Get::Always-Include-Phased-Updates=true -y --no-install-recommends libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libsystemd-dev python3-distutils-extra pkg-config python3.5 python3-pip git lsb-release python3-setuptools gcc python3-dev python3-wheel pep8 python3-pyflakes python3-bson make curl jq build-essential python3-pytest python3-async-timeout language-selector-common python3-pytest-xdist
 pip3 install -r requirements.txt
 
 make gitdeps

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -67,6 +67,10 @@ def make_server_args_parser():
               "list screen."))
     parser.add_argument(
         '--source-catalog', dest='source_catalog', action='store')
+    parser.add_argument(
+        '--output-base', action='store', dest='output_base',
+        default='.subiquity',
+        help='in dryrun, control basedir of files')
     return parser
 
 
@@ -82,10 +86,10 @@ def main():
     if opts.dry_run:
         if opts.snaps_from_examples is None:
             opts.snaps_from_examples = True
-        logdir = ".subiquity"
+        logdir = opts.output_base
     if opts.socket is None:
         if opts.dry_run:
-            opts.socket = '.subiquity/socket'
+            opts.socket = opts.output_base + '/socket'
         else:
             opts.socket = '/run/subiquity/socket'
     os.makedirs(os.path.dirname(opts.socket), exist_ok=True)

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -103,8 +103,8 @@ class InstallController(SubiquityController):
         config_location = '/var/log/installer/subiquity-curtin-install.conf'
         log_location = INSTALL_LOG
         if self.app.opts.dry_run:
-            config_location = '.subiquity' + config_location
-            log_location = '.subiquity' + INSTALL_LOG
+            config_location = self.app.opts.output_base + config_location
+            log_location = self.app.opts.output_base + INSTALL_LOG
         os.makedirs(os.path.dirname(config_location), exist_ok=True)
         os.makedirs(os.path.dirname(log_location), exist_ok=True)
         with open(config_location, 'w') as conf:

--- a/subiquity/server/curtin.py
+++ b/subiquity/server/curtin.py
@@ -37,7 +37,8 @@ class _CurtinCommand:
 
     _count = 0
 
-    def __init__(self, runner, command, *args, config=None):
+    def __init__(self, opts, runner, command, *args, config=None):
+        self.opts = opts
         self.runner = runner
         self._event_contexts = {}
         _CurtinCommand._count += 1
@@ -134,7 +135,7 @@ class _DryRunCurtinCommand(_CurtinCommand):
                 "scripts/replay-curtin-log.py",
                 self.event_file,
                 self._event_syslog_id,
-                '.subiquity' + INSTALL_LOG,
+                self.opts.output_base + INSTALL_LOG,
                 ]
         else:
             return super().make_command(command, *args, config=config)
@@ -153,7 +154,8 @@ async def start_curtin_command(app, context, command, *args, config=None):
             cls = _DryRunCurtinCommand
     else:
         cls = _CurtinCommand
-    curtin_cmd = cls(app.command_runner, command, *args, config=config)
+    curtin_cmd = cls(app.opts, app.command_runner, command, *args,
+                     config=config)
     await curtin_cmd.start(context)
     return curtin_cmd
 

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -259,7 +259,7 @@ class SubiquityServer(Application):
     def make_model(self):
         root = '/'
         if self.opts.dry_run:
-            root = os.path.abspath('.subiquity')
+            root = os.path.abspath(self.opts.output_base)
         return SubiquityModel(
             root, self.hub, INSTALL_MODEL_NAMES, POSTINSTALL_MODEL_NAMES)
 
@@ -298,7 +298,7 @@ class SubiquityServer(Application):
                         os.path.dirname(
                             os.path.dirname(__file__))),
                     "examples", "snaps"),
-                self.scale_factor)
+                self.scale_factor, opts.output_base)
             self.snapd = AsyncSnapd(connection)
         elif os.path.exists(self.snapd_socket_path):
             connection = SnapdConnection(self.root, self.snapd_socket_path)

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -134,7 +134,7 @@ class BaseNetworkController(BaseController):
         super().__init__(app)
         self.apply_config_task = SingleInstanceTask(self._apply_config)
         if self.opts.dry_run:
-            self.root = os.path.abspath(".subiquity")
+            self.root = os.path.abspath(self.opts.output_base)
             netplan_path = self.netplan_path
             netplan_dir = os.path.dirname(netplan_path)
             if os.path.exists(netplan_dir):

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -62,7 +62,7 @@ class Application:
 
         self.root = '/'
         if opts.dry_run:
-            self.root = '.subiquity'
+            self.root = opts.output_base
         self.state_dir = os.path.join(self.root, 'run', self.project)
         os.makedirs(self.state_path('states'), exist_ok=True)
 

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -119,14 +119,12 @@ class ResponseSet:
         return _FakeFileResponse(f)
 
 
-update_marker_file = '.subiquity/run/subiquity/updating'
-
-
 class FakeSnapdConnection:
-    def __init__(self, snap_data_dir, scale_factor):
+    def __init__(self, snap_data_dir, scale_factor, output_base):
         self.snap_data_dir = snap_data_dir
         self.scale_factor = scale_factor
         self.response_sets = {}
+        self.output_base = output_base
 
     def configure_proxy(self, proxy):
         log.debug("pretending to restart snapd to pick up proxy config")
@@ -135,6 +133,7 @@ class FakeSnapdConnection:
     def post(self, path, body, **args):
         if path == "v2/snaps/subiquity" and body['action'] == 'refresh':
             # The post-refresh hook does this in the real world.
+            update_marker_file = self.output_base + '/run/subiquity/updating'
             open(update_marker_file, 'w').close()
             return _FakeMemoryResponse({
                 "type": "async",

--- a/system_setup/cmd/server.py
+++ b/system_setup/cmd/server.py
@@ -39,6 +39,9 @@ def make_server_args_parser():
                         dest='prefill',
                         help='Prefills UI models with data provided in'
                         ' a prefill.yaml file yet allowing overrides.')
+    parser.add_argument('--output-base', action='store', dest='output_base',
+                        default='.subiquity',
+                        help='in dryrun, control basedir of files')
     return parser
 
 
@@ -56,10 +59,10 @@ def main():
     opts.kernel_cmdline = ""
     opts.machine_config = NOPROBERARG
     if opts.dry_run:
-        logdir = ".subiquity"
+        logdir = opts.output_base
     if opts.socket is None:
         if opts.dry_run:
-            opts.socket = '.subiquity/socket'
+            opts.socket = opts.output_base + '/socket'
         else:
             opts.socket = '/run/subiquity/socket'
     os.makedirs(os.path.dirname(opts.socket), exist_ok=True)

--- a/system_setup/cmd/tui.py
+++ b/system_setup/cmd/tui.py
@@ -55,6 +55,9 @@ def make_client_args_parser():
                         dest='prefill',
                         help='Prefills UI models with data provided in'
                         ' a prefill.yaml file yet allowing overrides.')
+    parser.add_argument('--output-base', action='store', dest='output_base',
+                        default='.subiquity',
+                        help='in dryrun, control basedir of files')
     return parser
 
 
@@ -75,10 +78,10 @@ def main():
     server_state_file = "/run/subiquity/server-state"
     opts, unknown = parser.parse_known_args(args)
     if '--dry-run' in args:
-        server_state_file = ".subiquity/run/subiquity/server-state"
+        server_state_file = opts.output_base + "/run/subiquity/server-state"
         if opts.socket is None:
             need_start_server = True
-            server_output_dir = '.subiquity'
+            server_output_dir = opts.output_base
             sock_path = os.path.join(server_output_dir, 'socket')
             opts.socket = sock_path
             server_args = ['--dry-run', '--socket=' + sock_path] + unknown
@@ -111,7 +114,7 @@ def main():
     os.makedirs(os.path.basename(opts.socket), exist_ok=True)
     logdir = LOGDIR
     if opts.dry_run:
-        logdir = ".subiquity"
+        logdir = opts.output_base
     logfiles = setup_logger(dir=logdir, base='systemsetup-client')
 
     logger = logging.getLogger('subiquity')

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -77,7 +77,7 @@ class SystemSetupServer(SubiquityServer):
     def make_model(self):
         root = '/'
         if self.opts.dry_run:
-            root = os.path.abspath('.subiquity')
+            root = os.path.abspath(self.opts.output_base)
         model = SystemSetupModel(root, self.hub, INSTALL_MODEL_NAMES,
                                  POSTINSTALL_MODEL_NAMES)
         model.set_source_variant(self.variant)


### PR DESCRIPTION
By splitting up the output directory instead of just writing to .subiquity,
we can run api tests in parallel.  About 7x speedup on my machine over running
them serially.