### PR TITLE
Allow to use HTTP 409 for tasks cancelled on server end

### DIFF
--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -18,6 +18,7 @@ import os
 import traceback
 
 from aiohttp import web
+from aiohttp.web_exceptions import HTTPConflict
 
 from subiquity.common.serialize import Serializer
 
@@ -123,6 +124,8 @@ def _make_handler(controller, definition, implementation, serializer):
                 resp = web.json_response(
                     serializer.serialize(def_ret_ann, result),
                     headers={'x-status': 'ok'})
+            except HTTPConflict as e:
+                resp = e
             except Exception as exc:
                 tb = traceback.TracebackException.from_exception(exc)
                 resp = web.Response(


### PR DESCRIPTION
_This was originally implemented as part of https://github.com/canonical/subiquity/pull/1196 to avoid potential UI freezes when tasks are not cancelled._ 

We now allow the server controller to raise a HTTPConflict exception inHTTP request handlers.

This will indicate that we cancelled a task that we were waiting on to satisfy a HTTP request.

The problem that we are trying to solve is this:
 * the client sometimes runs an HTTP query that is blocking on the server side (most of the time it has the wait=True parameter). The server will most likely await on a coroutine before returning an HTTP response.
 * in the meantime the client can send another HTTP query that will cancel the task we are waiting on. E.g., skip the check for updates.
 * the response to the original HTTP request will not be able to contain the information that the clients expects ; because the task to retrieve the information was cancelled.
 * the client should have a simple way to be informed that the server wasn't able to complete the action requested.

Example of usage:

```python
# Client side
async def _wait_drivers(self) -> List[str]:
     try:
         response: DriversResponse = await self.endpoint.GET(wait=True)
     except ServerTaskCancelled:
         log.warning("_wait_drivers: task interrupted on server end")
         return []
     return response.drivers

# Server side
async def GET(self, wait: bool = False) -> DriversResponse:
    if wait:
        try:
            await self._drivers_task
        except asyncio.CancelledError:
            raise HTTPConflict(text="Drivers listing task was interrupted.")
        return DriversResponse(install=self.model.do_install, drivers=self.drivers)

```


Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>