### PR TITLE
Multiple fixes for size: -1 partitions

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -25,6 +25,7 @@ python3-dev
 python3-distutils-extra
 python3-flake8
 python3-jsonschema
+python3-more-itertools
 python3-nose
 python3-parameterized
 python3-pip

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -552,7 +552,7 @@ class _Device(_Formattable, ABC):
 
     @property
     def available_for_partitions(self):
-        return align_down(self.size, 1 << 20) - GPT_OVERHEAD
+        raise NotImplementedError
 
     def available(self):
         # A _Device is available if:
@@ -604,6 +604,12 @@ class Disk(_Device):
     device_id = attr.ib(default=None)
 
     _info = attr.ib(default=None)
+
+    @property
+    def available_for_partitions(self):
+        margin_before = self.alignment_data().min_start_offset
+        margin_after = self.alignment_data().min_end_offset
+        return align_down(self.size, 1 << 20) - margin_before - margin_after
 
     def alignment_data(self):
         ptable = self.ptable_for_new_partition()

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1172,12 +1172,12 @@ class FilesystemModel(object):
         return None
 
     def assign_omitted_offsets(self):
-        """ For disks that use storage_version 2, assign offsets to partitions
-        that do not already have one. """
-        for disk in self._all(type="disk"):
-            if disk._m.storage_version != 2:
-                continue
+        """ Assign offsets to partitions that do not already have one.
+        This method does nothing for storage version 1. """
+        if self.storage_version != 2:
+            return
 
+        for disk in self._all(type="disk"):
             info = disk.alignment_data()
 
             def au(v):  # au == "align up"

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -26,6 +26,8 @@ import pathlib
 import platform
 import tempfile
 
+import more_itertools
+
 from curtin import storage_config
 from curtin.block import partition_kname
 from curtin.util import human2bytes
@@ -1188,11 +1190,9 @@ class FilesystemModel(object):
             def ad(v):  # ad == "align down"
                 return v - v % info.part_align
 
-            primary_parts = list(filter(
-                lambda x: not is_logical_partition(x),
-                disk.partitions()))
-            logical_parts = list(filter(
-                lambda x: is_logical_partition(x),
+            # Extended is considered a primary partition too.
+            primary_parts, logical_parts = map(list, more_itertools.partition(
+                is_logical_partition,
                 disk.partitions()))
 
             prev_end = info.min_start_offset

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1262,6 +1262,10 @@ class FilesystemModel(object):
                             "{} has negative size but is not final partition "
                             "of {}".format(p, parent))
 
+                    # Exclude the current partition itself so that its
+                    # incomplete size is not used as is.
+                    filtered_parent._partitions.remove(p)
+
                     from subiquity.common.filesystem.gaps import (
                         largest_gap_size,
                         )

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -693,10 +693,7 @@ class TestAutoInstallConfig(unittest.TestCase):
 
         self.assertEqual(extended.offset, 2048 * 512)
         self.assertEqual(logical.offset, 4096 * 512)
-        # FIXME https://launchpad.net/bugs/1991929
-        # The partition lacks 1MiB at the end
-        # self.assertEqual(logical.size, extended.size - ebr_space)
-        self.assertEqual(logical.size, extended.size - ebr_space - (1 << 20))
+        self.assertEqual(logical.size, extended.size - ebr_space)
 
     def test_partition_remaining_size_in_extended_and_logical(self):
         model = make_model(bootloader=Bootloader.BIOS, storage_version=2)
@@ -758,10 +755,7 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertEqual(extended.size, 120832 * 512)
         self.assertEqual(p5.offset, 86016 * 512)
         self.assertEqual(p6.offset, 108544 * 512)
-        # FIXME https://launchpad.net/bugs/1991929
-        # the partition lacks 1MiB at the end
-        # self.assertEqual(p6.size, 96256 * 512)
-        self.assertEqual(p6.size, 96256 * 512 - (1 << 20))
+        self.assertEqual(p6.size, 96256 * 512)
 
     def test_lv_percent(self):
         model = make_model()


### PR DESCRIPTION
* fixed implementation of `disk.available_for_partitions` that always considered the disk had a GPT.
* fixed bug forcing the user to hard-code all offsets when using storage version 2 with a partition with `size: -1`. https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1991413
* fixed sometimes wrong size assigned to a partition that had `size: -1`. The value `-1` (that is an valid integer) was used accidentally in the computations to determine the appropriate size for the partition. https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1991929
* fixed my recent unit tests that were not specifying the partition table type. This resulted in a GPT partition table (that use different alignment and space constraints).

I am now able run a successful autoinstall with the data from https://bugs.launchpad.net/subiquity/+bug/1989977 without hard-coding any offset. The 1MiB that was missing on the final logical partition in the earlier implementation is now claimed properly.
I added this test case as a unit test: `test_partition_remaining_size_in_extended_and_logical_multiple`