### PR TITLE
Start of UI for TPM-backed FDE

### DIFF
--- a/examples/answers-tpm.yaml
+++ b/examples/answers-tpm.yaml
@@ -1,0 +1,44 @@
+#source-catalog: examples/tpm-sources.yaml
+Source:
+  source: src-prefer-encrypted
+Serial:
+  rich: false
+Welcome:
+  lang: en_US
+Refresh:
+  update: no
+Keyboard:
+  layout: us
+Zdev:
+  accept-default: yes
+Network:
+  accept-default: yes
+Proxy:
+  proxy: ""
+Mirror:
+  country-code: us
+Filesystem:
+  tpm-default: yes
+Identity:
+  realname: Ubuntu
+  username: ubuntu
+  hostname: ubuntu-server
+  # ubuntu
+  password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+UbuntuPro:
+  token: ""
+SSH:
+  install_server: true
+  pwauth: false
+  authorized_keys:
+    - |
+      ssh-rsa AAAAAAAAAAAAAAAAAAAAAAAAA # ssh-import-id lp:subiquity
+SnapList:
+  snaps:
+    hello:
+      channel: stable
+      classic: false
+InstallProgress:
+  reboot: yes
+Drivers:
+  install: no

--- a/examples/snaps/v2-systems-classic.json
+++ b/examples/snaps/v2-systems-classic.json
@@ -1,0 +1,234 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "label": "classic",
+    "model": {
+      "architecture": "amd64",
+      "authority-id": "developer1",
+      "base": "core22",
+      "brand-id": "developer1",
+      "classic": "true",
+      "distribution": "ubuntu",
+      "grade": "dangerous",
+      "model": "developer1-22-classic-dangerous",
+      "serial-authority": [
+        "generic"
+      ],
+      "series": "16",
+      "sign-key-sha3-384": "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu",
+      "snaps": [
+        {
+          "default-channel": "22/edge",
+          "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+          "name": "pc",
+          "type": "gadget"
+        },
+        {
+          "default-channel": "22/edge",
+          "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+          "name": "pc-kernel",
+          "type": "kernel"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
+          "name": "core22",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+          "name": "snapd",
+          "type": "snapd"
+        }
+      ],
+      "timestamp": "2022-09-06T22:00:00+00:00",
+      "type": "model"
+    },
+    "brand": {
+      "id": "developer1",
+      "username": "developer1",
+      "display-name": "Developer 1",
+      "validation": "unproven"
+    },
+    "actions": [
+      {
+        "title": "Install",
+        "mode": "install"
+      }
+    ],
+    "volumes": {
+      "pc": {
+        "schema": "gpt",
+        "bootloader": "grub",
+        "id": "",
+        "structure": [
+          {
+            "name": "mbr",
+            "filesystem-label": "",
+            "offset": null,
+            "offset-write": null,
+            "size": 440,
+            "type": "mbr",
+            "role": "mbr",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-boot.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "BIOS Boot",
+            "filesystem-label": "",
+            "offset": 1048576,
+            "offset-write": {
+              "relative-to": "mbr",
+              "offset": 92
+            },
+            "size": 1048576,
+            "type": "DA,21686148-6449-6E6F-744E-656564454649",
+            "role": "",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-core.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-seed",
+            "filesystem-label": "ubuntu-seed",
+            "offset": null,
+            "offset-write": null,
+            "size": 1258291200,
+            "type": "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "role": "system-seed",
+            "id": "",
+            "filesystem": "vfat",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-boot",
+            "filesystem-label": "ubuntu-boot",
+            "offset": null,
+            "offset-write": null,
+            "size": 786432000,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-boot",
+            "id": "",
+            "filesystem": "ext4",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-save",
+            "filesystem-label": "ubuntu-save",
+            "offset": null,
+            "offset-write": null,
+            "size": 33554432,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-save",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-data",
+            "filesystem-label": "ubuntu-data",
+            "offset": null,
+            "offset-write": null,
+            "size": 1073741824,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-data",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          }
+        ]
+      }
+    },
+    "storage-encryption": {
+      "support": "unavailable",
+      "storage-safety": "prefer-encrypted",
+      "unavailable-reason": "not encrypting device storage as checking TPM gave: secure boot is disabled"
+    }
+  }
+}

