### PR TITLE
Updates for Ubuntu-Pro with magic-attach

### DIFF
--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -27,6 +27,7 @@ from subiquitycore.async_helpers import schedule_task
 from subiquity.client.controller import SubiquityTuiController
 from subiquity.common.types import (
     UbuntuProInfo,
+    UbuntuProResponse,
     UbuntuProCheckTokenStatus as TokenStatus,
     UbuntuProSubscription,
     UPCSWaitStatus,
@@ -68,8 +69,10 @@ class UbuntuProController(SubiquityTuiController):
             await self.endpoint.skip.POST()
             raise Skip("Not running LTS version")
 
-        ubuntu_pro_info = await self.endpoint.GET()
-        return UbuntuProView(self, ubuntu_pro_info.token)
+        ubuntu_pro_info: UbuntuProResponse = await self.endpoint.GET()
+        return UbuntuProView(self,
+                             token=ubuntu_pro_info.token,
+                             has_network=ubuntu_pro_info.has_network)
 
     async def run_answers(self) -> None:
         """ Interact with the UI to go through the pre-attach process if

--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -19,6 +19,7 @@ import contextlib
 import logging
 from typing import Callable, Optional
 
+import aiohttp
 from urwid import Widget
 
 from subiquitycore.async_helpers import schedule_task
@@ -28,6 +29,7 @@ from subiquity.common.types import (
     UbuntuProInfo,
     UbuntuProCheckTokenStatus as TokenStatus,
     UbuntuProSubscription,
+    UPCSWaitStatus,
     )
 from subiquity.ui.views.ubuntu_pro import (
     UbuntuProView,
@@ -50,6 +52,9 @@ class UbuntuProController(SubiquityTuiController):
     def __init__(self, app) -> None:
         """ Initializer for the client-side UA controller. """
         self._check_task: Optional[asyncio.Future] = None
+        self._magic_attach_task: Optional[asyncio.Future] = None
+
+        self.cs_initiated = False
 
         super().__init__(app)
 
@@ -145,6 +150,51 @@ class UbuntuProController(SubiquityTuiController):
         """ Cancel the asynchronous token check (if started). """
         if self._check_task is not None:
             self._check_task.cancel()
+
+    def contract_selection_initiate(
+            self, on_initiated: Callable[[str, str], None]) -> None:
+        """ Initiate the contract selection asynchronously. Calls on_initiated
+        when the contract-selection has initiated. """
+        async def inner() -> None:
+            answer = await self.endpoint.contract_selection.initiate.POST()
+            self.cs_initiated = True
+            on_initiated(user_code=answer.user_code)
+        self._magic_attach_task = schedule_task(inner())
+
+    def contract_selection_wait(
+            self,
+            on_contract_selected: Callable[[str], None],
+            on_timeout: Callable[[None], None]) -> None:
+        """ Asynchronously wait for the contract selection to finish.
+        Calls on_contract_selected with the contract-token once the contract
+        gets selected
+        Otherwise, calls on_timeout if no contract got selected within the
+        allowed time frame. """
+        async def inner() -> None:
+            try:
+                answer = await self.endpoint.contract_selection.wait.GET()
+            except aiohttp.ServerDisconnectedError:
+                log.debug("contract selection was cancelled on the server end")
+            else:
+                if answer.status == UPCSWaitStatus.TIMEOUT:
+                    self.cs_initiated = False
+                    on_timeout()
+                else:
+                    on_contract_selected(answer.contract_token)
+
+        self._monitor_task = schedule_task(inner())
+
+    def contract_selection_cancel(
+            self, on_cancelled: Callable[[None], None]) -> None:
+        """ Cancel the asynchronous contract selection (if started). """
+        async def inner() -> None:
+            await self.endpoint.contract_selection.cancel.POST()
+            self.cs_initiated = False
+            on_cancelled()
+
+        if self._magic_attach_task is not None:
+            self._magic_attach_task.cancel()
+            schedule_task(inner())
 
     def cancel(self) -> None:
         self.app.prev_screen()

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -56,6 +56,8 @@ from subiquity.common.types import (
     TimeZoneInfo,
     UbuntuProInfo,
     UbuntuProCheckTokenAnswer,
+    UPCSInitiateResponse,
+    UPCSWaitResponse,
     UsernameValidation,
     WLANSupportInstallState,
     ZdevInfo,
@@ -340,6 +342,16 @@ class API:
         class check_token:
             def GET(token: Payload[str]) \
                     -> UbuntuProCheckTokenAnswer: ...
+
+        class contract_selection:
+            class initiate:
+                def POST() -> UPCSInitiateResponse: ...
+
+            class wait:
+                def GET() -> UPCSWaitResponse: ...
+
+            class cancel:
+                def POST() -> None: ...
 
     class identity:
         def GET() -> IdentityData: ...

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -55,6 +55,7 @@ from subiquity.common.types import (
     StorageResponseV2,
     TimeZoneInfo,
     UbuntuProInfo,
+    UbuntuProResponse,
     UbuntuProCheckTokenAnswer,
     UPCSInitiateResponse,
     UPCSWaitResponse,
@@ -333,7 +334,7 @@ class API:
             def POST(data: Payload[List[str]]): ...
 
     class ubuntu_pro:
-        def GET() -> UbuntuProInfo: ...
+        def GET() -> UbuntuProResponse: ...
         def POST(data: Payload[UbuntuProInfo]) -> None: ...
 
         class skip:

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -533,6 +533,13 @@ class UbuntuProInfo:
     token: str = attr.ib(repr=False)
 
 
+@attr.s(auto_attribs=True)
+class UbuntuProResponse:
+    """ Response to GET request to /ubuntu_pro """
+    token: str = attr.ib(repr=False)
+    has_network: bool
+
+
 class UbuntuProCheckTokenStatus(enum.Enum):
     VALID_TOKEN = enum.auto()
     INVALID_TOKEN = enum.auto()

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -541,6 +541,26 @@ class UbuntuProCheckTokenStatus(enum.Enum):
 
 
 @attr.s(auto_attribs=True)
+class UPCSInitiateResponse:
+    """ Response to Ubuntu Pro contract selection initiate request. """
+    user_code: str
+    validity_seconds: int
+
+
+class UPCSWaitStatus(enum.Enum):
+    SUCCESS = enum.auto()
+    TIMEOUT = enum.auto()
+
+
+@attr.s(auto_attribs=True)
+class UPCSWaitResponse:
+    """ Response to Ubuntu Pro contract selection wait request. """
+    status: UPCSWaitStatus
+
+    contract_token: Optional[str]
+
+
+@attr.s(auto_attribs=True)
 class UbuntuProService:
     name: str
     description: str

--- a/subiquity/server/contract_selection.py
+++ b/subiquity/server/contract_selection.py
@@ -1,0 +1,123 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+""" Module that deals with contract token selection. """
+
+import asyncio
+import logging
+from typing import Any, List
+import time
+
+from subiquity.server.ubuntu_advantage import (
+    UAInterface,
+    APIUsageError,
+    )
+
+from subiquitycore.async_helpers import schedule_task
+
+
+log = logging.getLogger("subiquity.server.contract_selection")
+
+
+class UPCSExpiredError(Exception):
+    """ Exception to be raised when a contract selection expired. """
+
+
+class UnknownError(Exception):
+    """ Exception to be raised in case of unexpected error. """
+    def __init__(self, message: str = "", errors: List[Any] = []) -> None:
+        self.errors = errors
+        super().__init__(message)
+
+
+class ContractSelection:
+    """ Represents an already initiated contract selection. """
+    def __init__(
+            self,
+            client: UAInterface,
+            magic_token: str,
+            user_code: str,
+            validity_seconds: int) -> None:
+        """ Initialize the contract selection. """
+        self.client = client
+        self.magic_token = magic_token
+        self.user_code = user_code
+        self.validity_seconds = validity_seconds
+        self.task = asyncio.create_task(self._run_polling())
+
+    @classmethod
+    async def initiate(cls, client: UAInterface) \
+            -> "ContractSelection":
+        """ Initiate a contract selection and return a ContractSelection
+        request object. """
+        answer = await client.strategy.magic_initiate_v1()
+
+        if answer["result"] != "success":
+            raise UnknownError(errors=answer["errors"])
+
+        return cls(
+                client=client,
+                magic_token=answer["data"]["attributes"]["token"],
+                validity_seconds=answer["data"]["attributes"]["expires_in"],
+                user_code=answer["data"]["attributes"]["user_code"])
+
+    async def _run_polling(self) -> str:
+        """ Runs the polling and eventually return a contract token. """
+        # Wait an initial 30 seconds before sending the first request, then
+        # send requests at regular interval every 10 seconds.
+        await asyncio.sleep(30 / self.client.strategy.scale_factor)
+
+        start_time = time.monotonic()
+        answer = await self.client.strategy.magic_wait_v1(
+                magic_token=self.magic_token)
+
+        call_duration = time.monotonic() - start_time
+
+        if answer["result"] == "success":
+            return answer["data"]["attributes"]["contract_token"]
+
+        exception = UnknownError()
+        for error in answer["errors"]:
+            if error["code"] == "magic-attach-token-error" and \
+               call_duration >= 60 / self.client.strategy.scale_factor:
+                # Assume it's a timeout if it lasted more than 1 minute.
+                exception = UPCSExpiredError(error["title"])
+            else:
+                log.warning("magic_wait_v1: %s: %s",
+                            error["code"], error["title"])
+
+        raise exception
+
+    def cancel(self):
+        """ Cancel the polling task and asynchronously delete the associated
+        resource. """
+        self.task.cancel()
+
+        async def delete_resource() -> None:
+            """ Release the resource on the server. """
+            try:
+                answer = await self.client.strategy.magic_revoke_v1(
+                        magic_token=self.magic_token)
+
+            except APIUsageError as e:
+                log.warn("failed to revoke magic-token: %r", e)
+            else:
+                if answer["result"] != "success":
+                    log.debug("successfully revoked magic-token")
+                    return
+                for error in answer["errors"]:
+                    log.warning("magic_revoke_v1: %s: %s",
+                                error["code"], error["title"])
+
+        schedule_task(delete_resource())

--- a/subiquity/server/controllers/ubuntu_pro.py
+++ b/subiquity/server/controllers/ubuntu_pro.py
@@ -24,6 +24,7 @@ from subiquity.common.types import (
     UbuntuProInfo,
     UbuntuProCheckTokenAnswer,
     UbuntuProCheckTokenStatus,
+    UbuntuProResponse,
     UPCSInitiateResponse,
     UPCSWaitStatus,
     UPCSWaitResponse,
@@ -128,9 +129,11 @@ class UbuntuProController(SubiquityController):
         """ Loads the last-known state of the model. """
         self.model.token = token
 
-    async def GET(self) -> UbuntuProInfo:
+    async def GET(self) -> UbuntuProResponse:
         """ Handle a GET request coming from the client-side controller. """
-        return UbuntuProInfo(token=self.model.token)
+        has_network = self.app.base_model.network.has_network
+        return UbuntuProResponse(token=self.model.token,
+                                 has_network=has_network)
 
     async def POST(self, data: UbuntuProInfo) -> None:
         """ Handle a POST request coming from the client-side controller and

--- a/subiquity/server/tests/test_contract_selection.py
+++ b/subiquity/server/tests/test_contract_selection.py
@@ -1,0 +1,132 @@
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import patch, AsyncMock
+
+from subiquity.server.contract_selection import (
+    ContractSelection,
+    UnknownError,
+    UPCSExpiredError,
+    )
+
+
+class TestContractSelection(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.client = AsyncMock()
+
+    async def test_init(self):
+        with patch.object(ContractSelection, "_run_polling",
+                          return_value=None) as run_polling:
+
+            cs = ContractSelection(client=self.client,
+                                   magic_token="magic",
+                                   user_code="user-code",
+                                   validity_seconds=200)
+
+        self.assertIs(cs.client, self.client)
+        self.assertEqual(cs.magic_token, "magic")
+        self.assertEqual(cs.user_code, "user-code")
+        self.assertEqual(cs.validity_seconds, 200)
+        self.assertIsNone(await cs.task)
+
+        run_polling.assert_called_once_with()
+
+    async def test_initiate_error(self):
+        ret = {
+            "errors": ["Initiate failed"],
+            "result": "failure",
+        }
+        with patch.object(self.client.strategy,
+                          "magic_initiate_v1", return_value=ret):
+
+            with self.assertRaises(UnknownError) as cm:
+                await ContractSelection.initiate(self.client)
+            self.assertIn("Initiate failed", cm.exception.errors)
+
+    @patch.object(ContractSelection, "_run_polling", return_value=None)
+    async def test_initiate_ok(self, run_polling):
+        ret = {
+            "result": "success",
+            "data": {
+                "attributes": {
+                    "token": "magic-12345",
+                    "user_code": "ABCDEF",
+                    "expires_in": 200,
+                },
+            },
+        }
+        with patch.object(self.client.strategy,
+                          "magic_initiate_v1", return_value=ret):
+
+            cs = await ContractSelection.initiate(self.client)
+
+        self.assertEqual(cs.magic_token, "magic-12345")
+        self.assertEqual(cs.user_code, "ABCDEF")
+
+    @patch("asyncio.sleep")
+    async def test_run_polling_errors(self, sleep):
+        ret = {
+            "result": "failure",
+            "errors": [
+                {
+                    "title": "The magic attach token is invalid..",
+                    "code": "magic-attach-token-error",
+                },
+            ],
+        }
+        with patch.object(ContractSelection,
+                          "_run_polling", return_value=None):
+            cs = ContractSelection(client=self.client,
+                                   magic_token="magic-token",
+                                   user_code="ABCDEF",
+                                   validity_seconds=200)
+        await cs.task
+
+        self.client.strategy.scale_factor = 1
+        with patch.object(self.client.strategy,
+                          "magic_wait_v1", return_value=ret):
+            # 100 seconds elapsed, should be considered a timeout
+            with patch("time.monotonic", side_effect=[100, 200]):
+                with self.assertRaises(UPCSExpiredError):
+                    await cs._run_polling()
+
+            # 50 seconds elapsed, should be considered an unknown error
+            with patch("time.monotonic", side_effect=[100, 150]):
+                with self.assertRaises(UnknownError):
+                    await cs._run_polling()
+
+    @patch("asyncio.sleep")
+    async def test_run_polling_ok(self, sleep):
+        ret = {
+            "result": "success",
+            "data": {
+                "attributes": {
+                    "contract_token": "C12345257",
+                },
+            },
+        }
+        with patch.object(ContractSelection,
+                          "_run_polling", return_value=None):
+            cs = ContractSelection(client=self.client,
+                                   magic_token="magic-token",
+                                   user_code="ABCDEF",
+                                   validity_seconds=200)
+        await cs.task
+
+        self.client.strategy.scale_factor = 1
+        with patch.object(self.client.strategy,
+                          "magic_wait_v1", return_value=ret):
+            self.assertEqual((await cs._run_polling()), "C12345257")

--- a/subiquity/server/tests/test_ubuntu_advantage.py
+++ b/subiquity/server/tests/test_ubuntu_advantage.py
@@ -152,6 +152,51 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
                 await strategy.query_info(token="123456789")
             mock_arun.assert_called_once_with(command, check=False)
 
+    async def test_api_call(self):
+        strategy = UAClientUAInterfaceStrategy()
+        with patch(self.arun_command_sym) as mock_arun:
+            mock_arun.return_value = CompletedProcess([], 0)
+            mock_arun.return_value.stdout = '{"result": "success"}'
+            result = await strategy._api_call(
+                    endpoint="u.pro.attach.magic.wait.v1",
+                    params=[("magic_token", "132456")])
+            self.assertEqual(result, {"result": "success"})
+
+        command = (
+            "ubuntu-advantage",
+            "api",
+            "u.pro.attach.magic.wait.v1",
+            "--args", "magic_token=132456",
+        )
+        mock_arun.assert_called_once_with(command, check=False)
+
+    async def test_magic_initiate_v1(self):
+        strategy = UAClientUAInterfaceStrategy()
+        with patch.object(strategy, "_api_call", return_value={}) as api_call:
+            await strategy.magic_initiate_v1()
+
+        api_call.assert_called_once_with(
+                endpoint="u.pro.attach.magic.initiate.v1",
+                params=[])
+
+    async def test_magic_wait_v1(self):
+        strategy = UAClientUAInterfaceStrategy()
+        with patch.object(strategy, "_api_call", return_value={}) as api_call:
+            await strategy.magic_wait_v1(magic_token="ABCDEF")
+
+        api_call.assert_called_once_with(
+                endpoint="u.pro.attach.magic.wait.v1",
+                params=[("magic_token", "ABCDEF")])
+
+    async def test_magic_revoke_v1(self):
+        strategy = UAClientUAInterfaceStrategy()
+        with patch.object(strategy, "_api_call", return_value={}) as api_call:
+            await strategy.magic_revoke_v1(magic_token="ABCDEF")
+
+        api_call.assert_called_once_with(
+                endpoint="u.pro.attach.magic.revoke.v1",
+                params=[("magic_token", "ABCDEF")])
+
 
 class TestUAInterface(unittest.IsolatedAsyncioTestCase):
 

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -1320,3 +1320,31 @@ class TestManyPrimaries(TestAPI):
             }
             with self.assertRaises(ClientResponseError):
                 await inst.post('/storage/v2/add_partition', data)
+
+
+class TestUbuntuProContractSelection(TestAPI):
+    @timeout()
+    async def test_upcs_flow(self):
+        async with start_server('examples/simple.json') as inst:
+            # Wait should fail if no initiate first.
+            with self.assertRaises(Exception):
+                await inst.get('/ubuntu_pro/contract_selection/wait')
+
+            # Cancel should fail if no initiate first.
+            with self.assertRaises(Exception):
+                await inst.post('/ubuntu_pro/contract_selection/cancel')
+
+            await inst.post('/ubuntu_pro/contract_selection/initiate')
+            # Double initiate should fail
+            with self.assertRaises(Exception):
+                await inst.post('/ubuntu_pro/contract_selection/initiate')
+
+            # This call should block for long enough.
+            with self.assertRaises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                        inst.get('/ubuntu_pro/contract_selection/wait'),
+                        timeout=0.5)
+
+            await inst.post('/ubuntu_pro/contract_selection/cancel')
+            with self.assertRaises(Exception):
+                await inst.get('/ubuntu_pro/contract_selection/wait')

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -648,11 +648,12 @@ class HowToRegisterWidget(Stretchy):
     """ Widget showing some instructions to register to Ubuntu Pro.
     +-------------------- How to register --------------------+
     |                                                         |
-    | You can register for a free Ubuntu One account and get  |
-    | a personal token for up to 3 machines.                  |
+    |_Create your Ubuntu One account with your email. Each    |
+    | Ubuntu One account gets a free personal Ubuntu Pro      |
+    | subscription for up to three machines, including        |
+    | laptops, servers or cloud virtual machines.             |
     |                                                         |
-    | To register an account, visit ubuntu.com/pro on another |
-    | device.                                                 |
+    | Visit ubuntu.com/pro to get started.                    |
     |                                                         |
     |                       [ Continue ]                      |
     +---------------------------------------------------------+
@@ -664,14 +665,15 @@ class HowToRegisterWidget(Stretchy):
         ok = ok_btn(label=_("Continue"), on_press=lambda unused: self.close())
 
         title = _("How to register")
-        header = _("You can register for a free Ubuntu One account and get a"
-                   " personal token for up to 3 machines.")
+        header = _("Create your Ubuntu One account with your email. Each"
+                   " Ubuntu One account gets a free personal Ubuntu Pro"
+                   " subscription for up to three machines, including"
+                   " laptops, servers or cloud virtual machines.")
 
         widgets: List[Widget] = [
             Text(header),
             Text(""),
-            Text("To register an account, visit ubuntu.com/pro on another"
-                 " device."),
+            Text(_("Visit ubuntu.com/pro to get started.")),
             Text(""),
             button_pile([ok]),
         ]

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -146,9 +146,9 @@ class UpgradeModeForm(Form):
 class UpgradeYesNoForm(Form):
     """ Represents a form asking if we want to upgrade to Ubuntu Pro.
     +---------------------------------------------------------+
