### PR TITLE
storage/v2: permit delete with storage-version=2

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -82,7 +82,8 @@ class FilesystemManipulator:
         return part
 
     def delete_partition(self, part, override_preserve=False):
-        if not override_preserve and part.device.preserve:
+        if not override_preserve and part.device.preserve and \
+                self.model.storage_version < 2:
             raise Exception("cannot delete partitions from preserved disks")
         self.clear(part)
         self.model.remove_partition(part)

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -454,14 +454,26 @@ class TestAdd(TestAPI):
 class TestDelete(TestAPI):
     @timeout()
     async def test_v2_delete_without_reformat(self):
-        async with start_server('examples/win10.json') as inst:
-            disk_id = 'disk-sda'
+        cfg = 'examples/win10.json'
+        extra = ['--storage-version', '1']
+        async with start_server(cfg, extra_args=extra) as inst:
             data = {
-                'disk_id': disk_id,
+                'disk_id': 'disk-sda',
                 'partition': {'number': 1}
             }
             with self.assertRaises(ClientResponseError):
                 await inst.post('/storage/v2/delete_partition', data)
+
+    @timeout()
+    async def test_v2_delete_without_reformat_is_ok_with_sv2(self):
+        cfg = 'examples/win10.json'
+        extra = ['--storage-version', '2']
+        async with start_server(cfg, extra_args=extra) as inst:
+            data = {
+                'disk_id': 'disk-sda',
+                'partition': {'number': 1}
+            }
+            await inst.post('/storage/v2/delete_partition', data)
 
     @timeout()
     async def test_v2_delete_with_reformat(self):


### PR DESCRIPTION
On preserved disks, we can now allow partition deletes without requiring
a wholesale format of the disk, if using storage-verison=2.