### PR TITLE
Add type hints to overlayfs helpers and add some unit tests.

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -20,6 +20,8 @@ import shutil
 import tempfile
 from typing import List, Optional, Union
 
+import attr
+
 from curtin.config import merge_config
 
 from subiquitycore.file_util import write_file, generate_config_yaml
@@ -44,18 +46,18 @@ class _MountBase:
             fp.write(content)
 
 
+@attr.s(auto_attribs=True, kw_only=True)
 class Mountpoint(_MountBase):
-    def __init__(self, *, mountpoint: str):
-        self.mountpoint: str = mountpoint
+    mountpoint: str
 
 
+@attr.s(auto_attribs=True, kw_only=True)
 class OverlayMountpoint(_MountBase):
-    def __init__(self, *, lowers, upperdir: Optional[str], mountpoint: str):
-        # The first element in lowers will be the bottom layer and the last
-        # element will be the top layer.
-        self.lowers: List[Lower] = lowers
-        self.upperdir: Optional[str] = upperdir
-        self.mountpoint: str = mountpoint
+    # The first element in lowers will be the bottom layer and the last element
+    # will be the top layer.
+    lowers: List["Lower"]
+    upperdir: Optional[str]
+    mountpoint: str
 
 
 Lower = Union[Mountpoint, str, OverlayMountpoint]

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
 import os
 
 from curtin.commands.extract import get_handler_for_source
@@ -54,7 +55,7 @@ class SourceController(SubiquityController):
     def __init__(self, app):
         super().__init__(app)
         self._handler = None
-        self.source_path = None
+        self.source_path: Optional[str] = None
 
     def start(self):
         path = '/cdrom/casper/install-sources.yaml'


### PR DESCRIPTION
Hello,

After struggling quite a bit with issues related to how we use overlays, I decided to do some improvements (hopefully?) to make it easier to work with overlays:
* added type hints where relevant to make it easier to understand what is what in the different contexts. Sometimes we expect `str` objects, sometimes we expect `Mountpoints` objects, sometimes expect `OverlayMountpoints` objects, or a combination of all the above ; with usually the name for the variables irrespective of the type. The recent refactoring of APT configuration also changed the type returned by the overlay-related functions (i.e., from the upperdir to the mountpoint) so it felt challenging to figure out what was what. I hope that the type hints make it a little simpler now.
* added some unit tests for the functions translating different objects (i.e., `str`, `Mountpoint`, `OverlayMountpoint` or a list of all of the above) into an options string that can be passed to `mount -t overlay`.
* changed the signature of `AptConfigurer.setup_overlay(self, lowers)` a little bit:
Before this change, we could pass either a sequence of `Lower` or a single `Lower` directly:
```python
# These three forms were passing type-checking before
setup_overlay("/lower1")
setup_overlay(["/lower1"])
setup_overlay(["/lower1", "/lower2"])
```
We now force the user to pass a _sequence_ of `Lower`'s (where `Lower` is either a `str`, `Mountpoint` or `OverlayMountpoint`).
```python
# Now these two forms only pass type-checking.
setup_overlay(["/lower1"])
setup_overlay(["/lower1", "/lower2"])
```
* made `DryRunAptConfigurer.setup_overlay(self, source)` consistent with `AptConfigurer.setup_overlay(self, lowers)`.
* made use of `attr.define` (i.e., a newer API for `attr.s`) for `Mountpoint` and `OverlayMountpoint` so that using one of these object in a function from the `logging` module prints out some useful information (e.g., list of lowers, upper, mountpoint); while keeping the signature identical. This is very useful for debugging! **EDIT** finally used `attr.s` instead since `attr.define` is not available on focal.

Thanks,
Olivier