### PR TITLE
make test_v2_multi_disk_multi_boot api test more correct

### DIFF
--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -451,6 +451,8 @@ class TestAdd(TestAPI):
             resp = await inst.get('/storage/v2')
             vda = first(resp['disks'], 'id', 'disk-vda')
             vdb = first(resp['disks'], 'id', 'disk-vdb')
+            await inst.post('/storage/v2/reformat_disk', disk_id=vda['id'])
+            await inst.post('/storage/v2/reformat_disk', disk_id=vdb['id'])
             await inst.post('/storage/v2/add_boot_partition',
                             disk_id=vda['id'])
             await inst.post('/storage/v2/add_boot_partition',


### PR DESCRIPTION
This calls add_boot_partition on disks that are filled by pre-existing
partitions. That should not work, and does not in a branch I am working
on.