### PR TITLE
ubuntu-pro: remove hardcoded test for jammy

### DIFF
--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -50,9 +50,7 @@ class UbuntuProController(SubiquityTuiController):
         dry_run: bool = self.app.opts.dry_run
 
         lsb = lsb_release(dry_run=dry_run)
-        # TODO Remove explicit check for jammy when 22.04 gets marked as a LTS
-        # version instead of a "(development branch)".
-        if "LTS" not in lsb["description"] and lsb["codename"] != "jammy":
+        if "LTS" not in lsb["description"]:
             await self.endpoint.skip.POST()
             raise Skip("Not running LTS version")
 


### PR DESCRIPTION
During the development cycle of 22.04, jammy was not yet marked an LTS
version. To have Ubuntu Pro screen fire up on that version, we had to
explicitly make an exception for Jammy.

Since Jammy is official LTS now, we can drop this explicit check.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>