### PR TITLE
[WSL] Enables users to skip installing language packs

### DIFF
--- a/autoinstall-system-setup-schema.json
+++ b/autoinstall-system-setup-schema.json
@@ -48,6 +48,15 @@
         "locale": {
             "type": "string"
         },
+        "wslsetupoptions": {
+            "type": "object",
+            "properties": {
+                "install_language_support_packages": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
         "identity": {
             "type": "object",
             "properties": {

--- a/examples/answers-system-setup-init.yaml
+++ b/examples/answers-system-setup-init.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+WSLSetupOptions:
+  install_language_support_packages: true
 WSLIdentity:
   realname: Ubuntu
   username: ubuntu

--- a/examples/autoinstall-system-setup-full.yaml
+++ b/examples/autoinstall-system-setup-full.yaml
@@ -4,6 +4,8 @@ early-commands:
         - ["sleep", "1"]
         - echo a
 locale: en_US
+wslsetupoptions:
+  install_language_support_packages: true
 identity:
   realname: Ubuntu
   username: ubuntu

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -133,6 +133,7 @@ class SubiquityClient(TuiApplication):
         self.server_updated = None
         self.restarting = False
         self.global_overlays = []
+        self.native_language = ""
 
         try:
             self.our_tty = os.ttyname(0)

--- a/subiquity/client/controllers/welcome.py
+++ b/subiquity/client/controllers/welcome.py
@@ -40,6 +40,10 @@ class WelcomeController(SubiquityTuiController):
             self.done((self.answers['lang'], ""))
 
     def done(self, lang):
+        """ Completes this controller. lang must be a tuple of strings
+        containing the language code and its native representation
+        respectively.
+        """
         (code, native) = lang
         log.debug("WelcomeController.done %s next_screen", code)
         i18n.switch_language(code)

--- a/subiquity/client/controllers/welcome.py
+++ b/subiquity/client/controllers/welcome.py
@@ -37,11 +37,13 @@ class WelcomeController(SubiquityTuiController):
 
     def run_answers(self):
         if 'lang' in self.answers:
-            self.done(self.answers['lang'])
+            self.done((self.answers['lang'], ""))
 
-    def done(self, code):
+    def done(self, lang):
+        (code, native) = lang
         log.debug("WelcomeController.done %s next_screen", code)
         i18n.switch_language(code)
+        self.app.native_language = native
         self.app.next_screen(self.endpoint.POST(code))
 
     def cancel(self, sender=None):

--- a/subiquity/client/controllers/welcome.py
+++ b/subiquity/client/controllers/welcome.py
@@ -44,10 +44,11 @@ class WelcomeController(SubiquityTuiController):
         containing the language code and its native representation
         respectively.
         """
-        (code, native) = lang
+        # ('de_DE.UTF-8', 'Deutsch')
+        (code, display_name) = lang
         log.debug("WelcomeController.done %s next_screen", code)
         i18n.switch_language(code)
-        self.app.native_language = native
+        self.app.native_language = display_name
         self.app.next_screen(self.endpoint.POST(code))
 
     def cancel(self, sender=None):

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -64,6 +64,7 @@ from subiquity.common.types import (
     ZdevInfo,
     WSLConfigurationBase,
     WSLConfigurationAdvanced,
+    WSLSetupOptions,
     )
 
 
@@ -76,6 +77,7 @@ class API:
     updates = simple_endpoint(str)
     wslconfbase = simple_endpoint(WSLConfigurationBase)
     wslconfadvanced = simple_endpoint(WSLConfigurationAdvanced)
+    wslsetupoptions = simple_endpoint(WSLSetupOptions)
 
     class meta:
         class status:

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -621,4 +621,3 @@ class WSLConfigurationAdvanced:
 @attr.s(auto_attribs=True)
 class WSLSetupOptions:
     install_language_support_packages: bool = attr.ib(default=True)
-

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -614,3 +614,11 @@ class WSLConfigurationAdvanced:
     interop_enabled:  bool = attr.ib(default=True)
     interop_appendwindowspath: bool = attr.ib(default=True)
     systemd_enabled:  bool = attr.ib(default=False)
+
+
+# Options that affect the setup experience itself, but won't reflect in the
+# /etc/wsl.conf configuration file.
+@attr.s(auto_attribs=True)
+class WSLSetupOptions:
+    install_language_support_packages: bool = attr.ib(default=True)
+

--- a/subiquity/ui/views/tests/test_welcome.py
+++ b/subiquity/ui/views/tests/test_welcome.py
@@ -22,7 +22,7 @@ class WelcomeViewTests(unittest.TestCase):
         view = self.make_view_with_languages([('code', 'native')])
         but = view_helpers.find_button_matching(view, "^native$")
         view_helpers.click(but)
-        view.controller.done.assert_called_once_with('code')
+        view.controller.done.assert_called_once_with(('code', 'native'))
 
     def test_initial_focus(self):
         # The initial focus for the view is the button for the first

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -99,8 +99,7 @@ class WelcomeView(BaseView):
             excerpt=_("Use UP, DOWN and ENTER keys to select your language."))
 
     def choose_language(self, sender, lang):
-        (code, _) = lang
-        log.debug('WelcomeView %s', code)
+        log.debug('WelcomeView %s', lang)
         self.controller.done(lang)
 
     def local_help(self):

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -85,7 +85,7 @@ class WelcomeView(BaseView):
                 forward_btn(
                     label=native,
                     on_press=self.choose_language,
-                    user_arg=code))
+                    user_arg=(code, native)))
 
         lb = ListBox(btns)
         back = None
@@ -98,9 +98,10 @@ class WelcomeView(BaseView):
             buttons=[back] if back else None,
             excerpt=_("Use UP, DOWN and ENTER keys to select your language."))
 
-    def choose_language(self, sender, code):
+    def choose_language(self, sender, lang):
+        (code, _) = lang
         log.debug('WelcomeView %s', code)
-        self.controller.done(code)
+        self.controller.done(lang)
 
     def local_help(self):
         return _("Help choosing a language"), _(HELP)

--- a/system_setup/client/client.py
+++ b/system_setup/client/client.py
@@ -61,6 +61,7 @@ class SystemSetupClient(SubiquityClient):
 
     controllers = [
         "Welcome",
+        "WSLSetupOptions",
         "WSLIdentity",
         "WSLConfigurationBase",
         "Summary",

--- a/system_setup/client/controllers/__init__.py
+++ b/system_setup/client/controllers/__init__.py
@@ -18,12 +18,14 @@ from .identity import WSLIdentityController
 from .wslconfbase import WSLConfigurationBaseController
 from .summary import SummaryController
 from .wslconfadvanced import WSLConfigurationAdvancedController
+from .wslsetupoptions import WSLSetupOptionsController
 
 from subiquity.client.controllers import WelcomeController
 
 
 __all__ = [
     'WelcomeController',
+    'WSLSetupOptionsController',
     'WSLIdentityController',
     'WSLConfigurationBaseController',
     'WSLConfigurationAdvancedController',

--- a/system_setup/client/controllers/wslsetupoptions.py
+++ b/system_setup/client/controllers/wslsetupoptions.py
@@ -1,0 +1,45 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from subiquity.client.controller import SubiquityTuiController
+from subiquity.common.types import WSLSetupOptions
+from system_setup.ui.views.wslsetupoptions import WSLSetupOptionsView
+
+log = logging.getLogger('system_setup.client.controllers.wslsetupoptions')
+
+
+class WSLSetupOptionsController(SubiquityTuiController):
+    endpoint_name = 'wslsetupoptions'
+
+    async def make_ui(self):
+        data = await self.endpoint.GET()
+        return WSLSetupOptionsView(self, data)
+
+    def run_answers(self):
+        if all(elem in self.answers for elem in
+            ['install_language_support_packages']):
+            configuration = WSLSetupOptions(**self.answers)
+            self.done(configuration)
+
+    def done(self, configuration_data):
+        log.debug(
+            "WSLSetupOptionsController.done next_screen user_spec=%s",
+            configuration_data)
+        self.app.next_screen(self.endpoint.POST(configuration_data))
+
+    def cancel(self):
+        self.app.prev_screen()

--- a/system_setup/client/controllers/wslsetupoptions.py
+++ b/system_setup/client/controllers/wslsetupoptions.py
@@ -27,7 +27,10 @@ class WSLSetupOptionsController(SubiquityTuiController):
 
     async def make_ui(self):
         data = await self.endpoint.GET()
-        return WSLSetupOptionsView(self, data)
+        log.debug("%s", self.app)
+        cur_lang = self.app.native_language
+
+        return WSLSetupOptionsView(self, data, cur_lang)
 
     def run_answers(self):
         if all(elem in self.answers for elem in

--- a/system_setup/client/controllers/wslsetupoptions.py
+++ b/system_setup/client/controllers/wslsetupoptions.py
@@ -31,7 +31,7 @@ class WSLSetupOptionsController(SubiquityTuiController):
 
     def run_answers(self):
         if all(elem in self.answers for elem in
-            ['install_language_support_packages']):
+                ['install_language_support_packages']):
             configuration = WSLSetupOptions(**self.answers)
             self.done(configuration)
 

--- a/system_setup/client/controllers/wslsetupoptions.py
+++ b/system_setup/client/controllers/wslsetupoptions.py
@@ -27,7 +27,6 @@ class WSLSetupOptionsController(SubiquityTuiController):
 
     async def make_ui(self):
         data = await self.endpoint.GET()
-        log.debug("%s", self.app)
         cur_lang = self.app.native_language
 
         return WSLSetupOptionsView(self, data, cur_lang)

--- a/system_setup/models/system_setup.py
+++ b/system_setup/models/system_setup.py
@@ -24,6 +24,7 @@ from subiquity.server.types import InstallerChannels
 
 from .wslconfbase import WSLConfigurationBaseModel
 from .wslconfadvanced import WSLConfigurationAdvancedModel
+from .wslsetupoptions import WSLSetupOptionsModel
 
 
 log = logging.getLogger('system_setup.models.system_setup')
@@ -57,6 +58,7 @@ class SystemSetupModel(SubiquityModel):
         self.packages = []
         self.userdata = {}
         self.locale = LocaleModel(self.chroot_prefix)
+        self.wslsetupoptions = WSLSetupOptionsModel()
         self.identity = IdentityModel()
         self.network = None
         self.wslconfbase = WSLConfigurationBaseModel()

--- a/system_setup/models/wslsetupoptions.py
+++ b/system_setup/models/wslsetupoptions.py
@@ -41,4 +41,3 @@ class WSLSetupOptionsModel(object):
 
     def __repr__(self):
         return "<WSL Setup Options: {}>".format(self.wslsetupoptions)
-

--- a/system_setup/models/wslsetupoptions.py
+++ b/system_setup/models/wslsetupoptions.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import attr
+
+log = logging.getLogger('system_setup.models.wslsetupoptions')
+
+
+@attr.s
+class WSLSetupOptions(object):
+    install_language_support_packages = attr.ib()
+
+
+class WSLSetupOptionsModel(object):
+    """ Model representing basic wsl configuration
+    """
+
+    def __init__(self):
+        self._wslsetupoptions = None
+
+    def apply_settings(self, result):
+        d = result.__dict__
+        self._wslsetupoptions = WSLSetupOptions(**d)
+
+    @property
+    def wslsetupoptions(self):
+        return self._wslsetupoptions
+
+    def __repr__(self):
+        return "<WSL Setup Options: {}>".format(self.wslsetupoptions)
+

--- a/system_setup/server/controllers/__init__.py
+++ b/system_setup/server/controllers/__init__.py
@@ -26,6 +26,7 @@ from .wslconfbase import WSLConfigurationBaseController
 from .wslconfadvanced import WSLConfigurationAdvancedController
 from .configure import ConfigureController
 from .shutdown import SetupShutdownController
+from .wslsetupoptions import WSLSetupOptionsController
 
 __all__ = [
     'EarlyController',
@@ -39,4 +40,5 @@ __all__ = [
     'WSLConfigurationBaseController',
     'WSLConfigurationAdvancedController',
     'ConfigureController',
+    'WSLSetupOptionsController',
 ]

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -196,6 +196,8 @@ class ConfigureController(SubiquityController):
                 log.error("Packages list in dry-run should never be empty.")
                 return False
 
+            log.debug('%s ignored for testing.',
+                      self.model.wslsetupoptions.wslsetupoptions)
             packs_dir = os.path.join(self.model.root,
                                      "var/cache/apt/archives/")
             os.makedirs(packs_dir, exist_ok=True)
@@ -220,7 +222,15 @@ class ConfigureController(SubiquityController):
             log.info("No missing recommended packages. Nothing to do.")
             return True
 
-        cmd = [aptCommand, "install", "-y"] + packages
+        cmd = []
+        if self.model.wslsetupoptions.wslsetupoptions.\
+            install_language_support_packages is True:
+            cmd = [aptCommand, "install", "-y"]
+
+        else:
+            cmd = ["/usr/bin/apt-mark", "install"]
+
+        cmd = cmd + packages
         acp = await arun_command(cmd, env=env)
 
         return acp.returncode == 0

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -224,7 +224,7 @@ class ConfigureController(SubiquityController):
 
         cmd = []
         if self.model.wslsetupoptions.wslsetupoptions.\
-            install_language_support_packages is True:
+                install_language_support_packages is True:
             cmd = [aptCommand, "install", "-y"]
 
         else:

--- a/system_setup/server/controllers/wslsetupoptions.py
+++ b/system_setup/server/controllers/wslsetupoptions.py
@@ -76,4 +76,3 @@ class WSLSetupOptionsController(SubiquityController):
     async def POST(self, data: WSLSetupOptions):
         self.model.apply_settings(data)
         await self.configured()
-

--- a/system_setup/server/controllers/wslsetupoptions.py
+++ b/system_setup/server/controllers/wslsetupoptions.py
@@ -1,0 +1,79 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import attr
+
+from subiquitycore.context import with_context
+
+from subiquity.common.apidef import API
+from subiquity.common.types import WSLSetupOptions
+from subiquity.server.controller import SubiquityController
+
+from system_setup.common.wsl_conf import default_loader
+from system_setup.common.wsl_utils import convert_if_bool
+
+log = logging.getLogger('system_setup.server.controllers.wslsetupoptions')
+
+
+class WSLSetupOptionsController(SubiquityController):
+
+    endpoint = API.wslsetupoptions
+
+    autoinstall_key = model_name = "wslsetupoptions"
+    autoinstall_schema = {
+        'type': 'object',
+        'properties': {
+            'install_language_support_packages': {'type': 'boolean'},
+            },
+        'additionalProperties': False,
+        }
+
+    def __init__(self, app):
+        super().__init__(app)
+
+        # load the config file
+        data = default_loader()
+
+        if data:
+            proc_data = \
+                {key: convert_if_bool(value) for (key, value) in data.items()}
+            conf_data = WSLSetupOptions(**proc_data)
+            self.model.apply_settings(conf_data)
+
+    def load_autoinstall_data(self, data):
+        if data is not None:
+            identity_data = WSLSetupOptions(**data)
+            self.model.apply_settings(identity_data)
+
+    @with_context()
+    async def apply_autoinstall_config(self, context=None):
+        pass
+
+    def make_autoinstall(self):
+        r = attr.asdict(self.model.wslconfbase)
+        return r
+
+    async def GET(self) -> WSLSetupOptions:
+        data = WSLSetupOptions()
+        if self.model.wslsetupoptions is not None:
+            data.install_language_support_packages = \
+                self.model.wslsetupoptions.install_language_support_packages
+        return data
+
+    async def POST(self, data: WSLSetupOptions):
+        self.model.apply_settings(data)
+        await self.configured()
+

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -31,6 +31,7 @@ INSTALL_MODEL_NAMES = ModelNames({
         "wslconfbase",
     },
     wsl_setup={
+        "wslsetupoptions",
         "identity",
     },
     wsl_configuration={
@@ -51,6 +52,7 @@ class SystemSetupServer(SubiquityServer):
         "Reporting",
         "Error",
         "WSLLocale",
+        "WSLSetupOptions",
         "WSLIdentity",
         "WSLConfigurationBase",
         "WSLConfigurationAdvanced",

--- a/system_setup/ui/views/wslsetupoptions.py
+++ b/system_setup/ui/views/wslsetupoptions.py
@@ -18,7 +18,6 @@
 WSLSetupOptions provides user with options to customize the setup experience.
 """
 
-from gettext import install
 from urwid import (
     connect_signal,
 )
@@ -33,15 +32,6 @@ from subiquity.common.types import WSLSetupOptions
 
 
 class WSLSetupOptionsForm(Form):
-    def __init__(self, initial):
-        super().__init__(initial=initial)
-        connect_signal(self.install_language_support_packages.widget, "change",
-                       self.toggle_help)
-
-
-=======
-class WSLSetupOptionsForm(Form):
->>>>>>> 18290ac4 (Fixed help strings)
     install_language_support_packages = \
         BooleanField(_("Install packages for better language support"),
                      help=_("Not recommended for slow internet connections."))

--- a/system_setup/ui/views/wslsetupoptions.py
+++ b/system_setup/ui/views/wslsetupoptions.py
@@ -36,7 +36,9 @@ CAPTION = _("Install packages for better {lang} language support")
 class WSLSetupOptionsForm(Form):
     install_language_support_packages = \
         BooleanField("",
-                     help=_("Not recommended for slow internet connections."))
+                     help=('info_minor',
+                           _("Not recommended for slow internet connections."))
+                     )
 
 
 class WSLSetupOptionsView(BaseView):

--- a/system_setup/ui/views/wslsetupoptions.py
+++ b/system_setup/ui/views/wslsetupoptions.py
@@ -30,10 +30,12 @@ from subiquitycore.ui.utils import screen
 from subiquitycore.view import BaseView
 from subiquity.common.types import WSLSetupOptions
 
+CAPTION = _("Install packages for better {lang} language support")
+
 
 class WSLSetupOptionsForm(Form):
     install_language_support_packages = \
-        BooleanField(_("Install packages for better language support"),
+        BooleanField("",
                      help=_("Not recommended for slow internet connections."))
 
 
@@ -41,7 +43,7 @@ class WSLSetupOptionsView(BaseView):
     title = _("Enhance your experience")
     excerpt = _("Adjust the following options for a more complete experience.")
 
-    def __init__(self, controller, configuration_data):
+    def __init__(self, controller, configuration_data, cur_lang):
         self.controller = controller
 
         initial = {
@@ -49,6 +51,8 @@ class WSLSetupOptionsView(BaseView):
                 configuration_data.install_language_support_packages,
         }
         self.form = WSLSetupOptionsForm(initial=initial)
+        self.form.install_language_support_packages.caption = \
+            CAPTION.format(lang=cur_lang)
 
         connect_signal(self.form, 'submit', self.done)
         super().__init__(

--- a/system_setup/ui/views/wslsetupoptions.py
+++ b/system_setup/ui/views/wslsetupoptions.py
@@ -1,0 +1,76 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" WSLSetupOptions
+
+WSLSetupOptions provides user with options to customize the setup experience.
+"""
+
+from gettext import install
+from urwid import (
+    connect_signal,
+)
+
+from subiquitycore.ui.form import (
+    Form,
+    BooleanField,
+)
+from subiquitycore.ui.utils import screen
+from subiquitycore.view import BaseView
+from subiquity.common.types import WSLSetupOptions
+
+
+class WSLSetupOptionsForm(Form):
+    def __init__(self, initial):
+        super().__init__(initial=initial)
+        connect_signal(self.install_language_support_packages.widget, "change",
+                       self.toggle_help)
+
+
+=======
+class WSLSetupOptionsForm(Form):
+>>>>>>> 18290ac4 (Fixed help strings)
+    install_language_support_packages = \
+        BooleanField(_("Install packages for better language support"),
+                     help=_("Not recommended for slow internet connections."))
+
+
+
+class WSLSetupOptionsView(BaseView):
+    title = _("Enhance your experience")
+    excerpt = _("Adjust the following options for a more complete experience.")
+
+    def __init__(self, controller, configuration_data):
+        self.controller = controller
+
+        initial = {
+            'install_language_support_packages':
+                configuration_data.install_language_support_packages,
+        }
+        self.form = WSLSetupOptionsForm(initial=initial)
+
+        connect_signal(self.form, 'submit', self.done)
+        super().__init__(
+            screen(
+                self.form.as_rows(),
+                [self.form.done_btn],
+                focus_buttons=True,
+                excerpt=self.excerpt,
+            )
+        )
+
+    def done(self, result):
+        self.controller.done(WSLSetupOptions(**self.form.as_data()))
+

--- a/system_setup/ui/views/wslsetupoptions.py
+++ b/system_setup/ui/views/wslsetupoptions.py
@@ -37,7 +37,6 @@ class WSLSetupOptionsForm(Form):
                      help=_("Not recommended for slow internet connections."))
 
 
-
 class WSLSetupOptionsView(BaseView):
     title = _("Enhance your experience")
     excerpt = _("Adjust the following options for a more complete experience.")
@@ -63,4 +62,3 @@ class WSLSetupOptionsView(BaseView):
 
     def done(self, result):
         self.controller.done(WSLSetupOptions(**self.form.as_data()))
-


### PR DESCRIPTION
All this chunk of code because of one boolean flag.

The motivation for this work is detailed in https://github.com/canonical/ubuntu-desktop-installer/issues/1073 and https://github.com/ubuntu/WSL/issues/174. In short, 
setting up Ubuntu on WSL 2 with our OOBE may take a while, specially on slower connections or machines. Also, WSL 2 is known by having some internal issue limiting the internet speed when compared to the host system. That may turn the moment of installing language packs into an eternity.

I can foresee opportunity for extending the customisability of our setup experience with other options that won't reflect in the `/etc/wsl.conf` (where the options set in the types `WSLConfBase` and `WSLConfAdvanced` currently are writtent to). So I chose to create a new type and endpoint for this kind of customization. Since the endpoint is specific for `system_setup` I had to change `subiquity/tests/api/test_api.py` to let me start a `system_setup` server, so I could exercise that endpoint.

I tried rendering a CheckBox for that just below the languages listbox, but that hurts usability, because one would need to visit all the elements inside the list box to be able to reach the flag in the bottom of the screen. Placing it above would hurt the existing look. So, a new page is required, even though the page contains only one boolean flag. For now, at least. I also took the freedom to cache the native language string into the app, so other pieces of the UI can later reuse it. That enables referring to the language in the CheckBox caption, for instance (per this recommendation https://github.com/canonical/ubuntu-desktop-installer/issues/1073#issuecomment-1223914664). This is how it looks:

![image](https://user-images.githubusercontent.com/11138291/186177456-d6b1abc8-8b99-4207-b859-8e86ec913b37.png)

