### PR TITLE
Enables TCPSite for WSL

### DIFF
--- a/system_setup/cmd/server.py
+++ b/system_setup/cmd/server.py
@@ -42,6 +42,13 @@ def make_server_args_parser():
     parser.add_argument('--output-base', action='store', dest='output_base',
                         default='.subiquity',
                         help='in dryrun, control basedir of files')
+    parser.add_argument('--tcp-port',
+                        dest='tcp_port',
+                        type=int,
+                        choices=range(49152, 60999),
+                        help='The TCP port Subiquity must listen to. It means '
+                        'TCP will be used instead of Unix domain sockets. '
+                        'Only localhost connections are accepted.')
     return parser
 
 

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -39,7 +39,8 @@ INSTALL_MODEL_NAMES = ModelNames({
 
 POSTINSTALL_MODEL_NAMES = ModelNames(set())
 
-LOCALHOST_ADDR="127.0.0.1"
+LOCALHOST_ADDR = "127.0.0.1"
+
 
 class SystemSetupServer(SubiquityServer):
     prefillInfo = None

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -98,7 +98,7 @@ class SystemSetupServer(SubiquityServer):
         if port is None:
             return await super().start_site(runner)
 
-        # Subiquity runs with root privileges. We don't wont outsiders to
-        # connect to it.
+        # Subiquity runs with root privileges, that's why we don't want
+        # outsiders to connect to it. Only localhost loopback is allowed.
         site = web.TCPSite(runner, host=LOCALHOST_ADDR, port=port)
         await site.start()


### PR DESCRIPTION
Per aiohttp documentation, the `host` parameter of the TCPSite sets the interface on which the server will listen on. Listening on 127.0.0.1, as you know, means only clients running on the same host can reach that server. Interestingly, with WSL2, clients running on Windows can make requests to 127.0.0.1 which crosses the vEthernet adapter and reach the VM as if it was the same host. This behavior was tested on Windows 10 and 11. Thus by simply locking to the loopback interface can give us some level of security and keep the solution simple.

This PR enables the component in charge of starting the server to choose which port to bind to. This is a key feature to enable migrating the OOBE GUI to a Windows application.