### PR TITLE
filesystem: going back to guided also does reset

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -242,16 +242,17 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
     def guided(self):
         self.app.aio_loop.create_task(self._guided())
 
-    def reset(self):
+    def reset(self, refresh_view):
         log.info("Resetting Filesystem model")
         self.app.ui.block_input = True
-        self.app.aio_loop.create_task(self._reset())
+        self.app.aio_loop.create_task(self._reset(refresh_view))
 
-    async def _reset(self):
+    async def _reset(self, refresh_view):
         status = await self.endpoint.reset.POST()
         self.app.ui.block_input = False
         self.model.load_server_data(status)
-        self.ui.set_body(FilesystemView(self.model, self))
+        if refresh_view:
+            self.ui.set_body(FilesystemView(self.model, self))
 
     def cancel(self):
         self.app.prev_screen()

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -542,10 +542,11 @@ class FilesystemView(BaseView):
         self.show_stretchy_overlay(VolGroupStretchy(self))
 
     def cancel(self, button=None):
+        self.controller.reset(refresh_view=False)
         self.controller.guided()
 
     def reset(self, button):
-        self.controller.reset()
+        self.controller.reset(refresh_view=True)
 
     def done(self, button):
         self.controller.finish()


### PR DESCRIPTION
Per LP: #1968160, with 2 or more disks, go to guided storage config, hit
done.  At file system summary, hit back, and choose the other disk.
While this screen does say so, one might not notice that the first disk
is still setup to be formatted.

Instead, when going back to guided storage, a reset is also done.