--- a/examples/snaps/v2-systems-defective.json
+++ b/examples/snaps/v2-systems-defective.json
@@ -6,18 +6,18 @@
     "label": "classic",
     "model": {
       "architecture": "amd64",
-      "authority-id": "developer1",
+      "authority-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
       "base": "core22",
-      "brand-id": "developer1",
+      "brand-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
       "classic": "true",
       "distribution": "ubuntu",
       "grade": "dangerous",
-      "model": "developer1-22-classic-dangerous",
+      "model": "mwhudson-22-classic-dangerous",
       "serial-authority": [
         "generic"
       ],
       "series": "16",
-      "sign-key-sha3-384": "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu",
+      "sign-key-sha3-384": "AWEzKBCuROAYkR0dQfdgI95Ih9sWqwxpU1yezWkKT3EUX6LgNNgXFWSNUxC1S2_v",
       "snaps": [
         {
           "default-channel": "22/edge",
@@ -38,19 +38,19 @@
           "type": "base"
         },
         {
-          "default-channel": "latest/stable",
+          "default-channel": "latest/edge",
           "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
           "name": "snapd",
           "type": "snapd"
         }
       ],
-      "timestamp": "2022-09-06T22:00:00+00:00",
+      "timestamp": "2022-10-07T02:25:51+00:00",
       "type": "model"
     },
     "brand": {
-      "id": "developer1",
-      "username": "developer1",
-      "display-name": "Developer 1",
+      "id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "username": "mwhudson",
+      "display-name": "Michael Hudson-Doyle",
       "validation": "unproven"
     },
     "actions": [
@@ -226,8 +226,9 @@
       }
     },
     "storage-encryption": {
-      "support": "unavailable",
-      "storage-safety": "prefer-encrypted",
+      "support": "defective",
+      "storage-safety": "encrypted",
+      "encryption-type": "cryptsetup",
       "unavailable-reason": "not encrypting device storage as checking TPM gave: secure boot is disabled"
     }
   }

--- a/examples/snaps/v2-systems-mandatory.json
+++ b/examples/snaps/v2-systems-mandatory.json
@@ -1,0 +1,234 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "label": "classic",
+    "model": {
+      "architecture": "amd64",
+      "authority-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "base": "core22",
+      "brand-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "classic": "true",
+      "distribution": "ubuntu",
+      "grade": "dangerous",
+      "model": "mwhudson-22-classic-dangerous",
+      "serial-authority": [
+        "generic"
+      ],
+      "series": "16",
+      "sign-key-sha3-384": "AWEzKBCuROAYkR0dQfdgI95Ih9sWqwxpU1yezWkKT3EUX6LgNNgXFWSNUxC1S2_v",
+      "snaps": [
+        {
+          "default-channel": "22/edge",
+          "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+          "name": "pc",
+          "type": "gadget"
+        },
+        {
+          "default-channel": "22/edge",
+          "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+          "name": "pc-kernel",
+          "type": "kernel"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
+          "name": "core22",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+          "name": "snapd",
+          "type": "snapd"
+        }
+      ],
+      "timestamp": "2022-10-07T02:25:51+00:00",
+      "type": "model"
+    },
+    "brand": {
+      "id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "username": "mwhudson",
+      "display-name": "Michael Hudson-Doyle",
+      "validation": "unproven"
+    },
+    "actions": [
+      {
+        "title": "Install",
+        "mode": "install"
+      }
+    ],
+    "volumes": {
+      "pc": {
+        "schema": "gpt",
+        "bootloader": "grub",
+        "id": "",
+        "structure": [
+          {
+            "name": "mbr",
+            "filesystem-label": "",
+            "offset": null,
+            "offset-write": null,
+            "size": 440,
+            "type": "mbr",
+            "role": "mbr",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-boot.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "BIOS Boot",
+            "filesystem-label": "",
+            "offset": 1048576,
+            "offset-write": {
+              "relative-to": "mbr",
+              "offset": 92
+            },
+            "size": 1048576,
+            "type": "DA,21686148-6449-6E6F-744E-656564454649",
+            "role": "",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-core.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-seed",
+            "filesystem-label": "ubuntu-seed",
+            "offset": null,
+            "offset-write": null,
+            "size": 1258291200,
+            "type": "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "role": "system-seed",
+            "id": "",
+            "filesystem": "vfat",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-boot",
+            "filesystem-label": "ubuntu-boot",
+            "offset": null,
+            "offset-write": null,
+            "size": 786432000,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-boot",
+            "id": "",
+            "filesystem": "ext4",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-save",
+            "filesystem-label": "ubuntu-save",
+            "offset": null,
+            "offset-write": null,
+            "size": 33554432,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-save",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-data",
+            "filesystem-label": "ubuntu-data",
+            "offset": null,
+            "offset-write": null,
+            "size": 1073741824,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-data",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          }
+        ]
+      }
+    },
+    "storage-encryption": {
+      "support": "available",
+      "storage-safety": "encrypted",
+      "encryption-type": "cryptsetup"
+    }
+  }
+}

