### PR TITLE
Revert "Move to aiohttp for GeoIP requests"

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -15,7 +15,6 @@ os-prober
 pep8
 pkg-config
 python3-aiohttp
-python3-aioresponses
 python3-apport
 python3-async-timeout
 python3-attr

--- a/subiquity/server/geoip.py
+++ b/subiquity/server/geoip.py
@@ -14,12 +14,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from abc import ABC, abstractmethod
-import aiohttp
 import logging
 import enum
+import requests
 from xml.etree import ElementTree
 
 from subiquitycore.async_helpers import (
+    run_in_thread,
     SingleInstanceTask,
 )
 
@@ -75,14 +76,13 @@ class HTTPGeoIPStrategy(GeoIPStrategy):
     """ HTTP implementation to retrieve GeoIP information. We use the
     geoip.ubuntu.com service. """
     async def get_response(self) -> str:
-        url = "https://geoip.ubuntu.com/lookup"
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as response:
-                    response.raise_for_status()
-                    return await response.text()
-        except aiohttp.ClientError as e:
+            response = await run_in_thread(
+                requests.get, "https://geoip.ubuntu.com/lookup")
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
             raise LookupError from e
+        return response.text
 
 
 class GeoIP:


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu-power-systems/+bug/1969393

The patch that moved from requests to aiohttp for geoip seems to be the trigger that makes Subiquity crash with bad DNS.

The root cause is still TBD but reverting the patch seems to prevent Subiquity from crashing.

Let's test this patch again should we decide to merge it.