### PR TITLE
Use logger names consistent with directory structure

### DIFF
--- a/console_conf/ui/views/chooser.py
+++ b/console_conf/ui/views/chooser.py
@@ -44,7 +44,7 @@ from subiquitycore.ui.table import TableRow, TablePile
 from subiquitycore.view import BaseView
 
 
-log = logging.getLogger("console_conf.views.chooser")
+log = logging.getLogger("console_conf.ui.views.chooser")
 
 
 class ChooserBaseView(BaseView):

--- a/console_conf/ui/views/identity.py
+++ b/console_conf/ui/views/identity.py
@@ -24,7 +24,7 @@ from subiquitycore.ui.form import (
 )
 
 
-log = logging.getLogger("console_conf.views.identity")
+log = logging.getLogger("console_conf.ui.views.identity")
 
 sso_help = ("If you do not have an account, visit "
             "https://login.ubuntu.com to create one.")

--- a/console_conf/ui/views/login.py
+++ b/console_conf/ui/views/login.py
@@ -27,7 +27,7 @@ from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import button_pile, Padding
 from subiquitycore.view import BaseView
 
-log = logging.getLogger("subiquitycore.views.login")
+log = logging.getLogger("console_conf.ui.views.login")
 
 
 class LoginView(BaseView):

--- a/console_conf/ui/views/welcome.py
+++ b/console_conf/ui/views/welcome.py
@@ -24,7 +24,7 @@ from subiquitycore.ui.buttons import done_btn
 from subiquitycore.ui.utils import button_pile, screen
 from subiquitycore.view import BaseView
 
-log = logging.getLogger("console_conf.views.welcome")
+log = logging.getLogger("console_conf.ui.views.welcome")
 
 
 class WelcomeView(BaseView):

--- a/subiquity/client/controllers/zdev.py
+++ b/subiquity/client/controllers/zdev.py
@@ -19,7 +19,7 @@ from subiquity.client.controller import SubiquityTuiController
 from subiquity.ui.views import ZdevView
 
 
-log = logging.getLogger("subiquity.client.controller.zdev")
+log = logging.getLogger("subiquity.client.controllers.zdev")
 
 
 class ZdevController(SubiquityTuiController):

--- a/subiquity/common/errorreport.py
+++ b/subiquity/common/errorreport.py
@@ -46,7 +46,7 @@ from subiquity.common.types import (
     )
 
 
-log = logging.getLogger('subiquitycore.common.errorreport')
+log = logging.getLogger('subiquity.common.errorreport')
 
 
 @attr.s(eq=False)

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     from curtin.util import get_architecture
 
