### PR TITLE
track start position of partitions

### DIFF
--- a/subiquity/common/filesystem/actions.py
+++ b/subiquity/common/filesystem/actions.py
@@ -66,10 +66,10 @@ class DeviceAction(enum.Enum):
         r = _checkers[self](device)
         if isinstance(r, bool):
             return r, None
-        elif isinstance(r, str):
-            return False, r
+        elif r is None:
+            return False, _("Unknown reason")
         else:
-            return r
+            return False, str(r)
 
 
 @functools.singledispatch

--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -78,6 +78,7 @@ def _can_be_boot_device_disk(disk, *, with_reformatting=False):
         elif bl == Bootloader.PREP:
             if any(p.flag == "prep" for p in disk._partitions):
                 return True
+        return False  # Temporary measure until we allow partition editing
     return gaps.can_fit_bootloader_partition(disk)
 
 
@@ -93,6 +94,7 @@ def _can_be_boot_device_raid(raid, *, with_reformatting=False):
     if raid._has_preexisting_partition():
         if any(is_esp(p) for p in raid._partitions):
             return True
+        return False  # Temporary measure until we allow partition editing
     return gaps.can_fit_bootloader_partition(raid)
 
 

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -20,17 +20,20 @@ import attr
 from subiquity.models.filesystem import (
     align_up,
     align_down,
-    BIOS_GRUB_SIZE_BYTES,
     Bootloader,
     Disk,
     LVM_CHUNK_SIZE,
     LVM_VolGroup,
     GPT_OVERHEAD,
     Partition,
-    PREP_GRUB_SIZE_BYTES,
     Raid,
-    UEFI_GRUB_SIZE_BYTES,
     )
+
+from subiquity.common.filesystem.manipulator import (
+    BIOS_GRUB_SIZE_BYTES,
+    get_efi_size,
+    PREP_GRUB_SIZE_BYTES,
+)
 
 
 @attr.s(auto_attribs=True)
@@ -148,7 +151,7 @@ def can_fit_bootloader_partition(disk):
         return _can_fit_bootloader_partition_bios(disk)
     elif bl == Bootloader.UEFI:
         return _can_fit_bootloader_partition_of_size(
-            disk, UEFI_GRUB_SIZE_BYTES)
+            disk, get_efi_size(disk))
     elif bl == Bootloader.PREP:
         return _can_fit_bootloader_partition_of_size(
             disk, PREP_GRUB_SIZE_BYTES)

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -144,7 +144,7 @@ def _can_fit_bootloader_partition_of_size(disk, size):
 
 
 def can_fit_bootloader_partition(disk):
-    bl = disk._model.bootloader
+    bl = disk._m.bootloader
     if bl == Bootloader.BIOS:
         return _can_fit_bootloader_partition_bios(disk)
     elif bl == Bootloader.UEFI:

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -63,8 +63,6 @@ def parts_and_gaps_disk(device):
     for p in sorted(device._partitions, key=lambda p: p.offset):
         used = align_up(used + p.size, 1 << 20)
         r.append(p)
-    if device._has_preexisting_partition():
-        return r
     if device.ptable == 'vtoc' and len(device._partitions) >= 3:
         return r
     end = align_down(device.size, 1 << 20) - GPT_OVERHEAD

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -130,6 +130,7 @@ def _can_fit_bootloader_partition_bios(disk):
                 return True
         if isinstance(pg, Gap) and pg.size >= BIOS_GRUB_SIZE_BYTES:
             return True
+    return False
 
 
 def _can_fit_bootloader_partition_of_size(disk, size):
@@ -141,6 +142,7 @@ def _can_fit_bootloader_partition_of_size(disk, size):
                 return True
         if isinstance(pg, Gap) and pg.size >= size:
             return True
