### PR TITLE
Force ubuntu-advantage screen show in jammy installer until it is marked LTS

### DIFF
--- a/subiquity/client/controllers/ubuntu_advantage.py
+++ b/subiquity/client/controllers/ubuntu_advantage.py
@@ -49,7 +49,11 @@ class UbuntuAdvantageController(SubiquityTuiController):
         """ Generate the UI, based on the data provided by the model. """
 
         dry_run: bool = self.app.opts.dry_run
-        if "LTS" not in lsb_release(dry_run=dry_run)["description"]:
+
+        lsb = lsb_release(dry_run=dry_run)
+        # TODO Remove explicit check for jammy when 22.04 gets marked as a LTS
+        # version instead of a "(development branch)".
+        if "LTS" not in lsb["description"] and lsb["codename"] != "jammy":
             await self.endpoint.skip.POST()
             raise Skip("Not running LTS version")
 

--- a/subiquity/server/tests/test_ubuntu_advantage.py
+++ b/subiquity/server/tests/test_ubuntu_advantage.py
@@ -204,3 +204,8 @@ class TestUAInterface(unittest.TestCase):
             name="cis",
             description="Center for Internet Security Audit Tools",
         ), services)
+
+        # Test with "Z" suffix for the expiration date.
+        subscription["expires"] = "2035-12-31T00:00:00Z"
+        services = run_coro(
+                interface.get_activable_services(token="XXX"))

--- a/subiquity/server/ubuntu_advantage.py
+++ b/subiquity/server/ubuntu_advantage.py
@@ -155,7 +155,10 @@ class UAInterface:
         """
         info = await self.get_subscription(token)
 
-        expiration = dt.fromisoformat(info["expires"])
+        # Sometimes, a time zone offset of 0 is replaced by the letter Z. This
+        # is specified in RFC 3339 but not supported by fromisoformat.
+        # See https://bugs.python.org/issue35829
+        expiration = dt.fromisoformat(info["expires"].replace("Z", "+00:00"))
         if expiration.timestamp() <= dt.utcnow().timestamp():
             raise ExpiredUATokenError(token, expires=info["expires"])
 


### PR DESCRIPTION
Because we decided to hide the ubuntu-advantage screen on non-LTS versions, we need to wait until jammy is marked LTS (i.e., until the `"LTS"` string is present in `/etc/lsb-release`) to test the screen in new installs.

Since we need to do more testing now, I've white-listed jammy so that installs show the ubuntu-advantage screen even though it's not marked LTS yet.
One thing to keep in mind though is that u-a-t returns `"available": false` for all services since Jammy is not yet marked LTS in the back-end. Therefore, the list of services shown is empty:

![services](https://user-images.githubusercontent.com/4038023/157209438-894c4d74-66a5-42bb-95ba-858f7e670be8.png)

Also, while testing with the ISO, I encountered a crash when the token expiration date came with the "Z" suffix instead of the "+00:00" UTC offset. This is specified by RFC3339 but not currently implemented by Python `datetime.date.fromisoformat`. I worked around this limitation by replacing any "Z" character with "+00:00".