### PR TITLE
snaplist: do not automatically mark configured on failed GET request

### DIFF
--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -170,13 +170,11 @@ class SnapListController(SubiquityController):
 
     async def GET(self, wait: bool = False) -> SnapListResponse:
         if self.loader.failed or not self.app.base_model.network.has_network:
-            await self.configured()
             return SnapListResponse(status=SnapCheckState.FAILED)
         if not self.loader.snap_list_fetched and not wait:
             return SnapListResponse(status=SnapCheckState.LOADING)
         await self.loader.get_snap_list_task().wait()
         if self.loader.failed or not self.app.base_model.network.has_network:
-            await self.configured()
             return SnapListResponse(status=SnapCheckState.FAILED)
         return SnapListResponse(
             status=SnapCheckState.DONE,


### PR DESCRIPTION
When a client sends a `GET /snaplist` request and an error occurs on the server side, we return a response of the following form:

```json
 { "status": "FAILED", ... }
```

This effectively gives a chance to the client to retry the same request and expect a different outcome (for instance when a temporary network failure occurs).

Having said that, when the server returns `"status": "FAILED"`, it also automatically marks the snaplist model configured. This is wrong because if the next `GET /snaplist` request succeeds, the user will be prompted to select some snaps to install ; but the installation will already be running in the background. Depending on the timing, it might or might not install the snaps that the user selected.

Fixed by not marking the snaplist model configured automatically. The client is made responsible from sending a `POST /snaplist` ; even in case of error.