### PR TITLE
subiquitymodel: validate merged cloud-config userdata_raw before reboot

### DIFF
--- a/examples/autoinstall-user-data.yaml
+++ b/examples/autoinstall-user-data.yaml
@@ -18,5 +18,5 @@ source:
 updates: security
 user-data:
   users:
-    - username: ubuntu
-      password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+    - name: ubuntu
+      passwd: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'

--- a/subiquity/server/controllers/tests/test_userdata.py
+++ b/subiquity/server/controllers/tests/test_userdata.py
@@ -1,0 +1,63 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from subiquity.server.controllers.userdata import (
+    UserdataController,
+)
+from subiquitycore.tests.mocks import make_app
+
+from cloudinit.config.schema import SchemaValidationError
+try:
+    from cloudinit.config.schema import SchemaProblem
+except ImportError:
+    def SchemaProblem(x, y): return (x, y)  # TODO(drop on cloud-init 22.3 SRU)
+
+
+class TestUserdataController(unittest.TestCase):
+    def setUp(self):
+        self.controller = UserdataController(make_app())
+
+    def test_load_autoinstall_data(self):
+        with self.subTest('Valid user-data resets userdata model'):
+            valid_schema = {"ssh_import_id": ["you"]}
+            self.controller.model = {"some": "old userdata"}
+            self.controller.load_autoinstall_data(valid_schema)
+            self.assertEqual(self.controller.model, valid_schema)
+
+        fake_error = SchemaValidationError(
+            schema_errors=(
+                SchemaProblem(
+                    "ssh_import_id",
+                    "'wrong' is not of type 'array'"
+                ),
+            ),
+        )
+        invalid_schema = {"ssh_import_id": "wrong"}
+        validate = self.controller.app.base_model.validate_cloudconfig_schema
+        validate.side_effect = fake_error
+        with self.subTest('Invalid user-data raises error'):
+            with self.assertRaises(SchemaValidationError) as ctx:
+                self.controller.load_autoinstall_data(invalid_schema)
+            expected_error = (
+                "Cloud config schema errors: ssh_import_id: 'wrong' is not of"
+                " type 'array'"
+            )
+            self.assertEqual(expected_error, str(ctx.exception))
+            validate.assert_called_with(
+                data=invalid_schema,
+                data_source="autoinstall.user-data"
+            )

--- a/subiquity/server/controllers/userdata.py
+++ b/subiquity/server/controllers/userdata.py
@@ -13,7 +13,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 from subiquity.server.controller import NonInteractiveController
+
+log = logging.getLogger("subiquity.server.controllers.userdata")
 
 
 class UserdataController(NonInteractiveController):
@@ -27,6 +31,10 @@ class UserdataController(NonInteractiveController):
 
     def load_autoinstall_data(self, data):
         self.model.clear()
+        if data:
+            self.app.base_model.validate_cloudconfig_schema(
+                data=data, data_source="autoinstall.user-data",
+            )
         self.model.update(data)
 
     def make_autoinstall(self):


### PR DESCRIPTION
This will raise noisy SchemaValidationErrors if either deprecated keys
or schema errors are provided in autoinstall.user-data or in the
merged userdata_raw provided to cloud-init in the installed target.


This is part of a series of PRs to support cloud-init/subiquity live-installer usability:
 1.  [Add /etc/cloud-init/clean.d/90-installer script to allow cloud-init clean to remove any installer artifacts for golden image creation](https://github.com/canonical/subiquity/pull/1347)
 2. [subiquity to read `/run/cloud-init/instance-data-sensitive.json` for autoinstall: config directives instead of initializing `Init.read_cfg()`](https://github.com/canonical/subiquity/pull/1352)
 3. [This PR] Perform schema initial validation on merged userdata_raw config within the installer environment to catch cloud-init-related user misconfiguration before final target system reboot
 4. [#1395] ubuntu-desktop-installer to disable cloud-init after installed system reboot via write_files directive
 5. TBD Consume cloud-init status --format (json/yaml) machine readable output to report more succinct status of cloud-init