### PR TITLE
test/api: replace use of deprecated "with timeout()"

### DIFF
--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -36,7 +36,7 @@ def timeout(multiplier=1):
     def wrapper(coro):
         @wraps(coro)
         async def run(*args, **kwargs):
-            with async_timeout.timeout(default_timeout * multiplier):
+            async with async_timeout.timeout(default_timeout * multiplier):
                 return await coro(*args, **kwargs)
         return run
     return wrapper


### PR DESCRIPTION
Running the API tests in Ubuntu 22.04 or newer versions result in the following warning:

```python
DeprecationWarning: with timeout() is deprecated, use async with timeout() instead
```
The deprecation message was introduced as part of async-timeout 4.0.0:
https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst#400-2021-11-01

The ability to use `async_timeout.timeout` as an async context manager was introduced in version 1.3.0 in 2017 so there is no problem using it:
https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst#130-2017-08-23

The version of python3-async-timeout present in the archives at the time of writing is:

 * 4.0.1 in jammy.
 * 3.0.1 in focal.
 * 2.0.0 in bionic.