### PR TITLE
Fix the missing `system_setup.common` error.

### DIFF
--- a/system_setup/common/__init__.py
+++ b/system_setup/common/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
When Subiquity is packaged as its own snap, that subdirectory is not present.
That is due the lack of an `__init__.py` file.