### PR TITLE
Fix unset SNAP_VERSION in WSL

### DIFF
--- a/system_setup/client/client.py
+++ b/system_setup/client/client.py
@@ -34,7 +34,7 @@ The installer will guide you through installing {description}.
 The installer only requires the up and down arrow keys, space (or
 return) and the occasional bit of typing.
 
-This is version {snap_version} of the installer.
+This is revision {snap_revision} of the installer.
 """)
 
 
@@ -44,7 +44,7 @@ def _about_msg(msg, dry_run):
     info.update({
         'id': newId,
         'description': info["description"].replace(info["id"], newId),
-        'snap_version': os.environ.get("SNAP_VERSION", "SNAP_VERSION")
+        'snap_revision': os.environ.get("SNAP_REVISION", "SNAP_REVISION")
         })
     return msg.format(**info)
 


### PR DESCRIPTION
In WSL, the environment variable SNAP_VERSION is unknown. This causes issue https://github.com/ubuntu/WSL/issues/212 to happen.

This PR fixes this by writing the revision instead of the version.
The revision is known by WSL thanks to [this line](https://github.com/ubuntu/wsl-setup/blob/7e6c9abb46cd7f370fc7d5647804278ebd03c976/wsl-setup#L71)