### PR TITLE
filesystem: fix udev infinite loop

### DIFF
--- a/subiquitycore/tests/test_async_helpers.py
+++ b/subiquitycore/tests/test_async_helpers.py
@@ -1,0 +1,47 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from parameterized import parameterized
+
+from subiquitycore.async_helpers import (
+    SingleInstanceTask,
+    TaskAlreadyRunningError,
+)
+
+
+class TestSingleInstanceTask(unittest.IsolatedAsyncioTestCase):
+    @parameterized.expand([(True, 2), (False, 1)])
+    async def test_cancellable(self, cancel_restart, expected_call_count):
+        async def fn():
+            await asyncio.sleep(3)
+            raise Exception('timeout')
+
+        mock_fn = AsyncMock(side_effect=fn)
+        sit = SingleInstanceTask(mock_fn, cancel_restart=cancel_restart)
+        await sit.start()
+        await asyncio.sleep(.01)
+        try:
+            await sit.start()
+        except TaskAlreadyRunningError:
+            restarted = False
+        else:
+            restarted = True
+        sit.task.cancel()
+        self.assertEqual(expected_call_count, mock_fn.call_count)
+        self.assertEqual(cancel_restart, restarted)

--- a/subiquitycore/tests/test_pubsub.py
+++ b/subiquitycore/tests/test_pubsub.py
@@ -13,38 +13,37 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import unittest
 from unittest.mock import MagicMock
 
-from subiquitycore.tests import SubiTestCase
 from subiquitycore.pubsub import MessageHub
-from subiquitycore.tests.util import run_coro
 
 
-class TestMessageHub(SubiTestCase):
+class TestMessageHub(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.hub = MessageHub()
 
-    def test_multicall(self):
+    async def test_multicall(self):
         cb = MagicMock()
         expected_calls = 3
         channel_id = 1234
         for _ in range(expected_calls):
             self.hub.subscribe(channel_id, cb)
-        run_coro(self.hub.abroadcast(channel_id))
+        await self.hub.abroadcast(channel_id)
         self.assertEqual(expected_calls, cb.call_count)
 
-    def test_multisubscriber(self):
+    async def test_multisubscriber(self):
         cbs = [MagicMock() for _ in range(4)]
         channel_id = 2345
         for cb in cbs:
             self.hub.subscribe(channel_id, cb)
-        run_coro(self.hub.abroadcast(channel_id))
+        await self.hub.abroadcast(channel_id)
         for cb in cbs:
             cb.assert_called_once_with()
 
-    def test_message_arg(self):
+    async def test_message_arg(self):
         cb = MagicMock()
         channel_id = 'test-message-arg'
         self.hub.subscribe(channel_id, cb)
-        run_coro(self.hub.abroadcast(channel_id, '0', 1, 'two', [3], four=4))
+        await self.hub.abroadcast(channel_id, '0', 1, 'two', [3], four=4)
         cb.assert_called_once_with('0', 1, 'two', [3], four=4)


### PR DESCRIPTION
If the probert probe triggers a udev event, we can loop forever.
Fixed by not restarting an active probe, which can lose information if
it appears mid-probe but that's better than an infinite loop.