+    return False
 
 
 def can_fit_bootloader_partition(disk):

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -36,7 +36,7 @@ from subiquity.models.filesystem import (
 @attr.s(auto_attribs=True)
 class Gap:
     device: object
-    start: int
+    offset: int
     size: int
     type: str = 'gap'
 

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -60,7 +60,7 @@ def parts_and_gaps_disk(device):
         return []
     r = []
     used = 0
-    for p in sorted(device._partitions, key=lambda p: p.offset):
+    for p in device.partitions():
         used = align_up(used + p.size, 1 << 20)
         r.append(p)
     if device.ptable == 'vtoc' and len(device._partitions) >= 3:

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -75,6 +75,16 @@ def scale_partitions(all_factors, disk_size):
     return ret
 
 
+def get_efi_size(disk):
+    all_factors = (uefi_scale, bootfs_scale, rootfs_scale)
+    return scale_partitions(all_factors, disk.size)[0]
+
+
+def get_bootfs_size(disk):
+    all_factors = (uefi_scale, bootfs_scale, rootfs_scale)
+    return scale_partitions(all_factors, disk.size)[1]
+
+
 class FilesystemManipulator:
 
     def create_mount(self, fs, spec):
@@ -138,14 +148,6 @@ class FilesystemManipulator:
         self.clear(part)
         self.model.remove_partition(part)
 
-    def _get_efi_size(self, disk):
-        all_factors = (uefi_scale, bootfs_scale, rootfs_scale)
-        return scale_partitions(all_factors, disk.size)[0]
-
-    def _get_bootfs_size(self, disk):
-        all_factors = (uefi_scale, bootfs_scale, rootfs_scale)
-        return scale_partitions(all_factors, disk.size)[1]
-
     def _create_boot_with_resize(self, disk, spec, **kwargs):
         part_size = spec['size']
         if part_size > gaps.largest_gap_size(disk):
@@ -156,7 +158,7 @@ class FilesystemManipulator:
     def _create_boot_partition(self, disk):
         bootloader = self.model.bootloader
         if bootloader == Bootloader.UEFI:
-            part_size = self._get_efi_size(disk)
+            part_size = get_efi_size(disk)
             log.debug('_create_boot_partition - adding EFI partition')
             spec = dict(size=part_size, fstype='fat32')
             if self.model._mount_for_path("/boot/efi") is None:

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -128,7 +128,7 @@ class FilesystemManipulator:
     def create_partition(self, device, gap, spec, flag="", wipe=None,
                          grub_device=None):
         part = self.model.add_partition(
-            device, spec["size"], flag, wipe, grub_device, start=gap.start)
+            device, spec["size"], flag, wipe, grub_device, offset=gap.offset)
         self.create_filesystem(part, spec)
         return part
 

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -21,13 +21,13 @@ from subiquity.common.filesystem import boot, gaps
 from subiquity.common.types import Bootloader
 from subiquity.models.filesystem import (
     align_up,
+    MiB,
     Partition,
     )
 
 log = logging.getLogger('subiquity.common.filesystem.manipulator')
 
 
-MiB = 1024 * 1024
 BIOS_GRUB_SIZE_BYTES = 1 * MiB
 PREP_GRUB_SIZE_BYTES = 8 * MiB
 

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -125,10 +125,10 @@ class FilesystemManipulator:
         self.model.remove_filesystem(fs)
     delete_format = delete_filesystem
 
-    def create_partition(self, device, spec, flag="", wipe=None,
+    def create_partition(self, device, gap, spec, flag="", wipe=None,
                          grub_device=None):
         part = self.model.add_partition(
-            device, spec["size"], flag, wipe, grub_device)
+            device, spec["size"], flag, wipe, grub_device, start=gap.start)
         self.create_filesystem(part, spec)
         return part
 

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -135,10 +135,9 @@ class FilesystemManipulator:
         self.model.remove_filesystem(fs)
     delete_format = delete_filesystem
 
-    def create_partition(self, device, gap, spec, flag="", wipe=None,
-                         grub_device=None):
+    def create_partition(self, device, gap, spec, **kw):
         part = self.model.add_partition(
-            device, spec["size"], flag, wipe, grub_device, offset=gap.offset)
+            device, spec["size"], offset=gap.offset, **kw)
         self.create_filesystem(part, spec)
         return part
 
@@ -153,7 +152,8 @@ class FilesystemManipulator:
         if part_size > gaps.largest_gap_size(disk):
             largest_part = max(disk.partitions(), key=lambda p: p.size)
             largest_part.size -= (part_size - gaps.largest_gap_size(disk))
-        return self.create_partition(disk, spec, **kwargs)
+        gap = gaps.largest_gap(disk)
+        return self.create_partition(disk, gap, spec, **kwargs)
 
     def _create_boot_partition(self, disk):
         bootloader = self.model.bootloader
@@ -291,7 +291,8 @@ class FilesystemManipulator:
                     spec['size'], part.size, gaps.largest_gap_size(disk))
                 spec['size'] = gaps.largest_gap_size(disk)
 
