### PR TITLE
cloud-config: schema drop deprecated dict user.groups value type (jammy branch)

### DIFF
--- a/subiquity/common/resources.py
+++ b/subiquity/common/resources.py
@@ -18,6 +18,7 @@
 
 import logging
 import os
+from typing import List
 
 log = logging.getLogger('subiquity.common.resources')
 
@@ -26,7 +27,7 @@ def resource_path(relative_path):
     return os.path.join(os.environ.get("SUBIQUITY_ROOT", "."), relative_path)
 
 
-def get_users_and_groups(chroot_prefix=[]):
+def get_users_and_groups(chroot_prefix=[]) -> List:
     # prevent import when calling just resource_path
     from subiquitycore.utils import run_command
 
@@ -43,5 +44,4 @@ def get_users_and_groups(chroot_prefix=[]):
     for line in cp.stdout.splitlines():
         target_groups.add(line.split(':')[0])
 
-    groups = target_groups.intersection(groups)
-    return groups
+    return list(target_groups.intersection(groups))

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -262,7 +262,7 @@ class SubiquityModel:
                 'gecos': user.realname,
                 'passwd': user.password,
                 'shell': '/bin/bash',
-                'groups': groups,
+                'groups': ','.join(sorted(groups)),
                 'lock_passwd': False,
                 }
             if self.ssh.authorized_keys:

--- a/subiquity/models/tests/test_subiquity.py
+++ b/subiquity/models/tests/test_subiquity.py
@@ -196,6 +196,10 @@ class TestSubiquityModel(unittest.TestCase):
             cloud_init_config = model._cloud_init_config()
             self.assertEqual(len(cloud_init_config['users']), 2)
             self.assertEqual(cloud_init_config['users'][0]['name'], 'mainuser')
+            self.assertEqual(
+                cloud_init_config['users'][0]['groups'],
+                'adm,cdrom,dip,lxd,plugdev,sudo'
+            )
             self.assertEqual(cloud_init_config['users'][1]['name'], 'user2')
 
         with self.subTest('Secondary user only'):

--- a/subiquity/models/tests/test_subiquity.py
+++ b/subiquity/models/tests/test_subiquity.py
@@ -15,6 +15,7 @@
 
 import fnmatch
 import unittest
+from unittest import mock
 import yaml
 
 from subiquitycore.pubsub import MessageHub
@@ -27,6 +28,24 @@ from subiquity.server.server import (
     POSTINSTALL_MODEL_NAMES,
     )
 from subiquity.server.types import InstallerChannels
+
+getent_group_output = '''
+root:x:0:
+daemon:x:1:
+bin:x:2:
+sys:x:3:
+adm:x:4:syslog
+tty:x:5:syslog
+disk:x:6:
+lp:x:7:
+mail:x:8:
+news:x:9:
+uucp:x:10:
+man:x:12:
+sudo:x:27:
+ssh:x:118:
+lxd:x:132:
+'''
 
 
 class TestModelNames(unittest.TestCase):
@@ -182,7 +201,8 @@ class TestSubiquityModel(unittest.TestCase):
         config = model.render()
         self.assertNotIn('apt', config)
 
-    def test_cloud_init_user_list_merge(self):
+    @mock.patch('subiquitycore.utils.run_command')
+    def test_cloud_init_user_list_merge(self, run_cmd):
         main_user = IdentityData(
             username='mainuser',
             crypted_password='dummy_value',
@@ -193,14 +213,17 @@ class TestSubiquityModel(unittest.TestCase):
             model = self.make_model()
             model.identity.add_user(main_user)
             model.userdata = {'users': [secondary_user]}
+
+            run_cmd.return_value.stdout = getent_group_output
             cloud_init_config = model._cloud_init_config()
             self.assertEqual(len(cloud_init_config['users']), 2)
             self.assertEqual(cloud_init_config['users'][0]['name'], 'mainuser')
             self.assertEqual(
                 cloud_init_config['users'][0]['groups'],
-                'adm,cdrom,dip,lxd,plugdev,sudo'
+                'adm,lxd,sudo'
             )
             self.assertEqual(cloud_init_config['users'][1]['name'], 'user2')
+            run_cmd.assert_called_with(['getent', 'group'], check=True)
 
         with self.subTest('Secondary user only'):
             model = self.make_model()


### PR DESCRIPTION
Align with latest cloud-init schema avoid using depracated
value types for users. groups definitions in cloud-config.

Also fix get_users_and_groups to return a list instead of
dict as all call sites expected it to return a list.

Also fix the unit tests.

Cherry-pick
  7f233bc09b00cc885a76a3d9305bea0707bf0c31
  62ad68bd7668149e1eb9acf661bc0e98e951f66b

Co-authored-by: Chad Smith <chad.smith@canonical.com>