### PR TITLE
ubuntu-pro: fixed model not being marked configured on LTS

### DIFF
--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -69,9 +69,10 @@ class UbuntuProController(SubiquityTuiController):
             await self.endpoint.skip.POST()
             raise Skip("Not running LTS version")
 
-        # TODO remove these two lines when all dependencies for Ubuntu Pro are
-        # available in focal-updates.
+        # TODO remove these three lines when all dependencies for Ubuntu Pro
+        # are available in focal-updates.
         if not self.app.opts.dry_run:
+            await self.endpoint.skip.POST()
             raise Skip("Skipping Ubuntu Pro for now")
 
         ubuntu_pro_info: UbuntuProResponse = await self.endpoint.GET()


### PR DESCRIPTION
To disable Ubuntu Pro, I recently wrote a patch that raises a Skip exception from the make_ui function. Unfortunately, I forgot that one must mark the ubuntu_pro model configured. 

On non-LTS releases, Ubuntu Pro is already skipped properly so this does not cause any trouble.
While testing an install of 22.04.1 though, this bug prevents the installation from executing the late stages (Subiquity is waiting on Ubuntu Pro to be marked configured).

This fix needs to be back-ported to the ubuntu/kinetic branch.