### PR TITLE
Systemd experimental support

### DIFF
--- a/autoinstall-system-setup-schema.json
+++ b/autoinstall-system-setup-schema.json
@@ -99,6 +99,9 @@
                 },
                 "automount_mountfstab": {
                     "type": "boolean"
+                },
+                "systemd_enabled": {
+                    "type": "boolean"
                 }
             },
             "additionalProperties": false

--- a/examples/answers-system-setup-reconf.yaml
+++ b/examples/answers-system-setup-reconf.yaml
@@ -8,5 +8,6 @@ WSLConfigurationAdvanced:
   interop_appendwindowspath: false
   automount_enabled: false
   automount_mountfstab: false
+  systemd_enabled: true
 Summary:
   reboot: yes

--- a/examples/autoinstall-system-setup-full.yaml
+++ b/examples/autoinstall-system-setup-full.yaml
@@ -19,4 +19,5 @@ wslconfadvanced:
   interop_appendwindowspath: false
   automount_enabled: false
   automount_mountfstab: false
+  systemd_enabled: true
 shutdown: 'poweroff'

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -458,3 +458,4 @@ class WSLConfigurationAdvanced:
     automount_mountfstab:  bool = attr.ib(default=True)
     interop_enabled:  bool = attr.ib(default=True)
     interop_appendwindowspath: bool = attr.ib(default=True)
+    systemd_enabled:  bool = attr.ib(default=False)

--- a/system_setup/client/controllers/wslconfadvanced.py
+++ b/system_setup/client/controllers/wslconfadvanced.py
@@ -32,7 +32,8 @@ class WSLConfigurationAdvancedController(SubiquityTuiController):
     def run_answers(self):
         if all(elem in self.answers for elem in
                ['interop_enabled', 'interop_appendwindowspath',
-                'automount_enabled', 'automount_mountfstab']):
+                'automount_enabled', 'automount_mountfstab',
+                'systemd_enabled']):
 
             reconfiguration = WSLConfigurationAdvanced(**self.answers)
             self.done(reconfiguration)

--- a/system_setup/common/wsl_conf.py
+++ b/system_setup/common/wsl_conf.py
@@ -60,15 +60,16 @@ conf_type_to_file = {
 }
 
 
-def wsl_config_loader(data, config_ref, id):
+def wsl_config_loader(config_ref, id):
     """
     Loads the configuration from the given file type,
     section and reference config.
 
-    :param data: dict, the data to load into
-    :param pathname: string, the path to the file to load
+    :param config_ref: dict, default entries
     :param id: string, the name of the section to load
+    return the data loaded
     """
+    data = {}
     pathname = conf_type_to_file[id]
     if not os.path.exists(pathname):
         return data
