### PR TITLE
tests: consistently run Subiquity commands

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -155,13 +155,13 @@ for answers in examples/answers*.yaml; do
         # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
         LANG=C.UTF-8 timeout --foreground 60 \
             python3 -m subiquity.cmd.tui < "$tty" \
-            --bootloader uefi \
-            --answers "$answers" \
             --dry-run \
-            --snaps-from-examples \
-            --machine-config "$config" \
             --output-base "$tmpdir" \
-            "${opts[@]}"
+            --answers "$answers" \
+            "${opts[@]}" \
+            --machine-config "$config" \
+            --bootloader uefi \
+            --snaps-from-examples
         validate
         grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' $tmpdir/subiquity-server-debug.log
     else
@@ -176,9 +176,9 @@ for answers in examples/answers*.yaml; do
             fi
             DRYRUN_RECONFIG="$reconf_settings" LANG=C.UTF-8 timeout --foreground 60 \
                 python3 -m system_setup.cmd.tui < "$tty" \
+                --dry-run \
                 --answers "$answers" \
-                --output-base "$tmpdir" \
-                --dry-run
+                --output-base "$tmpdir"
             validate "system_setup" "$validate_subtype"
         fi
     fi
@@ -187,13 +187,13 @@ done
 
 LANG=C.UTF-8 timeout --foreground 60 \
     python3 -m subiquity.cmd.tui \
-    --autoinstall examples/autoinstall.yaml \
     --dry-run \
+    --output-base "$tmpdir" \
     --machine-config examples/existing-partitions.json \
     --bootloader bios \
+    --autoinstall examples/autoinstall.yaml \
     --kernel-cmdline autoinstall \
-    --output-base "$tmpdir" \
-    --source-catalog=examples/install-sources.yaml
+    --source-catalog examples/install-sources.yaml
 validate
 python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/subiquity-curtin-apt.conf \
         apt.disable_components='[non-free, restricted]' \
@@ -220,10 +220,10 @@ grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: 
 clean
 LANG=C.UTF-8 timeout --foreground 60 \
     python3 -m subiquity.cmd.tui \
-    --autoinstall examples/autoinstall-user-data.yaml \
-    --output-base "$tmpdir" \
     --dry-run \
+    --output-base "$tmpdir" \
     --machine-config examples/simple.json \
+    --autoinstall examples/autoinstall-user-data.yaml \
     --kernel-cmdline autoinstall
 validate
 grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' $tmpdir/subiquity-server-debug.log
@@ -234,9 +234,9 @@ if [ "${RELEASE%.*}" -ge 20 ]; then
         clean
         LANG=C.UTF-8 timeout --foreground 60 \
             python3 -m system_setup.cmd.tui \
-            --autoinstall "examples/autoinstall-system-setup${mode}.yaml" \
+            --dry-run \
             --output-base "$tmpdir" \
-            --dry-run
+            --autoinstall "examples/autoinstall-system-setup${mode}.yaml"
         validate "system_setup" "autoinstall${mode}"
     done
 

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -148,12 +148,20 @@ for answers in examples/answers*.yaml; do
             config=examples/simple.json
         fi
         serial=$(sed -n 's/^#serial/x/p' $answers || true)
-        opts=''
+        opts=()
         if [ -n "$serial" ]; then
-            opts='--serial'
+            opts+=(--serial)
         fi
         # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
-        timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --bootloader uefi --answers $answers --dry-run --snaps-from-examples --machine-config $config --output-base $tmpdir $opts" < $tty
+        LANG=C.UTF-8 timeout --foreground 60 \
+            python3 -m subiquity.cmd.tui < "$tty" \
+            --bootloader uefi \
+            --answers "$answers" \
+            --dry-run \
+            --snaps-from-examples \
+            --machine-config "$config" \
+            --output-base "$tmpdir" \
+            "${opts[@]}"
         validate
         grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' $tmpdir/subiquity-server-debug.log
     else
@@ -166,18 +174,26 @@ for answers in examples/answers*.yaml; do
                 reconf_settings="true"
                 validate_subtype="answers-reconf"
             fi
-            timeout --foreground 60 sh -c "DRYRUN_RECONFIG=$reconf_settings LANG=C.UTF-8 python3 -m system_setup.cmd.tui --answers $answers --output-base $tmpdir --dry-run " < $tty
+            DRYRUN_RECONFIG="$reconf_settings" LANG=C.UTF-8 timeout --foreground 60 \
+                python3 -m system_setup.cmd.tui < "$tty" \
+                --answers "$answers" \
+                --output-base "$tmpdir" \
+                --dry-run
             validate "system_setup" "$validate_subtype"
         fi
     fi
     clean
 done
 
-timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoinstall examples/autoinstall.yaml \
-                               --dry-run --machine-config examples/existing-partitions.json --bootloader bios \
-                               --kernel-cmdline 'autoinstall' \
-                               --output-base $tmpdir \
-                               --source-catalog=examples/install-sources.yaml"
+LANG=C.UTF-8 timeout --foreground 60 \
+    python3 -m subiquity.cmd.tui \
+    --autoinstall examples/autoinstall.yaml \
+    --dry-run \
+    --machine-config examples/existing-partitions.json \
+    --bootloader bios \
+    --kernel-cmdline autoinstall \
+    --output-base "$tmpdir" \
+    --source-catalog=examples/install-sources.yaml
 validate
 python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/subiquity-curtin-apt.conf \
         apt.disable_components='[non-free, restricted]' \
@@ -202,9 +218,13 @@ grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: 
     $tmpdir/subiquity-server-debug.log
 
 clean
-timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoinstall examples/autoinstall-user-data.yaml \
-                               --output-base $tmpdir \
-                               --dry-run --machine-config examples/simple.json --kernel-cmdline 'autoinstall'"
+LANG=C.UTF-8 timeout --foreground 60 \
+    python3 -m subiquity.cmd.tui \
+    --autoinstall examples/autoinstall-user-data.yaml \
+    --output-base "$tmpdir" \
+    --dry-run \
+    --machine-config examples/simple.json \
+    --kernel-cmdline autoinstall
 validate
 grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' $tmpdir/subiquity-server-debug.log
 
@@ -212,7 +232,11 @@ grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: 
 if [ "${RELEASE%.*}" -ge 20 ]; then
     for mode in "" "-full" "-no-shutdown"; do
         clean
-        timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m system_setup.cmd.tui --autoinstall examples/autoinstall-system-setup${mode}.yaml --output-base $tmpdir --dry-run"
+        LANG=C.UTF-8 timeout --foreground 60 \
+            python3 -m system_setup.cmd.tui \
+            --autoinstall "examples/autoinstall-system-setup${mode}.yaml" \
+            --output-base "$tmpdir" \
+            --dry-run
         validate "system_setup" "autoinstall${mode}"
     done
 


### PR DESCRIPTION
The use of `sh -c "$command"` to run the subiquity commands was not necessary and it makes it easy to forget to quote arguments here and there.
Instead, we can execute commands directly with, which saves us the shell invocation + potential trouble where quoting properly is not straightforward.

Also, I took the opportunity to reorder the arguments passed to Subiquity in a consistent order across the different invocations that we have:
1. Arguments used by the client & the server (e.g., `--dry-run`, `--output-base`) 
2. Arguments used by the client only
3. Arguments used by the server only