### PR TITLE
ubuntu-advantage: disable for 22.04.0 release

### DIFF
--- a/subiquity/client/controllers/ubuntu_advantage.py
+++ b/subiquity/client/controllers/ubuntu_advantage.py
@@ -48,6 +48,9 @@ class UbuntuAdvantageController(SubiquityTuiController):
     async def make_ui(self) -> UbuntuAdvantageView:
         """ Generate the UI, based on the data provided by the model. """
 
+        # Currently disabled in 22.04
+        await self.endpoint.skip.POST()
+        raise Skip
         dry_run: bool = self.app.opts.dry_run
         if "LTS" not in lsb_release(dry_run=dry_run)["description"]:
             await self.endpoint.skip.POST()


### PR DESCRIPTION
Don't show the ubuntu-advantage screen for Ubuntu 22.04.0 but keep the possibility to provide a contract token through autoinstall.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>