### PR TITLE
Autoinstall doc update

### DIFF
--- a/documentation/autoinstall-quickstart-s390x.md
+++ b/documentation/autoinstall-quickstart-s390x.md
@@ -6,15 +6,15 @@ This page is just a slightly adapted page of [the autoinstall quickstart page](a
 
 ## Download an ISO
 
-At the time of writing (just before focal release), the best place to go is here:
-<http://cdimage.ubuntu.com/ubuntu/releases/20.04/release/>
+At the time of writing (just after the kinetic release), the best place to go is here:
+<https://cdimage.ubuntu.com/ubuntu/releases/22.10/release/>
 
-<pre><code>wget http://cdimage.ubuntu.com/ubuntu/releases/20.04/release/ubuntu-20.04-live-server-s390x.iso -P ~/Downloads</code></pre>
+<pre><code>wget https://cdimage.ubuntu.com/ubuntu/releases/22.10/release/ubuntu-22.10-live-server-s390x.iso -P ~/Downloads</code></pre>
 
 ## Mount the ISO
 
 <pre><code>mkdir -p ~/iso
-sudo mount -r ~/Downloads/ubuntu-20.04-live-server-s390x.iso ~/iso</code></pre>
+sudo mount -r ~/Downloads/ubuntu-22.10-live-server-s390x.iso ~/iso</code></pre>
 
 ## Write your autoinstall config
 
@@ -74,7 +74,7 @@ You may need to add the default user to the kvm group:  <<BR>>
 
 <pre><code>kvm -no-reboot -name auto-inst-test -nographic -m 2048 \
     -drive file=disk-image.qcow2,format=qcow2,cache=none,if=virtio \
-    -cdrom ~/Downloads/ubuntu-20.04-live-server-s390x.iso \
+    -cdrom ~/Downloads/ubuntu-22.10-live-server-s390x.iso \
     -kernel ~/iso/boot/kernel.ubuntu \
     -initrd ~/iso/boot/initrd.ubuntu \
     -append 'autoinstall ds=nocloud-net;s=http://_gateway:3003/ console=ttysclp0'</code></pre>

--- a/documentation/autoinstall-quickstart.md
+++ b/documentation/autoinstall-quickstart.md
@@ -50,7 +50,7 @@ python3 -m http.server 3003</code></pre>
 
 ### Run the install!
 
-<pre><code>kvm -no-reboot -m 1024 \
+<pre><code>kvm -no-reboot -m 2048 \
     -drive file=image.img,format=raw,cache=none,if=virtio \
     -cdrom ~/Downloads/ubuntu-22.10-live-server-amd64.iso \
     -kernel /mnt/casper/vmlinuz \
@@ -61,7 +61,7 @@ This will boot, download the config from the server set up in the previous step 
 
 ### Boot the installed system
 
-<pre><code>kvm -no-reboot -m 1024 \
+<pre><code>kvm -no-reboot -m 2048 \
     -drive file=image.img,format=raw,cache=none,if=virtio</code></pre>
 
 This will boot into the freshly installed system and you should be able to log in as ubuntu/ubuntu.
@@ -102,7 +102,7 @@ cloud-localds ~/seed.iso user-data meta-data</code></pre>
 
 ### Run the install!
 
-<pre><code>kvm -no-reboot -m 1024 \
+<pre><code>kvm -no-reboot -m 2048 \
     -drive file=image.img,format=raw,cache=none,if=virtio \
     -drive file=~/seed.iso,format=raw,cache=none,if=virtio \
     -cdrom ~/Downloads/ubuntu-22.10-live-server-amd64.iso</code></pre>
@@ -115,7 +115,7 @@ The whole process should take about 5 minutes.
 
 ### Boot the installed system
 
-<pre><code>kvm -no-reboot -m 1024 \
+<pre><code>kvm -no-reboot -m 2048 \
     -drive file=image.img,format=raw,cache=none,if=virtio</code></pre>
 
 This will boot into the freshly installed system and you should be able to log in as ubuntu/ubuntu.

--- a/documentation/autoinstall-quickstart.md
+++ b/documentation/autoinstall-quickstart.md
@@ -2,7 +2,9 @@
 
 The intent of this page is to provide simple instructions to perform an autoinstall in a VM on your machine.
 
-This page assumes you are on the amd64 architecture. There is a version for [s390x](autoinstall-quickstart-s390x.md) too.
+This page assumes that you are willing to install the latest Ubuntu release available i.e., 22.10 at the time of writing. For other releases, you would need to substitute the name of the ISO image but the instructions should otherwise remain the same.
+
+This page also assumes you are on the amd64 architecture. There is a version for [s390x](autoinstall-quickstart-s390x.md) too.
 
 ## Providing the autoinstall data over the network
 
@@ -10,11 +12,11 @@ This method is the one that generalizes most easily to doing an entirely network
 
 ### Download the ISO
 
-Go to the [20.04 ISO download page](http://releases.ubuntu.com/20.04/) and download the latest Ubuntu 20.04 live-server ISO.
+Go to the [22.10 ISO download page](https://releases.ubuntu.com/22.10/) and download the latest Ubuntu 22.10 live-server ISO.
 
 ### Mount the ISO
 
-<pre><code>sudo mount -r ~/Downloads/ubuntu-20.04-live-server-amd64.iso /mnt</code></pre>
+<pre><code>sudo mount -r ~/Downloads/ubuntu-22.10-live-server-amd64.iso /mnt</code></pre>
 
 ### Write your autoinstall config
 
@@ -50,7 +52,7 @@ python3 -m http.server 3003</code></pre>
 
 <pre><code>kvm -no-reboot -m 1024 \
     -drive file=image.img,format=raw,cache=none,if=virtio \
-    -cdrom ~/Downloads/ubuntu-20.04-live-server-amd64.iso \
+    -cdrom ~/Downloads/ubuntu-22.10-live-server-amd64.iso \
     -kernel /mnt/casper/vmlinuz \
     -initrd /mnt/casper/initrd \
     -append 'autoinstall ds=nocloud-net;s=http://_gateway:3003/'</code></pre>
@@ -70,7 +72,7 @@ This is the method to use when you want to create media that you can just plug i
 
 ### Download the live-server ISO
 
-Go to the [20.04 ISO download page](http://releases.ubuntu.com/20.04/) and download the latest Ubuntu 20.04 live-server ISO.
+Go to the [22.10 ISO download page](https://releases.ubuntu.com/22.10/) and download the latest Ubuntu 22.10 live-server ISO.
 
 ### Create your user-data & meta-data files
 
@@ -103,7 +105,7 @@ cloud-localds ~/seed.iso user-data meta-data</code></pre>
 <pre><code>kvm -no-reboot -m 1024 \
     -drive file=image.img,format=raw,cache=none,if=virtio \
     -drive file=~/seed.iso,format=raw,cache=none,if=virtio \
-    -cdrom ~/Downloads/ubuntu-20.04-live-server-amd64.iso</code></pre>
+    -cdrom ~/Downloads/ubuntu-22.10-live-server-amd64.iso</code></pre>
 
 This will boot and run the install. Unless you interrupt boot to add 'autoinstall' to the kernel command line, the installer will prompt for confirmation before touching the disk.
 

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -504,7 +504,7 @@ Supported values are:
 ### shutdown
 
 **type:** string (enumeration)
-**default:** do nothing
+**default:** `reboot`
 **can be interactive:** no
 
 Request the system to shutdown or reboot automatically after the installation has finished.

--- a/documentation/autoinstall.md
+++ b/documentation/autoinstall.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The server installer for 20.04 supports a new mode of operation: automated installation, autoinstallation for short. You might also know this feature as unattended or handsoff or preseeded installation.
+Since version 20.04, the server installer supports the automated installation mode, autoinstallation for short. You might also know this feature as unattended or handsoff or preseeded installation.
 
 Autoinstallation lets you answer all those configuration questions ahead of time with an *autoinstall config* and lets the installation process run without any interaction.
 


### PR DESCRIPTION
This PR namely updates the quickstart guides (both the generic one and the one specific for s390x).
The instructions still apply well with the new kinetic release. I did testing with 1024MiB of RAM and it worked surprisingly well but I still decided to bump this value to 2048MiB ; which seems reasonable, The s390x quickstart guide already used 2048MiB of RAM so it is now consistent.

I didn't find a good way to avoid making the documentation dependent on a specific ubuntu release. Therefore, the documentation explicitly mentions 22.10 / kinetic but the instructions work the same on a jammy or focal image (tested).

It also fixes a mistake in the shutdown autoinstall section ; where the default value that I documented was wrong.

I think once I address any potential comments, the document will be ready to be published on discourse / wiki.