### PR TITLE
reserved-usernames: add groups created by udev (src:systemd)

### DIFF
--- a/reserved-usernames
+++ b/reserved-usernames
@@ -1,4 +1,4 @@
-# Static users from base-passwd/passwd.master (3.5.11).
+# Static users from base-passwd/passwd.master (3.5.41).
 root
 daemon
 bin
@@ -18,7 +18,7 @@ irc
 gnats
 nobody
 
-# Other static groups from base-passwd/group.master (3.5.11).
+# Other static groups from base-passwd/group.master (3.5.41).
 adm
 tty
 disk
@@ -43,7 +43,7 @@ staff
 users
 nogroup
 
-# Reserved usernames listed in base-passwd/README (3.5.11).
+# Reserved usernames listed in base-passwd/README (3.5.41).
 netplan
 ftn
 mysql
@@ -59,6 +59,17 @@ qmailp
 asterisk
 vpopmail
 vchkpw
+slurm
+hacluster
+haclient
+grsec-tpe
+grsec-sock-all
+grsec-sock-clt
+grsec-sock-srv
+grsec-proc
+ceph
+opensrf
+libvirt-qemu
 
 # Ubuntu creates the admin group and adds the first user to it in order to
 # grant them sudo privileges.
@@ -75,6 +86,7 @@ cupsys
 dcc
 dhcp
 dictd
+dnsmasq
 dovecot
 fetchmail
 firebird
@@ -84,8 +96,10 @@ gdm
 haldaemon
 hplilp
 identd
+input
 jwhois
 klog
+kvm
 lpadmin
 maas
 messagebus
@@ -93,6 +107,7 @@ mythtv
 netdev
 powerdev
 radvd
+render
 saned
 sbuild
 scanner

--- a/reserved-usernames
+++ b/reserved-usernames
@@ -111,6 +111,7 @@ render
 saned
 sbuild
 scanner
+sgx
 slocate
 ssh
 sshd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -159,9 +159,15 @@ parts:
       echo "get passwd/user-default-groups" | \
         debconf-communicate user-setup | \
         cut -d ' ' -f 2- > $SNAPCRAFT_PART_INSTALL/users-and-groups
-      cp /usr/lib/user-setup/reserved-usernames $SNAPCRAFT_PART_INSTALL/
     stage:
       - users-and-groups
+  user-setup:
+    plugin: nil
+    source: https://git.launchpad.net/ubuntu/+source/user-setup
+    source-type: git
+    override-build:
+      cp -a reserved-usernames $SNAPCRAFT_PART_INSTALL/
+    stage:
       - reserved-usernames
   keyboard-data:
     plugin: nil


### PR DESCRIPTION
The package udev (part of the systemd source package) creates system groups at installation.

In version 251.4, the following system groups are created:

 * input
 * sgx
 * kvm
 * render

When a user accidentally picks a username that corresponds to one of these udev groups, Subiquity gladly accepts it. However, on first boot, cloud-init fails to create the user because a group of the same name already exists.

Added these 4 groups to reserved-usernames so that they get rejected in the identity screen.

fixes https://bugs.launchpad.net/subiquity/+bug/1987341