### PR TITLE
Check child forms status when disabling/enabling Done button of a form

### DIFF
--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -80,6 +80,7 @@ class LVMOptionsForm(SubForm):
 
     def _toggle(self, sender, val):
         self.luks_options.enabled = val
+        self.validated()
 
     encrypt = BooleanField(_("Encrypt the LVM group with LUKS"), help=NO_HELP)
     luks_options = SubFormField(LUKSOptionsForm, "", help=NO_HELP)
@@ -146,6 +147,7 @@ class GuidedChoiceForm(SubForm):
 
     def _toggle(self, sender, val):
         self.lvm_options.enabled = val
+        self.validated()
 
 
 class GuidedForm(Form):
@@ -165,6 +167,7 @@ class GuidedForm(Form):
 
     def _toggle_guided(self, sender, new_value):
         self.guided_choice.enabled = new_value
+        self.validated()
 
 
 HELP = _("""

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -111,27 +111,6 @@ class _Validator(WidgetWrap):
         self.field.validate()
 
 
-class FormField(abc.ABC):
-
-    next_index = 0
-    takes_default_style = True
-    caption_first = True
-
-    def __init__(self, caption=None, help=None):
-        self.caption = caption
-        self.help = help
-        self.index = FormField.next_index
-        FormField.next_index += 1
-
-    @abc.abstractmethod
-    def _make_widget(self, form):
-        pass
-
-    def bind(self, form):
-        widget = self._make_widget(form)
-        return BoundFormField(self, form, widget)
-
-
 class WantsToKnowFormField(object):
     """A marker class."""
     def set_bound_form_field(self, bff):
@@ -161,16 +140,8 @@ class BoundFormField(object):
             widget.set_bound_form_field(self)
 
     def is_in_error(self) -> bool:
-        """ Tells whether this field is in error. We will also check if any of
-        the enabled subform reports an error.
-        """
-        if self.in_error:
-            return True
-
-        if not self._enabled or not isinstance(self.widget, SubFormWidget):
-            return False
-
-        return self.widget.form.has_validation_error()
+        """ Tells whether this field is in error. """
+        return self.in_error
 
     def _build_table(self):
         widget = self.widget
@@ -308,6 +279,42 @@ class BoundFormField(object):
         self._enabled = val
         for row in self._rows:
             row.enabled = val
+
+
+class BoundSubFormField(BoundFormField):
+    def is_in_error(self):
+        """ Tells whether this field is in error. We will also check if the
+        subform (if enabled) reports an error.
+        """
+        if super().is_in_error():
+            return True
+
+        if not self._enabled:
+            return False
+
+        return self.widget.form.has_validation_error()
+
+
+class FormField(abc.ABC):
+
+    next_index = 0
+    takes_default_style = True
+    caption_first = True
+    bound_field_class = BoundFormField
+
+    def __init__(self, caption=None, help=None):
+        self.caption = caption
+        self.help = help
+        self.index = FormField.next_index
+        FormField.next_index += 1
+
+    @abc.abstractmethod
+    def _make_widget(self, form):
+        pass
+
+    def bind(self, form):
+        widget = self._make_widget(form)
+        return self.bound_field_class(self, form, widget)
 
 
 def simple_field(widget_maker):
@@ -517,7 +524,7 @@ class Form(object, metaclass=MetaForm):
             narrow_rows=narrow_rows)
 
     def has_validation_error(self) -> bool:
-        """ Tells if any field (or subformfield) is in error. """
+        """ Tells if any field is in error. """
         return any(map(lambda f: f.is_in_error(), self._fields))
 
     def validated(self):
@@ -554,6 +561,7 @@ class SubFormWidget(WidgetWrap):
 class SubFormField(FormField):
 
     takes_default_style = False
+    bound_field_class = BoundSubFormField
 
     def __init__(self, form_cls, caption=None, help=None):
         super().__init__(caption=caption, help=help)

--- a/subiquitycore/ui/tests/test_form.py
+++ b/subiquitycore/ui/tests/test_form.py
@@ -1,0 +1,151 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+from subiquitycore.ui.form import (
+    Form,
+    StringField,
+    SubForm,
+    SubFormField,
+    )
+
+
+class TestForm(TestCase):
+
+    def test_has_validation_error(self):
+        """ Make sure Form.has_validation_form() returns:
+        * True if any field is in error
+        * False otherwise. """
+        class DummyForm(Form):
+            field1 = StringField("DummyStringOne", help="")
+            field2 = StringField("DummyStringTwo", help="")
+
+        form = DummyForm()
+
+        form.field1.in_error = False
+        form.field2.in_error = False
+        self.assertFalse(form.has_validation_error())
+
+        form.field1.in_error = True
+        form.field2.in_error = True
+        self.assertTrue(form.has_validation_error())
+
+        form.field1.in_error = True
+        form.field2.in_error = False
+        self.assertTrue(form.has_validation_error())
+
+    def test_has_validation_error_with_subform(self):
+        """ Make sure Form.has_validation_form() is affected by fields from
+        child forms (only if the child form is enabled). """
+        class DummySubForm(SubForm):
+            field1 = StringField("DummyString", help="")
+
+        class DummyForm(Form):
+            field1 = StringField("DummyString", help="")
+            dummy_subform = SubFormField(DummySubForm, "", help="")
+
+        form = DummyForm()
+        subform = form.dummy_subform.widget.form
+
+        form.field1.in_error = False
+        subform.field1.in_error = False
+        self.assertFalse(form.has_validation_error())
+
+        form.field1.in_error = True
+        subform.field1.in_error = False
+        self.assertTrue(form.has_validation_error())
+
+        form.field1.in_error = False
+        subform.field1.in_error = True
+        self.assertTrue(form.has_validation_error())
+
+        form.field1.in_error = True
+        subform.field1.in_error = True
+        self.assertTrue(form.has_validation_error())
+
+        # Make sure fields in disabled subforms are ignored.
+        form.field1.in_error = False
+        subform.field1.in_error = True
+        form.dummy_subform.enabled = False
+        self.assertFalse(form.has_validation_error())
+
+    def test_has_validation_error_with_subsubform(self):
+        """ Make sure enabling/disabling parent forms also acts as if sub forms
+        are disabled. """
+        class DummySubSubForm(SubForm):
+            field1 = StringField("DummyString", help="")
+
+        class DummySubForm(SubForm):
+            dummy_subform = SubFormField(DummySubSubForm, "", help="")
+
+        class DummyForm(Form):
+            dummy_subform = SubFormField(DummySubForm, "", help="")
+
+        form = DummyForm()
+        subform = form.dummy_subform.widget.form
+        subsubform = subform.dummy_subform.widget.form
+
+        subsubform.field1.in_error = True
+        self.assertTrue(form.has_validation_error())
+
+        # If subsubform is disabled, it should be ignored.
+        subsubform.field1.in_error = True
+        subform.dummy_subform.enabled = False
+        self.assertFalse(form.has_validation_error())
+
+        # If subform is disabled, it should also be ignored.
+        subsubform.field1.in_error = True
+        subform.dummy_subform.enabled = True
+        form.dummy_subform.enabled = False
+        self.assertFalse(form.has_validation_error())
+
+    def test_done_button_auto_toggle(self):
+        """ Make sure calling validated() enables or disables the Done button.
+        """
+        class DummyForm(Form):
+            field1 = StringField("DummyString", help="")
+
+        form = DummyForm()
+        done_button = form.buttons.base_widget.contents[0][0]
+
+        form.field1.in_error = False
+        form.validated()
+        self.assertTrue(done_button.enabled)
+
+        form.field1.in_error = True
+        form.validated()
+        self.assertFalse(done_button.enabled)
+
+    def test_subform_validated_propagates(self):
+        """ Make sure calling validated() in a subform affects the Done button
+        in the parent form. """
+        class DummySubForm(SubForm):
+            field1 = StringField("DummyString", help="")
+
+        class DummyForm(Form):
+            dummy_subform = SubFormField(DummySubForm, "", help="")
+
+        form = DummyForm()
+        subform = form.dummy_subform.widget.form
+        done_button = form.buttons.base_widget.contents[0][0]
+
+        subform.field1.in_error = False
+        subform.validated()
+        self.assertTrue(done_button.enabled)
+
+        subform.field1.in_error = True
+        subform.validated()
+        self.assertFalse(done_button.enabled)


### PR DESCRIPTION
When the validation of a field fails in a form, we disable the Done button. With child forms, however, it did not work because they have their own set of hidden buttons ; that are not the ones the users interacts with.

This patch makes parent forms recurse on the child forms when checking if any field is in error. Also, when a child form undertakes validation, it now propagates to the parent, so that the done button can be immediately enabled/disabled.

Having a validation error in a child form that is not currently enabled should not prevent the user from moving forward, so we disable recursion for child forms that are disabled.

--

The above change was needed as part of the Ubuntu Pro changes where we make use of child forms for manual token or Ubuntu One email. Since Guided Storage also makes use of SubForms, I took some time to check how that screen would be affected. I'm quite happy about the change.

Before, the Done button would never be disabled in the GuidedStorage screen, even in case of invalid LUKS passphrase or some other error. The Done button is now disabled if a validation error occurs ; unless it's in a disabled child form.

![luks-enabled-passwords-do-not-match](https://user-images.githubusercontent.com/4038023/172591412-8c5b268b-5e3f-4fcd-abbf-4502edbd992e.png)
![luks-disabled-passwords-do-not-match](https://user-images.githubusercontent.com/4038023/172591417-b140e846-13a7-44e5-a8ae-20069356341f.png)
