### PR TITLE
Sets WslSetupOptions as an optional controller

### DIFF
--- a/system_setup/server/controllers/wslsetupoptions.py
+++ b/system_setup/server/controllers/wslsetupoptions.py
@@ -46,12 +46,14 @@ class WSLSetupOptionsController(SubiquityController):
 
         # load the config file
         data = default_loader()
+        conf_data = WSLSetupOptions()
 
         if data:
             proc_data = \
                 {key: convert_if_bool(value) for (key, value) in data.items()}
             conf_data = WSLSetupOptions(**proc_data)
-            self.model.apply_settings(conf_data)
+
+        self.model.apply_settings(conf_data)
 
     def load_autoinstall_data(self, data):
         if data is not None:

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -31,7 +31,6 @@ INSTALL_MODEL_NAMES = ModelNames({
         "wslconfbase",
     },
     wsl_setup={
-        "wslsetupoptions",
         "identity",
     },
     wsl_configuration={


### PR DESCRIPTION
We have strong defaults for that controller, so clients should only need to POST if the desired options are not the default ones.

This PR makes sure the controller is configured even if clients won't POST anything. That's useful for the GUI.