### PR TITLE
autoinstall reference documentation update

### DIFF
--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -473,12 +473,25 @@ The timezone to configure on the system. The special value "geoip" can be used t
 
 **type:** string (enumeration)
 **default:** `security`
+**can be interactive:** no
 
 The type of updates that will be downloaded and installed after the system install.
 Supported values are:
 
  * `security` -> download and install updates from the -security pocket
  * `all` -> also download and install updates from the -updates pocket
+
+### shutdown
+
+**type:** string (enumeration)
+**default:** do nothing
+**can be interactive:** no
+
+Request the system to shutdown or reboot automatically after the installation has finished.
+Supported values are:
+
+ * `reboot`
+ * `shutdown`
 
 <a name="late-commands"></a>
 

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -461,6 +461,26 @@ The installer will update the target with debconf set-selection values. Users wi
 
 A list of packages to install into the target system. More precisely, a list of strings to pass to "`apt-get install`", so this includes things like task selection (`dns-server^`) and installing particular versions of a package (`my-package=1-1`).
 
+### kernel
+
+**type:** mapping (mutually exclusive), see below
+**default:** default kernel
+**can be interactive:** no
+
+Which kernel gets installed. Either the name of the package or the name of the flavor must be specified.
+
+#### package
+
+**type:** string
+
+The name of the package, e.g., `linux-image-5.13.0-40-generic`
+
+#### flavor
+
+**type:** string
+
+The flavor of the kernel, e.g., `generic` or `hwe`.
+
 ### timezone
 
 **type:** string

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -132,6 +132,23 @@ Corresponds to the value of `grp:` option from the `XKBOPTIONS` setting. Accepta
 
 The version of subiquity released with 20.04 GA does not accept `null` for this field due to a bug.
 
+### source
+**type:** mapping, see below
+**default:** see below
+**can be interactive:** yes
+
+#### search_drivers
+**type:** boolean
+**default:** `true`
+
+Whether the installer should search for available third-party drivers. When set to `false`, it disables the drivers screen and [section](#drivers).
+
+#### id
+**type:** string
+**default:** identifier of the first available source.
+
+Identifier of the source to install (e.g., `"ubuntu-server-minimized"`).
+
 <a name="network"></a>
 
 ### network

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -398,6 +398,21 @@ A list of SSH public keys to install in the initial user's account.
 **type:** boolean
 **default:** `true` if `authorized_keys` is empty, `false` otherwise
 
+<a name="drivers"></a>
+
+### drivers
+
+**type:** mapping, see below
+**default:** see below
+**can be interactive:** yes
+
+#### install
+
+**type:** boolean
+**default:** `false`
+
+Whether to install the available third-party drivers.
+
 <a name="snaps"></a>
 
 ### snaps

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -43,7 +43,7 @@ A list of config keys to still show in the UI. So for example:
 
 Would stop on the network screen and allow the user to change the defaults. If a value is provided for an interactive section it is used as the default.
 
-You can use the special section name of "*" to indicate that the installer should ask all the usual questions -- in this case, the `autoinstall.yaml` file is not really an "autoinstall" file at all, instead just a way to change the defaults in the UI.
+You can use the special section name of "\*" to indicate that the installer should ask all the usual questions -- in this case, the `autoinstall.yaml` file is not really an "autoinstall" file at all, instead just a way to change the defaults in the UI.
 
 Not all config keys correspond to screens in the UI. This documentation indicates if a given section can be interactive or not.
 
@@ -137,10 +137,10 @@ The version of subiquity released with 20.04 GA does not accept `null` for this 
 ### network
 
 **type:** netplan-format mapping, see below
-**default:** DHCP on interfaces named eth* or en*
+**default:** DHCP on interfaces named eth\* or en\*
 **can be interactive:** yes
 
-[netplan](https://netplan.io/reference) formatted network configuration. This will be applied during installation as well as in the installed system. The default is to interpret the config for the install media, which runs DHCPv4 on any interface with a name matching "eth*" or "en*" but then disables any interface that does not receive an address.
+[netplan](https://netplan.io/reference) formatted network configuration. This will be applied during installation as well as in the installed system. The default is to interpret the config for the install media, which runs DHCPv4 on any interface with a name matching "eth\*" or "en\*" but then disables any interface that does not receive an address.
 
 For example, to run dhcp6 on a particular NIC:
 

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -461,6 +461,14 @@ The installer will update the target with debconf set-selection values. Users wi
 
 A list of packages to install into the target system. More precisely, a list of strings to pass to "`apt-get install`", so this includes things like task selection (`dns-server^`) and installing particular versions of a package (`my-package=1-1`).
 
+### timezone
+
+**type:** string
+**default:** no timezone
+**can be interactive:** no
+
+The timezone to configure on the system. The special value "geoip" can be used to query the timezone automatically over the network.
+
 <a name="late-commands"></a>
 
 ### late-commands

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -369,6 +369,19 @@ The hostname for the system.
 
 The password for the new user, crypted. This is required for use with sudo, even if SSH access is configured.
 
+### ubuntu-pro
+
+**type:** mapping, see below
+**default:** see below
+**can be interactive:** yes
+
+#### token
+
+**type:** string
+**default:** no token
+
+A contract token to attach to an existing Ubuntu Pro subscription.
+
 <a name="ssh"></a>
 
 ### ssh

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -469,6 +469,17 @@ A list of packages to install into the target system. More precisely, a list of 
 
 The timezone to configure on the system. The special value "geoip" can be used to query the timezone automatically over the network.
 
+### updates
+
+**type:** string (enumeration)
+**default:** `security`
+
+The type of updates that will be downloaded and installed after the system install.
+Supported values are:
+
+ * `security` -> download and install updates from the -security pocket
+ * `all` -> also download and install updates from the -updates pocket
+
 <a name="late-commands"></a>
 
 ### late-commands

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -84,14 +84,14 @@ The mapping contains keys:
 #### update
 
 **type:** boolean
-**default**: `no`
+**default:** `no`
 
 Whether to update or not.
 
 #### channel
 
 **type:** string
-**default**: `"stable/ubuntu-$REL"`
+**default:** `"stable/ubuntu-$REL"`
 
 The channel to check for updates.
 
@@ -112,21 +112,21 @@ The mapping contains keys:
 #### layout
 
 **type:** string
-**default**: `"us"`
+**default:** `"us"`
 
 Corresponds to the `XKBLAYOUT` setting.
 
 #### variant
 
 **type:** string
-**default**: `""`
+**default:** `""`
 
 Corresponds to the `XKBVARIANT` setting.
 
 #### toggle
 
 **type:** string or null
-**default**: `null`
+**default:** `null`
 
 Corresponds to the value of `grp:` option from the `XKBOPTIONS` setting. Acceptable values are (but note that the installer does not validate these): `caps_toggle`, `toggle`, `rctrl_toggle`, `rshift_toggle`, `rwin_toggle`, `menu_toggle`, `alt_shift_toggle`, `ctrl_shift_toggle`, `ctrl_alt_toggle`, `alt_caps_toggle`, `lctrl_lshift_toggle`, `lalt_toggle`, `lctrl_toggle`, `lshift_toggle`, `lwin_toggle`, `sclk_toggle`
 

--- a/documentation/autoinstall-schema.md
+++ b/documentation/autoinstall-schema.md
@@ -25,7 +25,7 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
     "properties": {
         "version": {
             "type": "integer",
-            "minumum": 1,
+            "minimum": 1,
             "maximum": 1
         },
         "early-commands": {
@@ -94,6 +94,31 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
             },
             "additionalProperties": false
         },
+        "kernel": {
+            "type": "object",
+            "properties": {
+                "package": {
+                    "type": "string"
+                },
+                "flavor": {
+                    "type": "string"
+                }
+            },
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "package"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "flavor"
+                    ]
+                }
+            ]
+        },
         "keyboard": {
             "type": "object",
             "properties": {
@@ -114,6 +139,17 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
                 "layout"
             ],
             "additionalProperties": false
+        },
+        "source": {
+            "type": "object",
+            "properties": {
+                "search_drivers": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                }
+            }
         },
         "network": {
             "oneOf": [
@@ -257,6 +293,32 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
                 }
             ]
         },