--- a/examples/snaps/v2-systems-prefer-encrypted.json
+++ b/examples/snaps/v2-systems-prefer-encrypted.json
@@ -1,0 +1,234 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "label": "classic",
+    "model": {
+      "architecture": "amd64",
+      "authority-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "base": "core22",
+      "brand-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "classic": "true",
+      "distribution": "ubuntu",
+      "grade": "dangerous",
+      "model": "mwhudson-22-classic-dangerous",
+      "serial-authority": [
+        "generic"
+      ],
+      "series": "16",
+      "sign-key-sha3-384": "AWEzKBCuROAYkR0dQfdgI95Ih9sWqwxpU1yezWkKT3EUX6LgNNgXFWSNUxC1S2_v",
+      "snaps": [
+        {
+          "default-channel": "22/edge",
+          "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+          "name": "pc",
+          "type": "gadget"
+        },
+        {
+          "default-channel": "22/edge",
+          "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+          "name": "pc-kernel",
+          "type": "kernel"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
+          "name": "core22",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+          "name": "snapd",
+          "type": "snapd"
+        }
+      ],
+      "timestamp": "2022-10-07T02:25:51+00:00",
+      "type": "model"
+    },
+    "brand": {
+      "id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "username": "mwhudson",
+      "display-name": "Michael Hudson-Doyle",
+      "validation": "unproven"
+    },
+    "actions": [
+      {
+        "title": "Install",
+        "mode": "install"
+      }
+    ],
+    "volumes": {
+      "pc": {
+        "schema": "gpt",
+        "bootloader": "grub",
+        "id": "",
+        "structure": [
+          {
+            "name": "mbr",
+            "filesystem-label": "",
+            "offset": null,
+            "offset-write": null,
+            "size": 440,
+            "type": "mbr",
+            "role": "mbr",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-boot.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "BIOS Boot",
+            "filesystem-label": "",
+            "offset": 1048576,
+            "offset-write": {
+              "relative-to": "mbr",
+              "offset": 92
+            },
+            "size": 1048576,
+            "type": "DA,21686148-6449-6E6F-744E-656564454649",
+            "role": "",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-core.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-seed",
+            "filesystem-label": "ubuntu-seed",
+            "offset": null,
+            "offset-write": null,
+            "size": 1258291200,
+            "type": "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "role": "system-seed",
+            "id": "",
+            "filesystem": "vfat",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-boot",
+            "filesystem-label": "ubuntu-boot",
+            "offset": null,
+            "offset-write": null,
+            "size": 786432000,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-boot",
+            "id": "",
+            "filesystem": "ext4",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-save",
+            "filesystem-label": "ubuntu-save",
+            "offset": null,
+            "offset-write": null,
+            "size": 33554432,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-save",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-data",
+            "filesystem-label": "ubuntu-data",
+            "offset": null,
+            "offset-write": null,
+            "size": 1073741824,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-data",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          }
+        ]
+      }
+    },
+    "storage-encryption": {
+      "support": "available",
+      "storage-safety": "prefer-encrypted",
+      "encryption-type": "cryptsetup"
+    }
+  }
+}

