### PR TITLE
filesystem: add disk scaling for /boot and efi

### DIFF
--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -20,7 +20,11 @@ from subiquity.common.filesystem.actions import (
     )
 from subiquity.common.filesystem import gaps
 from subiquity.common.filesystem.manipulator import (
+    bootfs_scale,
     FilesystemManipulator,
+    PartitionScaleFactors,
+    scale_partitions,
+    uefi_scale,
     )
 from subiquity.models.tests.test_filesystem import (
     make_disk,
@@ -225,3 +229,57 @@ class TestFilesystemManipulator(unittest.TestCase):
             disk1, disk1p2, {'fstype': 'ext4', 'mount': '/'})
         efi_mnt = manipulator.model._mount_for_path("/boot/efi")
         self.assertEqual(efi_mnt.device.volume, disk1p1)
+
+
+class TestPartitionSizeScaling(unittest.TestCase):
+    def test_scale_factors(self):
+        psf = [
+            PartitionScaleFactors(minimum=100, priority=500, maximum=500),
+            PartitionScaleFactors(minimum=1000, priority=9500, maximum=-1),
+        ]
+
+        # match priorities, should get same values back
+        self.assertEqual([500, 9500], scale_partitions(psf, 10000))
+
+        # half priorities, should be scaled
+        self.assertEqual([250, 4750], scale_partitions(psf, 5000))
+
+        # hit max on first partition, second should use rest of space
+        self.assertEqual([500, 19500], scale_partitions(psf, 20000))
+
+        # minimums
+        self.assertEqual([100, 1000], scale_partitions(psf, 1100))
+
+        # ints
+        self.assertEqual([105, 1996], scale_partitions(psf, 2101))
+
+    def test_no_max_equal_minus_one(self):
+        psf = [
+            PartitionScaleFactors(minimum=100, priority=500, maximum=500),
+            PartitionScaleFactors(minimum=100, priority=500, maximum=500),
+        ]
+
+        self.assertEqual([500, 500], scale_partitions(psf, 2000))
+
+    def test_efi(self):
+        manipulator = make_manipulator(Bootloader.UEFI)
+        tests = [
+            # something large to hit maximums
+            (30 << 30, uefi_scale.maximum, bootfs_scale.maximum),
+            # and something small to hit minimums
+            (8 << 30, uefi_scale.minimum, bootfs_scale.minimum),
+        ]
+        for disk_size, uefi, bootfs in tests:
+            disk = make_disk(manipulator.model, preserve=True, size=disk_size)
+            self.assertEqual(uefi, manipulator._get_efi_size(disk))
+            self.assertEqual(bootfs, manipulator._get_bootfs_size(disk))
+
+        # something in between for scaling
+        disk_size = 15 << 30
+        disk = make_disk(manipulator.model, preserve=True, size=disk_size)
+        efi_size = manipulator._get_efi_size(disk)
+        self.assertTrue(uefi_scale.maximum > efi_size)
+        self.assertTrue(efi_size > uefi_scale.minimum)
+        bootfs_size = manipulator._get_bootfs_size(disk)
+        self.assertTrue(bootfs_scale.maximum > bootfs_size)
+        self.assertTrue(bootfs_size > bootfs_scale.minimum)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -54,7 +54,6 @@ from subiquity.common.types import (
     )
 from subiquity.models.filesystem import (
     align_down,
-    dehumanize_size,
     LVM_CHUNK_SIZE,
     Raid,
     )
@@ -141,7 +140,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             self.add_boot_disk(disk)
         self.create_partition(
             device=disk, spec=dict(
-                size=dehumanize_size('1G'),
+                size=self._get_bootfs_size(disk),
                 fstype="ext4",
                 mount='/boot'
                 ))


### PR DESCRIPTION
Add a scaling system to adjust the size of /boot and efi partitions in
response to the size of the disk.

Caveat:  scaling for efi is not smart enough to know if /boot is needed or not.