### PR TITLE
fixes targetting jammy.1

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,8 +11,15 @@ apps:
   subiquity:
     command: usr/bin/subiquity-cmd
     environment:
+      # Save original values of environment variables, we want to restore them
+      # for the debug shell (LP: #1975629) and restart (LP: #1978139)
+      PYTHONPATH_ORIG: $PYTHONPATH
+      PATH_ORIG: $PATH
+      PYTHONIOENCODING_ORIG: $PYTHONIOENCODING
       PYTHONIOENCODING: utf-8
+      SUBIQUITY_ROOT_ORIG: $SUBIQUITY_ROOT
       SUBIQUITY_ROOT: $SNAP
+      PYTHON_ORIG: $PYTHON
       PYTHON: $SNAP/usr/bin/python3.8
   probert:
     command: bin/probert

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,8 +31,15 @@ apps:
     daemon: simple
     restart-condition: always
     environment:
+      # Save original values of environment variables, we want to restore them
+      # for the debug shell (LP: #1975629).
+      PYTHONPATH_ORIG: $PYTHONPATH
+      PATH_ORIG: $PATH
+      PYTHONIOENCODING_ORIG: $PYTHONIOENCODING
       PYTHONIOENCODING: utf-8
+      SUBIQUITY_ROOT_ORIG: $SUBIQUITY_ROOT
       SUBIQUITY_ROOT: $SNAP
+      PYTHON_ORIG: $PYTHON
       PYTHON: $SNAP/usr/bin/python3.8
   os-prober:
     command: usr/bin/os-prober

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,6 +4,8 @@ version: git
 summary: Ubuntu installer
 description: The Ubuntu server installer
 confinement: classic
+source-code: https://github.com/canonical/subiquity
+issues: https://bugs.launchpad.net/subiquity/+filebug
 
 apps:
   subiquity:

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -31,6 +31,7 @@ from subiquitycore.async_helpers import (
 from subiquitycore.screen import is_linux_tty
 from subiquitycore.tuicontroller import Skip
 from subiquitycore.tui import TuiApplication
+from subiquitycore.utils import orig_environ
 from subiquitycore.view import BaseView
 
 from subiquity.client.controller import Confirm
@@ -544,8 +545,10 @@ class SubiquityClient(TuiApplication):
             os.system("clear")
             print(DEBUG_SHELL_INTRO)
 
+        env = orig_environ(os.environ)
+        cmd = ["bash"]
         self.run_command_in_foreground(
-            ["bash"], before_hook=_before, after_hook=after_hook, cwd='/')
+            cmd, env=env, before_hook=_before, after_hook=after_hook, cwd='/')
 
     def note_file_for_apport(self, key, path):
         self.error_reporter.note_file_for_apport(key, path)

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -203,7 +203,7 @@ class SubiquityClient(TuiApplication):
                 cmdline.extend(['--server-pid', self.opts.server_pid])
             log.debug("restarting %r", cmdline)
 
-        os.execvp(cmdline[0], cmdline)
+        os.execvpe(cmdline[0], cmdline, orig_environ(os.environ))
 
     def resp_hook(self, response):
         headers = response.headers

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -467,7 +467,7 @@ class SubiquityClient(TuiApplication):
     async def _select_initial_screen(self, index):
         endpoint_names = []
         for c in self.controllers.instances[:index]:
-            if c.endpoint_name:
+            if getattr(c, 'endpoint_name', None) is not None:
                 endpoint_names.append(c.endpoint_name)
         if endpoint_names:
             await self.client.meta.mark_configured.POST(endpoint_names)

--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -216,7 +216,7 @@ class RefreshController(SubiquityController):
     async def start_update(self, context):
         change = await self.app.snapd.post(
             'v2/snaps/{}'.format(self.snap_name),
-            {'action': 'refresh'})
+            {'action': 'refresh', 'ignore-running': True})
         context.description = "change id: {}".format(change)
         return change
 

--- a/subiquitycore/tests/test_utils.py
+++ b/subiquitycore/tests/test_utils.py
@@ -1,0 +1,64 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# from unittest.mock import Mock
+
+from subiquitycore.tests import SubiTestCase
+from subiquitycore.utils import orig_environ
+
+
+class TestOrigEnviron(SubiTestCase):
+    def test_empty(self):
+        env = {}
+        expected = env
+        self.assertEqual(expected, orig_environ(env))
+
+    def test_orig_path(self):
+        env = {'PATH': 'a', 'PATH_ORIG': 'b'}
+        expected = {'PATH': 'b'}
+        self.assertEqual(expected, orig_environ(env))
+
+    def test_not_this_key(self):
+        env = {'PATH': 'a', 'PATH_ORIG_AAAAA': 'b'}
+        expected = env
+        self.assertEqual(expected, orig_environ(env))
+
+    def test_remove_empty_key(self):
+        env = {'STUFF': 'a', 'STUFF_ORIG': ''}
+        expected = {}
+        self.assertEqual(expected, orig_environ(env))
+
+    def test_practical(self):
+        snap = '/snap/subiquity/1234'
+        env = {
+            'TERM': 'linux',
+            'PYTHONIOENCODING_ORIG': '',
+            'PYTHONIOENCODING': 'utf-8',
+            'SUBIQUITY_ROOT_ORIG': '',
+            'SUBIQUITY_ROOT': snap,
+            'PYTHON_ORIG': '',
+            'PYTHON': f'{snap}/usr/bin/python3.8',
+            'PYTHONPATH_ORIG': '',
+            'PYTHONPATH': f'{snap}/stuff/things',
+            'PY3OR2_PYTHON_ORIG': '',
+            'PY3OR2_PYTHON': f'{snap}/usr/bin/python3.8',
+            'PATH_ORIG': '/usr/bin:/bin',
+            'PATH': '/usr/bin:/bin:/snap/bin'
+        }
+        expected = {
+            'TERM': 'linux',
+            'PATH': '/usr/bin:/bin',
+        }
+        self.assertEqual(expected, orig_environ(env))

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -35,6 +35,21 @@ def _clean_env(env):
     return env
 
 
+def orig_environ(env):
+    if env is None:
+        env = os.environ
+    ret = env.copy()
+    for key, val in env.items():
+        if key.endswith('_ORIG'):
+            key_to_restore = key[:-len('_ORIG')]
+            if val:
+                ret[key_to_restore] = val
+            else:
+                del ret[key_to_restore]
+            del ret[key]
+    return ret
+
+
 def run_command(cmd: List[str], *, input=None, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE, encoding='utf-8', errors='replace',
                 env=None, **kw) -> subprocess.CompletedProcess:


### PR DESCRIPTION
* LP: #[1974077](http://pad.lv/1974077) cherry-pick fix 44464480a60c9c415ef3f4c51beddf76b9aa3e7b for autoinstall interactive-sections
* LP: #[1975629](http://pad.lv/1975629) cherry-pick fixes 74e118d735c7f361b8e3dc129f32e3a0906e4dd5 and 5b30732f148f5ae6260037121adda9f0b0fb7ebf for debug shell
* cherry-pick improvements bd6647d6ec5366778df38a2a1b8e6aed8ba5ca22 for snap metadata to set source-code and issues fields
* LP: #[1978139](http://pad.lv/1978139) cherry-pick a9520b71003b292be286e0ffdb8b3909a4e1ea6c, 135a870509a521f6e5088767e5367f2c41bd4763, 942e5f5f1bd9dcf44d41ce3fb64da4529210a0f1 for fix related to snap refresh when using SSH