### PR TITLE
autoinstall: reject null values in autoinstall top level sections

### DIFF
--- a/subiquity/server/controller.py
+++ b/subiquity/server/controller.py
@@ -50,6 +50,7 @@ class SubiquityController(BaseController):
     def setup_autoinstall(self):
         if not self.app.autoinstall_config:
             return
+        validate = True
         with self.context.child("load_autoinstall_data"):
             key_candidates = [self.autoinstall_key]
             if self.autoinstall_key_alias is not None:
@@ -63,8 +64,9 @@ class SubiquityController(BaseController):
                     pass
             else:
                 ai_data = self.autoinstall_default
+                validate = False
 
-            if ai_data is not None and self.autoinstall_schema is not None:
+            if validate and self.autoinstall_schema is not None:
                 jsonschema.validate(ai_data, self.autoinstall_schema)
             self.load_autoinstall_data(ai_data)
 

--- a/subiquity/server/controllers/drivers.py
+++ b/subiquity/server/controllers/drivers.py
@@ -60,7 +60,7 @@ class DriversController(SubiquityController):
         }
 
     def load_autoinstall_data(self, data):
-        if data is not None and "install" in data:
+        if "install" in data:
             self.model.do_install = data["install"]
 
     def start(self):

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -76,11 +76,6 @@ class SourceController(SubiquityController):
         return {"search_drivers": self.model.search_drivers}
 
     def load_autoinstall_data(self, data: Any) -> None:
-        if data is None:
-            # For some reason, the schema validator does not reject
-            # "source: null" despite "type" being "object"
-            data = self.autoinstall_default
-
         # search_drivers is marked required so the schema validator should
         # reject any missing data.
         assert "search_drivers" in data

--- a/subiquity/server/controllers/ubuntu_pro.py
+++ b/subiquity/server/controllers/ubuntu_pro.py
@@ -61,6 +61,7 @@ class UbuntuProController(SubiquityController):
             },
         },
     }
+    autoinstall_default = {}
 
     def __init__(self, app) -> None:
         """ Initializer for server-side Ubuntu Pro controller. """
@@ -79,8 +80,6 @@ class UbuntuProController(SubiquityController):
 
     def load_autoinstall_data(self, data: dict) -> None:
         """ Load autoinstall data and update the model. """
-        if data is None:
-            return
         self.model.token = data.get("token", "")
 
     def make_autoinstall(self) -> dict:


### PR DESCRIPTION
_opening this PR so split the original https://github.com/canonical/subiquity/pull/1375_

When working on the above PR, I realized that the top level autoinstall sections accepted the `null` value although such a configuration should have been rejected according to the JSON schema:

```yaml
source: null      # invalid - source should be of type object
keyboard: null    # invalid - keyboard should be of type object
snaps: null       # invalid - snaps should be of type array
...
```

This happened because the JSON validation was skipped when a section was set to `null`. The goal was to allow the controllers to set `autoinstall_default` to `None` (which is a sensible thing to do).

However, instead of skipping validation when the section resolves to `None`, the better thing to do is to skip the validation when `autoinstall_default` is effectively used.

If we want to accept `null` for a given section, we can by adding `"null"` to the list of accepted types:

```diff
- "type": "object"
+ "type": ["object", "null"]
```
the `proxy` section is an example.


