### PR TITLE
filesystem: evaluate only once the status of the raid / LVM creation buttons

### DIFF
--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -516,8 +516,8 @@ class FilesystemView(BaseView):
                     raid_devices.add(p)
                 if p.ok_for_lvm_vg:
                     lvm_devices.add(p)
-            self._create_raid_btn.enabled = len(raid_devices) > 1
-            self._create_vg_btn.enabled = len(lvm_devices) > 0
+        self._create_raid_btn.enabled = len(raid_devices) > 1
+        self._create_vg_btn.enabled = len(lvm_devices) > 0
         self.mount_list.refresh_model_inputs()
         self.avail_list.refresh_model_inputs()
         self.used_list.refresh_model_inputs()


### PR DESCRIPTION
When refreshing the filesystem GUI, we used to set the status (i.e., enabled or disabled) of the `"Create LVM volume group"` and `"Create software RAID"` buttons multiple times ; once for each disk found.

When multiple disks are listed, this creates intermediate status changes that are not wanted.
Example:

disk0 -> unpartitioned
disk1 -> 3 partitions (all formatted as ext4)
disk2 -> unpartitioned

1. `"Create software RAID"` button gets set to `disabled` after finding a first unpartitioned disk (i.e., disk0);
2. `"Create software RAID"` button gets set again to `disabled` after finding a partitioned disk with no unmounted partitions (i.e., disk1) ;
3. `"Create software RAID"` button gets set to `enabled` after finding a second unpartitioned disk (i.e., disk2).

Fixed by evaluating the status of the buttons only once after looping through all disks.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>