### PR TITLE
Removes apt python library from system_setup

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -100,10 +100,16 @@ validate () {
             fi
             # Extract value of the LANG variable from etc/default/locale (with or without quotes)
             lang="$(grep -Eo 'LANG=([^.@ _]+)' $tmpdir/etc/default/locale | cut -d= -f 2- | cut -d\" -f 2-)"
-            if ! ls $tmpdir/var/cache/apt/archives/ | grep --fixed-strings --quiet -- "$lang"; then
+            if ! ls $tmpdir/var/cache/apt/archives/*.log | grep --fixed-strings --quiet -- "$lang"; then
                 echo "expected $lang language packs in directory var/cache/apt/archives/"
                 exit 1
             fi
+            for f in $tmpdir/var/cache/apt/archives/*.log ; do
+                if ! [ -s $f ]; then  
+                    echo "apt failed for package $f"
+                    exit 1
+                fi
+            done
             if [ -z "$( diff -Nup $tmpdir/etc/locale.gen $tmpdir/etc/locale.gen.test)" ] ; then
                 echo "expected changes in etc/locale.gen"
                 exit 1

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -123,7 +123,7 @@ class ConfigureController(SubiquityController):
 
         return True
 
-    async def __recommended_language_packs(self, lang, env) \
+    async def __recommended_language_packs(self, lang) \
             -> Optional[List[str]]:
         """ Return a list of package names recommended by
          check-language-support (or a fake list if in dryrun).
@@ -146,18 +146,14 @@ class ConfigureController(SubiquityController):
         clsLang = langCodes[0]
         packages = []
         # Running that command doesn't require root.
-        snap_dir = os.getenv("SNAP")
-        if snap_dir is None:
-            snap_dir = "/"
-
+        snap_dir = os.getenv("SNAP", default="/")
         data_dir = os.path.join(snap_dir, "usr/share/language-selector")
         if not os.path.exists(data_dir):
             log.error("Misconfigured snap environment pointed L-S-C data dir"
                       " to %s", data_dir)
             return None
 
-        cp = await arun_command([clsCommand, "-d", data_dir, "-l", clsLang],
-                                env=env)
+        cp = await arun_command([clsCommand, "-d", data_dir, "-l", clsLang])
         if cp.returncode != 0:
             log.error('Command "%s" failed with return code %d',
                       cp.args, cp.returncode)

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -266,9 +266,8 @@ class ConfigureController(SubiquityController):
         shutil.copy(localeGenPath, "{}.test".format(testLocGenPath))
         return testLocGenPath
 
-    async def apply_locale(self, lang):
+    async def apply_locale(self, lang, env):
         """ Effectively apply the locale setup to the new system."""
-        env = os.environ.copy()
         localeGenPath = self._locale_gen_file_path()
         if self._update_locale_gen_file(localeGenPath, lang) is False:
             log.error("Failed to update locale.gen")
@@ -299,7 +298,7 @@ class ConfigureController(SubiquityController):
 
         return uid
 
-    async def _create_user(self, root_dir):
+    async def create_user(self, root_dir, env):
         """ Helper method to create the user from the identity model
             and store it's UID. """
         wsl_id = self.model.identity.user
@@ -339,13 +338,14 @@ class ConfigureController(SubiquityController):
             create_user_base = ["-P", root_dir]
             assign_grp_base = ["-P", root_dir]
 
-        create_user_cmd = ["useradd"] + create_user_base + \
+        # TODO: Figure out if Hardcoded paths here cause trouble for runtests.
+        create_user_cmd = ["/usr/sbin/useradd"] + create_user_base + \
                           ["-m", "-s", "/bin/bash", "-c", wsl_id.realname,
                            "-p", wsl_id.password, username]
-        assign_grp_cmd = ["usermod"] + assign_grp_base + \
+        assign_grp_cmd = ["/usr/sbin/usermod"] + assign_grp_base + \
                          ["-a", "-G", ",".join(usergroups_list), username]
 
-        create_user_proc = await arun_command(create_user_cmd)
+        create_user_proc = await arun_command(create_user_cmd, env=env)
         if create_user_proc.returncode != 0:
             raise Exception("Failed to create user %s: %s"
                             % (username, create_user_proc.stderr))
@@ -355,7 +355,7 @@ class ConfigureController(SubiquityController):
         if self.default_uid is None:
             log.error("Could not retrieve %s UID", username)
 
-        assign_grp_proc = await arun_command(assign_grp_cmd)
+        assign_grp_proc = await arun_command(assign_grp_cmd, env=env)
         if assign_grp_proc.returncode != 0:
             raise Exception(("Failed to assign group to user %s: %s")
                             % (username, assign_grp_proc.stderr))
@@ -386,9 +386,14 @@ class ConfigureController(SubiquityController):
             root_dir = self.model.root
 
             if variant == "wsl_setup":
-                await self._create_user(root_dir)
                 lang = self.model.locale.selected_language
-                await self.apply_locale(lang)
+                envcp = os.environ.copy()
+                # Ensures a safe escape out of the snap environment for WSL.
+                if not self.app.opts.dry_run:
+                    envcp['LD_LIBRARY_PATH']=''
+                    envcp['LD_PRELOAD']=''
+                await self.create_user(root_dir, envcp)
+                await self.apply_locale(lang, envcp)
 
             else:
                 wsl_config_update(self.model.wslconfadvanced.wslconfadvanced,

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -179,12 +179,11 @@ class ConfigureController(SubiquityController):
             log.error('Failed to detect recommended language packs.')
             return False
 
-        cp = await arun_command([aptCommand,"update"], env=env)
+        cp = await arun_command([aptCommand, "update"], env=env)
 
         if cp.returncode != 0:
             # TODO: deal with the error case.
             log.error("Failed to update apt cache.\n%s", cp.stderr)
-
 
         if self.app.opts.dry_run:  # only empty in dry-run on failure.
             if len(packages) == 0:
@@ -197,7 +196,7 @@ class ConfigureController(SubiquityController):
             try:
                 for package in packages:
                     # Just write the package uri to a file.
-                    lcp = await arun_command([aptCommand,"install",package,
+                    lcp = await arun_command([aptCommand, "install", package,
                                               "--simulate"], env=env)
                     archive = os.path.join(packs_dir, package)
                     with open(archive, "wt") as f:
@@ -213,11 +212,10 @@ class ConfigureController(SubiquityController):
             log.info("No missing recommended packages. Nothing to do.")
             return True
 
-        cmd = [aptCommand,"install","-y"] + packages
+        cmd = [aptCommand, "install", "-y"] + packages
         acp = await arun_command(cmd, env=env)
 
-        return acp.returncode==0
-
+        return acp.returncode == 0
 
     def _update_locale_gen_file(self, localeGenPath, lang) -> bool:
         """ Uncomment the line in locale.gen file matching lang,
@@ -389,8 +387,8 @@ class ConfigureController(SubiquityController):
                 envcp = os.environ.copy()
                 # Ensures a safe escape out of the snap environment for WSL.
                 if not self.app.opts.dry_run:
-                    envcp['LD_LIBRARY_PATH']=''
-                    envcp['LD_PRELOAD']=''
+                    envcp['LD_LIBRARY_PATH'] = ''
+                    envcp['LD_PRELOAD'] = ''
                 await self.create_user(root_dir, envcp)
                 await self.apply_locale(lang, envcp)
 


### PR DESCRIPTION
It's been quite painful trying to work with apt python library in the WSL snap environment so far, so today we decided to drop it in favor of `subprocess.run` with the environment adjusted to ensure we can run system `apt` instead of adding it to the snap.

This pull request only affects the scope of `system_setup` and adjusts `apply_locale()` and `create_user()` functions to perform their duties using system binaries.

Besides the subiquity CI tests, this code has been tested in WSL and behaved as expected.