### PR TITLE
Installing os-probe requires fakeroot

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -206,6 +206,8 @@ parts:
     build-packages:
       - build-essential
       - debhelper
+      - fakeroot
     override-build: |
-      ./debian/rules build install
+      ./debian/rules build
+      fakeroot ./debian/rules install
       cp -a debian/os-prober/{usr,var} $SNAPCRAFT_PART_INSTALL


### PR DESCRIPTION
Building with --destructive-mode fails with error:

    dh install
       dh_testroot
    dh_testroot: error: You must run this as root (or use fakeroot).
    make: *** [debian/rules:6: install] Error 255

Use fakeroot for installation.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>