+        "ubuntu-pro": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "minLength": 24,
+                    "maxLength": 30,
+                    "pattern": "^C[1-9A-HJ-NP-Za-km-z]+$",
+                    "description": "A valid token starts with a C and is followed by 23 to 29 Base58 characters.\nSee https://pkg.go.dev/github.com/btcsuite/btcutil/base58#CheckEncode"
+                }
+            }
+        },
+        "ubuntu-advantage": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "minLength": 24,
+                    "maxLength": 30,
+                    "pattern": "^C[1-9A-HJ-NP-Za-km-z]+$",
+                    "description": "A valid token starts with a C and is followed by 23 to 29 Base58 characters.\nSee https://pkg.go.dev/github.com/btcsuite/btcutil/base58#CheckEncode"
+                }
+            },
+            "deprecated": true,
+            "description": "Compatibility only - use ubuntu-pro instead"
+        },
         "proxy": {
             "type": [
                 "string",
@@ -278,6 +340,41 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
                 },
                 "sources": {
                     "type": "object"
+                },
+                "disable_components": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "universe",
+                            "multiverse",
+                            "restricted",
+                            "contrib",
+                            "non-free"
+                        ]
+                    }
+                },
+                "preferences": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "package": {
+                                "type": "string"
+                            },
+                            "pin": {
+                                "type": "string"
+                            },
+                            "pin-priority": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "package",
+                            "pin",
+                            "pin-priority"
+                        ]
+                    }
                 }
             }
         },
@@ -345,6 +442,24 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
                 "additionalProperties": false
             }
         },
+        "drivers": {
+            "type": "object",
+            "properties": {
+                "install": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "timezone": {
+            "type": "string"
+        },
+        "updates": {
+            "type": "string",
+            "enum": [
+                "security",
+                "all"
+            ]
+        },
         "late-commands": {
             "type": "array",
             "items": {
@@ -356,6 +471,13 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
                     "type": "string"
                 }
             }
+        },
+        "shutdown": {
+            "type": "string",
+            "enum": [
+                "reboot",
+                "poweroff"
+            ]
         }
     },
     "required": [

--- a/documentation/autoinstall.md
+++ b/documentation/autoinstall.md
@@ -120,7 +120,7 @@ Here is an example file that shows off most features:
 <a href="autoinstall-reference.md#user-data">user-data</a>:
     disable_root: false
 <a href="autoinstall-reference.md#late-commands">late-commands</a>:
-    - sed -ie 's/GRUB_TIMEOUT=.*/GRUB_TIMEOUT=30/' /target/etc/default/grub
+    - sed -ie 's/GRUB_TIMEOUT=.\*/GRUB_TIMEOUT=30/' /target/etc/default/grub
 <a href="autoinstall-reference.md#error-commands">error-commands</a>:
     - tar c /var/log/installer | nc 192.168.0.1 1000
 </code></pre>


### PR DESCRIPTION
This PR updates the autoinstall-reference documentation with the new keys that were added after the 20.04 release.