### PR TITLE
filesystem: fix curtin config to disable swapfile

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1398,7 +1398,7 @@ class FilesystemModel(object):
         if self.swap is not None:
             config['swap'] = self.swap
         elif not self._should_add_swapfile():
-            config['swap'] = {'swap': 0}
+            config['swap'] = {'size': 0}
         if self.grub is not None:
             config['grub'] = self.grub
         return config


### PR DESCRIPTION
If subiquity detects it should not add a swapfile (e.g., swap partition present, or root filesystem on btrfs), it renders this curtin config:
```
swap:
  swap: 0
```
But that should be:
```
swap:
  size: 0
```
Per the curtin docs [1]:
```
  swap
  size: <Size string>
  Configure the exact size of the swapfile. Setting size to 0 will disable swap.
```
[1] https://curtin.readthedocs.io/en/latest/topics/config.html#swap

Tests: (build snap/modify ISO as in README.md)

- before:
```
$ cat /proc/swaps
Filename	... 
/swap.img	... 
/dev/vda3	...

$ sudo grep -A1 ^swap: \
   /var/log/installer/curtin-install/subiquity-partitioning.conf
swap:
  swap: 0
```
- after:
```
$ cat /proc/swaps 
Filename	... 
/dev/vda3	...

$ sudo grep -A1 ^swap: \
   /var/log/installer/curtin-install/subiquity-partitioning.conf
swap: 
  size: 0
```

LP: #1927103

Signed-off-by: Mauricio Faria de Oliveira <mfo@canonical.com>