### PR TITLE
Fix not awaited ubuntu-drivers command existence check

### DIFF
--- a/subiquity/server/controllers/drivers.py
+++ b/subiquity/server/controllers/drivers.py
@@ -78,7 +78,7 @@ class DriversController(SubiquityController):
         async with apt.overlay() as d:
             try:
                 # Make sure ubuntu-drivers is available.
-                self.ubuntu_drivers.ensure_cmd_exists(d.mountpoint)
+                await self.ubuntu_drivers.ensure_cmd_exists(d.mountpoint)
             except CommandNotFoundError:
                 self.drivers = []
             else:

--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -137,7 +137,9 @@ class UbuntuDriversRunDriversInterface(UbuntuDriversInterface):
         # TODO This does not tell us if the "--recommended" option is
         # available.
         try:
-            await arun_command(["command", "-v", "ubuntu-drivers"])
+            await arun_command(
+                    ["sh", "-c", "command -v ubuntu-driver"],
+                    check=True)
         except subprocess.CalledProcessError:
             raise CommandNotFoundError(
                     "Command ubuntu-drivers is not available in this system")


### PR DESCRIPTION
The `ensure_cmd_exists()` coroutine from ubuntu_drivers was never awaited. Therefore, the check would always silently succeed. Taking a look in `server-output` would show the warning though:

```
RuntimeWarning: coroutine 'UbuntuDriversHasDriversInterface.ensure_cmd_exists' was never awaited
  self.ubuntu_drivers.ensure_cmd_exists(d.mountpoint)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

Also, the implementation of `ensure_cmd_exists()` when `SUBIQUITY_DEBUG=run-drivers` is set was failing because we use a shell builtin as an executable. This was not noticed since `ensure_cmd_exists()` was not executed and `arun_command` does not check for errors by default.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>