### PR TITLE
Refactor how we handle confirmation fields - use passphrase instead of password where relevant

### DIFF
--- a/examples/answers-lvm-dmcrypt.yaml
+++ b/examples/answers-lvm-dmcrypt.yaml
@@ -40,8 +40,8 @@ Filesystem:
           - [disk index 0, part 1]
           - [disk index 0, part 2]
         encrypt: true
-        password: "passw0rd"
-        confirm_password: "passw0rd"
+        passphrase: "passw0rd"
+        confirm_passphrase: "passw0rd"
     - obj: [volgroup name vg-1]
       action: EDIT
       data:
@@ -50,8 +50,8 @@ Filesystem:
       action: EDIT
       data:
         encrypt: true
-        password: "passw0rd"
-        confirm_password: "passw0rd"
+        passphrase: "passw0rd"
+        confirm_passphrase: "passw0rd"
     - obj: [volgroup name vg-1]
       action: CREATE_LV
       data:

--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -114,8 +114,8 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
                 value['lvm_options'] = {
                     'encrypt': True,
                     'luks_options': {
-                        'password': passphrase,
-                        'confirm_password': passphrase,
+                        'passphrase': passphrase,
+                        'confirm_passphrase': passphrase,
                         }
                     }
             self.ui.body.form.guided_choice.value = value

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -59,15 +59,15 @@ subtitle = _("Configure a guided storage layout, or create a custom one:")
 
 class LUKSOptionsForm(SubForm):
 
-    password = PasswordField(_("Passphrase:"))
-    confirm_password = PasswordField(_("Confirm passphrase:"))
+    passphrase = PasswordField(_("Passphrase:"))
+    confirm_passphrase = PasswordField(_("Confirm passphrase:"))
 
-    def validate_password(self):
-        if len(self.password.value) < 1:
+    def validate_passphrase(self):
+        if len(self.passphrase.value) < 1:
             return _("Passphrase must be set")
 
-    def validate_confirm_password(self):
-        if self.password.value != self.confirm_password.value:
+    def validate_confirm_passphrase(self):
+        if self.passphrase.value != self.confirm_passphrase.value:
             return _("Passphrases do not match")
 
 
@@ -185,7 +185,7 @@ can easily be enlarged with standard LVM command line tools (or on the
 next screen).
 
 You can also choose to encrypt LVM volume group. This will require
-setting a password, that one will need to type on every boot before
+setting a passphrase, that one will need to type on every boot before
 the system boots.
 
 If you do not choose to use LVM, a single partition is created covering the
@@ -252,7 +252,7 @@ class GuidedDiskSelectionView(BaseView):
                 use_lvm=results['guided_choice']['use_lvm'])
             opts = results['guided_choice'].get('lvm_options', {})
             if opts.get('encrypt', False):
-                choice.password = opts['luks_options']['password']
+                choice.password = opts['luks_options']['passphrase']
         self.controller.guided_choice(choice)
 
     def manual(self, sender):

--- a/subiquity/ui/views/filesystem/lvm.py
+++ b/subiquity/ui/views/filesystem/lvm.py
@@ -48,9 +48,6 @@ from subiquity.ui.views.filesystem.compound import (
     get_possible_components,
     MultiDeviceField,
     )
-from subiquity.ui.views.identity import (
-    setup_password_validation,
-    )
 
 log = logging.getLogger('subiquity.ui.views.filesystem.lvm')
 
@@ -83,9 +80,9 @@ class VolGroupForm(CompoundDiskForm):
         self.deleted_vg_names = deleted_vg_names
         super().__init__(model, possible_components, initial)
         connect_signal(self.encrypt.widget, 'change', self._change_encrypt)
-        setup_password_validation(field=self.passphrase,
-                                  field_confirm=self.confirm_passphrase,
-                                  desc=_("Passphrases"))
+        self.confirm_passphrase.use_as_confirmation(
+                for_field=self.passphrase,
+                desc=_("Passphrases"))
         self._change_encrypt(None, self.encrypt.value)
 
     name = VGNameField(_("Name:"))

--- a/subiquity/ui/views/filesystem/lvm.py
+++ b/subiquity/ui/views/filesystem/lvm.py
@@ -83,22 +83,24 @@ class VolGroupForm(CompoundDiskForm):
         self.deleted_vg_names = deleted_vg_names
         super().__init__(model, possible_components, initial)
         connect_signal(self.encrypt.widget, 'change', self._change_encrypt)
