### PR TITLE
Ensures snap_dir='/' if not better specified.

### DIFF
--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -145,6 +145,13 @@ class ConfigureController(SubiquityController):
         packages = []
         # Running that command doesn't require root.
         snap_dir = os.getenv("SNAP", default="/")
+        # UDI sets the SNAP env var to '.' for development purposes.
+        # See:
+        # https://github.com/canonical/ubuntu-desktop-installer/commit/9eb6f04
+        # It is unlikely that under test or production that env var will
+        # ever by just '.'. On the other hand in dry-run we want it pointing to
+        # '/' if not properly set.
+        snap_dir = snap_dir if snap_dir != '.' else '/'
         data_dir = os.path.join(snap_dir, "usr/share/language-selector")
         if not os.path.exists(data_dir):
             log.error("Misconfigured snap environment pointed L-S-C data dir"


### PR DESCRIPTION
UDI sets the SNAP env var to '.' for development purposes, affecting the behavior of `system_setup`, which server is started by the GUI.

See: https://github.com/canonical/ubuntu-desktop-installer/commit/9eb6f04

It is unlikely that under test or production that env var will ever by just '.'. On the other hand in dry-run we want this controller to interpret it as '/' if not properly set, thus discarding the '.' directory.