### PR TITLE
Revert probert again to remove os-prober usage

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -183,7 +183,7 @@ parts:
       - libnl-route-3-dev
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: 693cd0040307c1390163c013f22fd82c8b27cd6b
+    source-commit: 2bb505172b5f97372eb1abd12ced4629e852504b
     requirements: [requirements.txt]
     stage:
       - "*"


### PR DESCRIPTION
os-prober is leaving around invalid devices and we don't know what to do
about it yet, but we do know that we don't require os-prober for
20.04.4.  Back this out.  LP: #1961640 LP: #1961628