### PR TITLE
keyboard: fix wrong keyboard layout in initramfs

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -442,6 +442,12 @@ class SubiquityModel:
                 '001-mount-cdrom': [
                     'mount', '--bind', '/cdrom', '/target/cdrom',
                     ],
+                # The below command must be run after updating
+                # etc/default/keyboard on the target so that the initramfs uses
+                # the keyboard mapping selected by the user.  See LP #1894009
+                '002-setupcon-save-only': [
+                    'curtin', 'in-target', '--', 'setupcon', '--save-only',
+                    ],
                 },
 
             'grub': {


### PR DESCRIPTION
During the installation, in the curthooks stage, curtin generates the initramfs. Unfortunately, the generated initramfs did not honor the keyboard mapping selected by the user during installation. Therefore, when LUKS encryption is used for the root file-system, the prompt for the passphrase ignores the keyboard layout set by the user.

To ensure that the initramfs uses the right keyboard layout, the `/etc/console-setup/cached_*` files must be updated before the initramfs gets created. At the beginning of the curthooks stage, we now call `setupcon --save-only` in the target to refresh those files if needed.

This PR addresses https://bugs.launchpad.net/subiquity/+bug/1894009