-    | (X)  Upgrade to Ubuntu Pro                              |
+    | (X)  Enable Ubuntu Pro                                  |
     |                                                         |
-    | ( )  Do this later                                      |
+    | ( )  Skip for now                                       |
     |                                                         |
     |      You can always enable Ubuntu Pro later via the     |
     |      'pro attach' command.                              |
@@ -163,10 +163,10 @@ class UpgradeYesNoForm(Form):
     group: List[RadioButtonField] = []
 
     upgrade = RadioButtonField(
-            group, _("Upgrade to Ubuntu Pro"),
+            group, _("Enable Ubuntu Pro"),
             help=NO_HELP)
     skip = RadioButtonField(
-            group, _("Do this later"),
+            group, _("Skip for now"),
             help="\n" + _("You can always enable Ubuntu Pro later via the"
                           " 'pro attach' command."))
 
@@ -275,13 +275,16 @@ class UbuntuProView(BaseView):
     def upgrade_yes_no_screen(self) -> Widget:
         """ Return a screen that asks the user to skip or upgrade.
         +---------------------------------------------------------+
-        | Upgrade this machine to Ubuntu Pro or skip this step.   |
+        | Upgrade this machine to Ubuntu Pro for security updates |
+        | on a much wider range of packages, until 2032. Assists  |
+        | with FedRAMP, FIPS, STIG, HIPAA and other compliance or |
+        | hardening requirements.                                 |
         |                                                         |
         | [ About Ubuntu Pro -> ]                                 |
         |                                                         |
-        | ( )  Upgrade to Ubuntu Pro                              |
+        | ( )  Enable Ubuntu Pro                                  |
         |                                                         |
-        | (X)  Do this later                                      |
+        | (X)  Skip for now                                       |
         |      You can always enable Ubuntu Pro later via the     |
         |      'pro attach' command.                              |
         |                                                         |
@@ -290,7 +293,10 @@ class UbuntuProView(BaseView):
         +---------------------------------------------------------+
         """
 