-        self.create_partition(disk, spec)
+        gap = gaps.largest_gap(disk)
+        self.create_partition(disk, gap, spec)
 
         log.debug("Successfully added partition")
 

--- a/subiquity/common/filesystem/tests/test_actions.py
+++ b/subiquity/common/filesystem/tests/test_actions.py
@@ -445,4 +445,4 @@ class TestActions(unittest.TestCase):
         self.assertActionNotSupported(lv, DeviceAction.TOGGLE_BOOT)
 
     def test_gap_PARTITION(self):
-        self.assertActionPossible(gaps.Gap(None, 0), DeviceAction.PARTITION)
+        self.assertActionPossible(gaps.Gap(None, 0, 0), DeviceAction.PARTITION)

--- a/subiquity/common/filesystem/tests/test_actions.py
+++ b/subiquity/common/filesystem/tests/test_actions.py
@@ -196,9 +196,10 @@ class TestActions(unittest.TestCase):
         # UEFI/PREP boot disk.
         old_disk = make_disk(model, preserve=True, ptable='gpt')
         self.assertActionPossible(old_disk, DeviceAction.TOGGLE_BOOT)
-        # If there is an existing partition though, it cannot.
+        # If there is an existing partition though, it can now that we can edit
+        # partition tables.
         make_partition(model, old_disk, preserve=True)
-        self.assertActionNotPossible(old_disk, DeviceAction.TOGGLE_BOOT)
+        self.assertActionPossible(old_disk, DeviceAction.TOGGLE_BOOT)
         # If there is an existing ESP/PReP partition though, fine!
         make_partition(model, old_disk, flag=flag, preserve=True)
         self.assertActionPossible(old_disk, DeviceAction.TOGGLE_BOOT)

--- a/subiquity/common/filesystem/tests/test_actions.py
+++ b/subiquity/common/filesystem/tests/test_actions.py
@@ -196,10 +196,10 @@ class TestActions(unittest.TestCase):
         # UEFI/PREP boot disk.
         old_disk = make_disk(model, preserve=True, ptable='gpt')
         self.assertActionPossible(old_disk, DeviceAction.TOGGLE_BOOT)
-        # If there is an existing partition though, it can now that we can edit
-        # partition tables.
+        # If there is an existing partition though, this is OK if we can edit
+        # partition tables.  So not yet, but soon.
         make_partition(model, old_disk, preserve=True)
-        self.assertActionPossible(old_disk, DeviceAction.TOGGLE_BOOT)
+        self.assertActionNotPossible(old_disk, DeviceAction.TOGGLE_BOOT)
         # If there is an existing ESP/PReP partition though, fine!
         make_partition(model, old_disk, flag=flag, preserve=True)
         self.assertActionPossible(old_disk, DeviceAction.TOGGLE_BOOT)

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -22,6 +22,8 @@ from subiquity.common.filesystem import gaps
 from subiquity.common.filesystem.manipulator import (
     bootfs_scale,
     FilesystemManipulator,
+    get_efi_size,
+    get_bootfs_size,
     PartitionScaleFactors,
     scale_partitions,
     uefi_scale,
@@ -271,15 +273,15 @@ class TestPartitionSizeScaling(unittest.TestCase):
         ]
         for disk_size, uefi, bootfs in tests:
             disk = make_disk(manipulator.model, preserve=True, size=disk_size)
-            self.assertEqual(uefi, manipulator._get_efi_size(disk))
-            self.assertEqual(bootfs, manipulator._get_bootfs_size(disk))
+            self.assertEqual(uefi, get_efi_size(disk))
+            self.assertEqual(bootfs, get_bootfs_size(disk))
 
         # something in between for scaling
         disk_size = 15 << 30
         disk = make_disk(manipulator.model, preserve=True, size=disk_size)
-        efi_size = manipulator._get_efi_size(disk)
+        efi_size = get_efi_size(disk)
         self.assertTrue(uefi_scale.maximum > efi_size)
         self.assertTrue(efi_size > uefi_scale.minimum)
-        bootfs_size = manipulator._get_bootfs_size(disk)
+        bootfs_size = get_bootfs_size(disk)
         self.assertTrue(bootfs_scale.maximum > bootfs_size)
         self.assertTrue(bootfs_size > bootfs_scale.minimum)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -669,7 +669,7 @@ class Partition(_Formattable):
     grub_device = attr.ib(default=False)
     name = attr.ib(default=None)
     multipath = attr.ib(default=None)