-        setup_password_validation(self, _("Passphrases"))
+        setup_password_validation(field=self.passphrase,
+                                  field_confirm=self.confirm_passphrase,
+                                  desc=_("Passphrases"))
         self._change_encrypt(None, self.encrypt.value)
 
     name = VGNameField(_("Name:"))
     devices = MultiDeviceField(_("Devices:"))
     size = ReadOnlyField(_("Size:"))
     encrypt = BooleanField(_("Create encrypted volume"))
-    password = PasswordField(_("Passphrase:"))
-    confirm_password = PasswordField(_("Confirm passphrase:"))
+    passphrase = PasswordField(_("Passphrase:"))
+    confirm_passphrase = PasswordField(_("Confirm passphrase:"))
 
     def _change_encrypt(self, sender, new_value):
-        self.password.enabled = new_value
-        self.confirm_password.enabled = new_value
+        self.passphrase.enabled = new_value
+        self.confirm_passphrase.enabled = new_value
         if not new_value:
-            self.password.validate()
-            self.confirm_password.validate()
+            self.passphrase.validate()
+            self.confirm_passphrase.validate()
 
     def validate_devices(self):
         if len(self.devices.value) < 1:
@@ -119,13 +121,13 @@ class VolGroupForm(CompoundDiskForm):
                 return _("{name} is not a valid name for a volume "
                          "group").format(name=v)
 
-    def validate_password(self):
-        if self.encrypt.value and len(self.password.value) < 1:
+    def validate_passphrase(self):
+        if self.encrypt.value and len(self.passphrase.value) < 1:
             return _("Passphrase must be set")
 
-    def validate_confirm_password(self):
+    def validate_confirm_passphrase(self):
         if self.encrypt.value and \
-          self.password.value != self.confirm_password.value:
+          self.passphrase.value != self.confirm_passphrase.value:
             return _("Passphrases do not match")
 
 
@@ -167,8 +169,8 @@ class VolGroupStretchy(Stretchy):
                 'devices': devices,
                 'name': existing.name,
                 'encrypt': bool(key),