-        excerpt = _("Upgrade this machine to Ubuntu Pro or skip this step.")
+        excerpt = _("Upgrade this machine to Ubuntu Pro for security updates"
+                    " on a much wider range of packages, until 2032. Assists"
+                    " with FedRAMP, FIPS, STIG, HIPAA and other compliance or"
+                    " hardening requirements.")
 
         about_pro_btn = menu_btn(
                 _("About Ubuntu Pro"),

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -577,16 +577,18 @@ class AboutProWidget(Stretchy):
     """ Widget showing some information about what Ubuntu Pro offers.
     +------------------- About Ubuntu Pro --------------------+
     |                                                         |
-    | Ubuntu Pro subscription gives you access to multiple    |
-    | security & compliance services, including:              |
-    |                                                         |
-    | • Security patching for over 30.000 packages, with a    |
-    |   focus on High and Critical CVEs (extended from 2.500) |
-    | • ...                                                   |
-    | • ...                                                   |
+    | Ubuntu Pro is the same base Ubuntu, with an additional  |
+    | layer of security and compliance services and security  |
+    | patches covering a wider range of packages.             |
+    |   • Security patch coverage for CVSS critical, high and |
+    |     selected medium vulnerabilities in all 23,000       |
+    |     packages in "universe" (extended from the normal    |
+    |     2,300 "main" packages).                             |
+    |   • ...                                                 |
+    |   • ...                                                 |
     |                                                         |
     | Ubuntu Pro is free for personal use on up to 3 machines.|
-    | More information on ubuntu.com/pro                      |
+    | More information is at ubuntu.com/pro                   |
     |                                                         |
     |                       [ Continue ]                      |
     +---------------------------------------------------------+
@@ -598,16 +600,17 @@ class AboutProWidget(Stretchy):
         ok = ok_btn(label=_("Continue"), on_press=lambda unused: self.close())
 
         title = _("About Ubuntu Pro")
-        header = _("Ubuntu Pro subscription gives you access to multiple"
-                   " security & compliance services, including:")
+        header = _("Ubuntu Pro is the same base Ubuntu, with an additional"
+                   " layer of security and compliance services and security"
+                   " patches covering a wider range of packages.")
 
         services = [
-            _("Security patching for over 30.000 packages, with a focus on"
-              " High and Critical CVEs (extended from 2.500)"),
-            _("10 years of security Maintenance (extended from 5 years)"),
-            _("Kernel Livepatch service for increased uptime and security"),
-            _("Ubuntu Security Guide for hardening profiles, including CIS"
-              " and DISA-STIG"),
+            _("Security patch coverage for CVSS critical, high and selected"
+              ' medium vulnerabilities in all 23,000 packages in "universe"'
+              ' (extended from the normal 2,300 "main" packages).'),
+            _("10 years of security patch coverage (extended from 5 years)."),
+            _("Kernel Livepatch to reduce required reboots."),
+            _("Ubuntu Security Guide for CIS and DISA-STIG hardening."),
             _("FIPS 140-2 NIST-certified crypto-modules for FedRAMP"
               " compliance"),
         ]
@@ -628,11 +631,11 @@ class AboutProWidget(Stretchy):
         widgets: List[Widget] = [
             Text(header),
             Text(""),
-            Pile([itemize(svc) for svc in services]),
+            Pile([itemize(svc, marker="  •") for svc in services]),
             Text(""),
             Text(_("Ubuntu Pro is free for personal use on up to 3"
                    " machines.")),
-            Text(_("More information on ubuntu.com/pro")),
+            Text(_("More information is at ubuntu.com/pro")),
             Text(""),
             button_pile([ok]),
         ]

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -95,14 +95,14 @@ class ContractTokenForm(SubForm):
     """ Represents a sub-form requesting Ubuntu Pro token.
     +---------------------------------------------------------+
     |      Token: C123456789ABCDEF                            |
-    |             This is your Ubuntu Pro token               |
+    |             From your admin, or from ubuntu.com/pro     |
     +---------------------------------------------------------+
     """
     ContractTokenField = simple_field(ContractTokenEditor)
 
     token = ContractTokenField(
             _("Token:"),
-            help=_("This is your Ubuntu Pro token"))
+            help=_("From your admin, or from ubuntu.com/pro"))
 
     def validate_token(self):
         """ Return an error if the token input does not match the expected
@@ -131,9 +131,9 @@ class UpgradeModeForm(Form):
     |      Code: 1A3-4V6                                      |
     |            Attach machine via your Ubuntu One account   |
     |                                                         |
-    | ( )  Add token manually                                 |
+    | ( )  Or add token manually                              |
     |      Token: C123456789ABCDEF                            |
-    |             This is your Ubuntu Pro token               |
+    |             From your admin, or from ubuntu.com/pro     |
     |                                                         |
     |                       [ Waiting  ]                      |
     |                       [ Back     ]                      |
@@ -151,7 +151,7 @@ class UpgradeModeForm(Form):
             UbuntuOneForm, "", help=NO_HELP)
 
     with_contract_token = RadioButtonField(
-            group, _("Add token manually"),
+            group, _("Or add token manually"),
             help=NO_HELP)
     with_contract_token_subform = SubFormField(
             ContractTokenForm, "", help=NO_HELP)