-    offset = attr.ib(offset=None)
+    offset = attr.ib(default=None)
 
     def available(self):
         if self.flag in ['bios_grub', 'prep'] or self.grub_device:
@@ -1375,7 +1375,7 @@ class FilesystemModel(object):
         _remove_backlinks(obj)
         self._actions.remove(obj)
 
-    def add_partition(self, device, size, offset, flag="", wipe=None,
+    def add_partition(self, device, size, offset=None, flag="", wipe=None,
                       grub_device=None):
         from subiquity.common.filesystem import boot
         real_size = align_up(size)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -502,7 +502,7 @@ class _Device(_Formattable, ABC):
         return 'gpt'
 
     def partitions(self):
-        return self._partitions
+        return sorted(self._partitions, key=lambda part: part.sort_value())
 
     @property
     def used(self):
@@ -670,6 +670,9 @@ class Partition(_Formattable):
     multipath = attr.ib(default=None)
     offset = attr.ib(default=None)
 
+    def sort_value(self):
+        return (self._number, self.offset)
+
     def available(self):
         if self.flag in ['bios_grub', 'prep'] or self.grub_device:
             return False
@@ -819,6 +822,9 @@ class LVM_LogicalVolume(_Formattable):
     wipe = attr.ib(default=None)
 
     preserve = attr.ib(default=False)
+
+    def sort_value(self):
+        return self.name
 
     def serialize_size(self):
         if self.size is None:
@@ -1374,7 +1380,7 @@ class FilesystemModel(object):
         _remove_backlinks(obj)
         self._actions.remove(obj)
 
-    def add_partition(self, device, size, offset=None, flag="", wipe=None,
+    def add_partition(self, device, size, *, offset=None, flag="", wipe=None,
                       grub_device=None):
         from subiquity.common.filesystem import boot
         real_size = align_up(size)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -36,6 +36,9 @@ from subiquity.common.types import Bootloader, OsProber
 log = logging.getLogger('subiquity.models.filesystem')
 
 
+MiB = 1024 * 1024
+
+
 def _set_backlinks(obj):
     if obj.id is None:
         base = obj.type
@@ -946,34 +949,31 @@ class PartitionAlignmentData:
     ebr_space: int = 0
 
 
-ONE_MB = 1 << 20
-
-
 class FilesystemModel(object):
 
     target = None
 
     _partition_alignment_data = {
         'gpt': PartitionAlignmentData(
-            part_align=ONE_MB,
-            min_gap_size=ONE_MB,
+            part_align=MiB,
+            min_gap_size=MiB,
             min_start_offset=GPT_OVERHEAD//2,
             min_end_offset=GPT_OVERHEAD//2,
             primary_part_limit=128),
         'msdos': PartitionAlignmentData(
-            part_align=ONE_MB,
-            min_gap_size=ONE_MB,
+            part_align=MiB,
+            min_gap_size=MiB,
             min_start_offset=GPT_OVERHEAD//2,
             min_end_offset=0,
-            ebr_space=ONE_MB,
+            ebr_space=MiB,
             primary_part_limit=4),
         # XXX check this one!!
         'vtoc': PartitionAlignmentData(
-            part_align=ONE_MB,
-            min_gap_size=ONE_MB,
+            part_align=MiB,
+            min_gap_size=MiB,
             min_start_offset=GPT_OVERHEAD//2,
             min_end_offset=0,
-            ebr_space=ONE_MB,
+            ebr_space=MiB,
             primary_part_limit=3),
         }
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -578,7 +578,7 @@ class Disk(_Device):
     _info = attr.ib(default=None)
 
     def alignment_data(self):
-        return self._model.alignment_data[self.ptable_for_new_partition()]
+        return self._m.alignment_data[self.ptable_for_new_partition()]
 
     def info_for_display(self):
         bus = self._info.raw.get('ID_BUS', None)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -33,7 +33,6 @@ from probert.storage import StorageInfo
 
 from subiquity.common.types import Bootloader, OsProber
 
-
 log = logging.getLogger('subiquity.models.filesystem')
 
 
@@ -1380,6 +1379,10 @@ class FilesystemModel(object):
         from subiquity.common.filesystem import boot
         real_size = align_up(size)
         log.debug("add_partition: rounded size from %s to %s", size, real_size)
+        if offset is None:
+            from subiquity.common.filesystem.gaps import largest_gap
+            gap = largest_gap(device)
+            offset = gap.offset
         if device._fs is not None:
             raise Exception("%s is already formatted" % (device,))
         p = Partition(

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -150,9 +150,9 @@ def make_disk(fs_model, **kw):
     if 'ptable' not in kw:
         kw['ptable'] = 'gpt'
     size = kw.pop('size', 100*(2**30))
-    fs_model._actions.append(Disk(
-        m=fs_model, info=FakeStorageInfo(size=size), **kw))
-    disk = fs_model._actions[-1]
+    info = FakeStorageInfo(size=size)
+    disk = Disk(m=fs_model, info=info, **kw)
+    fs_model._actions.append(disk)
     return disk
 
 

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -161,13 +161,18 @@ def make_model_and_disk(bootloader=None):
     return model, make_disk(model)
 
 
-def make_partition(model, device=None, *, preserve=False, size=None, **kw):
+def make_partition(model, device=None, *, preserve=False, size=None,
+                   offset=None, **kw):
     if device is None:
         device = make_disk(model)
-    if size is None:
-        size = gaps.largest_gap_size(device)//2
-    partition = Partition(
-        m=model, device=device, size=size, preserve=preserve, **kw)
+    if size is None or offset is None:
+        gap = gaps.largest_gap(device)
+        if size is None:
+            size = gap.size//2
+        if offset is None:
+            offset = gap.offset
+    partition = Partition(m=model, device=device, size=size, offset=offset,
+                          preserve=preserve, **kw)
     if preserve:
         partition.number = len(device._partitions)
     model._actions.append(partition)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -141,14 +141,16 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.reformat(disk)
         if DeviceAction.TOGGLE_BOOT in DeviceAction.supported(disk):
             self.add_boot_disk(disk)
+        gap = gaps.largest_gap(disk)
         self.create_partition(
-            device=disk, spec=dict(
+            device=disk, gap=gap, spec=dict(
                 size=get_bootfs_size(disk),
                 fstype="ext4",
                 mount='/boot'
                 ))
+        gap = gaps.largest_gap(disk)
         part = self.create_partition(
-            device=disk, spec=dict(
+            device=disk, gap=gap, spec=dict(
                 size=gaps.largest_gap_size(disk),
                 fstype=None,
                 ))

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -41,7 +41,10 @@ from subiquity.common.filesystem.actions import (
     DeviceAction,
     )
 from subiquity.common.filesystem import boot, gaps, labels
-from subiquity.common.filesystem.manipulator import FilesystemManipulator
+from subiquity.common.filesystem.manipulator import (
+    FilesystemManipulator,
+    get_bootfs_size,
+)
 from subiquity.common.types import (
     Bootloader,
     Disk,
@@ -140,7 +143,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             self.add_boot_disk(disk)
         self.create_partition(
             device=disk, spec=dict(
-                size=self._get_bootfs_size(disk),
+                size=get_bootfs_size(disk),
                 fstype="ext4",
                 mount='/boot'
                 ))

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -354,21 +354,21 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if data.partition.boot is not None:
             raise ValueError('add_partition does not support changing boot')
         disk = self.model._one(id=data.disk_id)
-        largest_size = gaps.largest_gap_size(disk)
-        if largest_size == 0:
+        gap = gaps.largest_gap(disk)
+        if gap.size == 0:
             raise ValueError('no space on disk')
         requested_size = data.partition.size or 0
-        if requested_size > largest_size:
+        if requested_size > gap.size:
             raise ValueError('new partition too large')
         if requested_size < 1:
-            requested_size = largest_size
+            requested_size = gap.size
         spec = {
             'size': requested_size,
             'fstype': data.partition.format,
             'mount': data.partition.mount,
         }
 
-        self.create_partition(disk, spec, '', 'superblock', None)
+        self.create_partition(disk, gap, spec, wipe='superblock')
         return await self.v2_GET()
 
     async def v2_delete_partition_POST(self, data: ModifyPartitionV2) \

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -280,7 +280,7 @@ class DeviceList(WidgetWrap):
         elif cd.type == "lvm_volgroup":
             cd.devices.remove(disk)
         else:
-            1/0
+            raise Exception(f'Attempted removal of unknown disktype {cd.type}')
         disk._constructed_device = None
         self.parent.refresh_model_inputs()
 

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -292,7 +292,7 @@ class DeviceList(WidgetWrap):
         self.parent.refresh_model_inputs()
 
     _partition_EDIT = _stretchy_shower(
-        lambda parent, part: PartitionStretchy(parent, part.device, part))
+        lambda parent, part: PartitionStretchy(parent, part))
     _partition_REMOVE = _disk_REMOVE
     _partition_DELETE = _stretchy_shower(ConfirmDeleteStretchy)
 
@@ -307,11 +307,11 @@ class DeviceList(WidgetWrap):
     _lvm_volgroup_DELETE = _partition_DELETE
 
     _lvm_partition_EDIT = _stretchy_shower(
-        lambda parent, part: PartitionStretchy(parent, part.volgroup, part))
+        lambda parent, part: PartitionStretchy(parent, part))
     _lvm_partition_DELETE = _partition_DELETE
 
     _gap_PARTITION = _stretchy_shower(
-        lambda parent, gap: PartitionStretchy(parent, gap.device))
+        lambda parent, gap: PartitionStretchy(parent, gap=gap))
 
     def _action(self, sender, value, device):
         action, meth = value

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -369,13 +369,16 @@ def initial_data_for_fs(fs):
 
 class PartitionStretchy(Stretchy):
 
-    def __init__(self, parent, disk, partition=None):
-        self.disk = disk
+    def __init__(self, parent, partition=None, gap=None):
+        if partition is not None:
+            disk = partition.device
+        else:
+            disk = gap.device
         self.partition = partition
+        self.gap = gap
         self.model = parent.model
         self.controller = parent.controller
         self.parent = parent
-        max_size = gaps.largest_gap_size(disk)
 
         initial = {}
         label = _("Create")
@@ -394,7 +397,8 @@ class PartitionStretchy(Stretchy):
             else:
                 label = _("Save")
             initial['size'] = humanize_size(self.partition.size)
-            max_size += self.partition.size
+            max_size = self.partition.size + \
+                gaps.trailing_gap_size(self.partition)
 
             if not boot.is_esp(partition):
                 initial.update(initial_data_for_fs(self.partition.fs()))
@@ -416,6 +420,7 @@ class PartitionStretchy(Stretchy):
                         break
                     x += 1
                 initial['name'] = name
+            max_size = gap.size
 
         self.form = PartitionForm(
             self.model, max_size, initial, lvm_names, partition, alignment)

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -371,9 +371,9 @@ class PartitionStretchy(Stretchy):
 
     def __init__(self, parent, partition=None, gap=None):
         if partition is not None:
-            disk = partition.device
+            self.disk = disk = partition.device
         else:
-            disk = gap.device
+            self.disk = disk = gap.device
         self.partition = partition
         self.gap = gap
         self.model = parent.model

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -167,7 +167,7 @@ class PartitionViewTests(unittest.TestCase):
             'size': "256M",
             }
         model, disk = make_model_and_disk()
-        partition = model.add_partition(disk, 512*(2**20), "boot")
+        partition = model.add_partition(disk, 512*(2**20), flag="boot")
         fs = model.add_filesystem(partition, "fat32")
         model.add_mount(fs, '/boot/efi')
         view, stretchy = make_partition_view(model, disk, partition)
@@ -190,7 +190,7 @@ class PartitionViewTests(unittest.TestCase):
 
     def test_edit_existing_unused_boot_partition(self):
         model, disk = make_model_and_disk()
-        partition = model.add_partition(disk, 512*(2**20), "boot")
+        partition = model.add_partition(disk, 512*(2**20), flag="boot")
         fs = model.add_filesystem(partition, "fat32")
         model._orig_config = model._render_actions()
         disk.preserve = partition.preserve = fs.preserve = True
@@ -211,7 +211,7 @@ class PartitionViewTests(unittest.TestCase):
 
     def test_edit_existing_used_boot_partition(self):
         model, disk = make_model_and_disk()
-        partition = model.add_partition(disk, 512*(2**20), "boot")
+        partition = model.add_partition(disk, 512*(2**20), flag="boot")
         fs = model.add_filesystem(partition, "fat32")
         model._orig_config = model._render_actions()
         partition.grub_device = True


### PR DESCRIPTION
* adjust some routines to accommodate the possibility that we may be editing partitions
* standardize on the term 'start' to indicate the starting position of the partition or gap
* standardize on a sort order for partitions based on number, falling back to offset
* several routines updated to expect a Gap object