### PR TITLE
Add python3-systemd as an explicit dependency

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -33,6 +33,7 @@ python3-pyudev
 python3-requests
 python3-requests-unixsocket
 python3-setuptools
+python3-systemd
 python3-urwid
 python3-wheel
 python3-yaml


### PR DESCRIPTION
Running `make install_depends` does not (always) pull python3-systemdwhich is a dependency of Subiquity.

In environments having Install-Recommends enabled, python3-systemd is pulled by apport which is itself pulled by python3-apport.

Fixed by adding it to the list of dependencies in apt-deps.txt

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>