### PR TITLE
storage: fix crash when coming back from FS screen

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -254,7 +254,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         self.app.aio_loop.create_task(self._guided_choice(choice))
 
     async def _guided(self):
-        self.ui.set_body(await self.make_ui())
+        self.ui.set_body((await self.make_ui())())
 
     def guided(self):
         self.app.aio_loop.create_task(self._guided())


### PR DESCRIPTION
In order to fix a screen not refreshing issue, the following patch changed the return type of `make_ui` from an object to a callable in the storage controller:

414a2235 storage: fix screen sometimes not refreshing after slow probing

The storage controller is the only one that reuses its `make_ui()` coroutine internally. Unfortunately, the code that calls `await make_ui()` was not updated in the storage controller:

```python
  File "/home/olivier/dev/canonical/subiquity/subiquity/client/controllers/filesystem.py", line 257, in _guided
    self.ui.set_body(await self.make_ui())
  File "/home/olivier/dev/canonical/subiquity/subiquity/ui/frame.py", line 41, in set_body
    super().set_body(widget)
  File "/home/olivier/dev/canonical/subiquity/subiquitycore/ui/frame.py", line 59, in set_body
    self.set_header(_(widget.title))
AttributeError: 'function' object has no attribute 'title'
```

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>