### PR TITLE
server: read config from /run/cloud-init/instance-data-sensitive.json

### DIFF
--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -13,14 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
+import json
 import os
 import shlex
-from unittest.mock import Mock
+import subprocess
+from unittest import mock
 
 from subiquitycore.utils import run_command
 from subiquitycore.tests import SubiTestCase
+import subiquity.server.server
 from subiquity.server.server import (
     SubiquityServer,
+    cloud_init_instance_data_path,
     cloud_autoinstall_path,
     iso_autoinstall_path,
     root_autoinstall_path,
@@ -31,14 +36,14 @@ class TestAutoinstallLoad(SubiTestCase):
     def setUp(self):
         self.tempdir = self.tmp_dir()
         os.makedirs(self.tempdir + '/cdrom', exist_ok=True)
-        opts = Mock()
+        opts = mock.Mock()
         opts.dry_run = True
         opts.output_base = self.tempdir
         opts.machine_config = 'examples/simple.json'
         opts.kernel_cmdline = {}
         opts.autoinstall = None
         self.server = SubiquityServer(opts, None)
-        self.server.base_model = Mock()
+        self.server.base_model = mock.Mock()
         self.server.base_model.root = opts.output_base
 
     def path(self, relative_path):
@@ -96,8 +101,60 @@ class TestAutoinstallLoad(SubiTestCase):
         with self.assertRaises(Exception):
             self.server.select_autoinstall()
 
+    @mock.patch('asyncio.wait_for')
+    async def test_wait_for_cloudinit_dryrun_sets_cloud_init_ok(
+        self, wait_for
+    ):
+        self.server.controllers = mock.Mock()
+        self.server.controllers.instances = []
+        self.assertIsNone(self.server.cloud_init_ok)
+        self.server.opts.dry_run = True
+        await self.server.wait_for_cloudinit()
+        self.assertTrue(self.server.cloud_init_ok)
+        self.assertEqual(0, wait_for.call_count)
+
+    @mock.patch(
+        'asyncio.wait_for', side_effect=asyncio.TimeoutError("out to lunch")
+    )
+    async def test_wait_for_cloudinit_timeout_on_cli(self, wait_for):
+        self.server.controllers = mock.Mock()
+        self.server.controllers.instances = []
+        self.server.opts.dry_run = False
+        await self.server.wait_for_cloudinit()
+        self.assertFalse(self.server.cloud_init_ok)
+
+    @mock.patch('asyncio.wait_for')
+    async def test_wait_for_cloudinit_writes_cloud_autoinstall(self, wait_for):
+        self.create(cloud_autoinstall_path, 'cloud')
+        test_data_path = os.path.join(
+            self.tempdir, cloud_init_instance_data_path.lstrip('/')
+        )
+        os.makedirs(os.path.dirname(test_data_path))
+        example_instance_data = json.dumps({
+            "merged_cfg": {"autoinstall": {"version": 1}}
+        })
+        self.create(
+            cloud_init_instance_data_path.lstrip('/'), example_instance_data
+        )
+        wait_for.return_value = subprocess.CompletedProcess(
+            args=['cloud-init', 'status', '--wait'], returncode=0,
+            stdout='\nstatus: done\n', stderr=''
+        )
+        self.server.controllers = mock.Mock()
+        self.server.controllers.instances = []
+        self.server.opts.dry_run = False
+        with mock.patch.object(
+            subiquity.server.server,
+            "cloud_init_instance_data_path",
+            test_data_path,
+        ):
+            await self.server.wait_for_cloudinit()
+        self.assertTrue(self.server.cloud_init_ok)
+        with open(self.path(cloud_autoinstall_path)) as stream:
+            self.assertEqual("---\nversion: 1\n...\n", stream.read())
+
     def test_early_commands_changes_autoinstall(self):
-        self.server.controllers = Mock()
+        self.server.controllers = mock.Mock()
         self.server.controllers.instances = []
         rootpath = self.path(root_autoinstall_path)
 


### PR DESCRIPTION
cloud-init emits a static JSON file early in boot the moment it
detects a valid datasource. This will occur in cloud-init's
early init-local or init boot stages. It will be present before
cloud-init status --wait unblocks.

Move away from calling into stages.Init, read_cfg, cloudify as
these entry points may change in the future. The flat
/run/cloud-init/instance-data*.json files are intended to be a stable
"api" for extenal consumers.


This is part of a series of PRs to support cloud-init/subiquity live-installer usability:
 1.  [Add /etc/cloud-init/clean.d/90-installer script to allow cloud-init clean to remove any installer artifacts for golden image creation](https://github.com/canonical/subiquity/pull/1347)
 2. [This PR] subiquity to read `/run/cloud-init/instance-data-sensitive.json` for autoinstall: config directives instead of initializing `Init.read_cfg()`
 3. [Perform schema initial validation on merged userdata_raw config within the installer environment to catch cloud-init-related user misconfiguration before final target system reboot](https://github.com/canonical/subiquity/pull/1359)
 4. TBD ubuntu-desktop-installer to disable cloud-init after installed system reboot via write_files directive
 5. TBD Consume cloud-init status --format (json/yaml) machine readable output to report more succinct status of cloud-init