### PR TITLE
Makes our gray ligther to increase contrast.

### DIFF
--- a/subiquitycore/palette.py
+++ b/subiquitycore/palette.py
@@ -28,7 +28,7 @@ COLORS = [
     # dark magenta
     ("brand",     (0x33, 0x33, 0x33)),
     # dark cyan
-    ("gray",      (0x66, 0x66, 0x66)),
+    ("gray",      (0x80, 0x80, 0x80)),
     # light gray
     ("fg",        (0xff, 0xff, 0xff)),
 ]


### PR DESCRIPTION
Per Design's recommendation in:
https://github.com/canonical/ubuntu-desktop-installer/issues/1073#issuecomment-1225569053

`#808080` choosen due its value being part of the xterm256-color color space.