### PR TITLE
Add client-side controller and view to install third-party drivers on server installer

### DIFF
--- a/examples/answers-bond.yaml
+++ b/examples/answers-bond.yaml
@@ -56,4 +56,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
-
+Drivers:
+  install: no

--- a/examples/answers-guided-lvm.yaml
+++ b/examples/answers-guided-lvm.yaml
@@ -32,5 +32,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
-
-
+Drivers:
+  install: no

--- a/examples/answers-imsm.yaml
+++ b/examples/answers-imsm.yaml
@@ -35,3 +35,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
+Drivers:
+  install: no

--- a/examples/answers-lvm-dmcrypt.yaml
+++ b/examples/answers-lvm-dmcrypt.yaml
@@ -79,3 +79,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
+Drivers:
+  install: no

--- a/examples/answers-lvm.yaml
+++ b/examples/answers-lvm.yaml
@@ -66,3 +66,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
+Drivers:
+  install: no

--- a/examples/answers-preserve.yaml
+++ b/examples/answers-preserve.yaml
@@ -40,3 +40,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
+Drivers:
+  install: no

--- a/examples/answers-raid-lvm.yaml
+++ b/examples/answers-raid-lvm.yaml
@@ -107,3 +107,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
+Drivers:
+  install: no

--- a/examples/answers-raid.yaml
+++ b/examples/answers-raid.yaml
@@ -66,3 +66,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
+Drivers:
+  install: no

--- a/examples/answers-serial.yaml
+++ b/examples/answers-serial.yaml
@@ -39,5 +39,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
-
-
+Drivers:
+  install: no

--- a/examples/answers-swap.yaml
+++ b/examples/answers-swap.yaml
@@ -39,5 +39,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
-
-
+Drivers:
+  install: no

--- a/examples/answers.yaml
+++ b/examples/answers.yaml
@@ -31,5 +31,5 @@ SnapList:
       classic: false
 InstallProgress:
   reboot: yes
-
-
+Drivers:
+  install: yes

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -113,6 +113,7 @@ class SubiquityClient(TuiApplication):
         "Identity",
         "UbuntuAdvantage",
         "SSH",
+        "Drivers",
         "SnapList",
         "Progress",
         ]

--- a/subiquity/client/controllers/__init__.py
+++ b/subiquity/client/controllers/__init__.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from subiquitycore.tuicontroller import RepeatedController
+from .drivers import DriversController
 from .filesystem import FilesystemController
 from .identity import IdentityController
 from .keyboard import KeyboardController
