### PR TITLE
deps: fix missing developer dep python3-mock for apt-deps make target

### DIFF
--- a/subiquity/tests/test_timezonecontroller.py
+++ b/subiquity/tests/test_timezonecontroller.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import mock
+from unittest import mock
 
 from subiquity.common.types import TimeZoneInfo
 from subiquity.models.timezone import TimeZoneModel


### PR DESCRIPTION
Fix missing python3-mock dep which allows folks to run unittests on a new jammy container

# Steps to reproduce
lxc launch ubuntu-daily:jammy dev-j
lxc exec dev-j bash
git clone https://github.com/canonical/subiquity.git
apt install make
make aptdeps
make unit

# Desired behavior
....
======================= 436 passed, 68 warnings in 4.88s =======================


# failure:
```
_________ ERROR collecting subiquity/tests/test_timezonecontroller.py __________
ImportError while importing test module '/root/subiquity/subiquity/tests/test_timezonecontroller.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
subiquity/tests/test_timezonecontroller.py:16: in <module>
    import mock
E   ModuleNotFoundError: No module named 'mock'
```