### PR TITLE
keyboard: run setxkbmap for the desktop installer

### DIFF
--- a/subiquity/server/controllers/keyboard.py
+++ b/subiquity/server/controllers/keyboard.py
@@ -16,6 +16,7 @@
 import logging
 from typing import Dict, Optional
 import os
+import shutil
 
 import attr
 
@@ -202,6 +203,11 @@ class KeyboardController(SubiquityController):
             ['setupcon', '--save', '--force', '--keyboard-only'],
             [resource_path('bin/subiquity-loadkeys')],
             ]
+        if shutil.which('setxkbmap'):
+            setxkbmap = ['setxkbmap', '-layout', self.model.setting.layout]
+            if self.model.setting.variant:
+                setxkbmap.extend(['-variant', self.model.setting.variant])
+            cmds.append(setxkbmap)
         if self.opts.dry_run:
             scale = os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "1")
             cmds = [['sleep', str(1/float(scale))]]


### PR DESCRIPTION
This helps to fix https://github.com/canonical/ubuntu-desktop-installer/issues/250. Related discussion at https://github.com/canonical/ubuntu-desktop-installer/pull/154#issuecomment-878660593.