### PR TITLE
guided: singledispatch and other refactors

### DIFF
--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -70,6 +70,17 @@ class Gap:
                        usable=self.usable)
         return (first_gap, rest_gap)
 
+    def within(self):
+        """Find the first gap that is contained wholly inside the supplied
+        gap."""
+        gap_end = self.offset + self.size
+        for pg in parts_and_gaps(self.device):
+            if isinstance(pg, Gap):
+                pg_end = pg.offset + pg.size
+                if pg.offset >= self.offset and pg_end <= gap_end:
+                    return pg
+        return None
+
 
 @functools.singledispatch
 def parts_and_gaps(device):
@@ -254,17 +265,6 @@ def at_offset(device, offset):
     for pg in parts_and_gaps(device):
         if isinstance(pg, Gap):
             if pg.offset == offset:
-                return pg
-    return None
-
-
-def within(device, gap):
-    """Find the first gap that is contained wholly inside the supplied gap."""
-    gap_end = gap.offset + gap.size
-    for pg in parts_and_gaps(device):
-        if isinstance(pg, Gap):
-            pg_end = pg.offset + pg.size
-            if pg.offset >= gap.offset and pg_end <= gap_end:
                 return pg
     return None
 

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -71,8 +71,7 @@ class Gap:
         return (first_gap, rest_gap)
 
     def within(self):
-        """Find the first gap that is contained wholly inside the supplied
-        gap."""
+        """Find the first gap that is contained wholly inside this gap."""
         gap_end = self.offset + self.size
         for pg in parts_and_gaps(self.device):
             if isinstance(pg, Gap):

--- a/subiquity/common/filesystem/tests/test_gaps.py
+++ b/subiquity/common/filesystem/tests/test_gaps.py
@@ -121,7 +121,7 @@ class TestWithin(unittest.TestCase):
     def test_identity(self):
         d = make_disk()
         [gap] = gaps.parts_and_gaps(d)
-        self.assertEqual(gap, gaps.within(d, gap))
+        self.assertEqual(gap, gap.within())
 
     def test_front_used(self):
         m, d = make_model_and_disk(size=200 << 20)
@@ -130,7 +130,7 @@ class TestWithin(unittest.TestCase):
         [orig_g1, p1, orig_g2] = gaps.parts_and_gaps(d)
         make_partition(m, d, offset=0, size=20 << 20)
         [p1, g1, p2, g2] = gaps.parts_and_gaps(d)
-        self.assertEqual(g1, gaps.within(d, orig_g1))
+        self.assertEqual(g1, orig_g1.within())
 
     def test_back_used(self):
         m, d = make_model_and_disk(size=200 << 20)
@@ -139,7 +139,7 @@ class TestWithin(unittest.TestCase):
         [orig_g1, p1, orig_g2] = gaps.parts_and_gaps(d)
         make_partition(m, d, offset=80 << 20, size=20 << 20)
         [g1, p1, p2, g2] = gaps.parts_and_gaps(d)
-        self.assertEqual(g1, gaps.within(d, orig_g1))
+        self.assertEqual(g1, orig_g1.within())
 
     def test_front_and_back_used(self):
         m, d = make_model_and_disk(size=200 << 20)
@@ -149,7 +149,7 @@ class TestWithin(unittest.TestCase):
         make_partition(m, d, offset=0, size=20 << 20)
         make_partition(m, d, offset=80 << 20, size=20 << 20)
         [p1, g1, p2, p3, g2] = gaps.parts_and_gaps(d)
-        self.assertEqual(g1, gaps.within(d, orig_g1))
+        self.assertEqual(g1, orig_g1.within())
 
     def test_multi_gap(self):
         m, d = make_model_and_disk(size=200 << 20)
@@ -158,7 +158,7 @@ class TestWithin(unittest.TestCase):
         [orig_g1, p1, orig_g2] = gaps.parts_and_gaps(d)
         make_partition(m, d, offset=20 << 20, size=20 << 20)
         [g1, p1, g2, p2, g3] = gaps.parts_and_gaps(d)
-        self.assertEqual(g1, gaps.within(d, orig_g1))
+        self.assertEqual(g1, orig_g1.within())
 
     def test_later_part_of_disk(self):
         m, d = make_model_and_disk(size=200 << 20)
