### PR TITLE
api extensions needed to talk to snapd API

### DIFF
--- a/subiquity/common/api/defs.py
+++ b/subiquity/common/api/defs.py
@@ -17,7 +17,11 @@ import inspect
 import typing
 
 
-class InvalidQueryArgs(Exception):
+class InvalidAPIDefinition(Exception):
+    pass
+
+
+class InvalidQueryArgs(InvalidAPIDefinition):
     def __init__(self, callable, param):
         self.callable = callable
         self.param = param
@@ -27,17 +31,44 @@ class InvalidQueryArgs(Exception):
                 f"arguments but has non-str parameter '{self.param}'")
 
 
-def api(cls, prefix=(), serialize_query_args=True):
+class MultiplePathParameters(InvalidAPIDefinition):
+    def __init__(self, cls, param1, param2):
+        self.cls = cls
+        self.param1 = param1
+        self.param2 = param2
+
+    def __str__(self):
+        return (f"{self.cls.__name__} has multiple path parameters "
+                f"{self.param1!r} and {self.param2!r}")
+
+
+def api(cls, prefix_names=(), prefix_path=(), path_params=(),
+        serialize_query_args=True):
     if hasattr(cls, 'serialize_query_args'):
         serialize_query_args = cls.serialize_query_args
     else:
         cls.serialize_query_args = serialize_query_args
-    cls.fullpath = '/' + '/'.join(prefix)
-    cls.fullname = prefix
+    cls.fullpath = '/' + '/'.join(prefix_path)
+    cls.fullname = prefix_names
+    seen_path_param = None
     for k, v in cls.__dict__.items():
         if isinstance(v, type):
+            v.__shortname__ = k
             v.__name__ = cls.__name__ + '.' + k
-            api(v, prefix + (k,), serialize_query_args)
+            path_part = k
+            path_param = ()
+            if getattr(v, '__parameter__', False):
+                if seen_path_param:
+                    raise MultiplePathParameters(cls, seen_path_param, k)
+                seen_path_param = k
+                path_part = '{' + path_part + '}'
+                path_param = (k,)
+            api(
+                v,
+                prefix_names + (k,),
+                prefix_path + (path_part,),
+                path_params + path_param,
+                serialize_query_args)
         if callable(v):
             v.__qualname__ = cls.__name__ + '.' + k
             if not cls.serialize_query_args:
@@ -45,6 +76,7 @@ def api(cls, prefix=(), serialize_query_args=True):
                 for param_name, param in params.items():
                     if param.annotation is not str:
                         raise InvalidQueryArgs(v, param)
+            v.__path_params__ = path_params
     return cls
 
 
@@ -53,6 +85,11 @@ T = typing.TypeVar("T")
 
 class Payload(typing.Generic[T]):
     pass
+
+
+def path_parameter(cls):
+    cls.__parameter__ = True
+    return cls
 
 
 def simple_endpoint(typ):

--- a/subiquity/common/api/defs.py
+++ b/subiquity/common/api/defs.py
@@ -13,18 +13,38 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import inspect
 import typing
 
 
-def api(cls, prefix=(), foo=None):
+class InvalidQueryArgs(Exception):
+    def __init__(self, callable, param):
+        self.callable = callable
+        self.param = param
+
+    def __str__(self):
+        return (f"{self.callable.__qualname__} does not serialize query "
+                f"arguments but has non-str parameter '{self.param}'")
+
+
+def api(cls, prefix=(), serialize_query_args=True):
+    if hasattr(cls, 'serialize_query_args'):
+        serialize_query_args = cls.serialize_query_args
+    else:
+        cls.serialize_query_args = serialize_query_args
     cls.fullpath = '/' + '/'.join(prefix)
     cls.fullname = prefix
     for k, v in cls.__dict__.items():
         if isinstance(v, type):
             v.__name__ = cls.__name__ + '.' + k
-            api(v, prefix + (k,))
+            api(v, prefix + (k,), serialize_query_args)
         if callable(v):
             v.__qualname__ = cls.__name__ + '.' + k
+            if not cls.serialize_query_args:
+                params = inspect.signature(v).parameters
+                for param_name, param in params.items():
+                    if param.annotation is not str:
+                        raise InvalidQueryArgs(v, param)
     return cls
 
 

