### PR TITLE
boot: fix too many primaries case

### DIFF
--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -246,7 +246,8 @@ def get_add_part_plan(device, *, spec, args, resize_partition=None):
             ])
     else:
         new_primaries = [p for p in partitions
-                         if not p.preserve and p.is_primary]
+                         if not p.preserve
+                         if p.flag not in ('extended', 'logical')]
         if not new_primaries:
             return None
         largest_part = max(new_primaries, key=lambda p: p.size)

--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -226,7 +226,7 @@ def get_add_part_plan(device, *, spec, args, resize_partition=None):
     # it's probably a bad idea for all cases.
 
     gap = gaps.largest_gap(device, in_extended=False)
-    if gap is not None and gap.size >= size:
+    if gap is not None and gap.size >= size and gap.is_usable:
         create_part_plan.gap = gap.split(size)[0]
         return create_part_plan
     elif resize_partition is not None and not resize_partition.is_logical:

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -773,10 +773,6 @@ class Partition(_Formattable):
     def is_logical(self):
         return self.flag == 'logical'
 
-    @property
-    def is_primary(self):
-        return self.flag != 'logical' and self.flag != 'extended'
-
     ok_for_lvm_vg = ok_for_raid
 
 


### PR DESCRIPTION
Partial progress on making guided respect the number of primary partitions.