### PR TITLE
Fix storage screen sometimes not refreshing after slow probing

### DIFF
--- a/subiquitycore/tui.py
+++ b/subiquitycore/tui.py
@@ -234,8 +234,6 @@ class TuiApplication(Application):
             except Exception:
                 self.controllers.index = cur_index
                 raise
-            else:
-                return
 
     async def move_screen(self, increment, coro):
         view_or_callable = await self.wait_with_progress(


### PR DESCRIPTION
_Not the greatest nor the worst way to fix https://bugs.launchpad.net/subiquity/+bug/1968161_

We now implement an _optional_ indirection mechanism for `make_ui()` functions and use it in the filesystem controller to work around the screen not refreshing issue.

Hopefully, the commit messages should explain in details what's going on and what the patches bring to the table.