@@ -167,7 +167,7 @@ class TestWithin(unittest.TestCase):
         [orig_g1, p1, orig_g2] = gaps.parts_and_gaps(d)
         make_partition(m, d, offset=120 << 20, size=20 << 20)
         [g1, p1, g2, p2, g3] = gaps.parts_and_gaps(d)
-        self.assertEqual(g2, gaps.within(d, orig_g2))
+        self.assertEqual(g2, orig_g2.within())
 
 
 class TestAfter(unittest.TestCase):

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -153,7 +153,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             return gaps.largest_gap(disk)
         else:
             # find what's left of the gap after adding boot
-            gap = gaps.within(disk, gap)
+            gap = gap.within()
             if gap is None:
                 raise Exception('failed to locate gap after adding boot')
             return gap

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -134,8 +134,8 @@ class TestGuided(TestCase):
         self.assertEqual(None, d1p2.mount)
         self.assertIsNone(gaps.largest_gap(self.d1))
 
-    def _guided_side_by_side(self, bl):
-        self._guided_setup(bl, 'msdos', storage_version=2)
+    def _guided_side_by_side(self, bl, ptable):
+        self._guided_setup(bl, ptable, storage_version=2)
         self.controller.add_boot_disk(self.d1)
         for p in self.d1._partitions:
             p.preserve = True
@@ -144,43 +144,60 @@ class TestGuided(TestCase):
                 self.model._probe_data['blockdev'][p._path()] = {
                     "ID_PART_ENTRY_TYPE": str(0xef)
                 }
-        # create an extended partition,
-        # and a few other partitions to make it more interesting
+        # Make it more interesting with other partitions.
+        # Also create the extended part if needed.
         g = gaps.largest_gap(self.d1)
         make_partition(self.model, self.d1, preserve=True,
                        size=10 << 30, offset=g.offset)
-        g = gaps.largest_gap(self.d1)
-        make_partition(self.model, self.d1, preserve=True,
-                       flag='extended', size=g.size, offset=g.offset)
-        g = gaps.largest_gap(self.d1)
-        make_partition(self.model, self.d1, preserve=True,
-                       flag='logical', size=10 << 30, offset=g.offset)
+        if ptable == 'msdos':
+            g = gaps.largest_gap(self.d1)
+            make_partition(self.model, self.d1, preserve=True,
+                           flag='extended', size=g.size, offset=g.offset)
+            g = gaps.largest_gap(self.d1)
+            make_partition(self.model, self.d1, preserve=True,
+                           flag='logical', size=10 << 30, offset=g.offset)
 
-    @parameterized.expand(bootloaders)
-    def test_guided_direct_side_by_side_logical(self, bl):
-        self._guided_side_by_side(bl)
+    @parameterized.expand(
+        [(bl, pt, flag)
+         for bl in list(Bootloader)
+         for pt, flag in (
+             ('msdos', 'logical'),
+             ('gpt', None)
+         )]
+    )
+    def test_guided_direct_side_by_side(self, bl, pt, flag):
+        self._guided_side_by_side(bl, pt)
         parts_before = self.d1._partitions.copy()
-        g = gaps.largest_gap(self.d1)
-        self.controller.guided_direct(g, mode='use_gap')
+        gap = gaps.largest_gap(self.d1)
+        target = GuidedStorageTargetUseGap(disk_id=self.d1.id, gap=gap)
+        self.controller.guided(GuidedChoiceV2(target=target, use_lvm=False))
         parts_after = gaps.parts_and_gaps(self.d1)[:-1]
         self.assertEqual(parts_before, parts_after)
-        p6 = gaps.parts_and_gaps(self.d1)[-1]
-        self.assertEqual('/', p6.mount)
-        self.assertEqual('logical', p6.flag)
+        p = gaps.parts_and_gaps(self.d1)[-1]
+        self.assertEqual('/', p.mount)
+        self.assertEqual(flag, p.flag)
 
