### PR TITLE
Fix guided direct

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -196,12 +196,15 @@ class FilesystemManipulator:
             self.add_boot_disk(disk)
 
             # adjust downward the partition size (if necessary) to accommodate
-            # bios/grub partition
-            if spec['size'] > gaps.largest_gap_size(disk):
+            # bios/grub partition.  It's OK and useful to assign a new gap:
+            # 1) with len(partitions()) == 0 there could only have been 1 gap
+            # 2) having just done add_boot_disk(), the gap is no longer valid.
+            gap = gaps.largest_gap(disk)
+            if spec['size'] > gap.size:
                 log.debug(
                     "Adjusting request down from %s to %s",
-                    spec['size'], gaps.largest_gap_size(disk))
-                spec['size'] = gaps.largest_gap_size(disk)
+                    spec['size'], gap.size)
+                spec['size'] = gap.size
 
         self.create_partition(disk, gap, spec)
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -94,6 +94,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             self._probe_once, propagate_errors=False)
         self._probe_task = SingleInstanceTask(
             self._probe, propagate_errors=False)
+        self.supports_resilient_boot = False
 
     def load_autoinstall_data(self, data):
         log.debug("load_autoinstall_data %s", data)


### PR DESCRIPTION
A scenario that should happen nearly always for guided direct, when we
add_boot_disk from partition_disk_handler we must update the gap or the
target partition is at the wrong offset.

(This bug was introduced with the offsets&gap work and is not preset on Jammy)

