### PR TITLE
codecs: add ability to install ubuntu-restricted-addons

### DIFF
--- a/autoinstall-schema.json
+++ b/autoinstall-schema.json
@@ -420,6 +420,14 @@
                 "additionalProperties": false
             }
         },
+        "codecs": {
+            "type": "object",
+            "properties": {
+                "install": {
+                    "type": "boolean"
+                }
+            }
+        },
         "drivers": {
             "type": "object",
             "properties": {

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -411,6 +411,23 @@ A list of SSH public keys to install in the initial user's account.
 **type:** boolean
 **default:** `true` if `authorized_keys` is empty, `false` otherwise
 
+<a name="codecs"></a>
+
+### codecs
+
+**type:** mapping, see below
+**default:** see below
+**can be interactive:** no
+
+Configure whether common restricted packages (including codecs) from [multiverse] should be installed.
+
+#### install
+
+**type:** boolean
+**default:** `false`
+
+Whether to install the ubuntu-restricted-addons package.
+
 <a name="drivers"></a>
 
 ### drivers

--- a/documentation/autoinstall-schema.md
+++ b/documentation/autoinstall-schema.md
@@ -442,6 +442,14 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
                 "additionalProperties": false
             }
         },
+        "codecs": {
+            "type": "object",
+            "properties": {
+                "install": {
+                    "type": "boolean"
+                }
+            }
+        },
         "drivers": {
             "type": "object",
             "properties": {

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -44,6 +44,7 @@ from subiquity.common.types import (
     ReformatDisk,
     RefreshStatus,
     ShutdownMode,
+    CodecsData,
     DriversResponse,
     DriversPayload,
     SnapInfo,
@@ -315,6 +316,10 @@ class API:
                 """
                 def POST(data: Payload[ModifyPartitionV2]) \
                     -> StorageResponseV2: ...
+
+    class codecs:
+        def GET() -> CodecsData: ...
+        def POST(data: Payload[CodecsData]) -> None: ...
 
     class drivers:
         def GET(wait: bool = False) -> DriversResponse: ...

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -543,6 +543,11 @@ class DriversResponse:
 
 
 @attr.s(auto_attribs=True)
+class CodecsData:
+    install: bool
+
+
+@attr.s(auto_attribs=True)
 class DriversPayload:
     install: bool
 

--- a/subiquity/models/codecs.py
+++ b/subiquity/models/codecs.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+log = logging.getLogger('subiquity.models.codecs')
+
+
+class CodecsModel:
+    do_install = False
+
+    async def target_packages(self):
+        # NOTE currently, ubuntu-restricted-addons is an empty package that
+        # pulls relevant packages through Recommends: Ideally, we should make
+        # sure to run the APT command for this package with the
+        # --install-recommends option.
+        return ["ubuntu-restricted-addons"] if self.do_install else []

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -46,6 +46,7 @@ from subiquitycore.lsb_release import lsb_release
 from subiquity.common.resources import get_users_and_groups
 from subiquity.server.types import InstallerChannels
 
+from .codecs import CodecsModel
 from .drivers import DriversModel
 from .filesystem import FilesystemModel
 from .identity import IdentityModel
@@ -173,6 +174,7 @@ class SubiquityModel:
             self.target = root
             self.chroot_prefix = []
 
+        self.codecs = CodecsModel()
         self.debconf_selections = DebconfSelectionsModel()
         self.drivers = DriversModel()
         self.filesystem = FilesystemModel()

--- a/subiquity/server/controllers/__init__.py
+++ b/subiquity/server/controllers/__init__.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .cmdlist import EarlyController, LateController, ErrorController
+from .codecs import CodecsController
 from .debconf import DebconfController
 from .drivers import DriversController
 from .filesystem import FilesystemController
@@ -39,6 +40,7 @@ from .userdata import UserdataController
 from .zdev import ZdevController
 
 __all__ = [
+    'CodecsController',
     'DebconfController',
     'DriversController',
     'EarlyController',

--- a/subiquity/server/controllers/codecs.py
+++ b/subiquity/server/controllers/codecs.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from subiquity.common.apidef import API
+from subiquity.common.types import CodecsData
+from subiquity.server.controller import SubiquityController
+
+log = logging.getLogger('subiquity.server.controllers.codecs')
+
+
+class CodecsController(SubiquityController):
+
+    endpoint = API.codecs
+
+    autoinstall_key = model_name = "codecs"
+    autoinstall_schema = {
+        'type': 'object',
+        'properties': {
+            'install': {
+                'type': 'boolean',
+            },
+        },
+    }
+    autoinstall_default = {"install": False}
+
+    def serialize(self):
+        return self.model.do_install
+
+    def deserialize(self, data):
+        if data is None:
+            return
+        self.model.do_install = data
+
+    def make_autoinstall(self):
+        return {
+            "install": self.model.do_install,
+        }
+
+    def load_autoinstall_data(self, data):
+        if data is not None and "install" in data:
+            self.model.do_install = data["install"]
+
+    async def GET(self) -> CodecsData:
+        return CodecsData(install=self.model.do_install)
+
+    async def POST(self, data: CodecsData) -> None:
+        self.model.do_install = data.install
+        await self.configured()

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -217,7 +217,7 @@ POSTINSTALL_MODEL_NAMES = ModelNames({
     "ubuntu_pro",
     "userdata",
     },
-    desktop={"timezone"})
+    desktop={"timezone", "codecs"})
 
 
 class SubiquityServer(Application):
@@ -260,6 +260,7 @@ class SubiquityServer(Application):
         "Identity",
         "SSH",
         "SnapList",
+        "Codecs",
         "Drivers",
         "TimeZone",
         "Install",


### PR DESCRIPTION
Subiquity now supports a new endpoint that can be used by the desktop installer to configure whether the `ubuntu-restricted-addons` package should be installed. This package contains third-party codecs commonly used on a desktop install.

```bash
$ curl --unix-socket /run/subiquity/socket http://a/codecs
{"install": false}

$ curl --unix-socket /run/subiquity/socket http://a/codecs -d '{"install": true}'

$ curl --unix-socket /run/subiquity/socket http://a/codecs
{"install": true}
```
I was considering naming this endpoint something else than `codecs`, like `restricted-addons` maybe?