### PR TITLE
snaplist: avoid showing snaplist screen on failure

### DIFF
--- a/subiquity/client/controllers/snaplist.py
+++ b/subiquity/client/controllers/snaplist.py
@@ -16,6 +16,10 @@
 import logging
 from typing import List
 
+from subiquitycore.tuicontroller import (
+    Skip,
+    )
+
 from subiquity.client.controller import (
     SubiquityTuiController,
     )
@@ -37,7 +41,8 @@ class SnapListController(SubiquityTuiController):
         if data.status == SnapCheckState.FAILED:
             # If loading snaps failed or network is disabled, skip the screen.
             log.debug('snaplist GET failed, mark done')
-            self.done([])
+            await self.endpoint.POST([])
+            raise Skip
         return SnapListView(self, data)
 
     def run_answers(self):


### PR DESCRIPTION
When creating the UI for snaplist, if the server returns a FAILED status when we request the list of snaps, we want to move on to the next screen.

However, calling `self.next_screen` in the `make_ui` function while also returning an actual view triggers a race condition. Depending on the order of execution of the instructions (which are asynchronous), the snaplist view can end up being shown even though we moved to the next screen. This ends up doing funny things upon clicking done.

Fixed by raising the `Skip` exception after making sure we mark snaplist configured.