--- a/examples/snaps/v2-systems-prefer-unencrypted.json
+++ b/examples/snaps/v2-systems-prefer-unencrypted.json
@@ -1,0 +1,234 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "label": "classic",
+    "model": {
+      "architecture": "amd64",
+      "authority-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "base": "core22",
+      "brand-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "classic": "true",
+      "distribution": "ubuntu",
+      "grade": "dangerous",
+      "model": "mwhudson-22-classic-dangerous",
+      "serial-authority": [
+        "generic"
+      ],
+      "series": "16",
+      "sign-key-sha3-384": "AWEzKBCuROAYkR0dQfdgI95Ih9sWqwxpU1yezWkKT3EUX6LgNNgXFWSNUxC1S2_v",
+      "snaps": [
+        {
+          "default-channel": "22/edge",
+          "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+          "name": "pc",
+          "type": "gadget"
+        },
+        {
+          "default-channel": "22/edge",
+          "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+          "name": "pc-kernel",
+          "type": "kernel"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
+          "name": "core22",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+          "name": "snapd",
+          "type": "snapd"
+        }
+      ],
+      "timestamp": "2022-10-07T02:25:51+00:00",
+      "type": "model"
+    },
+    "brand": {
+      "id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "username": "mwhudson",
+      "display-name": "Michael Hudson-Doyle",
+      "validation": "unproven"
+    },
+    "actions": [
+      {
+        "title": "Install",
+        "mode": "install"
+      }
+    ],
+    "volumes": {
+      "pc": {
+        "schema": "gpt",
+        "bootloader": "grub",
+        "id": "",
+        "structure": [
+          {
+            "name": "mbr",
+            "filesystem-label": "",
+            "offset": null,
+            "offset-write": null,
+            "size": 440,
+            "type": "mbr",
+            "role": "mbr",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-boot.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "BIOS Boot",
+            "filesystem-label": "",
+            "offset": 1048576,
+            "offset-write": {
+              "relative-to": "mbr",
+              "offset": 92
+            },
+            "size": 1048576,
+            "type": "DA,21686148-6449-6E6F-744E-656564454649",
+            "role": "",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-core.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-seed",
+            "filesystem-label": "ubuntu-seed",
+            "offset": null,
+            "offset-write": null,
+            "size": 1258291200,
+            "type": "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "role": "system-seed",
+            "id": "",
+            "filesystem": "vfat",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-boot",
+            "filesystem-label": "ubuntu-boot",
+            "offset": null,
+            "offset-write": null,
+            "size": 786432000,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-boot",
+            "id": "",
+            "filesystem": "ext4",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-save",
+            "filesystem-label": "ubuntu-save",
+            "offset": null,
+            "offset-write": null,
+            "size": 33554432,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-save",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-data",
+            "filesystem-label": "ubuntu-data",
+            "offset": null,
+            "offset-write": null,
+            "size": 1073741824,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-data",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          }
+        ]
+      }
+    },
+    "storage-encryption": {
+      "support": "available",
+      "storage-safety": "prefer-unencrypted",
+      "encryption-type": "cryptsetup"
+    }
+  }
+}

