### PR TITLE
Sets with the prefilled language before starting controllers

### DIFF
--- a/system_setup/server/controllers/locale.py
+++ b/system_setup/server/controllers/locale.py
@@ -20,7 +20,8 @@ log = logging.getLogger('system_setup.server.controllers.locale')
 
 
 class WSLLocaleController(LocaleController):
-    def start(self):
+    def __init__(self, app):
+        super().__init__(app)
         if self.app.prefillInfo:
             welcome = self.app.prefillInfo.get('Welcome', {'lang': None})
             win_lang = welcome.get('lang')
@@ -29,4 +30,3 @@ class WSLLocaleController(LocaleController):
                 log.debug('Prefilled Language: {}'
                           .format(self.model.selected_language))
 
-        super().start()

--- a/system_setup/server/controllers/locale.py
+++ b/system_setup/server/controllers/locale.py
@@ -29,4 +29,3 @@ class WSLLocaleController(LocaleController):
                 self.model.selected_language = win_lang
                 log.debug('Prefilled Language: {}'
                           .format(self.model.selected_language))
-


### PR DESCRIPTION
TUI client was able to GET() the language before it was set with the prefilled option in production. This attempts to ensure the earliest initialization possible.