### PR TITLE
os-prober: installer newer version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -197,11 +197,12 @@ parts:
 
   os-prober:
     plugin: nil
-    stage-packages: [os-prober]
-    override-stage: |
-      snapcraftctl stage
-      for file in $(grep -lr /usr | grep 'usr/[^/]*/[^/]*-probe[sr]'); do
-        sed -i 's, \(/usr\), $SNAP\1,' $file
-      done
-      sed -i 's/mkdir "$tmpmnt"/mkdir -p "$tmpmnt"/' \
-          usr/lib/os-probes/50mounted-tests
+    source-type: git
+    source: https://github.com/dbungert/os-prober
+    source-commit: 2f5ec629a224aa322cb34f1378793d9cef7006d1
+    build-packages:
+      - build-essential
+      - debhelper
+    override-build: |
+      ./debian/rules build install
+      cp -a debian/os-prober/{usr,var} $SNAPCRAFT_PART_INSTALL

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,6 +34,9 @@ apps:
       PYTHON: $SNAP/usr/bin/python3.8
   os-prober:
     command: usr/bin/os-prober
+    environment:
+      OS_PROBER_SHARE: $SNAP/usr/share
+      OS_PROBER_LIB: $SNAP/usr/lib
 
 parts:
   curtin:
@@ -199,7 +202,7 @@ parts:
     plugin: nil
     source-type: git
     source: https://github.com/dbungert/os-prober
-    source-commit: 2f5ec629a224aa322cb34f1378793d9cef7006d1
+    source-commit: 80d6a3157a814278af4f96da91f9ab7218e20fdc
     build-packages:
       - build-essential
       - debhelper

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -185,7 +185,7 @@ parts:
       - libnl-route-3-dev
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: 2bb505172b5f97372eb1abd12ced4629e852504b
+    source-commit: feada4cbd01a56bca8adbc98aab2507590a017d5
     requirements: [requirements.txt]
     stage:
       - "*"


### PR DESCRIPTION
The version of os-prober in focal has some device mapper code that we don't
want.  So instead pick up a version including the v1.75 changes.  Also pick up
my branch that allows setting env variables to find the os-prober dependent
scripts and utility program.