--- a/examples/snaps/v2-systems-unavailable.json
+++ b/examples/snaps/v2-systems-unavailable.json
@@ -1,0 +1,234 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "label": "unavailable",
+    "model": {
+      "architecture": "amd64",
+      "authority-id": "developer1",
+      "base": "core22",
+      "brand-id": "developer1",
+      "classic": "true",
+      "distribution": "ubuntu",
+      "grade": "dangerous",
+      "model": "developer1-22-classic-dangerous",
+      "serial-authority": [
+        "generic"
+      ],
+      "series": "16",
+      "sign-key-sha3-384": "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu",
+      "snaps": [
+        {
+          "default-channel": "22/edge",
+          "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+          "name": "pc",
+          "type": "gadget"
+        },
+        {
+          "default-channel": "22/edge",
+          "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+          "name": "pc-kernel",
+          "type": "kernel"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
+          "name": "core22",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+          "name": "snapd",
+          "type": "snapd"
+        }
+      ],
+      "timestamp": "2022-09-06T22:00:00+00:00",
+      "type": "model"
+    },
+    "brand": {
+      "id": "developer1",
+      "username": "developer1",
+      "display-name": "Developer 1",
+      "validation": "unproven"
+    },
+    "actions": [
+      {
+        "title": "Install",
+        "mode": "install"
+      }
+    ],
+    "volumes": {
+      "pc": {
+        "schema": "gpt",
+        "bootloader": "grub",
+        "id": "",
+        "structure": [
+          {
+            "name": "mbr",
+            "filesystem-label": "",
+            "offset": null,
+            "offset-write": null,
+            "size": 440,
+            "type": "mbr",
+            "role": "mbr",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-boot.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "BIOS Boot",
+            "filesystem-label": "",
+            "offset": 1048576,
+            "offset-write": {
+              "relative-to": "mbr",
+              "offset": 92
+            },
+            "size": 1048576,
+            "type": "DA,21686148-6449-6E6F-744E-656564454649",
+            "role": "",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "pc-core.img",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-seed",
+            "filesystem-label": "ubuntu-seed",
+            "offset": null,
+            "offset-write": null,
+            "size": 1258291200,
+            "type": "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "role": "system-seed",
+            "id": "",
+            "filesystem": "vfat",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-boot",
+            "filesystem-label": "ubuntu-boot",
+            "offset": null,
+            "offset-write": null,
+            "size": 786432000,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-boot",
+            "id": "",
+            "filesystem": "ext4",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "offset-write": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-save",
+            "filesystem-label": "ubuntu-save",
+            "offset": null,
+            "offset-write": null,
+            "size": 33554432,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-save",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-data",
+            "filesystem-label": "ubuntu-data",
+            "offset": null,
+            "offset-write": null,
+            "size": 1073741824,
+            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-data",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          }
+        ]
+      }
+    },
+    "storage-encryption": {
+      "support": "unavailable",
+      "storage-safety": "prefer-encrypted",
+      "unavailable-reason": "not encrypting device storage as checking TPM gave: secure boot is disabled"
+    }
+  }
+}

--- a/examples/tpm-sources.yaml
+++ b/examples/tpm-sources.yaml
@@ -43,3 +43,14 @@
   type: fsimage
   variant: server
   snapd_system_label: defective
+- description:
+    en: This test source requires TPM backed full disk encryption.
+  id: src-mandatory
+  locale_support: none
+  name:
+    en: TPM encryption required.
+  path: foo.squashfs
+  size: 530485248
+  type: fsimage
+  variant: server
+  snapd_system_label: mandatory

--- a/examples/tpm-sources.yaml
+++ b/examples/tpm-sources.yaml
@@ -1,6 +1,6 @@
 - description:
     en: This test source has encryption support set to "unavailable"
-  id: ubuntu-server-minimal
+  id: src-unavailable
   locale_support: none
   name:
     en: TPM encryption unavailable.
@@ -8,4 +8,38 @@
   size: 530485248
   type: fsimage
   variant: server
