### PR TITLE
identity: add leading capital letter to error messages

### DIFF
--- a/subiquity/ui/views/filesystem/lvm.py
+++ b/subiquity/ui/views/filesystem/lvm.py
@@ -83,7 +83,7 @@ class VolGroupForm(CompoundDiskForm):
         self.deleted_vg_names = deleted_vg_names
         super().__init__(model, possible_components, initial)
         connect_signal(self.encrypt.widget, 'change', self._change_encrypt)
-        setup_password_validation(self, _("passphrases"))
+        setup_password_validation(self, _("Passphrases"))
         self._change_encrypt(None, self.encrypt.value)
 
     name = VGNameField(_("Name:"))

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -191,7 +191,7 @@ def setup_password_validation(form, desc):
         password = form.password.value
         if not password.startswith(new_text):
             form.confirm_password.show_extra(
-                # desc is "passwords" or "passphrases"
+                # desc is "Passwords" or "Passphrases"
                 ("info_error", _("{desc} do not match").format(desc=desc)))
         else:
             form.confirm_password.show_extra('')
@@ -229,7 +229,7 @@ class IdentityView(BaseView):
         self.form = IdentityForm(controller, initial)
 
         connect_signal(self.form, 'submit', self.done)
-        setup_password_validation(self.form, _("passwords"))
+        setup_password_validation(self.form, _("Passwords"))
 
         super().__init__(
             screen(


### PR DESCRIPTION
Marking a draft because something weird happens.

In the LVM form, the error message should be "Passphrases do not match" but instead it is "Passwords do not match". It seems that the validator used is the one from IdentityForm, for some reason. 