### PR TITLE
filesystem: accept extended partition with size -1 in autoinstall

### DIFF
--- a/subiquity/common/filesystem/tests/test_gaps.py
+++ b/subiquity/common/filesystem/tests/test_gaps.py
@@ -91,7 +91,7 @@ class TestSplitGap(GapTestCase):
             min_end_offset=0, primary_part_limit=4, ebr_space=ebr_space))
 
         m = make_model(storage_version=2)
-        d = make_disk(m, size=100)
+        d = make_disk(m, size=100, ptable='dos')
         [gap] = gaps.parts_and_gaps(d)
         make_partition(m, d, offset=gap.offset, size=gap.size, flag='extended')
         [p, g] = gaps.parts_and_gaps(d)
@@ -360,7 +360,7 @@ class TestDiskGaps(unittest.TestCase):
         info = PartitionAlignmentData(
             part_align=10, min_gap_size=1, min_start_offset=0,
             min_end_offset=0, primary_part_limit=1)
-        m, d = make_model_and_disk(size=100)
+        m, d = make_model_and_disk(size=100, ptable='dos')
         p = make_partition(m, d, offset=0, size=100, flag='extended')
         g = gaps.Gap(d, offset=0, size=100,
                      in_extended=True, usable=GapUsable.YES)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1216,7 +1216,9 @@ class FilesystemModel(object):
                     from subiquity.common.filesystem.gaps import (
                         largest_gap_size,
                         )
-                    p.size = largest_gap_size(filtered_parent)
+                    p.size = largest_gap_size(
+                            filtered_parent,
+                            in_extended=is_logical_partition(p))
             elif isinstance(p.size, str):
                 if p.size.endswith("%"):
                     percentage = int(p.size[:-1])

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -26,6 +26,7 @@ from subiquity.models.filesystem import (
     FilesystemModel,
     get_raid_size,
     humanize_size,
+    NotFinalPartitionError,
     Partition,
     align_down,
     LVM_CHUNK_SIZE,
@@ -565,6 +566,82 @@ class TestAutoInstallConfig(unittest.TestCase):
         part1 = model._one(type="partition", id="part1")
         self.assertEqual(
             part1.size, disk.available_for_partitions - dehumanize_size('50M'))
+
+    def test_partition_not_final_remaining_size(self):
+        model = make_model()
+        make_disk(model, serial='aaaa', size=dehumanize_size("100M"))
+        fake_up_blockdata(model)
+        with self.assertRaises(NotFinalPartitionError):
+            model.apply_autoinstall_config([
+                {
+                    'type': 'disk',
+                    'id': 'disk0',
+                },
+                {
+                    'type': 'partition',
+                    'id': 'part0',
+                    'device': 'disk0',
+                    'size': dehumanize_size('50M'),
+                },
+                {
+                    'type': 'partition',
+                    'id': 'part1',
+                    'device': 'disk0',
+                    'size': -1,
+                },
+                {
+                    'type': 'partition',
+                    'id': 'part2',
+                    'device': 'disk0',
+                    'size': dehumanize_size('10M'),
+                },
+                ])
+
+    def test_extended_partition_remaining_size(self):
+        model = make_model(bootloader=Bootloader.BIOS, storage_version=2)
+        disk = make_disk(model, serial='aaaa', size=dehumanize_size("100M"),
+                         ptable='msdos')
+        ebr_space = disk.alignment_data().ebr_space
+        start_offset = disk.alignment_data().min_start_offset
+
+        fake_up_blockdata(model)
+        model.apply_autoinstall_config([
+            {
+                'type': 'disk',
+                'id': 'disk0',
+            },
+            {
+                'type': 'partition',
+                'id': 'part0',
+                'device': 'disk0',
+                'size': dehumanize_size('40M'),
+                'offset': start_offset,
+            },
+            {
+                'type': 'partition',
+                'id': 'part1',
+                'device': 'disk0',
+                'size': -1,
+                'flag': 'extended',
+                # p0 offset + p0 size
+                'offset': start_offset + dehumanize_size('40M'),
+            },
+            {
+                'type': 'partition',
+                'number': 5,
+                'id': 'part5',
+                'device': 'disk0',
+                'size': dehumanize_size('10M'),
+                'flag': 'logical',
+                # p1 (extended) offset + ebr_space
+                'offset': start_offset + dehumanize_size('40M') + ebr_space,
+
+            },
+            ])
+        extended = model._one(type="partition", id="part1")
+        self.assertEqual(
+                extended.size,
+                disk.available_for_partitions - dehumanize_size('40M'))
 
     def test_lv_percent(self):
         model = make_model()


### PR DESCRIPTION
~Marking a draft until tested in KVM. Using dry-run looked promising so far.~ :heavy_check_mark: 

Our documentation of autoinstall mentions that one can specify the size of a partition as -1 to use the remaining space on the disk.

Because it only makes sense in practice to support this option for the right-most partition of a given disk, specifying size: -1 is only accepted when defining the last partition of the disk.

Having said that, when making an autoinstall configuration that includes an extended partition, the user must define the logical partitions after the extended partition.

For the following configuration:

```
|                                  disk                                |
+--------------+--------------+--------------+-------------------------|
| p1 (primary) | p2 (primary) | p3 (primary) | p4 (extended)           |
|              |              |              | p5 (logic) | p6 (logic) |
```
, the representation in Subiquity will be analogous to:
```
[
  Partition(p1, "primary"),
  Partition(p2, "primary"),
  Partition(p3, "primary"),
  Partition(p4, "extended"),
  Partition(p5, "logical"),
  Partition(p6, "logical"),
]
```

This means that specifying size: -1 on p4 gets rejected because it is not the last partition defined.p6 is the last partition defined.

This is however a valid use-case because p5 and p6 are contained within p4. So p4 should be able to use the remaining space and there is no reason to reject this configuration

Fixed by ignoring logical partitions when checking if a size of -1 is allowed on an extended partition.