@@ -103,9 +104,8 @@ def default_loader(is_advanced=False):
     :param is_advanced: boolean, True if it is WSLConfigurationAdvanced,
                         else is WSLConfigurationBase
     """
-    data = {}
     conf_ref = config_adv_default if is_advanced else config_base_default
-    data = wsl_config_loader(data, conf_ref, "wsl")
+    data = wsl_config_loader(conf_ref, "wsl")
     return data
 
 

--- a/system_setup/common/wsl_conf.py
+++ b/system_setup/common/wsl_conf.py
@@ -131,7 +131,7 @@ def wsl_config_update(config_class, root_dir):
         config_sections = temp_conf_default[config_type]
 
         config = ConfigParser()
-        config.BasicInterpolcation = None
+        config.BasicInterpolation = None
 
         os.makedirs(os.path.join(root_dir, "etc"), exist_ok=True)
         conf_file = os.path.join(root_dir, conf_type_to_file[config_type][1:])

--- a/system_setup/models/wslconfadvanced.py
+++ b/system_setup/models/wslconfadvanced.py
@@ -25,6 +25,7 @@ class WSLConfigurationAdvanced(object):
     interop_appendwindowspath = attr.ib()
     automount_enabled = attr.ib()
     automount_mountfstab = attr.ib()
+    systemd_enabled = attr.ib()
 
 
 class WSLConfigurationAdvancedModel(object):

--- a/system_setup/server/controllers/wslconfadvanced.py
+++ b/system_setup/server/controllers/wslconfadvanced.py
@@ -39,7 +39,8 @@ class WSLConfigurationAdvancedController(SubiquityController):
             'interop_enabled': {'type': 'boolean'},
             'interop_appendwindowspath': {'type': 'boolean'},
             'automount_enabled': {'type': 'boolean'},
-            'automount_mountfstab': {'type': 'boolean'}
+            'automount_mountfstab': {'type': 'boolean'},
+            'systemd_enabled': {'type': 'boolean'}
         },
         'additionalProperties': False,
     }
@@ -80,6 +81,8 @@ class WSLConfigurationAdvancedController(SubiquityController):
                 self.model.wslconfadvanced.automount_enabled
             data.automount_mountfstab = \
                 self.model.wslconfadvanced.automount_mountfstab
+            data.systemd_enabled = \
+                self.model.wslconfadvanced.systemd_enabled
         return data
 
     async def POST(self, data: WSLConfigurationAdvanced):

--- a/system_setup/tests/golden/answers-reconf/wsl.conf
+++ b/system_setup/tests/golden/answers-reconf/wsl.conf
@@ -4,6 +4,9 @@ mountfstab = false
 options = metadata
 root = /custom_mnt_path
 
+[boot]
+command = /usr/libexec/wsl-systemd
+
 [interop]
 appendwindowspath = false
 enabled = false

--- a/system_setup/tests/golden/autoinstall-full/wsl.conf
+++ b/system_setup/tests/golden/autoinstall-full/wsl.conf
@@ -4,6 +4,9 @@ mountfstab = false
 options = metadata
 root = /custom_mnt_path
 
+[boot]
+command = /usr/libexec/wsl-systemd
+
 [interop]
 appendwindowspath = false
 enabled = false

--- a/system_setup/ui/views/wslconfadvanced.py
+++ b/system_setup/ui/views/wslconfadvanced.py
@@ -59,6 +59,10 @@ class WSLConfigurationAdvancedForm(Form):
         BooleanField(_("Append Windows Path"),
                      help=_("Whether Windows Path will be append in the"
                             " PATH environment variable in WSL."))
+    systemd_enabled = \
+        BooleanField(_("Enable Systemd"),
+                     help=_("EXPERIMENTAL - Whether systemd should be"
+                            " activated at boot time."))
 
 
 class WSLConfigurationAdvancedView(BaseView):
@@ -78,6 +82,8 @@ class WSLConfigurationAdvancedView(BaseView):
                 configuration_data.automount_enabled,
             'automount_mountfstab':
                 configuration_data.automount_mountfstab,
+            'systemd_enabled':
+                configuration_data.systemd_enabled,
         }
         self.form = WSLConfigurationAdvancedForm(initial=initial)
 
@@ -101,4 +107,6 @@ class WSLConfigurationAdvancedView(BaseView):
             .automount_enabled.value,
             automount_mountfstab=self.form
             .automount_mountfstab.value,
+            systemd_enabled=self.form
+            .systemd_enabled.value,
             ))

--- a/system_setup/ui/views/wslconfadvanced.py
+++ b/system_setup/ui/views/wslconfadvanced.py
@@ -43,7 +43,7 @@ class WSLConfigurationAdvancedForm(Form):
 
     automount_enabled = \
         BooleanField(_("Enable Auto-Mount"),
-                     help=_("Whether the Auto-Mount freature is enabled. "
+                     help=_("Whether the Auto-Mount feature is enabled. "
                             "This feature allows you to mount Windows drive"
                             " in WSL."))
     automount_mountfstab = \


### PR DESCRIPTION
Grow a new API for enabling/disabling systemd experimental support. We do this by chaining a specific command= in the boot section. We preserve the user customized command= content when systemd experimental support is not enabled.