### PR TITLE
filesystem: fix use of f-string without placeholder

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -155,7 +155,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             # find what's left of the gap after adding boot
             gap = gaps.within(disk, gap)
             if gap is None:
-                raise Exception(f'failed to locate gap after adding boot')
+                raise Exception('failed to locate gap after adding boot')
             return disk, gap
 
     def guided_direct(self, target, mode=None):


### PR DESCRIPTION
When running `make lint` with flake8 >= 4.0.0 (available in jammy), the following error is reported:

`subiquity/server/controllers/filesystem.py:158:33:F541 f-string is missing placeholders`

Github runs the lint job in a focal container, where only version 3.8.4 of flake8 is installed. F541 is not implemented in 3.8.4 so it does not fail.