### PR TITLE
Fix crash when UA token expiration date has Z suffix

### DIFF
--- a/subiquity/server/tests/test_ubuntu_advantage.py
+++ b/subiquity/server/tests/test_ubuntu_advantage.py
@@ -204,3 +204,8 @@ class TestUAInterface(unittest.TestCase):
             name="cis",
             description="Center for Internet Security Audit Tools",
         ), services)
+
+        # Test with "Z" suffix for the expiration date.
+        subscription["expires"] = "2035-12-31T00:00:00Z"
+        services = run_coro(
+                interface.get_activable_services(token="XXX"))

--- a/subiquity/server/ubuntu_advantage.py
+++ b/subiquity/server/ubuntu_advantage.py
@@ -155,7 +155,10 @@ class UAInterface:
         """
         info = await self.get_subscription(token)
 
-        expiration = dt.fromisoformat(info["expires"])
+        # Sometimes, a time zone offset of 0 is replaced by the letter Z. This
+        # is specified in RFC 3339 but not supported by fromisoformat.
+        # See https://bugs.python.org/issue35829
+        expiration = dt.fromisoformat(info["expires"].replace("Z", "+00:00"))
         if expiration.timestamp() <= dt.utcnow().timestamp():
             raise ExpiredUATokenError(token, expires=info["expires"])
 


### PR DESCRIPTION
Fixed in main as part of #1202 

RFC3339 allows dates to use the Z suffix instead of a time zone offset of 0. Unfortunately, this is not supported by Python
datetime.date.fromisoformat. Work around the issue by replacing the optional Z character with +00:00 before parsing the date.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>
(cherry picked from commit 23a66ad33599096e3744db62615bc11df1e7f2e7)