### PR TITLE
ubuntu-pro: update screens to match design mockups

### DIFF
--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -70,6 +70,7 @@ class UbuntuProController(SubiquityTuiController):
         async def inner() -> None:
             answer = await self.endpoint.check_token.GET(token)
             if answer.status == TokenStatus.VALID_TOKEN:
+                await self.endpoint.POST(UbuntuProInfo(token=token))
                 on_success(answer.subscription.services)
             else:
                 on_failure(answer.status)
@@ -85,6 +86,12 @@ class UbuntuProController(SubiquityTuiController):
         self.app.prev_screen()
 
     def done(self, token: str) -> None:
+        """ Submit the token and move on to the next screen. """
         self.app.next_screen(
             self.endpoint.POST(UbuntuProInfo(token=token))
         )
+
+    def next_screen(self) -> None:
+        """ Move on to the next screen. Assume the token should not be
+        submitted (or has already been submitted). """
+        self.app.next_screen()

--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -18,6 +18,8 @@ import asyncio
 import logging
 from typing import Callable, List, Optional
 
+from urwid import Widget
+
 from subiquitycore.async_helpers import schedule_task
 
 from subiquity.client.controller import SubiquityTuiController
@@ -26,7 +28,12 @@ from subiquity.common.types import (
     UbuntuProCheckTokenStatus as TokenStatus,
     UbuntuProService,
     )
-from subiquity.ui.views.ubuntu_pro import UbuntuProView
+from subiquity.ui.views.ubuntu_pro import (
+    UbuntuProView,
+    UpgradeYesNoForm,
+    UpgradeModeForm,
+    TokenAddedWidget,
+    )
 
 from subiquitycore.lsb_release import lsb_release
 from subiquitycore.tuicontroller import Skip
@@ -58,9 +65,66 @@ class UbuntuProController(SubiquityTuiController):
         ubuntu_pro_info = await self.endpoint.GET()
         return UbuntuProView(self, ubuntu_pro_info.token)
 
