### PR TITLE
ubuntu-pro: add info about subscription in former services screen

### DIFF
--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -16,7 +16,7 @@
 
 import asyncio
 import logging
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 from urwid import Widget
 
@@ -26,7 +26,7 @@ from subiquity.client.controller import SubiquityTuiController
 from subiquity.common.types import (
     UbuntuProInfo,
     UbuntuProCheckTokenStatus as TokenStatus,
-    UbuntuProService,
+    UbuntuProSubscription,
     )
 from subiquity.ui.views.ubuntu_pro import (
     UbuntuProView,
@@ -113,9 +113,9 @@ class UbuntuProController(SubiquityTuiController):
 
             click(find_button_matching(view, TokenAddedWidget.done_label))
 
-        def run_services_screen() -> None:
+        def run_subscription_screen() -> None:
             click(find_button_matching(view._w,
-                                       UbuntuProView.services_done_label))
+                                       UbuntuProView.subscription_done_label))
 
         if not self.answers["token"]:
             run_yes_no_screen(skip=True)
@@ -124,10 +124,10 @@ class UbuntuProController(SubiquityTuiController):
         run_yes_no_screen(skip=False)
         run_token_screen(self.answers["token"])
         await run_token_added_overlay()
-        run_services_screen()
+        run_subscription_screen()
 
     def check_token(self, token: str,
-                    on_success: Callable[[List[UbuntuProService]], None],
+                    on_success: Callable[[UbuntuProSubscription], None],
                     on_failure: Callable[[TokenStatus], None],
                     ) -> None:
         """ Asynchronously check the token passed as an argument. """
@@ -135,7 +135,7 @@ class UbuntuProController(SubiquityTuiController):
             answer = await self.endpoint.check_token.GET(token)
             if answer.status == TokenStatus.VALID_TOKEN:
                 await self.endpoint.POST(UbuntuProInfo(token=token))
-                on_success(answer.subscription.services)
+                on_success(answer.subscription)
             else:
                 on_failure(answer.status)
 

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -475,6 +475,7 @@ class UbuntuProService:
 class UbuntuProSubscription:
     contract_name: str
     account_name: str
+    contract_token: str
     services: List[UbuntuProService]
 
 

--- a/subiquity/server/ubuntu_advantage.py
+++ b/subiquity/server/ubuntu_advantage.py
@@ -216,4 +216,5 @@ class UAInterface:
         return UbuntuProSubscription(
                 account_name=info["account"]["name"],
                 contract_name=info["contract"]["name"],
+                contract_token=token,
                 services=activable_services)


### PR DESCRIPTION
What we used to call the services screen now includes the following information about the subscription:
* owner of the contract
* contract token
* name of the contract
The information is obtained via the `/ubuntu_pro/check_token` API which itself leans on u-a-c.
It also makes sense to call the screen "subscription screen" rather than "services screen" from now on.

![after](https://user-images.githubusercontent.com/4038023/177779023-ab065d59-2cdf-4225-a01f-bf2e316af18b.png)
