### PR TITLE
[WSL] Fixes wrong parameters being passed to init WslSetupOptions

### DIFF
--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -158,6 +158,13 @@ class SystemSetupServer(Server):
         env['SUBIQUITY_REPLAY_TIMESCALE'] = '100'
         cmd = ['python3', '-m', 'system_setup.cmd.server',
                '--dry-run', '--socket', socket, '--output-base', output_base]
+        root = os.path.abspath(output_base)
+        conffile = os.path.join(root, "etc/wsl.conf")
+        os.makedirs(os.path.dirname(conffile), exist_ok=True)
+        # The server should crash in the presence of a non-empty conf file.
+        with open(conffile, "w+") as f:
+            f.write("[automount]\noptions=metadata")
+
         if extra_args is not None:
             cmd.extend(extra_args)
         self.proc = await astart_command(cmd, env=env)

--- a/system_setup/common/wsl_conf.py
+++ b/system_setup/common/wsl_conf.py
@@ -56,11 +56,11 @@ config_adv_default = {
 }
 
 conf_type_to_file = {
-    "wsl": "/etc/wsl.conf",
+    "wsl": "etc/wsl.conf",
 }
 
 
-def wsl_config_loader(config_ref, id):
+def wsl_config_loader(pathname, config_ref, id):
     """
     Loads the configuration from the given file type,
     section and reference config.
@@ -70,9 +70,6 @@ def wsl_config_loader(config_ref, id):
     return the data loaded
     """
     data = {}
-    pathname = conf_type_to_file[id]
-    if not os.path.exists(pathname):
-        return data
     config = ConfigParser()
     config.read(pathname)
     for conf_sec in config:
@@ -97,15 +94,19 @@ def wsl_config_loader(config_ref, id):
     return data
 
 
-def default_loader(is_advanced=False):
+def default_loader(root_dir, is_advanced=False):
     """
     This will load the default WSL config for the given type.
 
     :param is_advanced: boolean, True if it is WSLConfigurationAdvanced,
                         else is WSLConfigurationBase
     """
+    id = "wsl"
+    pathname = os.path.join(root_dir, conf_type_to_file[id])
+    if not os.path.exists(pathname):
+        return {}
     conf_ref = config_adv_default if is_advanced else config_base_default
-    data = wsl_config_loader(conf_ref, "wsl")
+    data = wsl_config_loader(pathname, conf_ref, id)
     return data
 
 
@@ -134,7 +135,7 @@ def wsl_config_update(config_class, root_dir):
         config.BasicInterpolation = None
 
         os.makedirs(os.path.join(root_dir, "etc"), exist_ok=True)
-        conf_file = os.path.join(root_dir, conf_type_to_file[config_type][1:])
+        conf_file = os.path.join(root_dir, conf_type_to_file[config_type])
 
         config.read(conf_file)
 

--- a/system_setup/server/controllers/wslconfadvanced.py
+++ b/system_setup/server/controllers/wslconfadvanced.py
@@ -49,7 +49,8 @@ class WSLConfigurationAdvancedController(SubiquityController):
         super().__init__(app)
 
         # load the config file
-        data = default_loader(is_advanced=True)
+        root_dir = self.app.base_model.root
+        data = default_loader(root_dir, is_advanced=True)
 
         if data:
             proc_data = \

--- a/system_setup/server/controllers/wslconfbase.py
+++ b/system_setup/server/controllers/wslconfbase.py
@@ -48,7 +48,8 @@ class WSLConfigurationBaseController(SubiquityController):
         super().__init__(app)
 
         # load the config file
-        data = default_loader()
+        root_dir = self.app.base_model.root
+        data = default_loader(root_dir)
 
         if data:
             proc_data = \

--- a/system_setup/server/controllers/wslsetupoptions.py
+++ b/system_setup/server/controllers/wslsetupoptions.py
@@ -45,7 +45,8 @@ class WSLSetupOptionsController(SubiquityController):
         super().__init__(app)
 
         # load the config file
-        data = default_loader()
+        root_dir = self.app.base_model.root
+        data = default_loader(root_dir)
         conf_data = WSLSetupOptions()
 
         if data:

--- a/system_setup/server/controllers/wslsetupoptions.py
+++ b/system_setup/server/controllers/wslsetupoptions.py
@@ -22,9 +22,6 @@ from subiquity.common.apidef import API
 from subiquity.common.types import WSLSetupOptions
 from subiquity.server.controller import SubiquityController
 
-from system_setup.common.wsl_conf import default_loader
-from system_setup.common.wsl_utils import convert_if_bool
-
 log = logging.getLogger('system_setup.server.controllers.wslsetupoptions')
 
 
@@ -40,21 +37,6 @@ class WSLSetupOptionsController(SubiquityController):
             },
         'additionalProperties': False,
         }
-
-    def __init__(self, app):
-        super().__init__(app)
-
-        # load the config file
-        root_dir = self.app.base_model.root
-        data = default_loader(root_dir)
-        conf_data = WSLSetupOptions()
-
-        if data:
-            proc_data = \
-                {key: convert_if_bool(value) for (key, value) in data.items()}
-            conf_data = WSLSetupOptions(**proc_data)
-
-        self.model.apply_settings(conf_data)
 
     def load_autoinstall_data(self, data):
         if data is not None:


### PR DESCRIPTION
The recent WSLSetupOptions controller init method is misusing the default_loader().
That's meant for loading /etc/wsl.conf, but the WSLSetupOptions controller is, by design, not related to that config file.
That means it's init method is not necessary.

To be able to demonstrate that with tests, I had to revisit some older code, to make it testable, so I could inject a conf file causing (a very nasty) break.

When reviewing this, the last commit (2a598a8b5de72df0357a73a4fdf67020f49f0d5b) is the one that actually contains the fix. The previous ones were solely added for testability.