### PR TITLE
FilesystemModel._actions_from_config: catch config is None

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1157,6 +1157,9 @@ class FilesystemModel(object):
         byid = {}
         objs = []
         exclusions = set()
+        if config is None:
+            log.debug("config is None")
+            return []
         for action in config:
             if is_probe_data and action['type'] == 'mount':
                 if not action['path'].startswith(self.target):


### PR DESCRIPTION
None is not iterable. If _actions_from_config is called with config is
None, an exception "TypeError: 'NoneType' object is not iterable"
is raised. Let's just log this situation. (LP: #1965169)

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>