### PR TITLE
Implement geoip using asyncio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ aptdeps:
 		python3-requests-unixsocket python3-jsonschema python3-apport \
 		python3-bson xorriso isolinux python3-aiohttp cloud-init ssh-import-id \
 		curl jq build-essential python3-pytest python3-async-timeout \
-	        language-selector-common fuseiso python3-pytest-xdist
+	        language-selector-common fuseiso python3-pytest-xdist python3-aioresponses
 
 .PHONY: install_deps
 install_deps: aptdeps gitdeps

--- a/scripts/installdeps.sh
+++ b/scripts/installdeps.sh
@@ -11,7 +11,7 @@ ConditionPathExists=/dev/zfs
 EOF
 cp -r /etc/systemd/system/zfs-mount.service.d/ /etc/systemd/system/zfs-share.service.d/
 systemctl daemon-reload
-apt-get install -o APT::Get::Always-Include-Phased-Updates=true -y --no-install-recommends libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libsystemd-dev python3-distutils-extra pkg-config python3.5 python3-pip git lsb-release python3-setuptools gcc python3-dev python3-wheel pep8 python3-pyflakes python3-bson make curl jq build-essential python3-pytest python3-async-timeout language-selector-common python3-pytest-xdist
+apt-get install -o APT::Get::Always-Include-Phased-Updates=true -y --no-install-recommends libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libsystemd-dev python3-distutils-extra pkg-config python3.5 python3-pip git lsb-release python3-setuptools gcc python3-dev python3-wheel pep8 python3-pyflakes python3-bson make curl jq build-essential python3-pytest python3-async-timeout language-selector-common python3-pytest-xdist python3-aioresponses
 pip3 install -r requirements.txt
 
 make gitdeps

--- a/subiquity/server/geoip.py
+++ b/subiquity/server/geoip.py
@@ -75,9 +75,10 @@ class HTTPGeoIPStrategy(GeoIPStrategy):
     """ HTTP implementation to retrieve GeoIP information. We use the
     geoip.ubuntu.com service. """
     async def get_response(self) -> str:
+        url = "https://geoip.ubuntu.com/lookup"
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get("https://geoip.ubuntu.com/lookup") as response:
+                async with session.get(url) as response:
                     response.raise_for_status()
                     return await response.text()
         except aiohttp.ClientError as e:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -66,7 +66,11 @@ from subiquity.models.subiquity import (
     SubiquityModel,
     )
 from subiquity.server.controller import SubiquityController
-from subiquity.server.geoip import GeoIP
+from subiquity.server.geoip import (
+    GeoIP,
+    DryRunGeoIPStrategy,
+    HTTPGeoIPStrategy,
+    )
 from subiquity.server.errors import ErrorController
 from subiquity.server.runner import get_command_runner
 from subiquity.server.types import InstallerChannels
@@ -312,7 +316,12 @@ class SubiquityServer(Application):
         self.hub.subscribe(InstallerChannels.NETWORK_UP, self._network_change)
         self.hub.subscribe(InstallerChannels.NETWORK_PROXY_SET,
                            self._proxy_set)
-        self.geoip = GeoIP(self)
+        if self.opts.dry_run:
+            geoip_strategy = DryRunGeoIPStrategy()
+        else:
+            geoip_strategy = HTTPGeoIPStrategy()
+
+        self.geoip = GeoIP(self, strategy=geoip_strategy)
 
     def set_source_variant(self, variant):
         self.variant = variant

--- a/subiquity/server/tests/test_geoip.py
+++ b/subiquity/server/tests/test_geoip.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import mock
-
 from aioresponses import aioresponses
 
 from subiquitycore.tests import SubiTestCase

--- a/subiquity/server/tests/test_geoip.py
+++ b/subiquity/server/tests/test_geoip.py
@@ -49,30 +49,17 @@ empty_tz = '<Response><TimeZone></TimeZone></Response>'
 empty_cc = '<Response><CountryCode></CountryCode></Response>'
 
 
-class MockGeoIPResponse:
-    def __init__(self, text, status_code=200):
-        self.text = text
-        self.status_code = status_code
-
-    def raise_for_status(self, *args, **kwargs):
-        pass
-
-
-def requests_get_factory(text):
-    def requests_get(*args, **kwargs):
-        return MockGeoIPResponse(text)
-    return requests_get
-
-
 class TestGeoIP(SubiTestCase):
