### PR TITLE
Ensure the first user is in the users group and not in the lxd group

### DIFF
--- a/subiquity/models/tests/test_subiquity.py
+++ b/subiquity/models/tests/test_subiquity.py
@@ -56,7 +56,7 @@ uucp:x:10:
 man:x:12:
 sudo:x:27:
 ssh:x:118:
-lxd:x:132:
+users:x:100:
 '''
 
 
@@ -229,7 +229,7 @@ class TestSubiquityModel(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(cloud_init_config['users'][0]['name'], 'mainuser')
             self.assertEqual(
                 cloud_init_config['users'][0]['groups'],
-                'adm,lxd,sudo'
+                'adm,sudo,users'
             )
             self.assertEqual(cloud_init_config['users'][1]['name'], 'user2')
             run_cmd.assert_called_with(['getent', 'group'], check=True)

--- a/users-and-groups
+++ b/users-and-groups
@@ -1,1 +1,1 @@
-adm cdrom dip lpadmin plugdev sambashare debian-tor libvirtd lxd
+adm cdrom dip lpadmin plugdev sambashare debian-tor libvirtd users


### PR DESCRIPTION
Ensure the first user is in the users group and not in the lxd group.  This is necessary for new installs to support unprivileged lxd