-    def run_answers(self) -> None:
-        if "token" in self.answers:
-            self.done(self.answers["token"])
+    async def run_answers(self) -> None:
+        """ Interact with the UI to go through the pre-attach process if
+        requested. """
+        if "token" not in self.answers:
+            return
+
+        from subiquitycore.testing.view_helpers import (
+            click,
+            enter_data,
+            find_button_matching,
+            find_with_pred,
+            keypress,
+        )
+
+        view = self.app.ui.body
+
+        def run_yes_no_screen(skip: bool) -> None:
+            if skip:
+                radio = view.upgrade_yes_no_form.skip.widget
+            else:
+                radio = view.upgrade_yes_no_form.upgrade.widget
+
+            keypress(radio, key="enter")
+            click(find_button_matching(view, UpgradeYesNoForm.ok_label))
+
+        def run_token_screen(token: str) -> None:
+            keypress(view.upgrade_mode_form.with_contract_token.widget,
+                     key="enter")
+            data = {"with_contract_token_subform": {"token": token}}
+            # TODO: add this point, it would be good to trigger the validation
+            # code for the token field.
+            enter_data(view.upgrade_mode_form, data)
+            click(find_button_matching(view, UpgradeModeForm.ok_label))
+
+        async def run_token_added_overlay() -> None:
+            def is_token_added_overlay(widget: Widget) -> bool:
+                try:
+                    if widget._text == f" {TokenAddedWidget.title} ":
+                        return True
+                except AttributeError:
+                    return False
+
+            # Wait until the "Token added successfully" overlay is shown.
+            while not find_with_pred(view, is_token_added_overlay):
+                await asyncio.sleep(.2)
+
+            click(find_button_matching(view, TokenAddedWidget.done_label))
+
+        def run_services_screen() -> None:
+            click(find_button_matching(view._w,
+                                       UbuntuProView.services_done_label))
+
+        if not self.answers["token"]:
+            run_yes_no_screen(skip=True)
+            return
+
+        run_yes_no_screen(skip=False)
+        run_token_screen(self.answers["token"])
+        await run_token_added_overlay()
+        run_services_screen()
 
     def check_token(self, token: str,
                     on_success: Callable[[List[UbuntuProService]], None],

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -35,9 +35,11 @@ from subiquitycore.ui.buttons import (
     back_btn,
     cancel_btn,
     done_btn,
+    menu_btn,
     ok_btn,
     )
 from subiquitycore.ui.container import (
+    ListBox,
     Pile,
     WidgetWrap,
     )
@@ -58,6 +60,7 @@ from subiquitycore.ui.stretchy import (
     )
 from subiquitycore.ui.utils import (
     button_pile,
+    screen,
     SomethingFailed,
     )
 
@@ -203,7 +206,22 @@ class UbuntuProView(BaseView):
         connect_signal(self.form, 'submit', self.done)
         connect_signal(self.form, 'cancel', on_cancel)
 
-        super().__init__(self.form.as_screen(excerpt=_(self.excerpt)))
+        about_pro_btn = menu_btn(
+                _("About Ubuntu Pro"),
+                on_press=lambda unused: self.show_about_ubuntu_pro())
+
+        bp = button_pile([about_pro_btn])
+        bp.align = "left"
+        rows = [
+            bp,
+            Text(""),
+        ] + self.form.as_rows()
+        super().__init__(
+            screen(
+                ListBox(rows),
+                self.form.buttons,
+                excerpt=self.excerpt,
+                focus_buttons=True))
 
     def done(self, form: UbuntuProForm) -> None:
         """ If no token was supplied, move on to the next screen.
@@ -239,6 +257,10 @@ class UbuntuProView(BaseView):
     def cancel(self) -> None:
         """ Called when the user presses the Back button. """
         self.controller.cancel()
+
+    def show_about_ubuntu_pro(self) -> None:
+        """ Display an overlay that shows information about Ubuntu Pro. """
+        self.show_stretchy_overlay(AboutProWidget(self))
 
     def show_invalid_token(self) -> None:
         """ Display an overlay that indicates that the user-supplied token is

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -111,6 +111,9 @@ class UbuntuProForm(Form):
     |                                                         |
     | ( )  Skip Ubuntu Pro for now                            |
     |                                                         |
+    |      You can always enable Ubuntu Pro later via the     |
+    |      'ua attach' command.                               |
+    |                                                         |
     |                         [ Done ]                        |
     |                         [ Back ]                        |
     +---------------------------------------------------------+
@@ -123,8 +126,9 @@ class UbuntuProForm(Form):
             _("Enable now with my contract token"), help=NO_HELP)
     token_form = SubFormField(UbuntuProTokenForm, "", help=NO_HELP)
     skip_ua = RadioButtonField(
-            group,
-            _("Skip Ubuntu Pro for now"), help=NO_HELP)
+            group, _("Do this later"),
+            help="\n" + _("You can always enable Ubuntu Pro later via the"
+                          " 'ua attach' command."))
 
     def __init__(self, initial):
         super().__init__(initial)