--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -72,6 +72,13 @@ def _make_handler(controller, definition, implementation, serializer,
 
     check_def_params = []
 
+    for param_name in definition.__path_params__:
+        check_def_params.append(
+            inspect.Parameter(
+                param_name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=str))
+
     for param_name, param in def_params.items():
         if param_name in ('request', 'context'):
             raise Exception(
@@ -118,6 +125,8 @@ def _make_handler(controller, definition, implementation, serializer,
                         raise TypeError(
                             'missing required argument "{}"'.format(arg))
                     args[arg] = v
+                for param_name in definition.__path_params__:
+                    args[param_name] = request.match_info[param_name]
                 if 'context' in impl_params:
                     args['context'] = context
                 if 'request' in impl_params:

--- a/subiquity/common/api/tests/test_client.py
+++ b/subiquity/common/api/tests/test_client.py
@@ -17,7 +17,7 @@ import contextlib
 import unittest
 
 from subiquity.common.api.client import make_client
-from subiquity.common.api.defs import api, Payload
+from subiquity.common.api.defs import api, InvalidQueryArgs, Payload
 
 
 def extract(c):
@@ -89,3 +89,39 @@ class TestClient(unittest.TestCase):
         r = extract(client.GET(arg='v'))
         self.assertEqual(r, '"v"')
         self.assertEqual(requests, [("GET", '/', {'arg': '"v"'}, None)])
+
+    def test_serialize_query_args(self):
+        @api
+        class API:
+            serialize_query_args = False
+            def GET(arg: str) -> str: ...
+
+            class meth:
+                def GET(arg: str) -> str: ...
+
+                class more:
+                    serialize_query_args = True
+                    def GET(arg: str) -> str: ...
+
+        @contextlib.asynccontextmanager
+        async def make_request(method, path, *, params, json):
+            requests.append((method, path, params, json))
+            yield FakeResponse(params['arg'])
+
+        client = make_client(API, make_request)
+
+        requests = []
+        extract(client.GET(arg='v'))
+        extract(client.meth.GET(arg='v'))
+        extract(client.meth.more.GET(arg='v'))
+        self.assertEqual(requests, [
+            ("GET", '/', {'arg': 'v'}, None),
+            ("GET", '/meth', {'arg': 'v'}, None),
+            ("GET", '/meth/more', {'arg': '"v"'}, None)])
+
+        class API2:
+            serialize_query_args = False
+            def GET(arg: int) -> str: ...
+
+        with self.assertRaises(InvalidQueryArgs):
+            api(API2)

--- a/subiquity/common/api/tests/test_endtoend.py
+++ b/subiquity/common/api/tests/test_endtoend.py
@@ -124,10 +124,10 @@ class TestEndToEnd(unittest.IsolatedAsyncioTestCase):
     async def test_defaults(self):
         @api
         class API:
-            def GET(arg1: str, arg2: str = "arg2") -> str: ...
+            def GET(arg1: str = "arg1", arg2: str = "arg2") -> str: ...
 
         class Impl(ControllerBase):
-            async def GET(self, arg1: str, arg2: str = "arg2") -> str:
+            async def GET(self, arg1: str = "arg1", arg2: str = "arg2") -> str:
                 return '{}+{}'.format(arg1, arg2)
 
         async with makeE2EClient(API, Impl()) as client:
@@ -135,6 +135,8 @@ class TestEndToEnd(unittest.IsolatedAsyncioTestCase):
                 await client.GET(arg1="A", arg2="B"), 'A+B')
             self.assertEqual(
                 await client.GET(arg1="A"), 'A+arg2')
+            self.assertEqual(
+                await client.GET(arg2="B"), 'arg1+B')
 
     async def test_post(self):
         @api

--- a/subiquity/common/api/tests/test_endtoend.py
+++ b/subiquity/common/api/tests/test_endtoend.py
@@ -22,7 +22,12 @@ import aiohttp
 from aiohttp import web
 
 from subiquity.common.api.client import make_client
-from subiquity.common.api.defs import api, Payload
+from subiquity.common.api.defs import (
+    api,
+    MultiplePathParameters,
+    path_parameter,
+    Payload,
+    )
 
 from .test_server import (
     makeTestClient,
@@ -84,6 +89,37 @@ class TestEndToEnd(unittest.IsolatedAsyncioTestCase):
         async with makeE2EClient(API, Impl()) as client:
             self.assertEqual(
                 await client.GET(arg1="A", arg2="B"), 'A+B')
+
+    async def test_path_args(self):
+        @api
+        class API:
+            @path_parameter
+            class param1:
+                @path_parameter
+                class param2:
+                    def GET(arg1: str, arg2: str) -> str: ...
+
+        class Impl(ControllerBase):
+            async def param1_param2_GET(self, param1: str, param2: str,
+                                        arg1: str, arg2: str) -> str:
+                return '{}+{}+{}+{}'.format(param1, param2, arg1, arg2)
+
+        async with makeE2EClient(API, Impl()) as client:
+            self.assertEqual(
+                await client["1"]["2"].GET(arg1="A", arg2="B"), '1+2+A+B')
+
+    def test_only_one_path_parameter(self):
+        class API:
+            @path_parameter
+            class param1:
+                def GET(arg: str) -> str: ...
+
+            @path_parameter
+            class param2:
+                def GET(arg: str) -> str: ...
+
+        with self.assertRaises(MultiplePathParameters):
+            api(API)
 
     async def test_defaults(self):
         @api

--- a/subiquity/common/api/tests/test_server.py
+++ b/subiquity/common/api/tests/test_server.py
@@ -21,7 +21,7 @@ from aiohttp import web
 
 from subiquitycore.context import Context
 
-from subiquity.common.api.defs import api, Payload
+from subiquity.common.api.defs import api, path_parameter, Payload
 from subiquity.common.api.server import (
     bind,
     controller_for_request,
@@ -264,3 +264,18 @@ class TestBind(unittest.IsolatedAsyncioTestCase):
                 client.get('/meth?arg=whut'), 'whut')
             await self.assertResponse(
                 client.get('/meth/more?arg="whut"'), 'whut')
+
+    async def test_path_parameters(self):
+        @api
+        class API:
+            @path_parameter
+            class param:
+                def GET(arg: int): ...
+
+        class Impl(ControllerBase):
+            async def param_GET(self, param: str, arg: int):
+                return param + str(arg)
+
+        async with makeTestClient(API, Impl()) as client:
+            await self.assertResponse(
+                client.get('/value?arg=2'), 'value2')


### PR DESCRIPTION
Two things really:

 * snapd does not expect query arguments to be JSON, just strings
 * snapd sometimes has part of the path by an argument to the method (e.g. /v2/snaps/{snap_name})

I've been looking for an excuse to support the second part here for ages ;-)