### PR TITLE
boot: handle small disk case

### DIFF
--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -154,8 +154,9 @@ def get_boot_device_plan_bios(device) -> Optional[MakeBootDevicePlan]:
     if device.ptable == 'msdos':
         return attr_plan
     pgs = gaps.parts_and_gaps(device)
-    if isinstance(pgs[0], Partition) and pgs[0].flag == "bios_grub":
-        return attr_plan
+    if len(pgs) > 0:
+        if isinstance(pgs[0], Partition) and pgs[0].flag == "bios_grub":
+            return attr_plan
 
     gap = gaps.Gap(device=device,
                    offset=sizes.BIOS_GRUB_SIZE_BYTES,

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -458,6 +458,14 @@ class TestFilesystemManipulator(unittest.TestCase):
         self.assertFalse(boot.can_be_boot_device(disk))
 
     @parameterized.expand([(1,), (2,)])
+    def test_no_add_boot_BIOS_gpt_teeny_disk(self, version):
+        # Showed up in VM testing - the ISO created cloud-localds shows up as a
+        # potential install target, and weird things happen.
+        manipulator = make_manipulator(Bootloader.BIOS, version)
+        disk = make_disk(manipulator.model, ptable='gpt', size=1 << 20)
+        self.assertFalse(boot.can_be_boot_device(disk))
+
+    @parameterized.expand([(1,), (2,)])
     def test_add_boot_BIOS_msdos(self, version):
         manipulator = make_manipulator(Bootloader.BIOS, version)
         disk = make_disk(manipulator.model, preserve=True, ptable='msdos')


### PR DESCRIPTION
The BIOS boot plan check assumes that there is at least one result in
the list from gaps.parts_and_gaps(), but that isn't the case if the disk
is small.

Showed up in VM testing using cloud-localds to seed the autoinstall
file.