### PR TITLE
ubuntu-pro: fix type hints for contract selection callbacks

### DIFF
--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -160,7 +160,7 @@ class UbuntuProController(SubiquityTuiController):
             self._check_task.cancel()
 
     def contract_selection_initiate(
-            self, on_initiated: Callable[[str, str], None]) -> None:
+            self, on_initiated: Callable[[str], None]) -> None:
         """ Initiate the contract selection asynchronously. Calls on_initiated
         when the contract-selection has initiated. """
         async def inner() -> None:
@@ -172,7 +172,7 @@ class UbuntuProController(SubiquityTuiController):
     def contract_selection_wait(
             self,
             on_contract_selected: Callable[[str], None],
-            on_timeout: Callable[[None], None]) -> None:
+            on_timeout: Callable[[], None]) -> None:
         """ Asynchronously wait for the contract selection to finish.
         Calls on_contract_selected with the contract-token once the contract
         gets selected
@@ -193,7 +193,7 @@ class UbuntuProController(SubiquityTuiController):
         self._monitor_task = schedule_task(inner())
 
     def contract_selection_cancel(
-            self, on_cancelled: Callable[[None], None]) -> None:
+            self, on_cancelled: Callable[[], None]) -> None:
         """ Cancel the asynchronous contract selection (if started). """
         async def inner() -> None:
             await self.endpoint.contract_selection.cancel.POST()

--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -166,7 +166,7 @@ class UbuntuProController(SubiquityTuiController):
         async def inner() -> None:
             answer = await self.endpoint.contract_selection.initiate.POST()
             self.cs_initiated = True
-            on_initiated(user_code=answer.user_code)
+            on_initiated(answer.user_code)
         self._magic_attach_task = schedule_task(inner())
 
     def contract_selection_wait(


### PR DESCRIPTION
I ran mypy against the code base and it reported some errors in the new ubuntu pro implementation.

1. The type for a callable that takes no argument should be `Callable[[], ...]` and not `Callable[[None], ...]`.
2. The `on_initiated` callback only takes a single parameter today. It used to take two parameters when the expiry date was shown to the client, but we don't show it anymore.
3. There is no way (that I know of?)  to indicate expected keyword arguments for a callable. Maybe introducing a protocol [1] could solve this but for now let's call the callbacks with positional arguments only.

_None of these should impact subiquity at runtime so they don't need to be backported to ubuntu/kinetic_ 

[1] https://peps.python.org/pep-0544/