### PR TITLE
atp-deps.txt: add os-prober

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -11,6 +11,7 @@ libnl-genl-3-dev
 libnl-route-3-dev
 libsystemd-dev
 lsb-release
+os-prober
 pep8
 pkg-config
 python3-aiohttp


### PR DESCRIPTION
The build instruction contain a step

    PYTHONPATH=probert ./probert/bin/probert --all > mymachine.json

This requires package os-prober.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>