-    @parameterized.expand(bootloaders)
-    def test_guided_lvm_side_by_side_logical(self, bl):
-        self._guided_side_by_side(bl)
+    @parameterized.expand(
+        [(bl, pt, flag)
+         for bl in list(Bootloader)
+         for pt, flag in (
+             ('msdos', 'logical'),
+             ('gpt', None)
+         )]
+    )
+    def test_guided_lvm_side_by_side(self, bl, pt, flag):
+        self._guided_side_by_side(bl, pt)
         parts_before = self.d1._partitions.copy()
-        g = gaps.largest_gap(self.d1)
-        self.controller.guided_lvm(g, mode='use_gap')
+        gap = gaps.largest_gap(self.d1)
+        target = GuidedStorageTargetUseGap(disk_id=self.d1.id, gap=gap)
+        self.controller.guided(GuidedChoiceV2(target=target, use_lvm=True))
         parts_after = gaps.parts_and_gaps(self.d1)[:-2]
         self.assertEqual(parts_before, parts_after)
-        p6, p7 = gaps.parts_and_gaps(self.d1)[-2:]
-        self.assertEqual('/boot', p6.mount)
-        self.assertEqual('logical', p6.flag)
-        self.assertEqual(None, p7.mount)
-        self.assertEqual('logical', p7.flag)
+        p_boot, p_data = gaps.parts_and_gaps(self.d1)[-2:]
+        self.assertEqual('/boot', p_boot.mount)
+        self.assertEqual(flag, p_boot.flag)
+        self.assertEqual(None, p_data.mount)
+        self.assertEqual(flag, p_data.flag)
 
 
 class TestLayout(TestCase):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -93,7 +93,8 @@ class TestGuided(TestCase):
     @parameterized.expand(boot_expectations)
     def test_guided_direct(self, bootloader, ptable, p1mnt):
         self._guided_setup(bootloader, ptable)
-        self.controller.guided_direct(self.d1)
+        target = GuidedStorageTargetReformat(disk_id=self.d1.id)
+        self.controller.guided(GuidedChoiceV2(target=target, use_lvm=False))
         [d1p1, d1p2] = self.d1.partitions()
         self.assertEqual(p1mnt, d1p1.mount)
         self.assertEqual('/', d1p2.mount)
@@ -101,7 +102,8 @@ class TestGuided(TestCase):
 
     def test_guided_direct_BIOS_MSDOS(self):
         self._guided_setup(Bootloader.BIOS, 'msdos')
-        self.controller.guided_direct(self.d1)
+        target = GuidedStorageTargetReformat(disk_id=self.d1.id)
+        self.controller.guided(GuidedChoiceV2(target=target, use_lvm=False))
         [d1p1] = self.d1.partitions()
         self.assertEqual('/', d1p1.mount)
         self.assertIsNone(gaps.largest_gap(self.d1))
@@ -109,7 +111,8 @@ class TestGuided(TestCase):
     @parameterized.expand(boot_expectations)
     def test_guided_lvm(self, bootloader, ptable, p1mnt):
         self._guided_setup(bootloader, ptable)
-        self.controller.guided_lvm(self.d1)
+        target = GuidedStorageTargetReformat(disk_id=self.d1.id)
+        self.controller.guided(GuidedChoiceV2(target=target, use_lvm=True))
         [d1p1, d1p2, d1p3] = self.d1.partitions()
         self.assertEqual(p1mnt, d1p1.mount)
         self.assertEqual('/boot', d1p2.mount)
@@ -121,7 +124,8 @@ class TestGuided(TestCase):
 
     def test_guided_lvm_BIOS_MSDOS(self):
         self._guided_setup(Bootloader.BIOS, 'msdos')
-        self.controller.guided_lvm(self.d1)
+        target = GuidedStorageTargetReformat(disk_id=self.d1.id)
+        self.controller.guided(GuidedChoiceV2(target=target, use_lvm=True))
         [d1p1, d1p2] = self.d1.partitions()
         self.assertEqual('/boot', d1p1.mount)
         [vg] = self.model._all(type='lvm_volgroup')


### PR DESCRIPTION
* simplify `guided()` with singledispatch
* move gaps.within to a gap object method
* add warning about autoinstall having layout and manual config
* expand a side-by-side unit test to also cover gpt