### PR TITLE
source: allow to specify source ID in autoinstall config

### DIFF
--- a/autoinstall-schema.json
+++ b/autoinstall-schema.json
@@ -123,6 +123,9 @@
             "properties": {
                 "search_drivers": {
                     "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/autoinstall-schema.json
+++ b/autoinstall-schema.json
@@ -127,10 +127,7 @@
                 "id": {
                     "type": "string"
                 }
-            },
-            "required": [
-                "search_drivers"
-            ]
+            }
         },
         "network": {
             "oneOf": [

--- a/examples/autoinstall-user-data.yaml
+++ b/examples/autoinstall-user-data.yaml
@@ -13,6 +13,8 @@ late-commands:
   - echo a
 keyboard:
   layout: gb
+source:
+  id: ubuntu-server-minimal
 updates: security
 user-data:
   users:

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -225,8 +225,11 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --output-base "$tmpdir" \
     --machine-config examples/simple.json \
     --autoinstall examples/autoinstall-user-data.yaml \
-    --kernel-cmdline autoinstall
+    --kernel-cmdline autoinstall \
+    --source-catalog examples/install-sources.yaml
 validate
+python3 scripts/check-yaml-fields.py "$tmpdir"/var/log/installer/autoinstall-user-data \
+        'autoinstall.source.id="ubuntu-server-minimal"'
 grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' $tmpdir/subiquity-server-debug.log
 
 # The OOBE doesn't exist in WSL < 20.04

--- a/subiquity/models/source.py
+++ b/subiquity/models/source.py
@@ -88,6 +88,13 @@ class SourceModel:
         if self.current is None:
             self.current = self.sources[0]
 
+    def get_matching_source(self, id_: str) -> CatalogEntry:
+        """ Return a source object that has the ID requested. """
+        for source in self.sources:
+            if source.id == id_:
+                return source
+        raise KeyError
+
     def get_source(self):
         path = os.path.join(self._dir, self.current.path)
         if self.current.preinstalled_langs:

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -84,8 +84,10 @@ class SourceController(SubiquityController):
 
     def load_autoinstall_data(self, data: Any) -> None:
         if data is None:
-            # For some reason, the schema validator does not reject
-            # "source: null" despite "type" being "object"
+            # NOTE: The JSON schema does not allow data to be null in this
+            # context. However, Subiquity bypasses the schema validation when
+            # a section is set to null. So in practice, we can have data = None
+            # here.
             data = {**self.autoinstall_default, "id": None}
 
         self.model.search_drivers = data.get("search_drivers", True)

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -64,7 +64,6 @@ class SourceController(SubiquityController):
                  "type": "string",
              },
          },
-         "required": ["search_drivers"],
     }
     # Defaults to true for backward compatibility with existing autoinstall
     # configurations. Back then, then users were able to install third-party
@@ -89,11 +88,7 @@ class SourceController(SubiquityController):
             # "source: null" despite "type" being "object"
             data = {**self.autoinstall_default, "id": None}
 
-        # search_drivers is marked required so the schema validator should
-        # reject any missing data.
-        assert "search_drivers" in data
-
-        self.model.search_drivers = data["search_drivers"]
+        self.model.search_drivers = data.get("search_drivers", True)
 
         # At this point, the model has not yet loaded the sources from the
         # catalog. So we store the data and lean on apply_autoinstall_config.


### PR DESCRIPTION
This PR brings support for the following data in autoinstall configuration:
```yaml
source:
  id: ubuntu-server-minimal
```
One of the particularity of the source controller is that it does not have access to the source catalog by the time the autoinstall data is loaded. Therefore, we have to store the data first and do the magic later in `apply_autoinstall_config`.

The `search_drivers` key used to be required as part of the `source` section. This made sense (I wonder, really?) when `search_drivers` was the only key supported (what's the point of declaring the section if we're not setting any value?) but it should be made optional now since the user may want to specify the source ID without bothering with drivers stuff.

<details>
<summary>moved to https://github.com/canonical/subiquity/pull/1377</summary>
Also, I realized that the top level autoinstall sections accepted the `null` value although such a configuration should have been rejected according to the JSON schema:

```yaml
source: null      # invalid - source should be of type object
keyboard: null    # invalid - keyboard should be of type object
snaps: null       # invalid - snaps should be of type array
...
```

This happened because the JSON validation was skipped when a section was set to `null`. The goal was to allow the controllers to set `autoinstall_default` to `None` (which is a sensible thing to do).

However, instead of skipping validation when the section resolves to `None`, the better thing to do is to skip the validation when `autoinstall_default` is effectively used.

If we want to accept `null` for a given section, we can by adding `"null"` to the list of accepted types:

```diff
- "type": "object"
+ "type": ["object", "null"]
```
the `proxy` section is an example.
</details>
