### PR TITLE
track fs model objects device paths

### DIFF
--- a/scripts/replay-curtin-log.py
+++ b/scripts/replay-curtin-log.py
@@ -13,6 +13,8 @@ from typing import TextIO
 
 from systemd import journal
 
+import yaml
+
 scale_factor = float(os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "4"))
 
 def time_for_entry(e):
@@ -42,8 +44,22 @@ def main() -> int:
     parser.add_argument("replay-file")
     parser.add_argument("--event-identifier", required=True)
     parser.add_argument("--output", type=argparse.FileType("w"), default="-")
+    parser.add_argument("--config", type=argparse.FileType("r"), default=None)
 
     args = vars(parser.parse_args())
+
+    if args['config'] is not None:
+        config = yaml.safe_load(args['config'])
+        if 'storage' in config:
+            storage = config['storage']
+            device_map_path = storage.get('device_map_path')
+            if device_map_path is not None:
+                device_map = {}
+                for action in storage['config']:
+                    if action['type'] == 'partition' and 'path' not in action:
+                        device_map[action['id']] = 'xxx'
+                with open(device_map_path, 'w') as fp:
+                    json.dump(device_map, fp)
 
     prev_ev = None
     for line in open(args["replay-file"]):

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: 47c222681c81110a185497a64749f23596e29b16
+    source-commit: 9a28853b92436e89654604c6f2a5ca2aa7e40e68
     build-packages:
       - shared-mime-info
       - zlib1g-dev

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -711,6 +711,7 @@ class Partition(_Formattable):
     offset = attr.ib(default=None)
     resize = attr.ib(default=None)
     partition_type = attr.ib(default=None)
+    path = attr.ib(default=None)
 
     def __post_init__(self):
         if self.number is not None:
@@ -805,6 +806,7 @@ class Raid(_Device):
     wipe = attr.ib(default=None)
     ptable = attributes.ptable()
     metadata = attr.ib(default=None)
+    path = attr.ib(default=None)
     container = attributes.ref(backlink="_subvolumes", default=None)  # Raid
     _subvolumes = attributes.backlink(default=attr.Factory(list))
 
@@ -891,6 +893,7 @@ class LVM_LogicalVolume(_Formattable):
     wipe = attr.ib(default=None)
 
     preserve = attr.ib(default=False)
+    path = attr.ib(default=None)
 
     def serialize_size(self):
         if self.size is None:
@@ -921,6 +924,7 @@ class DM_Crypt:
     volume = attributes.ref(backlink="_constructed_device")  # _Formattable
     key = attr.ib(metadata={'redact': True}, default=None)
     keyfile = attr.ib(default=None)
+    path = attr.ib(default=None)
 
     def serialize_key(self):
         if self.key and not self.keyfile:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -146,6 +146,13 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 "autoinstall config did not create needed bootloader "
                 "partition")
 
+    def update_devices(self, device_map):
+        for action in self.model._actions:
+            path = device_map.get(action.id)
+            if path is not None:
+                log.debug("recording path %r for device %s", path, action.id)
+                action.path = path
+
     def guided_direct(self, gap):
         spec = dict(fstype="ext4", mount="/")
         self.create_partition(device=gap.device, gap=gap, spec=spec)

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -111,6 +111,20 @@ class CurtinInstallStep:
             config=str(self.config_file), private_mounts=False)
 
 
+@attr.s(auto_attribs=True)
+class CurtinPartitioningStep(CurtinInstallStep):
+    device_map_path: Path
+
+    @with_context(
+        description="executing curtin install {self.name} step")
+    async def run(self, context):
+        await super().run(context=context)
+        with open(self.device_map_path) as fp:
+            device_map = json.load(fp)
+        fs = self.controller.app.controllers.Filesystem
+        fs.update_devices(device_map)
+
+
 class InstallController(SubiquityController):
 
     def __init__(self, app):
@@ -174,6 +188,13 @@ class InstallController(SubiquityController):
             }
         }
 
+    def acquire_filesystem_config(self, step: CurtinPartitioningStep,
+                                  ) -> Dict[str, Any]:
+        cfg = self.acquire_initial_config(step)
+        cfg.update(self.model.filesystem.render())
+        cfg['storage']['device_map_path'] = str(step.device_map_path)
+        return cfg
+
     @with_context(description="umounting /target dir")
     async def unmount_target(self, *, context, target):
         await run_curtin_command(self.app, context, 'unmount', '-t', target,
@@ -211,8 +232,9 @@ class InstallController(SubiquityController):
 
         resume_data_file = Path(tempfile.mkdtemp()) / "resume-data.json"
 
-        def make_curtin_step(name, stages, acquire_config):
-            return CurtinInstallStep(
+        def make_curtin_step(name, stages, acquire_config, *,
+                             cls=CurtinInstallStep, **kw):
+            return cls(
                 controller=self,
                 name=name,
                 stages=stages,
@@ -222,6 +244,7 @@ class InstallController(SubiquityController):
                 resume_data_file=resume_data_file,
                 source=source,
                 acquire_config=acquire_config,
+                **kw,
             )
 
         generic_steps = [
@@ -232,7 +255,9 @@ class InstallController(SubiquityController):
             ).run,
             make_curtin_step(
                 name="partitioning", stages=["partitioning"],
-                acquire_config=self.acquire_generic_config,
+                acquire_config=self.acquire_filesystem_config,
+                cls=CurtinPartitioningStep,
+                device_map_path=logs_dir / "device-map.json",
             ).run,
             make_curtin_step(
                 name="extract", stages=["extract"],

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -115,8 +115,6 @@ class CurtinInstallStep:
 class CurtinPartitioningStep(CurtinInstallStep):
     device_map_path: Path
 
-    @with_context(
-        description="executing curtin install {self.name} step")
     async def run(self, context):
         await super().run(context=context)
         with open(self.device_map_path) as fp:

--- a/subiquity/server/curtin.py
+++ b/subiquity/server/curtin.py
@@ -153,14 +153,19 @@ class _DryRunCurtinCommand(_CurtinCommand):
                     continue
                 stages = json.loads(match_obj.groups()[0])
 
-            return [
+            cmd = [
                 sys.executable,
                 "scripts/replay-curtin-log.py",
                 "--event-identifier", self._event_syslog_id,
                 "--output", log_file,
+                ]
+            if config:
+                cmd.extend(['--config', config])
+            cmd.extend([
                 "--",
                 self.stages_mapping[tuple(stages)],
-                ]
+                ])
+            return cmd
         else:
             return super().make_command(command, *args, config=config)
 


### PR DESCRIPTION
Doing this for the non-core boot classic path is unnecessary but it does let me check the code works, which is nice.

I haven't VM tested this yet, but the over-elaborate dry-run / replay support gives some confidence it's not completely broken.