### PR TITLE
cdrom: make sure we unmount the cdrom only once

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -264,7 +264,7 @@ class AptConfigurer:
 
         await self.unmount(
                 Mountpoint(mountpoint=target_mnt.p('cdrom')),
-                remove=False)
+                remove=True)
         os.rmdir(target_mnt.p('cdrom'))
 
         await _restore_dir('etc/apt')


### PR DESCRIPTION
Until recently, subiquity and curtin had shared ownership regarding mounting/unmounting the cdrom to/from the target:

 * curtin was responsible for bind-mounting /cdrom to /target/cdrom
 * subiquity was responsible for unmounting /target/cdrom

We recently made subiquity responsible for bind-mounting the cdrom to the target too, which is a good thing.

Unfortunately, we now attempt to unmount the cdrom from the target twice, at the end of the installation:

 * once because we explicitly unmount the cdrom from the target before restoring the APT config on target
 * once because subiquity has a mechanism that automatically unmount everything that it mounted, in reverse order.

This leads to a crash at the end of the installation.

Fix this issue by making sure we only try to unmount the cdrom once. If we unmount it before restoring the APT config, then we don't want to unmount it automatically anymore.

Fixes https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1990239