@@ -302,9 +302,9 @@ class UbuntuProView(BaseView):
         |      Code: 1A3-4V6                                      |
         |            Attach machine via your Ubuntu One account   |
         |                                                         |
-        | ( )  Add token manually                                 |
+        | ( )  Or add token manually                              |
         |      Token: C123456789ABCDEF                            |
-        |             This is your Ubuntu Pro token               |
+        |             From your admin, or from ubuntu.com/pro     |
         |                                                         |
         |                        [ Continue ]                     |
         |                        [ Back     ]                     |

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -390,11 +390,13 @@ class UbuntuProView(BaseView):
         |                        [ Back     ]                     |
         +---------------------------------------------------------+
         """
+        security_updates_until = 2032
 
         excerpt = _("Upgrade this machine to Ubuntu Pro for security updates"
-                    " on a much wider range of packages, until 2032. Assists"
-                    " with FedRAMP, FIPS, STIG, HIPAA and other compliance or"
-                    " hardening requirements.")
+                    " on a much wider range of packages, until"
+                    f" {security_updates_until}. Assists with FedRAMP, FIPS,"
+                    " STIG, HIPAA and other compliance or hardening"
+                    " requirements.")
         excerpt_no_net = _("An Internet connection is required to enable"
                            " Ubuntu Pro.")
 
@@ -763,10 +765,14 @@ class AboutProWidget(Stretchy):
                    " layer of security and compliance services and security"
                    " patches covering a wider range of packages.")
 
+        universe_packages = 23000
+        main_packages = 2300
+
         services = [
             _("Security patch coverage for CVSS critical, high and selected"
-              ' medium vulnerabilities in all 23,000 packages in "universe"'
-              ' (extended from the normal 2,300 "main" packages).'),
+              f" medium vulnerabilities in all {universe_packages:,} packages"
+              f' in "universe" (extended from the normal {main_packages:,}'
+              ' "main" packages).'),
             _("10 years of security patch coverage (extended from 5 years)."),
             _("Kernel Livepatch to reduce required reboots."),
             _("Ubuntu Security Guide for CIS and DISA-STIG hardening."),

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -242,7 +242,7 @@ class UbuntuProView(BaseView):
         | To upgrade to Ubuntu Pro, you can enter your token      |
         | manually.                                               |
         |                                                         |
-        | [ How to Register -> ]                                  |
+        | [ How to register -> ]                                  |
         |                                                         |
         | (X)  Add token manually                                 |
         |      Token: C123456789ABCDEF                            |
@@ -257,7 +257,7 @@ class UbuntuProView(BaseView):
                     " manually.")
 
         how_to_register_btn = menu_btn(
-                _("How to Register"),
+                _("How to register"),
                 on_press=lambda unused: self.show_how_to_register()
                 )
         bp = button_pile([how_to_register_btn])

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -318,8 +318,6 @@ class UbuntuProView(BaseView):
             -> Widget:
         """
         +---------------------------------------------------------+
