### PR TITLE
ubuntu-pro: add subscription info in response to /ubuntu_pro/check_token

### DIFF
--- a/examples/uaclient-status-expired.json
+++ b/examples/uaclient-status-expired.json
@@ -1,6 +1,12 @@
 {
     "version": "27.4.2~21.10.1",
     "effective": null,
+    "contract": {
+        "name": "UA Apps - Essential (Virtual)"
+    },
+    "account": {
+        "name": "user@domain.com"
+    },
     "expires": "2010-12-31T00:00:00+00:00",
     "services": [
         {

--- a/examples/uaclient-status-valid.json
+++ b/examples/uaclient-status-valid.json
@@ -2,6 +2,12 @@
     "version": "27.4.2~21.10.1",
     "effective": null,
     "expires": "2035-12-31T00:00:00+00:00",
+    "contract": {
+        "name": "UA Apps - Essential (Virtual)"
+    },
+    "account": {
+        "name": "user@domain.com"
+    },
     "services": [
         {
             "name": "cis",

--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -70,7 +70,7 @@ class UbuntuProController(SubiquityTuiController):
         async def inner() -> None:
             answer = await self.endpoint.check_token.GET(token)
             if answer.status == TokenStatus.VALID_TOKEN:
-                on_success(answer.services)
+                on_success(answer.subscription.services)
             else:
                 on_failure(answer.status)
 

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -464,10 +464,17 @@ class UbuntuProService:
 
 
 @attr.s(auto_attribs=True)
+class UbuntuProSubscription:
+    contract_name: str
+    account_name: str
+    services: List[UbuntuProService]
+
+
+@attr.s(auto_attribs=True)
 class UbuntuProCheckTokenAnswer:
     status: UbuntuProCheckTokenStatus
 
-    services: Optional[List[UbuntuProService]]
+    subscription: Optional[UbuntuProSubscription]
 
 
 class ShutdownMode(enum.Enum):

--- a/subiquity/server/controllers/ubuntu_pro.py
+++ b/subiquity/server/controllers/ubuntu_pro.py
@@ -122,13 +122,12 @@ class UbuntuProController(SubiquityController):
     async def check_token_GET(self, token: str) \
             -> UbuntuProCheckTokenAnswer:
         """ Handle a GET request asking whether the contract token is valid or
-        not. If it is valid, we provide the list of activable services
-        associated with the subscription.
+        not. If it is valid, we provide the information about the subscription.
         """
-        services = None
+        subscription = None
         try:
-            services = await \
-                    self.ua_interface.get_activable_services(token=token)
+            subscription = await \
+                    self.ua_interface.get_subscription(token=token)
         except InvalidTokenError:
             status = UbuntuProCheckTokenStatus.INVALID_TOKEN
         except ExpiredTokenError:
@@ -138,4 +137,5 @@ class UbuntuProController(SubiquityController):
         else:
             status = UbuntuProCheckTokenStatus.VALID_TOKEN
 
-        return UbuntuProCheckTokenAnswer(status=status, services=services)
+        return UbuntuProCheckTokenAnswer(status=status,
+                                         subscription=subscription)


### PR DESCRIPTION
The response to `/ubuntu_pro/check_token` now includes information about the subscription: the name of the contract and the "name" of the account.

Instead of returning the list of services as an optional field, we now include the list of services in the subscription object. The
subscription object is itself marked optional. This is a backward incompatible change. CC: @jpnurmi 
A backward compatible implementation is possible but it will lead to multiple optional keys. I think the backward incompatible approach is better here.

```json
  {
    "status": "VALID_TOKEN",
    "services": [
      {
        "name": "esm-infra",
        "description": "UA Infra: Extended Security Maintenance (ESM)",
        "auto_enabled": true
      }
    ]
  }
```
  =>
```json
  {
    "status": "VALID_TOKEN",
    "subscription": {
        "account_name": "user@domain.com",
        "contract_name": "UA Apps - Essential (Virtual)",
        "services": [
          {
            "name": "esm-infra",
            "description": "UA Infra: Extended Security Maintenance (ESM)",
            "auto_enabled": true
          }
        ]
     }
  }
```

If the token is not valid, the subscription object will be null:

```python
  {
    "status": "EXPIRED_TOKEN",
    "subscription": null
  }
```