### PR TITLE
Enables variants to override creation and startup

### DIFF
--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -502,6 +502,9 @@ class SubiquityServer(Application):
             controller.add_routes(app)
         runner = web.AppRunner(app, keepalive_timeout=0xffffffff)
         await runner.setup()
+        await self.start_site(runner)
+
+    async def start_site(self, runner: web.AppRunner):
         site = web.UnixSite(runner, self.opts.socket)
         await site.start()
         # It is intended that a non-root client can connect.


### PR DESCRIPTION
No behavior changes with this PR, but it enables variants to opt in for customizing which site and how to start it. The plan is to patch system_setup on top of this to enable TCP on localhost as part of the plan of having the Flutter OOBE as a Windows application for WSL.