### PR TITLE
console-conf: fix crash on network info

### DIFF
--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -405,4 +405,4 @@ class NetworkController(BaseNetworkController, SubiquityController):
         self.delete_link(dev_name)
 
     async def info_GET(self, dev_name: str) -> str:
-        return self.get_info_for_netdev(dev_name)
+        return await self.get_info_for_netdev(dev_name)

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -434,7 +434,7 @@ class BaseNetworkController(BaseController):
             self.update_link(dev)
         self.apply_config()
 
-    def get_info_for_netdev(self, dev_name: str) -> str:
+    async def get_info_for_netdev(self, dev_name: str) -> str:
         device = self.model.get_netdev_by_name(dev_name)
         if device.info is not None:
             return yaml.dump(


### PR DESCRIPTION
If you run dryrun for console-conf, go to the network page, go to an
interface, then info, a crash of the form
    TypeError: object str can't be used in 'await' expression
can be seen.  The signature for the core version of get_info_for_netdev
is not async, but a non-async method returning str.

So skip the loading dialog, which wants the awaitable.