### PR TITLE
Faster curtin replay tests

### DIFF
--- a/subiquity/server/runner.py
+++ b/subiquity/server/runner.py
@@ -27,7 +27,7 @@ class LoggedCommandRunner:
     def __init__(self, ident,
                  *, use_systemd_user: Optional[bool] = None) -> None:
         self.ident = ident
-        self.env_whitelist = [
+        self.env_allowlist = [
             "PATH", "PYTHONPATH",
             "PYTHON",
             "TARGET_MOUNT_POINT",
@@ -58,7 +58,7 @@ class LoggedCommandRunner:
             # --pipe also opens a pipe on stdin. This will effectively make the
             # child process behave differently if it reads from stdin.
             prefix.append("--pipe")
-        for key in self.env_whitelist:
+        for key in self.env_allowlist:
             with suppress(KeyError):
                 prefix.extend(("--setenv", f"{key}={os.environ[key]}"))
 

--- a/subiquity/server/runner.py
+++ b/subiquity/server/runner.py
@@ -32,6 +32,7 @@ class LoggedCommandRunner:
             "PYTHON",
             "TARGET_MOUNT_POINT",
             "SNAP",
+            "SUBIQUITY_REPLAY_TIMESCALE",
         ]
         if use_systemd_user is not None:
             self.use_systemd_user = use_systemd_user

--- a/subiquity/server/tests/test_runner.py
+++ b/subiquity/server/tests/test_runner.py
@@ -53,7 +53,7 @@ class TestLoggedCommandRunner(SubiTestCase):
             "DUMMY": "should-not-be-exported",
         }
 
-        with patch.dict(os.environ, environ):
+        with patch.dict(os.environ, environ, clear=True):
             cmd = runner._forge_systemd_cmd(
                     ["/bin/ls", "/root"],
                     private_mounts=True, capture=False)


### PR DESCRIPTION
Allow the TIMESCALE value to flow to the curtin command runner.