-    @mock.patch('requests.get', new=requests_get_factory(xml))
     def setUp(self):
         strategy = HTTPGeoIPStrategy()
         self.geoip = GeoIP(make_app(), strategy)
 
         async def fn():
             self.assertTrue(await self.geoip.lookup())
-        run_coro(fn())
+
+        with aioresponses() as mocked:
+            mocked.get("https://geoip.ubuntu.com/lookup", body=xml)
+            run_coro(fn())
 
     def test_countrycode(self):
         self.assertEqual("us", self.geoip.countrycode)
@@ -86,37 +73,42 @@ class TestGeoIPBadData(SubiTestCase):
         strategy = HTTPGeoIPStrategy()
         self.geoip = GeoIP(make_app(), strategy)
 
-    @mock.patch('requests.get', new=requests_get_factory(partial))
     def test_partial_reponse(self):
         async def fn():
             self.assertFalse(await self.geoip.lookup())
-        run_coro(fn())
+        with aioresponses() as mocked:
+            mocked.get("https://geoip.ubuntu.com/lookup", body=partial)
+            run_coro(fn())
 
-    @mock.patch('requests.get', new=requests_get_factory(incomplete))
     def test_incomplete(self):
         async def fn():
             self.assertFalse(await self.geoip.lookup())
-        run_coro(fn())
+        with aioresponses() as mocked:
+            mocked.get("https://geoip.ubuntu.com/lookup", body=incomplete)
+            run_coro(fn())
         self.assertIsNone(self.geoip.countrycode)
         self.assertIsNone(self.geoip.timezone)
 
-    @mock.patch('requests.get', new=requests_get_factory(long_cc))
     def test_long_cc(self):
         async def fn():
             self.assertFalse(await self.geoip.lookup())
-        run_coro(fn())
+        with aioresponses() as mocked:
+            mocked.get("https://geoip.ubuntu.com/lookup", body=long_cc)
+            run_coro(fn())
         self.assertIsNone(self.geoip.countrycode)
 
-    @mock.patch('requests.get', new=requests_get_factory(empty_cc))
     def test_empty_cc(self):
         async def fn():
             self.assertFalse(await self.geoip.lookup())
-        run_coro(fn())
+        with aioresponses() as mocked:
+            mocked.get("https://geoip.ubuntu.com/lookup", body=empty_cc)
+            run_coro(fn())
         self.assertIsNone(self.geoip.countrycode)
 
-    @mock.patch('requests.get', new=requests_get_factory(empty_tz))
     def test_empty_tz(self):
         async def fn():
             self.assertFalse(await self.geoip.lookup())
-        run_coro(fn())
+        with aioresponses() as mocked:
+            mocked.get("https://geoip.ubuntu.com/lookup", body=empty_tz)
+            run_coro(fn())
         self.assertIsNone(self.geoip.timezone)

--- a/subiquity/server/tests/test_geoip.py
+++ b/subiquity/server/tests/test_geoip.py
@@ -15,10 +15,15 @@
 
 import mock
 
+from aioresponses import aioresponses
+
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
 from subiquitycore.tests.util import run_coro
-from subiquity.server.geoip import GeoIP
+from subiquity.server.geoip import (
+    GeoIP,
+    HTTPGeoIPStrategy,
+    )
 
 xml = '''
 <Response>
@@ -62,7 +67,8 @@ def requests_get_factory(text):
 class TestGeoIP(SubiTestCase):
     @mock.patch('requests.get', new=requests_get_factory(xml))
     def setUp(self):
-        self.geoip = GeoIP(make_app())
+        strategy = HTTPGeoIPStrategy()
+        self.geoip = GeoIP(make_app(), strategy)
 
         async def fn():
             self.assertTrue(await self.geoip.lookup())
@@ -77,7 +83,8 @@ class TestGeoIP(SubiTestCase):
 
 class TestGeoIPBadData(SubiTestCase):
     def setUp(self):
-        self.geoip = GeoIP(make_app())
+        strategy = HTTPGeoIPStrategy()
+        self.geoip = GeoIP(make_app(), strategy)
 
     @mock.patch('requests.get', new=requests_get_factory(partial))
     def test_partial_reponse(self):


### PR DESCRIPTION
GeoIP requests used to run on the default executor thread and would prevent the application from exiting if the GeoIP service would not respond quickly enough. We witnessed an obvious impact during an incident on geoip.ubuntu.com.

Move to aiohttp so that the HTTP calls are non blocking.

Also don't actually run HTTP requests in dry-run mode. We now use an hardcoded response.
