### PR TITLE
storage: log reason for not updating the screen after probing finishes

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -63,6 +63,9 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         status = await self.endpoint.guided.GET(wait=True)
         if isinstance(self.ui.body, SlowProbing):
             self.ui.set_body(self.make_guided_ui(status))
+        else:
+            log.debug("not refreshing the display. Current display is %r",
+                      self.ui.body)
 
     def make_guided_ui(self, status):
         if status.status == ProbeStatus.FAILED:


### PR DESCRIPTION
I created https://bugs.launchpad.net/subiquity/+bug/1968161 earlier today.

In the normal workflow, if the "Waiting for storage probing to complete" screen is shown, it will automatically be replaced by the "Guided storage configuration" screen when the probing operation finishes.

However, sometimes, it seems that we skip refreshing the display after the probing operation finishes.

My theory is that sometimes we try to replace the "Waiting for storage" screen with the "Guided storage configuration" screen *before* the "Waiting for storage" screen is actually displayed.

To confirm or refute this theory, I am adding a log line that shows what the current display is when we decide to skip refreshing the screen. When we reproduce the issue in the future, a quick look at the client logs should hopefully help us figure out what is going on.
