### PR TITLE
identity view: Allow uppercase in hostnames

### DIFF
--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -42,7 +42,7 @@ from subiquity.common.types import IdentityData, UsernameValidation
 log = logging.getLogger("subiquity.ui.views.identity")
 
 HOSTNAME_MAXLEN = 64
-HOSTNAME_REGEX = r'[a-z0-9_][a-z0-9_-]*'
+HOSTNAME_REGEX = r'[a-zA-Z0-9_][a-zA-Z0-9_-]*'
 REALNAME_MAXLEN = 160
 SSH_IMPORT_MAXLEN = 256 + 3  # account for lp: or gh:
 USERNAME_MAXLEN = 32


### PR DESCRIPTION
This regex is bizzarre enough already, allowing underscores despite them not
being valid at all, but the previous commit (9cdd829299d6a60a92466f62b91cba74c366d827)
mentions leaving it in for "backwards compatibility" (!?).

Hostnames are in fact allowed to contain uppercase letters, and per RFCs 883, 952, and 1123,
although notably they are required to be non-distinguishing. While many people have opinions
about hostname casing, I do not feel subiquity should impose opinions on users, and should
instead perform validations only.