-  snapd_system_label: classic
+  snapd_system_label: unavailable
+- description:
+    en: This test source has encryption support set to "prefer-encrypted" (and encryption available)
+  id: src-prefer-encrypted
+  locale_support: none
+  name:
+    en: TPM encryption preferred.
+  path: foo.squashfs
+  size: 530485248
+  type: fsimage
+  variant: server
+  snapd_system_label: prefer-encrypted
+  default: true
+- description:
+    en: This test source has encryption support set to "prefer-unencrypted" (and encryption available)
+  id: src-prefer-unencrypted
+  locale_support: none
+  name:
+    en: TPM encryption not preferred.
+  path: foo.squashfs
+  size: 530485248
+  type: fsimage
+  variant: server
+  snapd_system_label: prefer-unencrypted
+- description:
+    en: This test source has the invalid combination of encryption reqired and unavailable.
+  id: src-defective
+  locale_support: none
+  name:
+    en: TPM encryption defective.
+  path: foo.squashfs
+  size: 530485248
+  type: fsimage
+  variant: server
+  snapd_system_label: defective

--- a/examples/tpm-sources.yaml
+++ b/examples/tpm-sources.yaml
@@ -1,0 +1,11 @@
+- description:
+    en: This test source has encryption support set to "unavailable"
+  id: ubuntu-server-minimal
+  locale_support: none
+  name:
+    en: TPM encryption unavailable.
+  path: foo.squashfs
+  size: 530485248
+  type: fsimage
+  variant: server
+  snapd_system_label: classic

--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -55,6 +55,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         super().__init__(app)
         self.model = None
         self.answers.setdefault('guided', False)
+        self.answers.setdefault('tpm-default', False)
         self.answers.setdefault('guided-index', 0)
         self.answers.setdefault('manual', [])
         self.current_view: Optional[BaseView] = None
@@ -106,6 +107,9 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         while not isinstance(self.ui.body, GuidedDiskSelectionView):
             await asyncio.sleep(0.1)
 
+        if self.answers['tpm-default']:
+            self.ui.body.done(self.ui.body.form)
+            await self.app.confirm_install()
         if self.answers['guided']:
             if 'guided-index' in self.answers:
                 disk = self.ui.body.form.disks[self.answers['guided-index']]

--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -38,6 +38,7 @@ from subiquity.ui.views import (
     GuidedDiskSelectionView,
     )
 from subiquity.ui.views.filesystem.probing import (
+    DefectiveEncryptionError,
     SlowProbing,
     ProbingFailed,
     )
@@ -92,7 +93,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
     def make_guided_ui(self, status):
         se = self.storage_encryption = status.storage_encryption
         if se is not None and se.support == StorageEncryptionSupport.DEFECTIVE:
-            1/0  # should show an error page here
+            return DefectiveEncryptionError(self)
         if status.status == ProbeStatus.FAILED:
             self.app.show_error_report(status.error_report)
             return ProbingFailed(self, status.error_report)

--- a/subiquity/common/serialize.py
+++ b/subiquity/common/serialize.py
@@ -185,6 +185,7 @@ class Serializer:
             return dict(serialized)
 
     def _serialize_enum(self, annotation, context):
+        context.assert_type(annotation)
         return getattr(context.cur, self.serialize_enums_by)
 
     def _serialize(self, annotation, context):

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -320,6 +320,7 @@ class GuidedChoice:
     disk_id: str
     use_lvm: bool = False
     password: Optional[str] = attr.ib(default=None, repr=False)
+    use_tpm: bool = False
 
 
 class StorageEncryptionSupport(enum.Enum):

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -26,6 +26,8 @@ import attr
 
 from subiquitycore.models.network import NetDevInfo
 
+from subiquity.common.serialize import named_field
+
 
 class ErrorReportState(enum.Enum):
     INCOMPLETE = enum.auto()
@@ -318,6 +320,34 @@ class GuidedChoice:
     disk_id: str
     use_lvm: bool = False
     password: Optional[str] = attr.ib(default=None, repr=False)