-                'password': key,
-                'confirm_password': key,
+                'passphrase': key,
+                'confirm_passphrase': key,
                 }
 
         possible_components = get_possible_components(
@@ -205,11 +207,11 @@ class VolGroupStretchy(Stretchy):
         del result['size']
         mdc = self.form.devices.widget
         result['devices'] = mdc.active_devices
-        if 'confirm_password' in result:
-            del result['confirm_password']
+        if 'confirm_passphrase' in result:
+            del result['confirm_passphrase']
         safe_result = result.copy()
-        if 'password' in safe_result:
-            safe_result['password'] = '<REDACTED>'
+        if 'passphrase' in safe_result:
+            safe_result['passphrase'] = '<REDACTED>'
         log.debug("vg_done: {}".format(safe_result))
         self.parent.controller.volgroup_handler(self.existing, result)
         self.parent.refresh_model_inputs()

--- a/subiquity/ui/views/filesystem/tests/test_lvm.py
+++ b/subiquity/ui/views/filesystem/tests/test_lvm.py
@@ -69,14 +69,14 @@ class LVMViewTests(unittest.TestCase):
             'name': 'vg1',
             'devices': {part1: 'active', part2: 'active'},
             'encrypt': True,
-            'password': 'passw0rd',
-            'confirm_password': 'passw0rd',
+            'passphrase': 'passw0rd',
+            'confirm_passphrase': 'passw0rd',
             }
         expected_data = {
             'name': 'vg1',
             'devices': {part1, part2},
             'encrypt': True,
-            'password': 'passw0rd',
+            'passphrase': 'passw0rd',
             }
         view_helpers.enter_data(stretchy.form, form_data)
         view_helpers.click(stretchy.form.done_btn.base_widget)

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -27,7 +27,6 @@ from subiquitycore.ui.interactive import (
     StringEditor,
     )
 from subiquitycore.ui.form import (
-    BoundFormField,
     Form,
     simple_field,
     WantsToKnowFormField,
@@ -187,21 +186,6 @@ class IdentityForm(Form):
             return _("Passwords do not match")
 
 
-def setup_password_validation(field: BoundFormField,
-                              field_confirm: BoundFormField,
-                              desc: str) -> None:
-    """ Set up an automatic check for password vs password confirmation. """
-    def _check_password(sender, new_text):
-        password = field.value
-        if not password.startswith(new_text):
-            field_confirm.show_extra(
-                # desc is "Passwords" or "Passphrases"
-                ("info_error", _("{desc} do not match").format(desc=desc)))
-        else:
-            field_confirm.show_extra('')
-    connect_signal(field_confirm.widget, 'change', _check_password)
-
-
 class IdentityView(BaseView):
     title = _("Profile setup")
     excerpt = _("Enter the username and password you will use to log in to "
@@ -231,10 +215,11 @@ class IdentityView(BaseView):
 
         self.form = IdentityForm(controller, initial)
 
+        self.form.confirm_password.use_as_confirmation(
+                for_field=self.form.password,
+                desc=_("Passwords"))
+
         connect_signal(self.form, 'submit', self.done)
-        setup_password_validation(field=self.form.password,
-                                  field_confirm=self.form.confirm_password,
-                                  desc=_("Passwords"))
 
         super().__init__(
             screen(

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -280,6 +280,18 @@ class BoundFormField(object):
         for row in self._rows:
             row.enabled = val
 
+    def use_as_confirmation(self, for_field: "BoundFormField", desc: str) \
+            -> None:
+        """ Mark this field as a confirmation field for another field.
+        This will automatically compare the value of both fields when this
+        field (a.k.a., the confirmation field) is changed. """
+        def _check_confirmation(sender, new_text):
+            if not for_field.value.startswith(new_text):
+                self.show_extra(("info_error", _(f"{desc} do not match")))
+            else:
+                self.show_extra("")
+        connect_signal(self.widget, "change", _check_confirmation)
+
 
 class BoundSubFormField(BoundFormField):
     def is_in_error(self):

--- a/system_setup/ui/views/identity.py
+++ b/system_setup/ui/views/identity.py
@@ -72,7 +72,9 @@ class WSLIdentityView(BaseView):
         self.form = WSLIdentityForm(controller, initial)
 
         connect_signal(self.form, 'submit', self.done)
-        setup_password_validation(self.form, _("passwords"))
+        setup_password_validation(field=self.form.password,
+                                  field_confirm=self.form.confirm_password,
+                                  desc=_("passwords"))
 
         super().__init__(
             screen(

--- a/system_setup/ui/views/identity.py
+++ b/system_setup/ui/views/identity.py
@@ -23,7 +23,6 @@ from subiquity.common.types import IdentityData
 from subiquity.ui.views.identity import (
     IdentityForm,
     IdentityView,
-    setup_password_validation,
     )
 from subiquitycore.ui.utils import screen
 from subiquitycore.utils import crypt_password
@@ -72,9 +71,9 @@ class WSLIdentityView(BaseView):
         self.form = WSLIdentityForm(controller, initial)
 
         connect_signal(self.form, 'submit', self.done)
-        setup_password_validation(field=self.form.password,
-                                  field_confirm=self.form.confirm_password,
-                                  desc=_("passwords"))
+        self.form.confirm_password.use_as_confirmation(
+                for_field=self.form.password,
+                desc=_("Passwords"))
 
         super().__init__(
             screen(


### PR DESCRIPTION
The identity screen implements a mechanism to make sure that the confirmation password is the same as the original password. This implementation leans on hard-coded field names (i.e., "password" and "password_confirm") which is perfectly understandable since this is what we have in the identity screen.

Nevertheless, in the storage screen, we decided to import this mechanism and use it as-is to compare passphrases. The implementation prevents us from using different field names such as "passphrase" and "passphrase_confirm" ; which makes the code confusing.

To make things more developer-friendly (is that a thing?), I exported the confirmation mechanism from the identity screen to `subiquitycore.ui` and made it a method of `BoundFormField`.

Before:
```python
class FormWithPassphrase(Form):
    # XXX we are dealing with passphrases but setup_password_validation forces us to name fields
    # "password" and "confirm_passwords"
    password: PasswordField("Passphrase:")
    confirm_password: PasswordField("Passphrase confirmation:")


from subiquity.ui.views.identity import setup_password_validation
form = FormWithPassphrase(...)
setup_password_validation(form, desc=_("Passphrases"))
```

After:
```python
class FormWithPassphrase(Form):
    passphrase: PasswordField("Passphrase:")
    confirm_passphrase: PasswordField("Passphrase confirmation:")


form = FormWithPassphrase(...)
form.confirm_passphrase.use_as_confirmation(for_field=form.passphrase, desc=_("Passphrases"))
```

This removes the coupling between identity and storage ; which is a good thing.
It also makes the confirmation mechanism usable without using fields with hard-coded names. Yay! Maybe we might use it for email + confirmation email some day?

Where applicable, I've replaced the name of the values from "password" to "passphrase" but only on the client side ; so it does not break the backward compatibility of the API.