### PR TITLE
[system_setup] Avoid integration test failure due server exited

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -234,8 +234,7 @@ if [ "${RELEASE%.*}" -ge 20 ]; then
     # Test TCP connectivity (system_setup only)
     clean
     port=50321
-    LANG=C.UTF-8 timeout --foreground 60 \
-        python3 -m system_setup.cmd.server --dry-run --tcp-port=$port &
+    LANG=C.UTF-8 python3 -m system_setup.cmd.server --dry-run --tcp-port=$port &
     subiquity_pid=$!
     next_time=3
     until [ $next_time -eq 0 ] || [ ! -z "$(ss -Hlt sport = $port)" ]; do
@@ -268,7 +267,7 @@ if [ "${RELEASE%.*}" -ge 20 ]; then
             fi
         done
     done
-    kill $subiquity_pid
+    kill $subiquity_pid || true
     if [ $loopback_failed -ne 0 ]; then
         echo "Loopback was expected to connect"
         exit 1

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -242,6 +242,7 @@ if [ "${RELEASE%.*}" -ge 20 ]; then
     done
     if [ $next_time -eq 0 ]; then
         echo "Timeout reached before Subiquity TCP socket started listening"
+        kill $subiquity_pid || true
         exit 1
     fi
     loopback_failed=0


### PR DESCRIPTION
`timeout 60` might be too short for someone with lots of network interfaces.
Since we grab the PID and run the server in the background, the timeout is not critically necessary.