### PR TITLE
Fixing disk path matcher to really match agains DEVPATH of udev

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1120,7 +1120,8 @@ class FilesystemModel(object):
                 _udev_val(disk, "ID_VENDOR"), match['vendor'])
 
         def match_path(disk):
-            return fnmatch.fnmatchcase(disk.path, match['path'])
+            return fnmatch.fnmatchcase(
+                _udev_val(disk, "DEVPATH"), match['path'])
 
         def match_ssd(disk):
             is_ssd = disk.info_for_display()['rotational'] == 'false'


### PR DESCRIPTION
Hi,
the autoinstall-reference says:

> A match spec supports the following keys:
...
> path: foo: matches a disk where DEVPATH=foo in udev, supporting globbing (the globbing support distinguishes this from specifying path: foo directly in the disk action)

The code is not looking for DEVPATH, like the other matchers are looking for their udev value. Instead it takes the path in probe_data. In my example that path is just "/dev/sda", but that does not help me matching exactly the disk i want. DEVPATH holds the real device path ("/device/pci..."), where i can better match what i want. Also the code should fit to the documentation.

This will not fix https://bugs.launchpad.net/subiquity/+bug/1952228, but is somewhat related to that.