### PR TITLE
Better help message for system setup

### DIFF
--- a/system_setup/cmd/server.py
+++ b/system_setup/cmd/server.py
@@ -46,6 +46,7 @@ def make_server_args_parser():
                         dest='tcp_port',
                         type=int,
                         choices=range(49152, 60999),
+                        metavar="[49152 to 60999]",
                         help='The TCP port Subiquity must listen to. It means '
                         'TCP will be used instead of Unix domain sockets. '
                         'Only localhost connections are accepted.')


### PR DESCRIPTION
This is the end result (much better than printing the whole range of valid port numbers):

```
starting server
usage: system_setup [-h] [--dry-run] [--socket SOCKET]
                    [--autoinstall AUTOINSTALL] [--prefill PREFILL]
                    [--output-base OUTPUT_BASE] [--tcp-port [49152 to 60999]]

System Setup - Initial Boot Setup

options:
  -h, --help            show this help message and exit
  --dry-run             menu-only, do not call installer function
  --socket SOCKET
  --autoinstall AUTOINSTALL
  --prefill PREFILL     Prefills UI models with data provided in a
                        prefill.yaml file yet allowing overrides.
  --output-base OUTPUT_BASE
                        in dryrun, control basedir of files
  --tcp-port [49152 to 60999]
                        The TCP port Subiquity must listen to. It means TCP
                        will be used instead of Unix domain sockets. Only
                        localhost connections are accepted.


```