### PR TITLE
cloud-config: schema drop deprecated dict user.groups value type

### DIFF
--- a/subiquity/common/resources.py
+++ b/subiquity/common/resources.py
@@ -18,6 +18,7 @@
 
 import logging
 import os
+from typing import List
 
 log = logging.getLogger('subiquity.common.resources')
 
@@ -26,7 +27,7 @@ def resource_path(relative_path):
     return os.path.join(os.environ.get("SUBIQUITY_ROOT", "."), relative_path)
 
 
-def get_users_and_groups(chroot_prefix=[]):
+def get_users_and_groups(chroot_prefix=[]) -> List:
     # prevent import when calling just resource_path
     from subiquitycore.utils import run_command
 
@@ -43,5 +44,4 @@ def get_users_and_groups(chroot_prefix=[]):
     for line in cp.stdout.splitlines():
         target_groups.add(line.split(':')[0])
 
-    groups = target_groups.intersection(groups)
-    return groups
+    return list(target_groups.intersection(groups))

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -262,7 +262,7 @@ class SubiquityModel:
                 'gecos': user.realname,
                 'passwd': user.password,
                 'shell': '/bin/bash',
-                'groups': groups,
+                'groups': ','.join(sorted(groups)),
                 'lock_passwd': False,
                 }
             if self.ssh.authorized_keys:

--- a/subiquity/models/tests/test_subiquity.py
+++ b/subiquity/models/tests/test_subiquity.py
@@ -196,6 +196,10 @@ class TestSubiquityModel(unittest.TestCase):
             cloud_init_config = model._cloud_init_config()
             self.assertEqual(len(cloud_init_config['users']), 2)
             self.assertEqual(cloud_init_config['users'][0]['name'], 'mainuser')
+            self.assertEqual(
+                cloud_init_config['users'][0]['groups'],
+                'adm,cdrom,dip,lxd,plugdev,sudo'
+            )
             self.assertEqual(cloud_init_config['users'][1]['name'], 'user2')
 
         with self.subTest('Secondary user only'):


### PR DESCRIPTION
Align with latest cloud-init schema avoid using depracated
value types for users. groups definitions in cloud-config.

Also fix get_users_and_groups to return a list instead of
dict as all call sites expected it to return a list.