### PR TITLE
ubuntu-pro: add auto_enabled property for services

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -460,6 +460,7 @@ class UbuntuProCheckTokenStatus(enum.Enum):
 class UbuntuProService:
     name: str
     description: str
+    auto_enabled: bool
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/server/tests/test_ubuntu_advantage.py
+++ b/subiquity/server/tests/test_ubuntu_advantage.py
@@ -191,18 +191,22 @@ class TestUAInterface(unittest.TestCase):
         self.assertIn(UbuntuProService(
             name="esm-infra",
             description="UA Infra: Extended Security Maintenance (ESM)",
+            auto_enabled=True,
         ), services)
         self.assertIn(UbuntuProService(
             name="fips",
             description="NIST-certified core packages",
+            auto_enabled=False,
         ), services)
         self.assertNotIn(UbuntuProService(
             name="esm-apps",
             description="UA Apps: Extended Security Maintenance (ESM)",
+            auto_enabled=True,
         ), services)
         self.assertNotIn(UbuntuProService(
             name="cis",
             description="Center for Internet Security Audit Tools",
+            auto_enabled=False,
         ), services)
 
         # Test with "Z" suffix for the expiration date.

--- a/subiquity/server/ubuntu_advantage.py
+++ b/subiquity/server/ubuntu_advantage.py
@@ -174,6 +174,7 @@ class UAInterface:
             return UbuntuProService(
                name=service["name"],
                description=service["description"],
+               auto_enabled=service["auto_enabled"] == "yes",
             )
 
         activable_services: List[UbuntuProService] = []


### PR DESCRIPTION
The JSON returned by uaclient for a status request contains the `auto_enabled` property for each service. This property tells whether a given service is enabled automatically when `ua attach` is done. We will need this information going forward so we now include it in the success response to `/ubuntu_pro/check_token`:

```json
  {
    "status": "VALID_TOKEN",
    "services": [
      {
        "name": "esm-infra",
        "description": "UA Infra: Extended Security Maintenance (ESM)",
        "auto_enabled": true
      },
      {
        "name": "fips",
        "description": "NIST-certified core packages",
        "auto_enabled": false
      }
    ]
  }
```