### PR TITLE
Fix POST to drivers not using payload wrapper for install

### DIFF
--- a/subiquity/server/controllers/drivers.py
+++ b/subiquity/server/controllers/drivers.py
@@ -90,7 +90,9 @@ class DriversController(SubiquityController):
             await self.configured()
         else:
             # TODO Remove this once we have the GUI controller.
-            await self.POST(install=True)
+            await self.POST(data=DriversPayload(
+                install=True,
+                ))
 
     async def GET(self, wait: bool = False) -> DriversResponse:
         if wait:


### PR DESCRIPTION
In the following patch, I changed the signature of the POST request handler for `/drivers` so that we expect the a JSON body instead of query string parameters:

3c9e5ca98fee453c37660c961de26ebe8e7dcaa8  Use body for parameters of POST /drivers

I forgot to update the function calling `self.POST` explicitly (i.e. without making an actual HTTP request). Therefore, it prevents the `drivers` component from being marked configured when drivers are found - subsequently making Subiquity hang on "executing late commands".