### PR TITLE
examples: make the 'simple' mc disk bigger

### DIFF
--- a/examples/simple.json
+++ b/examples/simple.json
@@ -405,7 +405,7 @@
                     "range": "16",
                     "removable": "0",
                     "ro": "0",
-                    "size": "10737418240",
+                    "size": "107374182400",
                     "stat": "     411        0    16968      119        0        0        0        0        0      264        0        0        0        0        0",
                     "subsystem": "block",
                     "uevent": "MAJOR=8\nMINOR=0\nDEVNAME=sda\nDEVTYPE=disk"

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -1124,7 +1124,7 @@ class TestGap(TestAPI):
             resp = await inst.get('/storage/v2')
             sda = first(resp['disks'], 'id', 'disk-sda')
             gap = sda['partitions'][0]
-            expected = (10 << 30) - (2 << 20)
+            expected = (100 << 30) - (2 << 20)
             self.assertEqual(expected, gap['size'])
 
     async def test_gap_at_end(self):
@@ -1146,7 +1146,7 @@ class TestGap(TestAPI):
             [boot] = match(sda['partitions'], mount='/boot/efi')
             [p1, p2, gap] = sda['partitions']
             self.assertEqual('Gap', gap['$type'])
-            expected = (10 << 30) - p1['size'] - p2['size'] - (2 << 20)
+            expected = (100 << 30) - p1['size'] - p2['size'] - (2 << 20)
             self.assertEqual(expected, gap['size'])
 
     async def SKIP_test_two_gaps(self):


### PR DESCRIPTION
Increase size of the disk in the simple machine config to 100 GiB.
This file is used heavily as a basic starting machine config and it
should be large enough for many types of tests.