### PR TITLE
meta/status: replace POST_WAIT and POST_RUNNING by generic states

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -56,16 +56,27 @@ class ErrorReportRef:
 
 
 class ApplicationState(enum.Enum):
+    """ Represents the state of the application at a given time. """
+
+    # States reported during the initial stages of the installation.
     STARTING_UP = enum.auto()
     CLOUD_INIT_WAIT = enum.auto()
     EARLY_COMMANDS = enum.auto()
-    WAITING = enum.auto()
+
+    # State reported once before starting destructive actions.
     NEEDS_CONFIRMATION = enum.auto()
+
+    # States reported during installation. This sequence should be expected
+    # multiple times until we reach the late stages.
+    WAITING = enum.auto()
     RUNNING = enum.auto()
-    POST_WAIT = enum.auto()
-    POST_RUNNING = enum.auto()
+
+    # States reported while unattended-upgrades is running.
+    # TODO: check if these should be dropped in favor of RUNNING.
     UU_RUNNING = enum.auto()
     UU_CANCELLING = enum.auto()
+
+    # Final state
     DONE = enum.auto()
     ERROR = enum.auto()
     EXITED = enum.auto()

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -168,11 +168,11 @@ class InstallController(SubiquityController):
             await self.curtin_install(
                 context=context, source='cp://' + for_install_path)
 
-            self.app.update_state(ApplicationState.POST_WAIT)
+            self.app.update_state(ApplicationState.WAITING)
 
             await self.model.wait_postinstall()
 
-            self.app.update_state(ApplicationState.POST_RUNNING)
+            self.app.update_state(ApplicationState.RUNNING)
 
             await self.postinstall(context=context)
 

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -290,7 +290,7 @@ class TestFlow(TestAPI):
                 "token": "a1b2c3d4e6f7g8h9I0K1",
             }
             await inst.post('/ubuntu_pro', ua_params)
-            for state in 'RUNNING', 'POST_WAIT', 'POST_RUNNING', 'UU_RUNNING':
+            for state in 'RUNNING', 'WAITING', 'RUNNING', 'UU_RUNNING':
                 await inst.get('/meta/status', cur=state)
 
     @timeout()

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -156,12 +156,6 @@ class ProgressView(BaseView):
         elif state == ApplicationState.RUNNING:
             self.title = _("Installing system")
             btns = [self.view_log_btn]
-        elif state == ApplicationState.POST_WAIT:
-            self.title = _("Installing system")
-            btns = [self.view_log_btn]
-        elif state == ApplicationState.POST_RUNNING:
-            self.title = _("Installing system")
-            btns = [self.view_log_btn]
         elif state == ApplicationState.UU_RUNNING:
             self.title = _("Install complete!")
             self.reboot_btn.base_widget.set_label(

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -384,9 +384,9 @@ class ConfigureController(SubiquityController):
 
             await self.model.wait_postinstall()
 
-            self.app.update_state(ApplicationState.POST_WAIT)
+            self.app.update_state(ApplicationState.WAITING)
 
-            self.app.update_state(ApplicationState.POST_RUNNING)
+            self.app.update_state(ApplicationState.RUNNING)
 
             variant = self.app.variant
             root_dir = self.model.root


### PR DESCRIPTION
With the plan to call curtin multiple times where each invocation has a specific purpose, we want the client to have a simple way to monitor the status of the installation.

Instead of defining new application states for each stage, we will report the more generic `WAITING` / `NEEDS_CONFIRMATION` / `RUNNING` states in a loop until we get to the final stages of the installation.

To start with, we are dropping `POST_WAIT` and `POST_RUNNING` in favor or `WAITING` and `RUNNING`.

Since this impacts both Subiquity, the desktop installer and console-setup. I'm marking the PR a draft until enough testing is done.