+
+
+class StorageEncryptionSupport(enum.Enum):
+    DISABLED = 'disabled'
+    AVAILABLE = 'available'
+    UNAVAILABLE = 'unavailable'
+    DEFECTIVE = 'defective'
+
+
+class StorageSafety(enum.Enum):
+    UNSET = 'unset'
+    ENCRYPTED = 'encrypted'
+    PREFER_ENCRYPTED = 'prefer-encrypted'
+    PREFER_UNENCRYPTED = 'prefer-unencrypted'
+
+
+class EncryptionType(enum.Enum):
+    NONE = ''
+    CRYPTSETUP = 'cryptsetup'
+    DEVICE_SETUP_HOOK = 'device-setup-hook'
+
+
+@attr.s(auto_attribs=True)
+class StorageEncryption:
+    support: StorageEncryptionSupport
+    storage_safety: StorageSafety = named_field('storage-safety')
+    encryption_type: EncryptionType = named_field('encryption-type')
+    unavailable_reason: str = named_field('unavailable-reason')
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -355,6 +355,7 @@ class GuidedStorageResponse:
     status: ProbeStatus
     error_report: Optional[ErrorReportRef] = None
     disks: Optional[List[Disk]] = None
+    storage_encryption: Optional[StorageSafety] = None
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -347,8 +347,10 @@ class EncryptionType(enum.Enum):
 class StorageEncryption:
     support: StorageEncryptionSupport
     storage_safety: StorageSafety = named_field('storage-safety')
-    encryption_type: EncryptionType = named_field('encryption-type')
-    unavailable_reason: str = named_field('unavailable-reason')
+    encryption_type: EncryptionType = named_field(
+        'encryption-type', default=EncryptionType.NONE)
+    unavailable_reason: str = named_field(
+        'unavailable-reason', default='')
 
 
 @attr.s(auto_attribs=True)
@@ -356,7 +358,7 @@ class GuidedStorageResponse:
     status: ProbeStatus
     error_report: Optional[ErrorReportRef] = None
     disks: Optional[List[Disk]] = None
-    storage_encryption: Optional[StorageSafety] = None
+    storage_encryption: Optional[StorageEncryption] = None
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/models/source.py
+++ b/subiquity/models/source.py
@@ -35,6 +35,7 @@ class CatalogEntry:
     default: bool = False
     locale_support: str = attr.ib(default="locale-only")
     preinstalled_langs: typing.List[str] = attr.ib(default=attr.Factory(list))
+    snapd_system_label: typing.Optional[str] = None
 
 
 fake_entries = {

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -79,6 +79,7 @@ from subiquity.models.filesystem import (
 from subiquity.server.controller import (
     SubiquityController,
     )
+from subiquity.server.types import InstallerChannels
 
 
 log = logging.getLogger("subiquity.server.controllers.filesystem")
@@ -109,7 +110,12 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             self._probe_once, propagate_errors=False)
         self._probe_task = SingleInstanceTask(
             self._probe, propagate_errors=False, cancel_restart=False)
+        self._get_system_task = SingleInstanceTask(self._get_system)
         self.supports_resilient_boot = False
+        self.app.hub.subscribe(
+            (InstallerChannels.CONFIGURED, 'source'),
+            self._get_system_task.start_sync)
+        self._system = None
 
     def load_autoinstall_data(self, data):
         log.debug("load_autoinstall_data %s", data)
@@ -130,10 +136,19 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         await super().configured()
         self.stop_listening_udev()
 
+    async def _get_system(self):
+        label = self.app.base_model.source.current.snapd_system_label
+        if label is None:
+            self._system = None
+            return
+        self._system = await self.app.snapdapi.v2.systems[label].GET()
+        log.debug("got system %s", self._system)
+
     @with_context()
     async def apply_autoinstall_config(self, context=None):
         await self._start_task
         await self._probe_task.wait()
+        await self._get_system_task.wait()
         if False in self._errors:
             raise self._errors[False][0]
         if True in self._errors:
@@ -281,6 +296,12 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             return resp_cls(
                 status=ProbeStatus.FAILED,
                 error_report=self._errors[True][1].ref())
+        if self._get_system_task.task is None or \
+           not self._get_system_task.task.done():
+            if wait:
+                await self._get_system_task.wait()
+            else:
+                return resp_cls(status=ProbeStatus.PROBING)
         return None
 
     def full_probe_error(self):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -241,6 +241,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             'filesystem': self.fs_probe,
             }
         self.fsc._probe_task.task = mock.Mock()