@@ -191,8 +195,7 @@ class UbuntuProView(BaseView):
     title = _("Enable Ubuntu Pro")
     excerpt = _("If you want to enable Ubuntu Pro, you can do it now with"
                 " your contract token. "
-                "Otherwise, you can skip this step and enable Ubuntu Pro"
-                " later using the command `ua attach`.")
+                "Otherwise, you can skip this step.")
 
     def __init__(self, controller, token: str):
         """ Initialize the view with the default value for the token. """

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -192,8 +192,8 @@ class UbuntuProView(BaseView):
     +---------------------------------------------------------+
     """
 
-    title = _("Enable Ubuntu Pro")
-    excerpt = _("If you want to enable Ubuntu Pro, you can do it now with"
+    title = _("Upgrade to Ubuntu Pro")
+    excerpt = _("If you want to upgrade to Ubuntu Pro, you can do it now with"
                 " your contract token. "
                 "Otherwise, you can skip this step.")
 

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -269,6 +269,11 @@ class UbuntuProView(BaseView):
         """ Display an overlay that shows information about Ubuntu Pro. """
         self.show_stretchy_overlay(AboutProWidget(self))
 
+    def show_how_to_register(self) -> None:
+        """ Display an overlay that shows instructions to register to
+        Ubuntu Pro. """
+        self.show_stretchy_overlay(HowToRegisterWidget(self))
+
     def show_invalid_token(self) -> None:
         """ Display an overlay that indicates that the user-supplied token is
         invalid. """
@@ -369,6 +374,45 @@ class AboutProWidget(Stretchy):
         ]
 
         super().__init__(title, widgets, stretchy_index=2, focus_index=7)
+
+    def close(self) -> None:
+        """ Close the overlay. """
+        self.parent.remove_overlay()
+
+
+class HowToRegisterWidget(Stretchy):
+    """ Widget showing some instructions to register to Ubuntu Pro.
+    +-------------------- How to register --------------------+
+    |                                                         |
+    | You can register for a free Ubuntu One account and get  |
+    | a personal token for up to 3 machines.                  |
+    |                                                         |
+    | To register an account, visit ubuntu.com/pro on another |
+    | device.                                                 |
+    |                                                         |
+    |                       [ Continue ]                      |
+    +---------------------------------------------------------+
+    """
+    def __init__(self, parent: UbuntuProView) -> None:
+        """ Initializes the widget."""
+        self.parent = parent
+
+        ok = ok_btn(label=_("Continue"), on_press=lambda unused: self.close())
+
+        title = _("How to register")
+        header = _("You can register for a free Ubuntu One account and get a"
+                   " personal token for up to 3 machines.")
+
+        widgets: List[Widget] = [
+            Text(header),
+            Text(""),
+            Text("To register an account, visit ubuntu.com/pro on another"
+                 " device."),
+            Text(""),
+            button_pile([ok]),
+        ]
+
+        super().__init__(title, widgets, stretchy_index=2, focus_index=4)
 
     def close(self) -> None:
         """ Close the overlay. """

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -74,9 +74,8 @@ class ContractTokenEditor(StringEditor, WantsToKnowFormField):
     """ Represent a text-box editor for the Ubuntu Pro Token.  """
     def __init__(self):
         """ Initialize the text-field editor for UA token. """
-        self.valid_char_pat = r"[a-zA-Z0-9]"
-        self.error_invalid_char = _("The only characters permitted in this "
-                                    "field are alphanumeric characters.")
+        self.valid_char_pat = r"[1-9A-HJ-NP-Za-km-z]"
+        self.error_invalid_char = _("'{}' is not a valid character.")
         super().__init__()
 
     def valid_char(self, ch: str) -> bool:
@@ -85,7 +84,8 @@ class ContractTokenEditor(StringEditor, WantsToKnowFormField):
         """
         if len(ch) == 1 and not re.match(self.valid_char_pat, ch):
             self.bff.in_error = True
-            self.bff.show_extra(("info_error", self.error_invalid_char))
+            self.bff.show_extra(
+                    ("info_error", self.error_invalid_char.format(ch)))
             return False
         return super().valid_char(ch)
 
@@ -102,6 +102,12 @@ class ContractTokenForm(SubForm):
     token = ContractTokenField(
             _("Token:"),
             help=_("This is your Ubuntu Pro token"))