-        | Account Connected: user@domain.com                      |
-        |             Token: C1NWcZTHLteJXGVMM6YhvHDpGrhyy7       |
         |      Subscription: Ubuntu Pro - Physical 24/5           |
         |                                                         |
         | List of your enabled services:                          |
@@ -349,9 +347,7 @@ class UbuntuProView(BaseView):
         rows: List[Widget] = []
 
         rows.extend([
-            Text(_("Account Connected") + ": " + subscription.account_name),
-            Text(_("            Token") + ": " + subscription.contract_token),
-            Text(_("     Subscription") + ": " + subscription.contract_name),
+            Text(_("Subscription") + ": " + subscription.contract_name),
         ])
         rows.append(Text(""))
 

--- a/subiquitycore/palette.py
+++ b/subiquitycore/palette.py
@@ -71,6 +71,8 @@ PALETTE_COLOR = [
 
     ('starred',             'orange',  'bg'),
     ('starred focus',       'orange',  'gray'),
+
+    ('user_code',           'fg',      'good'),
 ]
 
 PALETTE_MONO = [
@@ -110,6 +112,8 @@ PALETTE_MONO = [
 
     ('starred',             'white',   'black'),
     ('starred focus',       'black',   'white'),
+
+    ('user_code',           'white',   'black'),
 ]
 
 urwid_8_names = (

--- a/subiquitycore/ui/utils.py
+++ b/subiquitycore/ui/utils.py
@@ -179,6 +179,7 @@ STYLE_NAMES = set([
     'scrollbar',
     'string_input focus',
     'string_input',
+    'user_code',
 ])
 
 


### PR DESCRIPTION
Apologies for the size of the diff :/

This adds the support for magic-attach / contract-selection in Subiquity.

Unfortunately, testing this PR on a current ubuntu server ISO will fail because we are relying on an unreleased feature of ubuntu-advantage-tools. Also the ubuntu.com/pro/attach website is not yet available for the user to do the contract selection.

The dry-run implementation exists but is limited. 
Upon reaching the Ubuntu Pro screen, the user is presented the user-code `AAAAAA`.
The user-code expires after 10 minutes (affected by `SUBIQUITY_REPLAY_TIMESCALE`).
When the user-code expires, a new contract selection is initiated and the next user-code (`AAAAAB`) will be presented instead,
The user has no way to select a contract in dry-run mode so the user-code will keep expiring until the user inputs a contract token instead.

More integration testing can be done by following the steps below:

* build the development version of ubuntu-advantage-tools
  * checkout https://github.com/canonical/ubuntu-advantage-client.git
  * `sbuild -d kinetic`
* deploy a LXD container (ubuntu 22.04 for instance)
* install the .deb built previously on the container
* apply the following diff to subiquity (after replacing "pleasant-griffon" with the name of the LXD container):
```diff
diff --git a/subiquity/server/controllers/ubuntu_pro.py b/subiquity/server/controllers/ubuntu_pro.py
index 831ae635..5e2c0f39 100644
--- a/subiquity/server/controllers/ubuntu_pro.py
+++ b/subiquity/server/controllers/ubuntu_pro.py
@@ -89,15 +89,11 @@ class UbuntuProController(SubiquityController):
     def __init__(self, app) -> None:
         """ Initializer for server-side Ubuntu Pro controller. """
         strategy: UAInterfaceStrategy
-        if app.opts.dry_run:
-            strategy = MockedUAInterfaceStrategy(scale_factor=app.scale_factor)
-        else:
-            # Make sure we execute `$PYTHON "$SNAP/usr/bin/ubuntu-advantage"`.
-            executable = (
-                os.environ["PYTHON"],
-                os.path.join(os.environ["SNAP"], "usr/bin/ubuntu-advantage"),
-            )
-            strategy = UAClientUAInterfaceStrategy(executable=executable)
+        # Make sure we execute `$PYTHON "$SNAP/usr/bin/ubuntu-advantage"`.
+        executable = (
+            "lxc", "exec", "pleasant-griffon", "--", "/usr/bin/ubuntu-advantage",
+        )
+        strategy = UAClientUAInterfaceStrategy(executable=executable)
         self.ua_interface = UAInterface(strategy)
         self.cs: Optional[ContractSelection] = None
         self.magic_token = Optional[str]
```
* the contracts CLI tool can be used to simulate what the user could do on ubuntu.com/pro/attach