### PR TITLE
Respects the output base dir on server.spawn() on API tests

### DIFF
--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -157,7 +157,7 @@ class SystemSetupServer(Server):
         env = os.environ.copy()
         env['SUBIQUITY_REPLAY_TIMESCALE'] = '100'
         cmd = ['python3', '-m', 'system_setup.cmd.server',
-               '--dry-run', '--socket', socket]
+               '--dry-run', '--socket', socket, '--output-base', output_base]
         if extra_args is not None:
             cmd.extend(extra_args)
         self.proc = await astart_command(cmd, env=env)


### PR DESCRIPTION
When removing some unused command line options from the function responsible for spawning the system_setup server under API test, I ended up introducing a hidden dependency on `.subiquity` directory, when the function that starts the server already provides a proper temporary directory to break such dependency.

This addresses that bug by respecting the `output_base` directory supplied by the `start_server` function.