### PR TITLE
Fixes missing directory for system_setup integration test

### DIFF
--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -58,8 +58,14 @@ class ConfigureController(SubiquityController):
         cmdFile = os.path.join(self.model.root, cmd)
         shutil.copy(os.path.join("/", cmd), cmdFile)
         # Supply LC_* definition files to avoid complains from localedef.
-        shutil.copytree("/usr/lib/locale/C.UTF-8/", outDir,
-                        dirs_exist_ok=True)
+        candidateSourceDirs = ["/usr/lib/locale/C.UTF-8/",
+                               "/usr/lib/locale/C.utf8/"]
+        sourceDirs = [d for d in candidateSourceDirs if os.path.exists(d)]
+        if len(sourceDirs) == 0 or sourceDirs is None:
+            log.error("No available LC_* definitions found in this system")
+            return ("", False)
+
+        shutil.copytree(sourceDirs[0], outDir, dirs_exist_ok=True)
         try:
             # Altering locale-gen script to output to the desired folder.
             with open(cmdFile, "r+") as f:

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -61,7 +61,7 @@ class ConfigureController(SubiquityController):
         candidateSourceDirs = ["/usr/lib/locale/C.UTF-8/",
                                "/usr/lib/locale/C.utf8/"]
         sourceDirs = [d for d in candidateSourceDirs if os.path.exists(d)]
-        if len(sourceDirs) == 0 or sourceDirs is None:
+        if len(sourceDirs) == 0:
             log.error("No available LC_* definitions found in this system")
             return ("", False)
 


### PR DESCRIPTION
By providing alternative directories to find LC_* locale definitions.

libc-bin package was recently updated to include the locale files for C.UTF-8 in `/usr/lib/locale/C.utf8` , breaking the system_setup tests. With this PR alternative directory paths are provided and tested for existence (and error checking as well) before attempting to copy the directory tree.