### PR TITLE
filesystem: part ids are not part nums

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -23,6 +23,7 @@ import math
 import os
 import pathlib
 import platform
+import random
 import tempfile
 
 from curtin import storage_config
@@ -42,12 +43,15 @@ GiB = 1024 * 1024 * 1024
 def _set_backlinks(obj):
     if obj.id is None:
         base = obj.type
-        i = 0
+        num = len(obj._m._all_ids) + 1
         while True:
-            val = "%s-%s" % (base, i)
+            # Create a semireadable id.
+            # The number on the end is not particularly meaningful,
+            # notably on a partition it is (usually) not the partition number.
+            rand = random.randint(0, 16**2 - 1)
+            val = f'{base}-{rand:02x}-{num}'
             if val not in obj._m._all_ids:
                 break
-            i += 1
         obj.id = val
     obj._m._all_ids.add(obj.id)
     for field in attr.fields(type(obj)):


### PR DESCRIPTION
The filesystem object IDs are really only meant to be a semireadable
unique string, and not for display to end users.  Partitions in
particular were bad in this respect, as they could look like the number
on the end was the partition number.

Uglify the object IDs a bit to try to convey the above.