### PR TITLE
Allow calling installdeps.sh from anywhere

### DIFF
--- a/scripts/installdeps.sh
+++ b/scripts/installdeps.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -eux
+cd "$(dirname ${BASH_SOURCE:0})/.."
+
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get -o APT::Get::Always-Include-Phased-Updates=true -y dist-upgrade
 mkdir -p /etc/systemd/system/zfs-mount.service.d/


### PR DESCRIPTION
It's nice for the desktop installer contributors to be able to run
"./path/to/subiquity/scripts/installdeps.sh" without changing dir.