+        self.fsc._get_system_task.task = mock.Mock()
         if bootloader == Bootloader.BIOS and ptable != 'msdos' and fix_bios:
             make_partition(self.model, self.disk, preserve=True,
                            flag='bios_grub', size=1 << 20, offset=1 << 20)

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -243,6 +243,15 @@ async def start_server_factory(factory, *args, **kwargs):
 @contextlib.asynccontextmanager
 async def start_server(*args, **kwargs):
     async with start_server_factory(Server, *args, **kwargs) as instance:
+        sources = await instance.get('/source')
+        await instance.post(
+            '/source', source_id=sources['sources'][0]['id'])
+        while True:
+            resp = await instance.get('/storage/v2')
+            print(resp)
+            if resp['status'] != 'PROBING':
+                break
+            await asyncio.sleep(0.5)
         yield instance
 
 

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -199,10 +199,10 @@ class GuidedChoiceForm(SubForm):
         if se is not None:
             self.remove_field('use_lvm')
             self.remove_field('lvm_options')
-            choice = choices[se.support][se.storage_safety]
-            self.use_tpm.enabled = choice.enabled
-            self.use_tpm.value = choice.default
-            self.use_tpm.help = choice.help
+            self.tpm_choice = choices[se.support][se.storage_safety]
+            self.use_tpm.enabled = self.tpm_choice.enabled
+            self.use_tpm.value = self.tpm_choice.default
+            self.use_tpm.help = self.tpm_choice.help
         else:
             self.remove_field('use_tpm')
 
@@ -323,7 +323,7 @@ class GuidedDiskSelectionView(BaseView):
         if self.storage_encryption is not None:
             choice = GuidedChoice(
                 disk_id=results['disk'].id,
-                use_tpm=results['use_tpm'])
+                use_tpm=results.get('use_tpm', sender.tpm_choice.default))
         elif results['guided']:
             choice = GuidedChoice(
                 disk_id=results['guided_choice']['disk'].id,

--- a/subiquity/ui/views/filesystem/probing.py
+++ b/subiquity/ui/views/filesystem/probing.py
@@ -96,7 +96,7 @@ class DefectiveEncryptionError(BaseView):
 
     title = _("Encryption requirements not met")
 
-    def __init__(self, controller, error_ref):
+    def __init__(self, controller):
         self.controller = controller
         super().__init__(screen([
             Text(rewrap(_(defective_text))),

--- a/subiquity/ui/views/filesystem/probing.py
+++ b/subiquity/ui/views/filesystem/probing.py
@@ -27,6 +27,7 @@ from subiquitycore.ui.spinner import (
     )
 from subiquitycore.ui.utils import (
     button_pile,
+    rewrap,
     screen,
     )
 from subiquitycore.view import BaseView
@@ -83,3 +84,25 @@ class ProbingFailed(BaseView):
 
     def show_error(self, sender=None):
         self.controller.app.show_error_report(self.error_ref)
+
+
+defective_text = _("""
+The model being installed requires TPM-backed encryption but this
+system does not support it.
+""")
+
+
+class DefectiveEncryptionError(BaseView):
+
+    title = _("Encryption requirements not met")
+
+    def __init__(self, controller, error_ref):
+        self.controller = controller
+        super().__init__(screen([
+            Text(rewrap(_(defective_text))),
+            Text(""),
+            ],
+            [other_btn(_("Back"), on_press=self.cancel)]))
+
+    def cancel(self, result=None):
+        self.controller.cancel()


### PR DESCRIPTION
This is definitely missing a few pieces (it should display an error in some situations vs just crashing) but it's a start. I'd also like to provide sample data for various different varieties of system and some integration (at least...) tests.

The main decision here are that we will change the source catalog to indicate the snapd label for the system being installed. We should probably extend this check if the system being installed defines a kernel and gadget snap -- a system that does not do this probably does not require any extra effort.