### PR TITLE
snapcraft.yaml: remove bson from python-packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -56,7 +56,6 @@ parts:
       - wheel
       - setuptools
       - pip
-      - bson
       - urwid
       - requests
       - requests-unixsocket


### PR DESCRIPTION
The one installed by pip no longer works with our error report code.