### PR TITLE
generated bond configuration (active-backup) is invalid

### DIFF
--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -105,6 +105,8 @@ class BondConfig:
         params = {
             'mode': self.mode,
             }
+        if mode == "active-backup":
+            params['mii-monitor-interval'] = 100
         if mode in BondParameters.supports_xmit_hash_policy:
             params['transmit-hash-policy'] = self.xmit_hash_policy
         if mode in BondParameters.supports_lacp_rate:


### PR DESCRIPTION
mii-monitor-interval default value is Zero. 
Mode Active-backup depends on mii-monitor-interval to set the correct value, which is usually 100.