### PR TITLE
Better detect server-side warnings / errors in integration tests

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -15,6 +15,11 @@ validate () {
         exit 1
     fi
 
+    if [ -s .subiquity/server-stderr ]; then
+        cat .subiquity/server-stderr
+        exit 1
+    fi
+
     if [ "${mode}" = "install" ]; then
         python3 scripts/validate-yaml.py .subiquity/var/log/installer/subiquity-curtin-install.conf
         if [ ! -e .subiquity/subiquity-client-debug.log ] || [ ! -e .subiquity/subiquity-server-debug.log ]; then

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -3,6 +3,7 @@ set -eux
 
 testschema=.subiquity/test-autoinstall-schema.json
 export PYTHONPATH=$PWD:$PWD/probert:$PWD/curtin
+export PYTHONTRACEMALLOC=3
 
 RELEASE=$(lsb_release -rs)
 

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -99,11 +99,12 @@ def main():
             server_args.extend(('--output-base', base))
             server_parser = make_server_args_parser()
             server_parser.parse_args(server_args)  # just to check
-            server_output = open(base + '/server-output', 'w')
+            server_stdout = open(os.path.join(base, 'server-stdout'), 'w')
+            server_stderr = open(os.path.join(base, 'server-stderr'), 'w')
             server_cmd = [sys.executable, '-m', 'subiquity.cmd.server'] + \
                 server_args
             server_proc = subprocess.Popen(
-                server_cmd, stdout=server_output, stderr=subprocess.STDOUT)
+                server_cmd, stdout=server_stdout, stderr=server_stderr)
             opts.server_pid = str(server_proc.pid)
             print("running server pid {}".format(server_proc.pid))
         elif opts.server_pid is not None:

--- a/system_setup/cmd/tui.py
+++ b/system_setup/cmd/tui.py
@@ -94,7 +94,8 @@ def main():
         server_args += ['--prefill='+opts.prefill]
 
     os.makedirs(server_output_dir, exist_ok=True)
-    server_output = open(os.path.join(server_output_dir, 'server-output'), 'w')
+    server_stdout = open(os.path.join(server_output_dir, 'server-stdout'), 'w')
+    server_stderr = open(os.path.join(server_output_dir, 'server-stderr'), 'w')
 
     if need_start_server:
         if os.path.exists(server_state_file):
@@ -104,7 +105,7 @@ def main():
         server_cmd = [sys.executable, '-m', 'system_setup.cmd.server'] + \
             server_args
         server_proc = subprocess.Popen(
-            server_cmd, stdout=server_output, stderr=subprocess.STDOUT)
+            server_cmd, stdout=server_stdout, stderr=server_stderr)
         opts.server_pid = str(server_proc.pid)
         print("running server pid {} with args: {}"
               .format(server_proc.pid, server_cmd))


### PR DESCRIPTION
Hello,

https://github.com/canonical/subiquity/pull/1201 showcased that some important server-side warnings could slip through our tests because we don't check the content of `server-output` for warnings.

A simple way to make sure we detect any warning is to check if the server's standard error is empty. Unfortunately, not only does the `server-output` file contain the server's standard error, but it also contains the server's standard output (sometimes interleaved?)

By redirecting the server's standard output and standard error to two distinct files instead of one, we can simplify the detection of warnings / errors.

I implemented the following change in both subiquity and system_setup:
   * the server's standard output goes to `server-stdout` ; whereas
   * the server's standard error goes to `server-stderr`.
   * integration tests now mark tests as failed if `server-stderr` is present and non-empty.

I am not aware of any explicit dependency on `server-output` but please let me know if you have reasons to think that changing the name of the file and its content can have side effects. We can implement the change as a CLI option instead.

Adding @CarlosNihelton as a reviewer to make sure we don't break anything on system_setup / WSL side.

We now also run integration tests with `PYTHONTRACEMALLOC=3` so that any warning / error comes with a few frames of context. NOTE: Using a higher value for `PYTHONTRACEMALLOC` shows more frames but also slows down the integrations tests more.

Output of `make integration` with a failing test:

```
[...]
+ validate
+ mode=install
+ '[' 0 -gt 0 ']'
++ ls -A .subiquity/var/crash
+ '[' -d .subiquity/var/crash -a -n '' ']'
+ '[' -s .subiquity/server-stderr ']'
+ cat .subiquity/server-stderr
/home/olivier/dev/canonical/subiquity/subiquity/server/controllers/drivers.py:81: RuntimeWarning: coroutine 'UbuntuDriversHasDriversInterface.ensure_cmd_exists' was never awaited
  self.ubuntu_drivers.ensure_cmd_exists(d.mountpoint)
Object allocated at (most recent call last):
  File "/usr/lib/python3.9/asyncio/events.py", lineno 80
    self._context.run(self._callback, *self._args)
  File "/home/olivier/dev/canonical/subiquity/subiquitycore/context.py", lineno 148
    return await meth(self, **kw)
  File "/home/olivier/dev/canonical/subiquity/subiquity/server/controllers/drivers.py", lineno 81
    self.ubuntu_drivers.ensure_cmd_exists(d.mountpoint)
+ exit 1
make: *** [Makefile:90: integration] Error 1
```

Thanks,
Olivier