### PR TITLE
v2/reformat: accept ptable argument

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -38,6 +38,7 @@ from subiquity.common.types import (
     IdentityData,
     NetworkStatus,
     ModifyPartitionV2,
+    ReformatDisk,
     RefreshStatus,
     ShutdownMode,
     DriversResponse,
@@ -263,7 +264,8 @@ class API:
                 def POST() -> StorageResponseV2: ...
 
             class reformat_disk:
-                def POST(disk_id: str) -> StorageResponseV2: ...
+                def POST(data: Payload[ReformatDisk]) \
+                    -> StorageResponseV2: ...
 
             class add_boot_partition:
                 def POST(disk_id: str) -> StorageResponseV2: ...

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -157,8 +157,10 @@ class FilesystemManipulator:
         for subobj in obj.fs(), obj.constructed_device():
             self.delete(subobj)
 
-    def reformat(self, disk):
+    def reformat(self, disk, ptable=None):
         disk.grub_device = False
+        if ptable is not None:
+            disk.ptable = ptable
         for p in list(disk.partitions()):
             self.delete_partition(p, True)
         self.clear(disk)

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -503,3 +503,28 @@ class TestFilesystemManipulator(unittest.TestCase):
         disk = make_disk(manipulator.model, preserve=True, size=2002*MiB)
         self._test_add_boot_full_resizes_larger(
             manipulator, disk, sizes.PREP_GRUB_SIZE_BYTES)
+
+
+class TestReformat(unittest.TestCase):
+    def setUp(self):
+        self.manipulator = make_manipulator()
+
+    def test_reformat_default(self):
+        disk = make_disk(self.manipulator.model, ptable=None)
+        self.manipulator.reformat(disk)
+        self.assertEqual(None, disk.ptable)
+
+    def test_reformat_keep_current(self):
+        disk = make_disk(self.manipulator.model, ptable='msdos')
+        self.manipulator.reformat(disk)
+        self.assertEqual('msdos', disk.ptable)
+
+    def test_reformat_to_gpt(self):
+        disk = make_disk(self.manipulator.model, ptable=None)
+        self.manipulator.reformat(disk, 'gpt')
+        self.assertEqual('gpt', disk.ptable)
+
+    def test_reformat_to_msdos(self):
+        disk = make_disk(self.manipulator.model, ptable=None)
+        self.manipulator.reformat(disk, 'msdos')
+        self.assertEqual('msdos', disk.ptable)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -340,6 +340,12 @@ class ModifyPartitionV2:
 
 
 @attr.s(auto_attribs=True)
+class ReformatDisk:
+    disk_id: str
+    ptable: Optional[str] = None
+
+
+@attr.s(auto_attribs=True)
 class IdentityData:
     realname: str = ''
     username: str = ''

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -53,6 +53,7 @@ from subiquity.common.types import (
     GuidedStorageResponse,
     ModifyPartitionV2,
     ProbeStatus,
+    ReformatDisk,
     StorageResponse,
     StorageResponseV2,
     )
@@ -339,8 +340,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.guided(data)
         return await self.v2_GET()
 
-    async def v2_reformat_disk_POST(self, disk_id: str) -> StorageResponseV2:
-        self.reformat(self.model._one(id=disk_id))
+    async def v2_reformat_disk_POST(self, data: ReformatDisk) \
+            -> StorageResponseV2:
+        self.reformat(self.model._one(id=data.disk_id), data.ptable)
         return await self.v2_GET()
 
     async def v2_add_boot_partition_POST(self, disk_id: str) \


### PR DESCRIPTION
Move storage/v2/reformat_disk to body instead of query args.
Add optional ptable arg, which can be used to format to a msdos table.