### PR TITLE
filesystem: guided lvm unit tests

### DIFF
--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -57,62 +57,67 @@ class TestSubiquityControllerFilesystem(TestCase):
 
 
 class TestGuided(TestCase):
-    def _guided_direct(self, bootloader, ptable):
+    def _guided_setup(self, bootloader, ptable):
         self.app = make_app()
         self.app.opts.bootloader = bootloader.value
         self.controller = FilesystemController(self.app)
         self.controller.model = make_model(bootloader)
         self.controller.model._probe_data = {'blockdev': {}}
         self.d1 = make_disk(self.controller.model, ptable=ptable)
+
+    @parameterized.expand([
+            (Bootloader.UEFI, 'gpt', '/boot/efi'),
+            (Bootloader.UEFI, 'msdos', '/boot/efi'),
+            (Bootloader.BIOS, 'gpt', None),
+            # BIOS + msdos is different
+            (Bootloader.PREP, 'gpt', None),
+            (Bootloader.PREP, 'msdos', None),
+        ])
+    def test_guided_direct(self, bootloader, ptable, p1mnt):
+        self._guided_setup(bootloader, ptable)
         self.controller.guided_direct(self.d1)
-
-    def test_guided_direct_UEFI_GPT(self):
-        self._guided_direct(Bootloader.UEFI, 'gpt')
         [d1p1, d1p2] = self.d1.partitions()
-        self.assertEqual('/boot/efi', d1p1.mount)
-        self.assertEqual('/', d1p2.mount)
-        self.assertEqual(d1p1.size + d1p1.offset, d1p2.offset)
-
-    def test_guided_direct_UEFI_MSDOS(self):
-        self._guided_direct(Bootloader.UEFI, 'msdos')
-        [d1p1, d1p2] = self.d1.partitions()
-        self.assertEqual('/boot/efi', d1p1.mount)
-        self.assertEqual('/', d1p2.mount)
-        self.assertEqual(d1p1.size + d1p1.offset, d1p2.offset)
-
-    def test_guided_direct_BIOS_GPT(self):
-        self._guided_direct(Bootloader.BIOS, 'gpt')
-        [d1p1, d1p2] = self.d1.partitions()
-        self.assertEqual(None, d1p1.mount)
+        self.assertEqual(p1mnt, d1p1.mount)
         self.assertEqual('/', d1p2.mount)
         self.assertEqual(d1p1.size + d1p1.offset, d1p2.offset)
 
     def test_guided_direct_BIOS_MSDOS(self):
-        self._guided_direct(Bootloader.BIOS, 'msdos')
+        self._guided_setup(Bootloader.BIOS, 'msdos')
+        self.controller.guided_direct(self.d1)
         [d1p1] = self.d1.partitions()
         self.assertEqual('/', d1p1.mount)
 
-    def test_guided_direct_PREP_GPT(self):
-        self._guided_direct(Bootloader.PREP, 'gpt')
-        [d1p1, d1p2] = self.d1.partitions()
-        self.assertEqual(None, d1p1.mount)
-        self.assertEqual('/', d1p2.mount)
+    @parameterized.expand([
+            (Bootloader.UEFI, 'gpt', '/boot/efi'),
+            (Bootloader.UEFI, 'msdos', '/boot/efi'),
+            (Bootloader.BIOS, 'gpt', None),
+            # BIOS + msdos is different
+            (Bootloader.PREP, 'gpt', None),
+            (Bootloader.PREP, 'msdos', None),
+        ])
+    def test_guided_lvm(self, bootloader, ptable, p1mnt):
+        self._guided_setup(bootloader, ptable)
+        self.controller.guided_lvm(self.d1)
+        [d1p1, d1p2, d1p3] = self.d1.partitions()
+        self.assertEqual(p1mnt, d1p1.mount)
+        self.assertEqual('/boot', d1p2.mount)
+        self.assertEqual(None, d1p3.mount)
         self.assertEqual(d1p1.size + d1p1.offset, d1p2.offset)
+        self.assertEqual(d1p2.size + d1p2.offset, d1p3.offset)
 
-    def test_guided_direct_PREP_MSDOS(self):
-        self._guided_direct(Bootloader.PREP, 'msdos')
+    def test_guided_lvm_BIOS_MSDOS(self):
+        self._guided_setup(Bootloader.BIOS, 'msdos')
+        self.controller.guided_lvm(self.d1)
         [d1p1, d1p2] = self.d1.partitions()
-        self.assertEqual(None, d1p1.mount)
-        self.assertEqual('/', d1p2.mount)
+        self.assertEqual('/boot', d1p1.mount)
+        self.assertEqual(None, d1p2.mount)
         self.assertEqual(d1p1.size + d1p1.offset, d1p2.offset)
 
 
 class TestLayout(TestCase):
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = 'UEFI'
-        self.app.report_start_event = mock.Mock()
-        self.app.report_finish_event = mock.Mock()
+        self.app.opts.bootloader = None
         self.fsc = FilesystemController(app=self.app)
 
     @parameterized.expand([('reformat_disk',), ('use_gap',)])


### PR DESCRIPTION
Add coverage for LVM cases
Use parameterized to reduce some redundancy.