+
+    def validate_token(self):
+        """ Return an error if the token input does not match the expected
+        format. """
+        if not 24 <= len(self.token.value) <= 30:
+            return _("Invalid token: should be between 24 and 30 characters")
 
 
 class UpgradeModeForm(Form):

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -61,7 +61,6 @@ from subiquitycore.ui.stretchy import (
 from subiquitycore.ui.utils import (
     button_pile,
     screen,
-    SomethingFailed,
     )
 
 from subiquitycore.ui.interactive import StringEditor
@@ -447,21 +446,12 @@ class UbuntuProView(BaseView):
     def show_invalid_token(self) -> None:
         """ Display an overlay that indicates that the user-supplied token is
         invalid. """
-        self.show_stretchy_overlay(
-                SomethingFailed(self,
-                                "Invalid token.",
-                                "The Ubuntu Pro token that you provided"
-                                " is invalid. Please make sure that you typed"
-                                " your token correctly."))
+        self.show_stretchy_overlay(InvalidTokenWidget(self))
 
     def show_expired_token(self) -> None:
         """ Display an overlay that indicates that the user-supplied token has
         expired. """
-        self.show_stretchy_overlay(
-                SomethingFailed(self,
-                                "Token expired.",
-                                "The Ubuntu Pro token that you provided"
-                                " has expired. Please use a different token."))
+        self.show_stretchy_overlay(ExpiredTokenWidget(self))
 
     def show_unknown_error(self) -> None:
         """ Display an overlay that indicates that we were unable to retrieve
@@ -477,6 +467,64 @@ class UbuntuProView(BaseView):
         via Ubuntu Pro subscription. After the user confirms, we will
         quit the current view and move on. """
         self._w = self.services_screen(services)
+
+
+class ExpiredTokenWidget(Stretchy):
+    """ Widget that shows that the supplied token is expired.
+
+    +--------------------- Expired token ---------------------+
+    |                                                         |
+    | Your token has expired. Please use another token to     |
+    | continue.                                               |
+    |                                                         |
+    |                         [ Okay ]                        |
+    +---------------------------------------------------------+
+    """
+    def __init__(self, parent: BaseView) -> None:
+        """ Initializes the widget. """
+        self.parent = parent
+        cont = done_btn(label=_("Okay"), on_press=lambda unused: self.close())
+        widgets = [
+            Text(_("Your token has expired. Please use another token"
+                   " to continue.")),
+            Text(""),
+            button_pile([cont]),
+            ]
+        super().__init__("Expired token", widgets,
+                         stretchy_index=0, focus_index=2)
+
+    def close(self) -> None:
+        """ Close the overlay. """
+        self.parent.remove_overlay()
+
+
+class InvalidTokenWidget(Stretchy):
+    """ Widget that shows that the supplied token is invalid.
+
+    +--------------------- Invalid token ---------------------+
+    |                                                         |
+    | Your token could not be verified. Please ensure it is   |
+    | correct and try again.                                  |
+    |                                                         |
+    |                         [ Okay ]                        |
+    +---------------------------------------------------------+
+    """
+    def __init__(self, parent: BaseView) -> None:
+        """ Initializes the widget. """
+        self.parent = parent
+        cont = done_btn(label=_("Okay"), on_press=lambda unused: self.close())
+        widgets = [
+            Text(_("Your token could not be verified. Please ensure it is"
+                   " correct and try again.")),
+            Text(""),
+            button_pile([cont]),
+            ]
+        super().__init__("Invalid token", widgets,
+                         stretchy_index=0, focus_index=2)
+
+    def close(self) -> None:
+        """ Close the overlay. """
+        self.parent.remove_overlay()
 
 
 class TokenAddedWidget(Stretchy):

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -213,7 +213,20 @@ class UbuntuProView(BaseView):
 
 
 class ShowServicesWidget(Stretchy):
-    """ Widget to show the activable services for UA subscription. """
+    """ Widget to show the activable services for UA subscription.
+    +------------------ Activable Services -------------------+
+    |                                                         |
+    | List of services that are activable through your Ubuntu |
+    | Pro subscription:                                       |
+    | * ...                                                   |
+    | * ...                                                   |
+    |                                                         |
+    | One the installation has finished, you can enable these |
+    | services using the 'ua' command-line tool.              |
+    |                                                         |
+    |                          [ OK ]                         |
+    +---------------------------------------------------------+
+    """
     def __init__(self, parent: UbuntuProView,
                  services: List[UbuntuProService]) -> None:
         """ Initializes the widget by including the list of services as a
@@ -246,7 +259,16 @@ class ShowServicesWidget(Stretchy):
 
 class ContinueAnywayWidget(Stretchy):
     """ Widget that requests the user if he wants to go back or continue
-    anyway. """
+    anyway.
+    +--------------------- Unknown error ---------------------+
+    |                                                         |
+    | Unable to check your subscription information. Do you   |
+    | want to go back or continue anyway?                     |
+    |                                                         |
+    |                   [ Back            ]                   |
+    |                   [ Continue anyway ]                   |
+    +---------------------------------------------------------+
+    """
     def __init__(self, parent: UbuntuProView) -> None:
         """ Initializes the widget by showing two buttons, one to go back and
         one to move forward anyway. """

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -118,11 +118,12 @@ class UbuntuProForm(Form):
     |      You can always enable Ubuntu Pro later via the     |
     |      'ua attach' command.                               |
     |                                                         |
-    |                         [ Done ]                        |
-    |                         [ Back ]                        |
+    |                       [ Continue ]                      |
+    |                       [ Back     ]                      |
     +---------------------------------------------------------+
     """
     cancel_label = _("Back")
+    ok_label = _("Continue")
     group = []
 
     with_token = RadioButtonField(
@@ -192,8 +193,8 @@ class UbuntuProView(BaseView):
     |                                                         |
     | ( )  Skip Ubuntu Pro for now                            |
     |                                                         |
-    |                         [ Done ]                        |
-    |                         [ Back ]                        |
+    |                       [ Continue ]                      |
+    |                       [ Back     ]                      |
     +---------------------------------------------------------+
     """
 

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -70,7 +70,7 @@ from subiquitycore.ui.interactive import StringEditor
 log = logging.getLogger('subiquity.ui.views.ubuntu_pro')
 
 
-class UATokenEditor(StringEditor, WantsToKnowFormField):
+class ContractTokenEditor(StringEditor, WantsToKnowFormField):
     """ Represent a text-box editor for the Ubuntu Pro Token.  """
     def __init__(self):
         """ Initialize the text-field editor for UA token. """
@@ -90,17 +90,18 @@ class UATokenEditor(StringEditor, WantsToKnowFormField):
         return super().valid_char(ch)
 
 
-class UbuntuProTokenForm(SubForm):
+class ContractTokenForm(SubForm):
     """ Represents a sub-form requesting Ubuntu Pro token.
     +---------------------------------------------------------+
     |      Token: C123456789ABCDEF                            |
     |             This is your Ubuntu Pro token               |
     +---------------------------------------------------------+
     """
-    UATokenField = simple_field(UATokenEditor)
+    ContractTokenField = simple_field(ContractTokenEditor)
 
-    token = UATokenField(_("Token:"),
-                         help=_("This is your Ubuntu Pro token"))
+    token = ContractTokenField(
+            _("Token:"),
+            help=_("This is your Ubuntu Pro token"))
 
 
 class UbuntuProForm(Form):
@@ -127,7 +128,7 @@ class UbuntuProForm(Form):
     with_token = RadioButtonField(
             group,
             _("Enable now with my contract token"), help=NO_HELP)
-    token_form = SubFormField(UbuntuProTokenForm, "", help=NO_HELP)
+    token_form = SubFormField(ContractTokenForm, "", help=NO_HELP)
     skip_ua = RadioButtonField(
             group, _("Do this later"),
             help="\n" + _("You can always enable Ubuntu Pro later via the"
@@ -149,7 +150,7 @@ class UbuntuProForm(Form):
         self.token_form.enabled = new_value
 
 
-class CheckingUAToken(WidgetWrap):
+class CheckingContractToken(WidgetWrap):
     """ Widget displaying a loading animation while checking ubuntu pro
     subscription. """
     def __init__(self, parent: BaseView):
@@ -250,7 +251,7 @@ class UbuntuProView(BaseView):
                     self.show_unknown_error()
 
             token: str = results["token_form"]["token"]
-            checking_token_overlay = CheckingUAToken(self)
+            checking_token_overlay = CheckingContractToken(self)
             self.show_overlay(checking_token_overlay,
                               width=checking_token_overlay.width,
                               min_width=None)

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -151,7 +151,7 @@ class UpgradeYesNoForm(Form):
     | ( )  Do this later                                      |
     |                                                         |
     |      You can always enable Ubuntu Pro later via the     |
-    |      'ua attach' command                                |
+    |      'pro attach' command.                              |
     |                                                         |
     |                       [ Continue ]                      |
     |                       [ Back     ]                      |
@@ -168,7 +168,7 @@ class UpgradeYesNoForm(Form):
     skip = RadioButtonField(
             group, _("Do this later"),
             help="\n" + _("You can always enable Ubuntu Pro later via the"
-                          " 'ua attach' command."))
+                          " 'pro attach' command."))
 
 
 class CheckingContractToken(WidgetWrap):
@@ -283,7 +283,7 @@ class UbuntuProView(BaseView):
         |                                                         |
         | (X)  Do this later                                      |
         |      You can always enable Ubuntu Pro later via the     |
-        |      'ua attach' command.                               |
+        |      'pro attach' command.                              |
         |                                                         |
         |                        [ Continue ]                     |
         |                        [ Back     ]                     |
@@ -324,7 +324,8 @@ class UbuntuProView(BaseView):
         | If you want to change the default enablements for your  |
         | token, you can do so via the ubuntu.com/pro web         |
         | interface. Alternatively, you can change enabled        |
-        | services using the `ua` command-line tool.              |
+        | services using the `pro' command-line tool once the     |
+        | installation is finished.                               |
         |                                                         |
         |                       [ Continue ]                      |
         |                       [ Back     ]                      |
@@ -372,7 +373,7 @@ class UbuntuProView(BaseView):
             Text(_("If you want to change the default enablements for your"
                    " token, you can do so via the ubuntu.com/pro web"
                    " interface. Alternatively you can change enabled services"
-                   " using the `ua` command-line tool once the installation"
+                   " using the `pro` command-line tool once the installation"
                    " is finished.")),
             Text(""),
         ]

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -200,6 +200,7 @@ class UbuntuProView(BaseView):
     """ Represent the view of the Ubuntu Pro configuration. """
 
     title = _("Upgrade to Ubuntu Pro")
+    services_done_label = _("Continue")
 
     def __init__(self, controller, token: str):
         """ Initialize the view with the default value for the token. """
@@ -361,7 +362,7 @@ class UbuntuProView(BaseView):
                 label=_("Back"),
                 on_press=lambda unused: on_back())
         continue_button = done_btn(
-                label=_("Continue"),
+                label=self.__class__.services_done_label,
                 on_press=lambda unused: on_continue())
 
         widgets: List[Widget] = [
@@ -538,12 +539,15 @@ class TokenAddedWidget(Stretchy):
     |                       [ Continue ]                      |
     +---------------------------------------------------------+
     """
+    title = _("Token added successfully")
+    done_label = _("Continue")
+
     def __init__(self, parent: UbuntuProView,
                  on_continue: Callable[[], None]) -> None:
         """ Initializes the widget. """
         self.parent = parent
         cont = done_btn(
-                label=_("Continue"),
+                label=self.__class__.done_label,
                 on_press=lambda unused: on_continue())
         widgets = [
             Text(_("Your token has been added successfully and your"
@@ -552,7 +556,7 @@ class TokenAddedWidget(Stretchy):
             Text(""),
             button_pile([cont]),
             ]
-        super().__init__("Token added successfully", widgets,
+        super().__init__(self.__class__.title, widgets,
                          stretchy_index=0, focus_index=2)
 
 

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -93,12 +93,14 @@ class UATokenEditor(StringEditor, WantsToKnowFormField):
 class UbuntuProTokenForm(SubForm):
     """ Represents a sub-form requesting Ubuntu Pro token.
     +---------------------------------------------------------+
-    |      Contract token: C123456789ABCDEF                   |
+    |      Token: C123456789ABCDEF                            |
+    |             This is your Ubuntu Pro token               |
     +---------------------------------------------------------+
     """
     UATokenField = simple_field(UATokenEditor)
 
-    token = UATokenField(_("Contract token:"), help=NO_HELP)
+    token = UATokenField(_("Token:"),
+                         help=_("This is your Ubuntu Pro token"))
 
 
 class UbuntuProForm(Form):
@@ -107,7 +109,8 @@ class UbuntuProForm(Form):
     +---------------------------------------------------------+
     | (X)  Enable now with my contract token                  |
     |                                                         |
-    |      Contract token: C123456789ABCDEF                   |
+    |      Token: C123456789ABCDEF                            |
+    |             This is your Ubuntu Pro token               |
     |                                                         |
     | ( )  Skip Ubuntu Pro for now                            |
     |                                                         |
@@ -183,7 +186,8 @@ class UbuntuProView(BaseView):
     |                                                         |
     | (X)  Enable now with my contract token                  |
     |                                                         |
-    |      Contract token: C123456789ABCDEF                   |
+    |      Token: C123456789ABCDEF                            |
+    |             This is your Ubuntu Pro token               |
     |                                                         |
     | ( )  Skip Ubuntu Pro for now                            |
     |                                                         |

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -399,10 +399,17 @@ class UbuntuProView(BaseView):
 
         def on_failure(status: UbuntuProCheckTokenStatus) -> None:
             self.remove_overlay()
+            token_field = form.with_contract_token_subform.widget.form.token
             if status == UbuntuProCheckTokenStatus.INVALID_TOKEN:
                 self.show_invalid_token()
+                token_field.in_error = True
+                token_field.show_extra(("info_error", "Invalid token"))
+                form.validated()
             elif status == UbuntuProCheckTokenStatus.EXPIRED_TOKEN:
                 self.show_expired_token()
+                token_field.in_error = True
+                token_field.show_extra(("info_error", "Expired token"))
+                form.validated()
             elif status == UbuntuProCheckTokenStatus.UNKNOWN_ERROR:
                 self.show_unknown_error()
 

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -19,6 +19,7 @@ import re
 from typing import List
 
 from urwid import (
+    Columns,
     connect_signal,
     LineBox,
     Text,
@@ -210,6 +211,77 @@ class UbuntuProView(BaseView):
         via Ubuntu Pro subscription. After the user confirms, we will
         quit the current view and move on. """
         self.show_stretchy_overlay(ShowServicesWidget(self, services))
+
+
+class AboutProWidget(Stretchy):
+    """ Widget showing some information about what Ubuntu Pro offers.
+    +------------------- About Ubuntu Pro --------------------+
+    |                                                         |
+    | Ubuntu Pro subscription gives you access to multiple    |
+    | security & compliance services, including:              |
+    |                                                         |
+    | • Security patching for over 30.000 packages, with a    |
+    |   focus on High and Critical CVEs (extended from 2.500) |
+    | • ...                                                   |
+    | • ...                                                   |
+    |                                                         |
+    | Ubuntu Pro is free for personal use on up to 3 machines.|
+    | More information on ubuntu.com/pro                      |
+    |                                                         |
+    |                       [ Continue ]                      |
+    +---------------------------------------------------------+
+    """
+    def __init__(self, parent: UbuntuProView) -> None:
+        """ Initializes the widget."""
+        self.parent = parent
+
+        ok = ok_btn(label=_("Continue"), on_press=lambda unused: self.close())
+
+        title = _("About Ubuntu Pro")
+        header = _("Ubuntu Pro subscription gives you access to multiple"
+                   " security & compliance services, including:")
+
+        services = [
+            _("Security patching for over 30.000 packages, with a focus on"
+              " High and Critical CVEs (extended from 2.500)"),
+            _("10 years of security Maintenance (extended from 5 years)"),
+            _("Kernel Livepatch service for increased uptime and security"),
+            _("Ubuntu Security Guide for hardening profiles, including CIS"
+              " and DISA-STIG"),
+            _("FIPS 140-2 NIST-certified crypto-modules for FedRAMP"
+              " compliance"),
+        ]
+
+        def itemize(item: str, marker: str = "•") -> Columns:
+            """ Return the text specified in a Text widget prepended with a
+            bullet point / marker. If the text is too long to fit in a single
+            line, the continuation lines are indented as shown below:
+            +---------------------------+
+            | * This is an example of   |
+            |   what such element would |
+            |   look like.              |
+            +---------------------------+
+            """
+            return Columns(
+                    [(len(marker), Text(marker)), Text(item)], dividechars=1)
+
+        widgets: List[Widget] = [
+            Text(header),
+            Text(""),
+            Pile([itemize(svc) for svc in services]),
+            Text(""),
+            Text(_("Ubuntu Pro is free for personal use on up to 3"
+                   " machines.")),
+            Text(_("More information on ubuntu.com/pro")),
+            Text(""),
+            button_pile([ok]),
+        ]
+
+        super().__init__(title, widgets, stretchy_index=2, focus_index=7)
+
+    def close(self) -> None:
+        """ Close the overlay. """
+        self.parent.remove_overlay()
 
 
 class ShowServicesWidget(Stretchy):

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -539,44 +539,74 @@ class HowToRegisterWidget(Stretchy):
 
 
 class ShowServicesWidget(Stretchy):
-    """ Widget to show the activable services for UA subscription.
-    +------------------ Activable Services -------------------+
+    """ Widget to show the activable services that are auto-enabled and the
+    ones that can be activated.
+    +------------------ Ubuntu Pro Services ------------------+
     |                                                         |
-    | List of services that are activable through your Ubuntu |
-    | Pro subscription:                                       |
+    | List of your enabled services:                          |
+    |                                                         |
     | * ...                                                   |
     | * ...                                                   |
     |                                                         |
-    | One the installation has finished, you can enable these |
-    | services using the 'ua' command-line tool.              |
+    | Other available services:                               |
     |                                                         |
-    |                          [ OK ]                         |
+    | * ...                                                   |
+    | * ...                                                   |
+    |                                                         |
+    | If you want to change the default enablements for your  |
+    | token, you can do so via the ubuntu.com/pro web         |
+    | interface. Alternatively, you can change enabled        |
+    | services using the `ua` command-line tool.              |
+    |                                                         |
+    |                       [ Continue ]                      |
     +---------------------------------------------------------+
     """
     def __init__(self, parent: UbuntuProView,
                  services: List[UbuntuProService]) -> None:
-        """ Initializes the widget by including the list of services as a
-        bullet-point list. """
+        """ Initializes the widget. """
         self.parent = parent
 
-        ok = ok_btn(label=_("OK"), on_press=self.ok)
+        ok = ok_btn(label=_("Continue"), on_press=self.ok)
+        # TODO missing a back button
 
-        title = _("Activable Services")
-        header = _("List of services that are activable through your "
-                   "Ubuntu Pro subscription:")
+        title = _("Ubuntu Pro Services")
+
+        auto_enabled = [svc for svc in services if svc.auto_enabled]
+        not_auto_enabled = [svc for svc in services if not svc.auto_enabled]
+
+        svc_rows: List[Widget] = []
+
+        if auto_enabled:
+            svc_rows.append(Text(_("List of your enabled services:")))
+            svc_rows.append(Text(""))
+            svc_rows.extend(
+                    [Text(f"* {svc.description}") for svc in auto_enabled])
+
+        if not_auto_enabled:
+            if auto_enabled:
+                # available here means activable
+                svc_rows.append(Text(""))
+                svc_rows.append(Text(_("Other available services:")))
+            else:
+                svc_rows.append(Text(_("Available services:")))
+            svc_rows.append(Text(""))
+            svc_rows.extend(
+                    [Text(f"* {svc.description}") for svc in not_auto_enabled])
 
         widgets: List[Widget] = [
-            Text(header),
             Text(""),
-            Pile([Text(f"* {svc.description}") for svc in services]),
+            Pile(svc_rows),
             Text(""),
-            Text("Once the installation has finished, you can enable these "
-                 "services using the `ua` command-line tool."),
+            Text(_("If you want to change the default enablements for your"
+                   " token, you can do so via the ubuntu.com/pro web"
+                   " interface. Alternatively you can change enabled services"
+                   " using the `ua` command-line tool once the installation"
+                   " is finished.")),
             Text(""),
             button_pile([ok]),
         ]
 
-        super().__init__(title, widgets, 2, 6)
+        super().__init__(title, widgets, stretchy_index=1, focus_index=5)
 
     def ok(self, sender) -> None:
         """ Close the overlay and submit the token. """


### PR DESCRIPTION
Hello,

This PR updates the different Ubuntu Pro screens to match the new mockups.
I deliberately did not include any of the related magic-attach related screens ; because I'm still working on that part.
The presence of the radio button in the screen asking to input the contract token can look stupid because there is no other radio button.
When magic-attach comes in, the user will either choose to manually input the token or to supply a Ubuntu One email address ; so the radio button will make sense when we get there. I could try to hide the radio button for now but the mechanism we have to manage subforms is a bit of an adventure ; so I'd prefer to keep it.

I've uploaded screen captures at https://people.canonical.com/~ogayot/subiquity-captures

Besides purely visual changes, the PR also includes:
* format checking for a contract token
* a way to prevent the user from supplying a second time a token which was already considered expired or invalid
* a way to submit the token asynchronously if check_token is successful
* the use of the new auto-enabled flag for Ubuntu Pro services

Thanks,
Olivier