### PR TITLE
Execute run-parts on /etc/subiquity/postinst.d before executing any other late_commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ PYTHONPATH=$(shell pwd):$(shell pwd)/probert:$(shell pwd)/curtin
 PROBERTDIR=./probert
 PROBERT_REPO=https://github.com/canonical/probert
 DRYRUN?=--dry-run --bootloader uefi --machine-config examples/simple.json \
-	--source-catalog examples/install-sources.yaml
+	--source-catalog examples/install-sources.yaml \
+	--postinst-hooks-dir examples/postinst.d/
 SYSTEM_SETUP_DRYRUN?=--dry-run
 export PYTHONPATH
 CWD := $(shell pwd)

--- a/examples/postinst.d/copy_nm_connections
+++ b/examples/postinst.d/copy_nm_connections
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+prefix="$TARGET_MOUNT_POINT"/etc/NetworkManager/system-connections
+
+echo "Copying NM connections to target"
+
+mkdir --parents -- "$prefix"
+cat > "$prefix"/subiquity-test.nmconnection << EOF
+[connection]
+id=Subiquity Test
+uuid=5bbf9dda-f3a9-4967-970e-aba55c8b18f0
+type=wifi
+interface-name=wlp0s20f3
+permissions=
+
+[wifi]
+mode=infrastructure
+ssid=TestConnection-5G
+
+[wifi-security]
+auth-alg=open
+key-mgmt=wpa-psk
+psk=nCjIqJ4G
+
+[ipv4]
+dns-search=
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=auto
+
+[proxy]
+EOF

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -16,6 +16,7 @@
 import argparse
 import logging
 import os
+import pathlib
 import shlex
 import sys
 
@@ -104,6 +105,9 @@ def make_server_args_parser():
         '--storage-version', action='store', type=int)
     parser.add_argument(
         '--use-os-prober', action='store_true', default=False)
+    parser.add_argument(
+        '--postinst-hooks-dir', default='/etc/subiquity/postinst.d',
+        type=pathlib.Path)
     return parser
 
 

--- a/subiquity/server/controllers/cmdlist.py
+++ b/subiquity/server/controllers/cmdlist.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import os
+import shlex
 from typing import List, Sequence, Union
 
 import attr
@@ -38,7 +39,7 @@ class Command:
         """ Return a user-friendly representation of the command. """
         if isinstance(self.args, str):
             return self.args
-        return ' '.join(self.args)
+        return shlex.join(self.args)
 
     def as_args_list(self) -> List[str]:
         """ Return the command as a list of arguments. """


### PR DESCRIPTION
This PR extends the early / late / error controllers so that they can declare builtin commands.
Builtin commands are executed before other commands declared in the relevant autoinstall section.

In the late controller, we now declare a builtin command that runs `run-parts /etc/subiquity/postinst.d`. The desktop installer can use this and place executable scripts under `/etc/subiquity/postinst.d` to copy network-manager connections and do other things.