### PR TITLE
add .path to Raid so for_client(raid-with-partitions) works

### DIFF
--- a/subiquity/common/filesystem/tests/test_labels.py
+++ b/subiquity/common/filesystem/tests/test_labels.py
@@ -18,12 +18,14 @@ import unittest
 
 from subiquity.common.filesystem.labels import (
     annotations,
+    for_client,
     usage_labels,
     )
 from subiquity.models.tests.test_filesystem import (
     make_model,
     make_model_and_disk,
     make_model_and_partition,
+    make_model_and_raid,
     make_partition,
     )
 
@@ -123,3 +125,11 @@ class TestUsageLabels(unittest.TestCase):
         self.assertEqual(
             usage_labels(partition),
             ["to be reformatted as ext4", "mounted at /"])
+
+
+class TestForClient(unittest.TestCase):
+
+    def test_for_client_raid_parts(self):
+        model, raid = make_model_and_raid()
+        make_partition(model, raid)
+        for_client(raid)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -773,6 +773,12 @@ class Raid(_Device):
     _subvolumes = attributes.backlink(default=attr.Factory(list))
 
     @property
+    def path(self):
+        # This is just here to make for_client(raid-with-partitions) work. It
+        # might not be very accurate.
+        return '/dev/md/' + self.name
+
+    @property
     def size(self):
         if self.preserve and self._m._probe_data:
             bd = self._m._probe_data['blockdev'].get('/dev/' + self.name)


### PR DESCRIPTION
This is pretty ugly but it expect it fixes the crash.

For https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1982903