### PR TITLE
snaplist: fix crash when pressing "Try again" on snaplist

### DIFF
--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -390,10 +390,13 @@ class SnapListView(BaseView):
         self.show_main_screen()
 
     def offer_retry(self):
+        def try_again_pressed(unused) -> None:
+            self.wait_load()
+
         self._w = screen(
             [Text(_("Sorry, loading snaps from the store failed."))],
             [
-                other_btn(label=_("Try again"), on_press=self.wait_load),
+                other_btn(label=_("Try again"), on_press=try_again_pressed),
                 ok_btn(label=_("Continue"), on_press=self.done),
             ])
 


### PR DESCRIPTION
When pressing the "Try again" button on the snaps list, Subiquity would crash with:

`TypeError: SnapListView.wait_load() takes 1 positional argument but 2 were given`

This happens because urwid passes the sender to the callback as a parameter - which we need to discard (or accept it in the signature).

Fixed by discarding the sender.

The screen showing the "Try again" button is shown when the initial GET call to /snaplist (without `wait=True`) returns `LOADING` and then the second call (with `wait=True`) returns `FAILED`.

The below patch can be applied to get to this screen in dry-run mode:

```diff
diff --git a/subiquity/server/controllers/snaplist.py b/subiquity/server/controllers/snaplist.py
index 53be46b2..b8993dba 100644
--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -169,6 +169,11 @@ class SnapListController(SubiquityController):
         return [attr.asdict(sel) for sel in self.model.selections]
 
     async def GET(self, wait: bool = False) -> SnapListResponse:
+        if wait:
+            return SnapListResponse(status=SnapCheckState.FAILED)
+        else:
+            return SnapListResponse(status=SnapCheckState.LOADING)
+
         if self.loader.failed or not self.app.base_model.network.has_network:
             await self.configured()
             return SnapListResponse(status=SnapCheckState.FAILED)
```