### PR TITLE
Log NetworkModel.has_network changes

### DIFF
--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -407,8 +407,17 @@ class NetworkModel(object):
 
     def __init__(self, project):
         self.devices_by_name = {}  # Maps interface names to NetworkDev
-        self.has_network = False
+        self._has_network = False
         self.project = project
+
+    @property
+    def has_network(self):
+        return self._has_network
+
+    @has_network.setter
+    def has_network(self, val):
+        log.debug('has_network %s', val)
+        self._has_network = val
 
     def parse_netplan_configs(self, netplan_root):
         self.config = netplan.Config()


### PR DESCRIPTION
Because it affects `/etc/apt/sources.list`.

```
2022-08-26 13:08:37,225 INFO root:37 start: subiquity/Meta/mark_configured_POST: 
2022-08-26 13:08:37,225 DEBUG subiquitycore.models.network:419 has_network True
2022-08-26 13:08:37,226 DEBUG subiquity.models.subiquity:219 model network for install stage is configured, to go {'filesystem'}
2022-08-26 13:08:37,226 DEBUG subiquity.models.subiquity:219 model network for postinstall stage is configured, to go {'timezone', 'identity'}
2022-08-26 13:08:37,226 INFO root:37 finish: subiquity/Meta/mark_configured_POST: SUCCESS: 200 null
2022-08-26 13:08:37,226 INFO aiohttp.access:206  [26/Aug/2022:13:08:37 +0000] "POST /meta/mark_configured?endpoint_names=%5B%22network%22%5D HTTP/1.1" 200 190 "-" "Dart/2.17 (dart:io)"
```