### PR TITLE
Kinetic merge 2022-09-29

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: 5b3d24d89238cae2d5636446cbf396e01654201d
+    source-commit: 47c222681c81110a185497a64749f23596e29b16
     build-packages:
       - shared-mime-info
       - zlib1g-dev

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -23,7 +23,6 @@ import math
 import os
 import pathlib
 import platform
-import random
 import tempfile
 
 from curtin import storage_config
@@ -43,15 +42,12 @@ GiB = 1024 * 1024 * 1024
 def _set_backlinks(obj):
     if obj.id is None:
         base = obj.type
-        num = len(obj._m._all_ids) + 1
+        i = 0
         while True:
-            # Create a semireadable id.
-            # The number on the end is not particularly meaningful,
-            # notably on a partition it is (usually) not the partition number.
-            rand = random.randint(0, 16**2 - 1)
-            val = f'{base}-{rand:02x}-{num}'
+            val = "%s-%s" % (base, i)
             if val not in obj._m._all_ids:
                 break
+            i += 1
         obj.id = val
     obj._m._all_ids.add(obj.id)
     for field in attr.fields(type(obj)):

--- a/subiquity/models/keyboard.py
+++ b/subiquity/models/keyboard.py
@@ -101,6 +101,14 @@ class KeyboardModel:
                     'permissions': 0o644,
                     },
                 },
+            'curthooks_commands': {
+                # The below command must be run after updating
+                # etc/default/keyboard on the target so that the initramfs uses
+                # the keyboard mapping selected by the user.  See LP #1894009
+                '002-setupcon-save-only': [
+                    'curtin', 'in-target', '--', 'setupcon', '--save-only',
+                    ],
+                },
             }
 
     def setting_for_lang(self, lang):

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -387,12 +387,6 @@ class SubiquityModel:
                 '001-mount-cdrom': [
                     'mount', '--bind', '/cdrom', '/target/cdrom',
                     ],
-                # The below command must be run after updating
-                # etc/default/keyboard on the target so that the initramfs uses
-                # the keyboard mapping selected by the user.  See LP #1894009
-                '002-setupcon-save-only': [
-                    'curtin', 'in-target', '--', 'setupcon', '--save-only',
-                    ],
                 },
 
             'grub': {

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -387,6 +387,12 @@ class SubiquityModel:
                 '001-mount-cdrom': [
                     'mount', '--bind', '/cdrom', '/target/cdrom',
                     ],
+                # The below command must be run after updating
+                # etc/default/keyboard on the target so that the initramfs uses
+                # the keyboard mapping selected by the user.  See LP #1894009
+                '002-setupcon-save-only': [
+                    'curtin', 'in-target', '--', 'setupcon', '--save-only',
+                    ],
                 },
 
             'grub': {


### PR DESCRIPTION
* cherry-picked bd79c1d from #1438 to revert the change to filesystem object IDs.  Curtin action object IDs are completely arbitrary, so one should not assume they have meaning.
* cherry-picked 2928ab8 from #1436 to fix success reporting for integration tests
* cherry-picked 76b1fae..870c99b from #1411 for LP: #[1894009](http://pad.lv/1894009)
* advance curtin to https://github.com/canonical/curtin/commit/47c222681c81110a185497a64749f23596e29b16 for LP: #[1987236](http://pad.lv/1987236) and to help ensure that cryptsetup is installed in the target system