@@ -32,6 +33,7 @@ from .zdev import ZdevController
 
 # see SubiquityClient.controllers for another list
 __all__ = [
+    'DriversController',
     'FilesystemController',
     'IdentityController',
     'KeyboardController',

--- a/subiquity/client/controllers/drivers.py
+++ b/subiquity/client/controllers/drivers.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import logging
+from typing import List
 
 from subiquitycore.tuicontroller import Skip
 
@@ -31,17 +32,14 @@ class DriversController(SubiquityTuiController):
 
     async def make_ui(self) -> DriversView:
         response: DriversResponse = await self.endpoint.GET()
-        if response.drivers is not None and not response.drivers:
+        if not response.drivers and response.drivers is not None:
             raise Skip
-        if response.drivers is None:
-            return DriversView(self, None, response.install)
-        else:
-            return DriversView(self, bool(response.drivers), response.install)
+        return DriversView(self, response.drivers, response.install)
 
-    async def _wait_drivers(self) -> bool:
+    async def _wait_drivers(self) -> List[str]:
         response: DriversResponse = await self.endpoint.GET(wait=True)
         assert response.drivers is not None
-        return bool(response.drivers)
+        return response.drivers
 
     async def run_answers(self):
         if 'install' not in self.answers:

--- a/subiquity/client/controllers/drivers.py
+++ b/subiquity/client/controllers/drivers.py
@@ -1,0 +1,79 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import logging
+
+from subiquitycore.tuicontroller import Skip
+
+from subiquity.common.types import DriversPayload, DriversResponse
+from subiquity.client.controller import SubiquityTuiController
+from subiquity.ui.views.drivers import DriversView
+
+log = logging.getLogger('subiquity.client.controllers.drivers')
+
+
+class DriversController(SubiquityTuiController):
+
+    endpoint_name = 'drivers'
+
+    async def make_ui(self) -> DriversView:
+        response: DriversResponse = await self.endpoint.GET()
+        if response.drivers is not None and not response.drivers:
+            raise Skip
+        if response.drivers is None:
+            return DriversView(self, None, response.install)
+        else:
+            return DriversView(self, bool(response.drivers), response.install)
+
+    async def _wait_drivers(self) -> bool:
+        response: DriversResponse = await self.endpoint.GET(wait=True)
+        assert response.drivers is not None
+        return bool(response.drivers)
+
+    async def run_answers(self):
+        if 'install' not in self.answers:
+            return
+
+        import urwid
+        from subiquitycore.testing.view_helpers import (
+            click,
+            find_button_matching,
+            find_with_pred,
+            )
+
+        def text_finder(txt):
+            def pred(w):
+                return isinstance(w, urwid.Text) and txt in w.text
+            return pred
+
+        view = self.app.ui.body
+        while find_with_pred(view, text_finder('Looking for')):
+            await asyncio.sleep(0.2)
+        if find_with_pred(view, text_finder('No applicable')):
+            click(find_button_matching(view, "Continue"))
+            return
+
+        view.form.install.value = self.answers['install']
+
+        click(view.form.done_btn)
+
+    def cancel(self):
+        self.app.prev_screen()
+
+    def done(self, install):
+        log.debug("DriversController.done next_screen install=%s", install)
+        self.app.next_screen(
+                self.endpoint.POST(DriversPayload(install=install)))

--- a/subiquity/client/controllers/drivers.py
+++ b/subiquity/client/controllers/drivers.py
@@ -62,10 +62,10 @@ class DriversController(SubiquityTuiController):
 
         click(view.form.done_btn.base_widget)
 
-    def cancel(self):
+    def cancel(self) -> None:
         self.app.prev_screen()
 
-    def done(self, install):
+    def done(self, install: bool) -> None:
         log.debug("DriversController.done next_screen install=%s", install)
         self.app.next_screen(
                 self.endpoint.POST(DriversPayload(install=install)))

--- a/subiquity/server/controllers/drivers.py
+++ b/subiquity/server/controllers/drivers.py
@@ -88,11 +88,6 @@ class DriversController(SubiquityController):
         log.debug("Available drivers to install: %s", self.drivers)
         if not self.drivers:
             await self.configured()
-        else:
-            # TODO Remove this once we have the GUI controller.
-            await self.POST(data=DriversPayload(
-                install=True,
-                ))
 
     async def GET(self, wait: bool = False) -> DriversResponse:
         if wait:

--- a/subiquity/ui/views/drivers.py
+++ b/subiquity/ui/views/drivers.py
@@ -93,10 +93,13 @@ class DriversView(BaseView):
         excerpt = _(
             "Third-party drivers were found. Do you want to install them?")
 
+        def on_cancel(_: DriversForm) -> None:
+            self.cancel()
+
         connect_signal(
             self.form, 'submit',
             lambda result: self.done(result.install.value))
-        connect_signal(self.form, 'cancel', self.cancel)
+        connect_signal(self.form, 'cancel', on_cancel)
 
         self._w = self.form.as_screen(excerpt=_(excerpt))
 
@@ -104,5 +107,5 @@ class DriversView(BaseView):
         log.debug("User input: %r", result)
         self.controller.done(result)
 
-    def cancel(self, result=None):
+    def cancel(self) -> None:
         self.controller.cancel()

--- a/subiquity/ui/views/drivers.py
+++ b/subiquity/ui/views/drivers.py
@@ -45,7 +45,7 @@ class DriversForm(Form):
 
     cancel_label = _("Back")
 
-    install = BooleanField(_("Install the drivers?"))
+    install = BooleanField(_("Install the drivers"))
 
 
 class DriversViewStatus(Enum):
@@ -56,7 +56,7 @@ class DriversViewStatus(Enum):
 
 class DriversView(BaseView):
 
-    title = _("Third-party drivers.")
+    title = _("Third-party drivers")
 
     form = None
 

--- a/subiquity/ui/views/drivers.py
+++ b/subiquity/ui/views/drivers.py
@@ -19,7 +19,7 @@
 import asyncio
 from enum import auto, Enum
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from urwid import (
     connect_signal,
@@ -60,11 +60,11 @@ class DriversView(BaseView):
 
     form = None
 
-    def __init__(self, controller, has_drivers: Optional[bool],
+    def __init__(self, controller, drivers: Optional[List[str]],
                  install: bool) -> None:
         self.controller = controller
 
-        if has_drivers is None:
+        if drivers is None:
             self.make_waiting(install)
         else:
             self.make_main(install)
@@ -89,9 +89,9 @@ class DriversView(BaseView):
     async def _wait(self, install: bool) -> None:
         """ Wait until the "list" of drivers is available and change the view
         accordingly. """
-        has_drivers = await self.controller._wait_drivers()
+        drivers = await self.controller._wait_drivers()
         self.spinner.stop()
-        if has_drivers:
+        if drivers:
             self.make_main(install)
         else:
             self.make_no_drivers()

--- a/subiquity/ui/views/drivers.py
+++ b/subiquity/ui/views/drivers.py
@@ -13,9 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-""" Install Path
-
-Provides high level options for Ubuntu install
+""" Module defining the view for third-party drivers installation.
 
 """
 import asyncio
@@ -42,6 +40,8 @@ log = logging.getLogger('subiquity.ui.views.drivers')
 
 
 class DriversForm(Form):
+    """ Form that shows a checkbox to configure whether we want to install the
+    available drivers or not. """
 
     cancel_label = _("Back")
 
@@ -69,7 +69,9 @@ class DriversView(BaseView):
         else:
             self.make_main(install)
 
-    def make_waiting(self, install: bool):
+    def make_waiting(self, install: bool) -> None:
+        """ Change the view into a spinner and start waiting for drivers
+        asynchronously. """
         self.spinner = Spinner(self.controller.app.aio_loop, style='dots')
         self.spinner.start()
         rows = [
@@ -84,7 +86,9 @@ class DriversView(BaseView):
         asyncio.create_task(self._wait(install))
         self.status = DriversViewStatus.WAITING
 
-    async def _wait(self, install: bool):
+    async def _wait(self, install: bool) -> None:
+        """ Wait until the "list" of drivers is available and change the view
+        accordingly. """
         has_drivers = await self.controller._wait_drivers()
         self.spinner.stop()
         if has_drivers:
@@ -92,7 +96,10 @@ class DriversView(BaseView):
         else:
             self.make_no_drivers()
 
-    def make_no_drivers(self):
+    def make_no_drivers(self) -> None:
+        """ Change the view into an information page that shows that no
+        third-party drivers are available for installation. """
+
         rows = [Text(_("No applicable third-party drivers were found."))]
         self.cont_btn = ok_btn(
                 _("Continue"),
@@ -101,6 +108,7 @@ class DriversView(BaseView):
         self.status = DriversViewStatus.NO_DRIVERS
 
     def make_main(self, install: bool) -> None:
+        """ Change the view to display the drivers form. """
         self.form = DriversForm(initial={'install': install})
 
         excerpt = _(

--- a/subiquity/ui/views/drivers.py
+++ b/subiquity/ui/views/drivers.py
@@ -117,9 +117,9 @@ class DriversView(BaseView):
         self._w = self.form.as_screen(excerpt=_(excerpt))
         self.status = DriversViewStatus.MAIN
 
-    def done(self, result):
-        log.debug("User input: %r", result)
-        self.controller.done(result)
+    def done(self, install: bool) -> None:
+        log.debug("User input: %r", install)
+        self.controller.done(install)
 
     def cancel(self) -> None:
         self.controller.cancel()

--- a/subiquity/ui/views/drivers.py
+++ b/subiquity/ui/views/drivers.py
@@ -1,0 +1,108 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Install Path
+
+Provides high level options for Ubuntu install
+
+"""
+import asyncio
+import logging
+from typing import Optional
+
+from urwid import (
+    connect_signal,
+    Text,
+    )
+
+from subiquitycore.ui.buttons import ok_btn
+from subiquitycore.ui.form import (
+    Form,
+    BooleanField,
+)
+from subiquitycore.ui.spinner import Spinner
+from subiquitycore.ui.utils import screen
+from subiquitycore.view import BaseView
+
+
+log = logging.getLogger('subiquity.ui.views.drivers')
+
+
+class DriversForm(Form):
+
+    cancel_label = _("Back")
+
+    install = BooleanField(_("Install the drivers?"))
+
+
+class DriversView(BaseView):
+
+    title = _("Third-party drivers.")
+
+    form = None
+
+    def __init__(self, controller, has_drivers: Optional[bool],
+                 install: bool) -> None:
+        self.controller = controller
+
+        if has_drivers is None:
+            self.make_waiting(install)
+        else:
+            self.make_main(install)
+
+    def make_waiting(self, install: bool):
+        self.spinner = Spinner(self.controller.app.aio_loop, style='dots')
+        self.spinner.start()
+        rows = [
+            Text(_("Looking for applicable third-party drivers...")),
+            Text(""),
+            self.spinner,
+            ]
+        btn = ok_btn(_("Continue"), on_press=lambda sender: self.done(False))
+        self._w = screen(rows, [btn])
+        asyncio.create_task(self._wait(install))
+
+    async def _wait(self, install: bool):
+        has_drivers = await self.controller._wait_drivers()
+        self.spinner.stop()
+        if has_drivers:
+            self.make_main(install)
+        else:
+            self.make_no_drivers()
+
+    def make_no_drivers(self):
+        rows = [Text(_("No applicable third-party drivers were found."))]
+        btn = ok_btn(_("Continue"), on_press=lambda sender: self.done(False))
+        self._w = screen(rows, [btn])
+
+    def make_main(self, install: bool) -> None:
+        self.form = DriversForm(initial={'install': install})
+
+        excerpt = _(
+            "Third-party drivers were found. Do you want to install them?")
+
+        connect_signal(
+            self.form, 'submit',
+            lambda result: self.done(result.install.value))
+        connect_signal(self.form, 'cancel', self.cancel)
+
+        self._w = self.form.as_screen(excerpt=_(excerpt))
+
+    def done(self, result):
+        log.debug("User input: %r", result)
+        self.controller.done(result)
+
+    def cancel(self, result=None):
+        self.controller.cancel()


### PR DESCRIPTION
We now have a GUI component to control whether we want to install available third-party drivers.
In normal conditions, the page shows a checkbox "Install the available drivers" alongside the list of drivers that are available. However, if no drivers are available, we will skip the page upon reaching it.

Now, if by the time we reach the page, we haven't been able to find the list of drivers available yet, then a progress bar will be displayed instead.
Then we will either display the list of drivers or show "no drivers are available". 

Hitting the "continue" button while the progress bar ls displayed will not install drivers if they are available.

To test the feature using dry-run:
```bash
# Test with a nvidia driver available
SUBIQUITY_DEBUG=has-drivers make dry-run

# Test with no drivers available
make dry-run
```

![looking](https://user-images.githubusercontent.com/4038023/156341867-7f2c051a-a4d4-400d-84ea-14abf65460cb.png)
![no-applicable](https://user-images.githubusercontent.com/4038023/156341887-721a5570-d533-44d5-9daf-a3b64f5efe08.png)
![install-drivers](https://user-images.githubusercontent.com/4038023/156341977-034b53b0-d27f-4c74-9897-76e8e46aab05.png)
