### PR TITLE
debug shell: use a clean environment

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,8 +31,15 @@ apps:
     daemon: simple
     restart-condition: always
     environment:
+      # Save original values of environment variables, we want to restore them
+      # for the debug shell (LP: #1975629).
+      PYTHONPATH_ORIG: $PYTHONPATH
+      PATH_ORIG: $PATH
+      PYTHONIOENCODING_ORIG: $PYTHONIOENCODING
       PYTHONIOENCODING: utf-8
+      SUBIQUITY_ROOT_ORIG: $SUBIQUITY_ROOT
       SUBIQUITY_ROOT: $SNAP
+      PYTHON_ORIG: $PYTHON
       PYTHON: $SNAP/usr/bin/python3.8
   os-prober:
     command: usr/bin/os-prober

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -31,6 +31,7 @@ from subiquitycore.async_helpers import (
 from subiquitycore.screen import is_linux_tty
 from subiquitycore.tuicontroller import Skip
 from subiquitycore.tui import TuiApplication
+from subiquitycore.utils import orig_environ
 from subiquitycore.view import BaseView
 
 from subiquity.client.controller import Confirm
@@ -553,8 +554,10 @@ class SubiquityClient(TuiApplication):
             os.system("clear")
             print(DEBUG_SHELL_INTRO)
 
+        env = orig_environ(os.environ)
+        cmd = ["bash"]
         self.run_command_in_foreground(
-            ["bash"], before_hook=_before, after_hook=after_hook, cwd='/')
+            cmd, env=env, before_hook=_before, after_hook=after_hook, cwd='/')
 
     def note_file_for_apport(self, key, path):
         self.error_reporter.note_file_for_apport(key, path)

--- a/subiquitycore/tests/test_utils.py
+++ b/subiquitycore/tests/test_utils.py
@@ -1,0 +1,64 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# from unittest.mock import Mock
+
+from subiquitycore.tests import SubiTestCase
+from subiquitycore.utils import orig_environ
+
+
+class TestOrigEnviron(SubiTestCase):
+    def test_empty(self):
+        env = {}
+        expected = env
+        self.assertEqual(expected, orig_environ(env))
+
+    def test_orig_path(self):
+        env = {'PATH': 'a', 'PATH_ORIG': 'b'}
+        expected = {'PATH': 'b'}
+        self.assertEqual(expected, orig_environ(env))
+
+    def test_not_this_key(self):
+        env = {'PATH': 'a', 'PATH_ORIG_AAAAA': 'b'}
+        expected = env
+        self.assertEqual(expected, orig_environ(env))
+
+    def test_remove_empty_key(self):
+        env = {'STUFF': 'a', 'STUFF_ORIG': ''}
+        expected = {}
+        self.assertEqual(expected, orig_environ(env))
+
+    def test_practical(self):
+        snap = '/snap/subiquity/1234'
+        env = {
+            'TERM': 'linux',
+            'PYTHONIOENCODING_ORIG': '',
+            'PYTHONIOENCODING': 'utf-8',
+            'SUBIQUITY_ROOT_ORIG': '',
+            'SUBIQUITY_ROOT': snap,
+            'PYTHON_ORIG': '',
+            'PYTHON': f'{snap}/usr/bin/python3.8',
+            'PYTHONPATH_ORIG': '',
+            'PYTHONPATH': f'{snap}/stuff/things',
+            'PY3OR2_PYTHON_ORIG': '',
+            'PY3OR2_PYTHON': f'{snap}/usr/bin/python3.8',
+            'PATH_ORIG': '/usr/bin:/bin',
+            'PATH': '/usr/bin:/bin:/snap/bin'
+        }
+        expected = {
+            'TERM': 'linux',
+            'PATH': '/usr/bin:/bin',
+        }
+        self.assertEqual(expected, orig_environ(env))

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -35,6 +35,21 @@ def _clean_env(env):
     return env
 
 
+def orig_environ(env):
+    if env is None:
+        env = os.environ
+    ret = env.copy()
+    for key, val in env.items():
+        if key.endswith('_ORIG'):
+            key_to_restore = key[:-len('_ORIG')]
+            if val:
+                ret[key_to_restore] = val
+            else:
+                del ret[key_to_restore]
+            del ret[key]
+    return ret
+
+
 def run_command(cmd: Sequence[str], *, input=None, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE, encoding='utf-8', errors='replace',
                 env=None, **kw) -> subprocess.CompletedProcess:


### PR DESCRIPTION
Per LP: #1975629, environment variables used to run Subiquity are leaked
into the debug environment, and in the case of things like PYTHONPATH
can harm commands run in that shell.