### PR TITLE
Adds language-selector-common to the snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -117,6 +117,7 @@ parts:
       - libsystemd0
       - iso-codes
       - lsb-release
+      - language-selector-common
       - ssh-import-id
       - libpython3.8-minimal
       - libpython3.8-stdlib


### PR DESCRIPTION
Would it be acceptable to add that package to the snap?

The system_setup configure controller requires it. UDI used to provide that, but now we are Subiquity-only-snap.