### PR TITLE
TUI Help/About message customisation point for variants

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -120,13 +120,13 @@ class SubiquityClient(TuiApplication):
 
     variant_to_controllers: Dict[str, List[str]] = {}
 
-    def __init__(self, opts):
+    def __init__(self, opts, about_msg=None):
         if is_linux_tty():
             self.input_filter = KeyCodesFilter()
         else:
             self.input_filter = DummyKeycodesFilter()
 
-        self.help_menu = HelpMenu(self)
+        self.help_menu = HelpMenu(self, about_msg)
         super().__init__(opts)
         self.interactive = None
         self.server_updated = None

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -396,7 +396,7 @@ class HelpMenu(PopUpLauncher):
 
     def __init__(self, app, about_msg=None):
         self.app = app
-        self.about_message = about_msg
+        self._about_message = about_msg
         self.btn = header_btn(_("Help"), on_press=self._open)
         self.ssh_info = None
         self.current_help = None
@@ -454,14 +454,14 @@ class HelpMenu(PopUpLauncher):
         return template.format(**info)
 
     def about(self, sender=None):
-        if not self.about_message:
-            self.about_message = self._default_about_msg()
+        if not self._about_message:
+            self._about_message = self._default_about_msg()
 
         self._show_overlay(
             SimpleTextStretchy(
                 self.app,
                 _("About the installer"),
-                self.about_message))
+                self._about_message))
 
     def ssh_help(self, sender=None):
         texts = ssh_help_texts(self.ssh_info)

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -394,8 +394,9 @@ class OpenHelpMenu(WidgetWrap):
 
 class HelpMenu(PopUpLauncher):
 
-    def __init__(self, app):
+    def __init__(self, app, about_msg=None):
         self.app = app
+        self.about_message = about_msg
         self.btn = header_btn(_("Help"), on_press=self._open)
         self.ssh_info = None
         self.current_help = None
@@ -440,7 +441,7 @@ class HelpMenu(PopUpLauncher):
 
         self.app.add_global_overlay(stretchy)
 
-    def about(self, sender=None):
+    def _default_about_msg(self):
         info = lsb_release(dry_run=self.app.opts.dry_run)
         if 'LTS' in info['description']:
             template = _(ABOUT_INSTALLER_LTS)
@@ -450,11 +451,17 @@ class HelpMenu(PopUpLauncher):
             'snap_version': os.environ.get("SNAP_VERSION", "SNAP_VERSION"),
             'snap_revision': os.environ.get("SNAP_REVISION", "SNAP_REVISION"),
             })
+        return template.format(**info)
+
+    def about(self, sender=None):
+        if not self.about_message:
+            self.about_message = self._default_about_msg()
+
         self._show_overlay(
             SimpleTextStretchy(
                 self.app,
                 _("About the installer"),
-                template.format(**info)))
+                self.about_message))
 
     def ssh_help(self, sender=None):
         texts = ssh_help_texts(self.ssh_info)

--- a/system_setup/client/client.py
+++ b/system_setup/client/client.py
@@ -14,11 +14,38 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 import sys
 
+from subiquitycore.lsb_release import lsb_release
 from subiquity.client.client import SubiquityClient
 
 log = logging.getLogger('system_setup.client.client')
+
+ABOUT_UBUNTU_WSL = _("""
+Welcome to the Ubuntu WSL Installer!
+
+A full Ubuntu environment, deeply integrated with Windows,
+for Linux application development and execution.
+Optimised for cloud, web, data science, IOT and fun!
+
+The installer will guide you through installing Ubuntu WSL
+{release} LTS.
+
+The installer only requires the up and down arrow keys, space (or
+return) and the occasional bit of typing.
+
+This is version {snap_version} of the installer.
+""")
+
+
+def _about_msg(msg, dry_run):
+    info = lsb_release(dry_run=dry_run)
+    info.update({
+        'snap_version': os.environ.get("SNAP_VERSION", "SNAP_VERSION"),
+        'snap_revision': os.environ.get("SNAP_REVISION", "SNAP_REVISION"),
+        })
+    return msg.format(**info)
 
 
 class SystemSetupClient(SubiquityClient):
@@ -46,3 +73,8 @@ class SystemSetupClient(SubiquityClient):
             "Summary",
         ]
     }
+
+    def __init__(self, opts):
+        super().__init__(opts)
+        self.help_menu.about_message = \
+            _about_msg(ABOUT_UBUNTU_WSL, self.opts.dry_run)

--- a/system_setup/client/client.py
+++ b/system_setup/client/client.py
@@ -23,14 +23,13 @@ from subiquity.client.client import SubiquityClient
 log = logging.getLogger('system_setup.client.client')
 
 ABOUT_UBUNTU_WSL = _("""
-Welcome to the Ubuntu WSL Installer!
+Welcome to the {id} Installer!
 
 A full Ubuntu environment, deeply integrated with Windows,
 for Linux application development and execution.
 Optimised for cloud, web, data science, IOT and fun!
 
-The installer will guide you through installing Ubuntu WSL
-{release} LTS.
+The installer will guide you through installing {description}.
 
 The installer only requires the up and down arrow keys, space (or
 return) and the occasional bit of typing.
@@ -41,9 +40,11 @@ This is version {snap_version} of the installer.
 
 def _about_msg(msg, dry_run):
     info = lsb_release(dry_run=dry_run)
+    newId = info["id"] + " WSL"
     info.update({
-        'snap_version': os.environ.get("SNAP_VERSION", "SNAP_VERSION"),
-        'snap_revision': os.environ.get("SNAP_REVISION", "SNAP_REVISION"),
+        'id': newId,
+        'description': info["description"].replace(info["id"], newId),
+        'snap_version': os.environ.get("SNAP_VERSION", "SNAP_VERSION")
         })
     return msg.format(**info)
 

--- a/system_setup/client/client.py
+++ b/system_setup/client/client.py
@@ -76,6 +76,4 @@ class SystemSetupClient(SubiquityClient):
     }
 
     def __init__(self, opts):
-        super().__init__(opts)
-        self.help_menu.about_message = \
-            _about_msg(ABOUT_UBUNTU_WSL, self.opts.dry_run)
+        super().__init__(opts, _about_msg(ABOUT_UBUNTU_WSL, opts.dry_run))

--- a/system_setup/models/system_setup.py
+++ b/system_setup/models/system_setup.py
@@ -58,6 +58,7 @@ class SystemSetupModel(SubiquityModel):
         self.userdata = {}
         self.locale = LocaleModel(self.chroot_prefix)
         self.identity = IdentityModel()
+        self.network = None
         self.wslconfbase = WSLConfigurationBaseModel()
         self.wslconfadvanced = WSLConfigurationAdvancedModel()
 


### PR DESCRIPTION
WSL installer TUI currently crashes if user clicks on Help menu due missing network parameter in the app basemodel. When fixing that we noticed that the Help/About message required some customisation. This PR aims to provide the customisation point for variants and provide the fix for the WSL case.
This aims to close https://github.com/ubuntu/WSL/issues/202 