-log = logging.getLogger('subiquitycore.models.mirror')
+log = logging.getLogger('subiquity.models.mirror')
 
 
 DEFAULT = {

--- a/subiquity/models/proxy.py
+++ b/subiquity/models/proxy.py
@@ -15,7 +15,7 @@
 
 import logging
 
-log = logging.getLogger('subiquitycore.models.proxy')
+log = logging.getLogger('subiquity.models.proxy')
 
 dropin_template = '''\
 [Service]

--- a/subiquity/models/ubuntu_advantage.py
+++ b/subiquity/models/ubuntu_advantage.py
@@ -16,7 +16,7 @@
 
 import logging
 
-log = logging.getLogger("subiquitycore.models.ubuntu_advantage")
+log = logging.getLogger("subiquity.models.ubuntu_advantage")
 
 
 class UbuntuAdvantageModel:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -62,7 +62,7 @@ from subiquity.server.controller import (
     )
 
 
-log = logging.getLogger("subiquity.server.controller.filesystem")
+log = logging.getLogger("subiquity.server.controllers.filesystem")
 block_discover_log = logging.getLogger('block-discover')
 
 

--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -28,7 +28,7 @@ from subiquity.common.types import ShutdownMode
 from subiquity.server.controller import SubiquityController
 from subiquity.server.controllers.install import ApplicationState
 
-log = logging.getLogger("subiquity.controllers.restart")
+log = logging.getLogger("subiquity.server.controllers.shutdown")
 
 
 class ShutdownController(SubiquityController):

--- a/subiquity/server/controllers/zdev.py
+++ b/subiquity/server/controllers/zdev.py
@@ -28,7 +28,7 @@ from subiquity.common.types import Bootloader, ZdevInfo
 from subiquity.server.controller import SubiquityController
 
 
-log = logging.getLogger("subiquity.server.controller.zdev")
+log = logging.getLogger("subiquity.server.controllers.zdev")
 
 lszdev_cmd = ['lszdev', '--quiet', '--pairs', '--columns',
               'id,type,on,exists,pers,auto,failed,names']

--- a/subiquity/server/geoip.py
+++ b/subiquity/server/geoip.py
@@ -25,7 +25,7 @@ from subiquitycore.async_helpers import (
 
 from subiquity.server.types import InstallerChannels
 
-log = logging.getLogger('subiquity.common.geoip')
+log = logging.getLogger('subiquity.server.geoip')
 
 
 class CheckState(enum.IntEnum):

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -52,7 +52,7 @@ from subiquity.common.errorreport import (
     )
 
 
-log = logging.getLogger('subiquity.ui.error')
+log = logging.getLogger('subiquity.ui.views.error')
 
 
 def close_btn(stretchy, label=None):

--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -47,7 +47,7 @@ from subiquity.models.filesystem import (
     humanize_size,
     )
 
-log = logging.getLogger('subiquity.ui.raid')
+log = logging.getLogger('subiquity.ui.views.filesystem.compound')
 
 
 LABEL, DEVICE, PART = range(3)

--- a/subiquity/ui/views/filesystem/delete.py
+++ b/subiquity/ui/views/filesystem/delete.py
@@ -31,7 +31,7 @@ from subiquity.common.filesystem import labels
 from .helpers import summarize_device
 
 
-log = logging.getLogger('subiquity.ui.filesystem.disk_info')
+log = logging.getLogger('subiquity.ui.views.filesystem.delete')
 
 
 class ConfirmDeleteStretchy(Stretchy):

--- a/subiquity/ui/views/filesystem/disk_info.py
+++ b/subiquity/ui/views/filesystem/disk_info.py
@@ -24,7 +24,7 @@ from subiquitycore.ui.table import ColSpec, TablePile, TableRow
 from subiquity.common.filesystem import labels
 
 
-log = logging.getLogger('subiquity.ui.filesystem.disk_info')
+log = logging.getLogger('subiquity.ui.views.filesystem.disk_info')
 
 
 labels_keys = [

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -75,7 +75,7 @@ from .lvm import VolGroupStretchy
 from .partition import PartitionStretchy, FormatEntireStretchy
 from .raid import RaidStretchy
 
-log = logging.getLogger('subiquity.ui.filesystem.filesystem')
+log = logging.getLogger('subiquity.ui.views.filesystem.filesystem')
 
 
 @attr.s

--- a/subiquity/ui/views/filesystem/lvm.py
+++ b/subiquity/ui/views/filesystem/lvm.py
@@ -52,7 +52,7 @@ from subiquity.ui.views.identity import (
     setup_password_validation,
     )
 
-log = logging.getLogger('subiquity.ui.lvm')
+log = logging.getLogger('subiquity.ui.views.filesystem.lvm')
 
 
 class VGNameEditor(StringEditor, WantsToKnowFormField):

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -54,7 +54,7 @@ from subiquity.ui.mount import (
     )
 
 
-log = logging.getLogger('subiquity.ui.filesystem.add_partition')
+log = logging.getLogger('subiquity.ui.views.filesystem.partition')
 
 
 DEFAULT_ALIGNMENT = 1 << 20

--- a/subiquity/ui/views/filesystem/probing.py
+++ b/subiquity/ui/views/filesystem/probing.py
@@ -32,7 +32,7 @@ from subiquitycore.ui.utils import (
 from subiquitycore.view import BaseView
 
 
-log = logging.getLogger("subiquity.ui.views.filesystem.slow")
+log = logging.getLogger("subiquity.ui.views.filesystem.probing")
 
 
 class SlowProbing(BaseView):

--- a/subiquity/ui/views/filesystem/raid.py
+++ b/subiquity/ui/views/filesystem/raid.py
@@ -52,7 +52,7 @@ from subiquity.ui.views.filesystem.compound import (
     MultiDeviceField,
     )
 
-log = logging.getLogger('subiquity.ui.raid')
+log = logging.getLogger('subiquity.ui.views.filesystem.raid')
 
 
 raidlevel_choices = [

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -58,7 +58,7 @@ from subiquitycore.ui.width import (
 from subiquity.common.types import PasswordKind
 from subiquity.ui.views.error import ErrorReportListStretchy
 
-log = logging.getLogger('subiquity.ui.help')
+log = logging.getLogger('subiquity.ui.views.help')
 
 
 def close_btn(app, stretchy):

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -38,7 +38,7 @@ from subiquity.common.resources import resource_path
 from subiquity.common.types import IdentityData
 
 
-log = logging.getLogger("subiquity.views.identity")
+log = logging.getLogger("subiquity.ui.views.identity")
 
 HOSTNAME_MAXLEN = 64
 HOSTNAME_REGEX = r'[a-z0-9_][a-z0-9_-]*'

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -36,7 +36,7 @@ from subiquitycore.ui.width import widget_width
 from subiquity.common.types import ApplicationState
 
 
-log = logging.getLogger("subiquity.views.installprogress")
+log = logging.getLogger("subiquity.ui.views.installprogress")
 
 
 class MyLineBox(LineBox):

--- a/subiquity/ui/views/mirror.py
+++ b/subiquity/ui/views/mirror.py
@@ -26,7 +26,7 @@ from subiquitycore.ui.form import (
 )
 
 
-log = logging.getLogger('subiquity.ui.mirror')
+log = logging.getLogger('subiquity.ui.views.mirror')
 
 mirror_help = _(
     "You may provide an archive mirror that will be used instead "

--- a/subiquity/ui/views/serial.py
+++ b/subiquity/ui/views/serial.py
@@ -26,7 +26,7 @@ from subiquitycore.ui.buttons import forward_btn, other_btn
 from subiquitycore.ui.utils import rewrap, screen
 from subiquitycore.view import BaseView
 
-log = logging.getLogger("subiquity.views.serial")
+log = logging.getLogger("subiquity.ui.views.serial")
 
 
 SERIAL_TEXT = """

--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -60,7 +60,7 @@ from subiquity.common.types import (
     )
 from subiquity.models.filesystem import humanize_size
 
-log = logging.getLogger("subiquity.views.snaplist")
+log = logging.getLogger("subiquity.ui.views.snaplist")
 
 
 class StarRadioButton(RadioButton):

--- a/subiquity/ui/views/ssh.py
+++ b/subiquity/ui/views/ssh.py
@@ -57,7 +57,7 @@ from subiquity.ui.views.identity import (
     )
 
 
-log = logging.getLogger('subiquity.ui.ssh')
+log = logging.getLogger('subiquity.ui.views.ssh')
 
 
 SSH_IMPORT_MAXLEN = 256 + 3  # account for lp: or gh:

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -31,7 +31,7 @@ from subiquitycore.view import BaseView
 
 from subiquity.common.resources import resource_path
 
-log = logging.getLogger("subiquity.views.welcome")
+log = logging.getLogger("subiquity.ui.views.welcome")
 
 
 HELP = _("""

--- a/subiquity/ui/views/zdev.py
+++ b/subiquity/ui/views/zdev.py
@@ -47,7 +47,7 @@ from subiquitycore.ui.utils import (
     )
 from subiquitycore.view import BaseView
 
-log = logging.getLogger('subiquity.ui.zdev')
+log = logging.getLogger('subiquity.ui.views.zdev')
 
 
 def status(zdevinfo):

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -48,7 +48,7 @@ from subiquitycore.utils import (
     )
 
 
-log = logging.getLogger("subiquitycore.controller.network")
+log = logging.getLogger("subiquitycore.controllers.network")
 
 
 class SubiquityNetworkEventReceiver(NetworkEventReceiver):

--- a/subiquitycore/ui/interactive.py
+++ b/subiquitycore/ui/interactive.py
@@ -30,7 +30,7 @@ from subiquitycore.ui.container import (
     )
 from subiquitycore.ui.selector import Selector
 
-log = logging.getLogger("subiquitycore.ui.input")
+log = logging.getLogger("subiquitycore.ui.interactive")
 
 
 class StringEditor(Edit):

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -62,7 +62,7 @@ from .network_configure_wlan_interface import NetworkConfigureWLANStretchy
 from subiquitycore.view import BaseView
 
 
-log = logging.getLogger('subiquitycore.views.network')
+log = logging.getLogger('subiquitycore.ui.views.network')
 
 
 def _stretchy_shower(cls, *args):

--- a/subiquitycore/ui/views/network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/network_configure_manual_interface.py
@@ -44,7 +44,7 @@ from subiquitycore.ui.utils import button_pile
 from subiquitycore.ui.buttons import done_btn
 
 log = logging.getLogger(
-    'subiquitycore.network.network_configure_ipv4_interface')
+    'subiquitycore.ui.views.network_configure_manual_interface')
 
 ip_families = {
     4: {

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -23,7 +23,7 @@ from subiquitycore.ui.utils import (
     )
 
 log = logging.getLogger(
-    'subiquitycore.network.network_configure_wlan_interface')
+    'subiquitycore.ui.views.network_configure_wlan_interface')
 
 
 class NetworkList(WidgetWrap):

--- a/system_setup/client/controllers/summary.py
+++ b/system_setup/client/controllers/summary.py
@@ -16,7 +16,7 @@ from subiquity.ui.views.installprogress import (
 from system_setup.ui.views.summary import SummaryView
 
 
-log = logging.getLogger('ubuntu_wsl_oobe.controllers.summary')
+log = logging.getLogger('system_setup.client.controllers.summary')
 
 
 class SummaryController(SubiquityTuiController):

--- a/system_setup/client/controllers/wslconfadvanced.py
+++ b/system_setup/client/controllers/wslconfadvanced.py
@@ -19,8 +19,7 @@ from subiquity.client.controller import SubiquityTuiController
 from subiquity.common.types import WSLConfigurationAdvanced
 from system_setup.ui.views.wslconfadvanced import WSLConfigurationAdvancedView
 
-log = logging.getLogger(
-    'system_setup.client.controllers.wslconfigurationadvanced')
+log = logging.getLogger('system_setup.client.controllers.wslconfadvanced')
 
 
 class WSLConfigurationAdvancedController(SubiquityTuiController):

--- a/system_setup/client/controllers/wslconfbase.py
+++ b/system_setup/client/controllers/wslconfbase.py
@@ -4,7 +4,7 @@ from subiquity.client.controller import SubiquityTuiController
 from subiquity.common.types import WSLConfigurationBase
 from system_setup.ui.views.wslconfbase import WSLConfigurationBaseView
 
-log = logging.getLogger('system_setup.client.controllers.wslconfigurationbase')
+log = logging.getLogger('system_setup.client.controllers.wslconfbase')
 
 
 class WSLConfigurationBaseController(SubiquityTuiController):

--- a/system_setup/models/system_setup.py
+++ b/system_setup/models/system_setup.py
@@ -26,7 +26,7 @@ from .wslconfbase import WSLConfigurationBaseModel
 from .wslconfadvanced import WSLConfigurationAdvancedModel
 
 
-log = logging.getLogger('system_setup.models.system_server')
+log = logging.getLogger('system_setup.models.system_setup')
 
 HOSTS_CONTENT = """\
 127.0.0.1 localhost

--- a/system_setup/models/wslconfadvanced.py
+++ b/system_setup/models/wslconfadvanced.py
@@ -16,7 +16,7 @@
 import logging
 import attr
 
-log = logging.getLogger('system_setup.models.wsl_configuration_advanced')
+log = logging.getLogger('system_setup.models.wslconfadvanced')
 
 
 @attr.s

--- a/system_setup/models/wslconfbase.py
+++ b/system_setup/models/wslconfbase.py
@@ -16,7 +16,7 @@
 import logging
 import attr
 
-log = logging.getLogger('system_setup.models.wsl_configuration_base')
+log = logging.getLogger('system_setup.models.wslconfbase')
 
 
 @attr.s

--- a/system_setup/server/controllers/shutdown.py
+++ b/system_setup/server/controllers/shutdown.py
@@ -21,7 +21,7 @@ from subiquitycore.context import with_context
 from subiquity.common.types import ShutdownMode
 from subiquity.server.controllers import ShutdownController
 
-log = logging.getLogger("system_setup.server.controllers.restart")
+log = logging.getLogger("system_setup.server.controllers.shutdown")
 
 
 class WSLShutdownMode(enum.Enum):

--- a/system_setup/server/controllers/wslconfadvanced.py
+++ b/system_setup/server/controllers/wslconfadvanced.py
@@ -25,8 +25,7 @@ from subiquity.server.controller import SubiquityController
 from system_setup.common.wsl_conf import default_loader
 from system_setup.common.wsl_utils import convert_if_bool
 
-log = logging.getLogger(
-    'system_setup.server.controllers.wsl_configuration_advanced')
+log = logging.getLogger('system_setup.server.controllers.wslconfadvanced')
 
 
 class WSLConfigurationAdvancedController(SubiquityController):

--- a/system_setup/server/controllers/wslconfbase.py
+++ b/system_setup/server/controllers/wslconfbase.py
@@ -25,8 +25,7 @@ from subiquity.server.controller import SubiquityController
 from system_setup.common.wsl_conf import default_loader
 from system_setup.common.wsl_utils import convert_if_bool
 
-log = logging.getLogger('system_setup.server' +
-                        '.controllers.wsl_configuration_base')
+log = logging.getLogger('system_setup.server.controllers.wslconfbase')
 
 
 class WSLConfigurationBaseController(SubiquityController):

--- a/system_setup/ui/views/summary.py
+++ b/system_setup/ui/views/summary.py
@@ -19,7 +19,7 @@ from subiquity.common.types import ApplicationState
 from subiquitycore.ui.container import ListBox
 from urwid import Text
 
-log = logging.getLogger("ubuntu_wsl_oobe.ui.views.summary")
+log = logging.getLogger("system_setup.ui.views.summary")
 
 
 class SummaryView(BaseView):


### PR DESCRIPTION
Refreshed name of loggers to make them consistent with the directory structure.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>