### PR TITLE
Make snaplist more robust to races and fix snap info prefetch

### DIFF
--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -66,6 +66,7 @@ class SnapdSnapInfoLoader:
             task = self.tasks[None] = \
                     SingleInstanceTask(self._load_list, propagate_errors=False)
             task.start_sync()
+            await task.wait()
             self.pending_snaps = self.model.get_snap_list()
             log.debug("fetched list of %s snaps", len(self.pending_snaps))
             while self.pending_snaps:

--- a/subiquity/server/controllers/tests/test_snaplist.py
+++ b/subiquity/server/controllers/tests/test_snaplist.py
@@ -1,0 +1,61 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import requests
+import unittest
+from unittest.mock import AsyncMock, Mock
+
+from subiquity.server.controllers.snaplist import (
+    SnapdSnapInfoLoader,
+    SnapListFetchError,
+)
+from subiquity.models.snaplist import SnapListModel
+from subiquitycore.tests.mocks import make_app
+
+
+class TestSnapdSnapInfoLoader(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.model = SnapListModel()
+        self.app = make_app()
+        self.app.snapd = AsyncMock()
+        self.app.report_start_event = Mock()
+        self.app.report_finish_event = Mock()
+
+        self.loader = SnapdSnapInfoLoader(
+                self.model, self.app.snapd, "server", self.app.context)
+
+    async def test_list_task_not_started(self):
+        self.assertFalse(self.loader.fetch_list_completed())
+        self.assertFalse(self.loader.fetch_list_failed())
+
+    async def test_list_task_failed(self):
+        self.app.snapd.get.side_effect = requests.exceptions.RequestException
+        self.loader.start()
+        # TODO remove
+        await asyncio.sleep(.1)
+        with self.assertRaises(SnapListFetchError):
+            await self.loader.get_snap_list_task().wait()
+        self.assertFalse(self.loader.fetch_list_completed())
+        self.assertTrue(self.loader.fetch_list_failed())
+
+    async def test_list_task_completed(self):
+        self.app.snapd.get.return_value = {"result": []}
+        self.loader.start()
+        # TODO remove
+        await asyncio.sleep(.1)
+        await self.loader.get_snap_list_task().wait()
+        self.assertTrue(self.loader.fetch_list_completed())
+        self.assertFalse(self.loader.fetch_list_failed())

--- a/subiquity/server/controllers/tests/test_snaplist.py
+++ b/subiquity/server/controllers/tests/test_snaplist.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import requests
 import unittest
 from unittest.mock import AsyncMock, Mock
@@ -44,18 +43,16 @@ class TestSnapdSnapInfoLoader(unittest.IsolatedAsyncioTestCase):
     async def test_list_task_failed(self):
         self.app.snapd.get.side_effect = requests.exceptions.RequestException
         self.loader.start()
-        # TODO remove
-        await asyncio.sleep(.1)
+        await self.loader.load_list_task_created.wait()
         with self.assertRaises(SnapListFetchError):
-            await self.loader.get_snap_list_task().wait()
+            await self.loader.get_snap_list_task()
         self.assertFalse(self.loader.fetch_list_completed())
         self.assertTrue(self.loader.fetch_list_failed())
 
     async def test_list_task_completed(self):
         self.app.snapd.get.return_value = {"result": []}
         self.loader.start()
-        # TODO remove
-        await asyncio.sleep(.1)
-        await self.loader.get_snap_list_task().wait()
+        await self.loader.load_list_task_created.wait()
+        await self.loader.get_snap_list_task()
         self.assertTrue(self.loader.fetch_list_completed())
         self.assertFalse(self.loader.fetch_list_failed())


### PR DESCRIPTION
This general idea about this PR is to make the snaplist more robust and fix some of the known issues.

List of changes in no particular order:

1. The list tasks now raises an exception in case of error.
    * To check if the task was successful, once can call `task.done() and not task.exception()`.
    * To check if it failed, one can call `task.done() and task.exception()`.
    * To check if the task was cancelled, one can call `task.cancelled()`
    * To check if the task is still running, one can call `not task.done()`

2. The use of `SingleInstanceTask` was replaced by a standard `asyncio.Task` object. This allows us to control better what happens in case of cancellation.

3. When waiting in the GET handler for `/snaplist`, if the loader is recreated (i.e., if a network event occurs), we catch the error and wait again on the newly created loader.

4. Fix race condition in GET handler for `/snaplist` that could lead to an empty or partially empty list of snaps when a network event would occur. https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1989193
 
5. After fetching the list of snaps, the loader will automatically start pre-fetching the info about the snaps. This addresses https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1989198

6. Added a mechanism to block until the snap list task gets created. Calling `loader.start()` does not _immediately_ create a task that will fetch the list of snaps. Therefore, calling:
```python
loader = SnapdSnapLoader(...)
loader.start()
await loader.get_snap_list_task()
```
raises a `KeyError`.

Here is the safer alternative:
```python
loader = SnapdSnapLoader(...)
loader.start()
await loader.load_list_task_created.wait()  # Will unblock once the task is created
await loader.get_snap_list_task()
```