### PR TITLE
doc: backport documentation updates for kinetic

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -12,6 +12,7 @@ libnl-route-3-dev
 libsystemd-dev
 lsb-release
 os-prober
+pandoc
 pep8
 pkg-config
 python3-aiohttp

--- a/documentation/.gitignore
+++ b/documentation/.gitignore
@@ -1,0 +1,2 @@
+/discourse/
+/html/

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -1,0 +1,29 @@
+SRC = $(wildcard *.md)
+
+DISCOURSE_MD = $(addprefix discourse/, $(SRC))
+HTML_MD = $(addprefix html/, $(SRC))
+HTML = $(HTML_MD:.md=.html)
+
+discourse/%.md: %.md
+	@mkdir --parents discourse
+	python3 ./substitute-links.py md-to-discourse --input $^ --output $@
+
+html/%.md: %.md
+	@mkdir --parents html
+	python3 ./substitute-links.py md-to-html --input $^ --output $@
+
+%.html: %.md
+	pandoc $^ --standalone --output $@
+
+.PHONY: html
+html: $(HTML)
+
+.PHONY: discourse
+discourse: $(DISCOURSE_MD)
+
+.PHONY: clean
+clean:
+	$(RM) $(DISCOURSE_MD)
+	$(RM) -d discourse
+	$(RM) $(HTML)
+	$(RM) -d html

--- a/documentation/autoinstall-quickstart-s390x.md
+++ b/documentation/autoinstall-quickstart-s390x.md
@@ -1,0 +1,91 @@
+# Autoinstall Quick Start for s390x
+
+The intent of this page is to provide simple instructions to perform an autoinstall in a VM on your machine on s390x.
+
+This page is just a slightly adapted page of [the autoinstall quickstart page](autoinstall-quickstart.md) mapped to s390x.
+
+## Download an ISO
+
+At the time of writing (just after the kinetic release), the best place to go is here:
+<https://cdimage.ubuntu.com/ubuntu/releases/22.10/release/>
+
+<pre><code>wget https://cdimage.ubuntu.com/ubuntu/releases/22.10/release/ubuntu-22.10-live-server-s390x.iso -P ~/Downloads</code></pre>
+
+## Mount the ISO
+
+<pre><code>mkdir -p ~/iso
+sudo mount -r ~/Downloads/ubuntu-22.10-live-server-s390x.iso ~/iso</code></pre>
+
+## Write your autoinstall config
+
+This means creating cloud-init config as follows:
+
+<pre><code>mkdir -p ~/www
+cd ~/www
+cat > user-data << 'EOF'
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: ubuntu-server
+    password: "$6$exDY1mhS4KUYCE/2$zmn9ToZwTKLhCw.b4/b.ZRTIZM30JZ4QrOQ2aOXJ8yk96xpcCof0kxKwuX1kqLG/ygbJ1f8wxED22bTL4F46P0"
+    username: ubuntu
+EOF
+touch meta-data</code></pre>
+
+The crypted password is just "ubuntu".
+
+## Serve the cloud-init config over http
+
+Leave this running in one terminal window:
+
+<pre><code>cd ~/www
+python3 -m http.server 3003</code></pre>
+
+## Create a target disk
+
+Proceed with a second terminal window:
+
+<pre><code>sudo apt install qemu-utils
+...</code></pre>
+
+<pre><code>qemu-img create -f qcow2 disk-image.qcow2 10G
+Formatting 'disk-image.qcow2', fmt=qcow2 size=10737418240 cluster_size=65536 lazy_refcounts=off refcount_bits=16
+
+qemu-img info disk-image.qcow2
+image: disk-image.qcow2
+file format: qcow2
+virtual size: 10 GiB (10737418240 bytes)
+disk size: 196 KiB
+cluster_size: 65536
+Format specific information:
+    compat: 1.1
+    lazy refcounts: false
+    refcount bits: 16
+    corrupt: false</code></pre>
+
+## Run the install!
+
+<pre><code>sudo apt install qemu-kvm
+...</code></pre>
+
+You may need to add the default user to the kvm group:  <<BR>>
+`sudo usermod -a -G kvm ubuntu   # re-login to make the changes take effect`
+
+<pre><code>kvm -no-reboot -name auto-inst-test -nographic -m 2048 \
+    -drive file=disk-image.qcow2,format=qcow2,cache=none,if=virtio \
+    -cdrom ~/Downloads/ubuntu-22.10-live-server-s390x.iso \
+    -kernel ~/iso/boot/kernel.ubuntu \
+    -initrd ~/iso/boot/initrd.ubuntu \
+    -append 'autoinstall ds=nocloud-net;s=http://_gateway:3003/ console=ttysclp0'</code></pre>
+
+This will boot, download the config from the server set up in the previous step and run the install.
+The installer reboots at the end but the -no-reboot flag to kvm means that kvm will exit when this happens.
+It should take about 5 minutes.
+
+## Boot the installed system
+
+<pre><code>kvm -no-reboot -name auto-inst-test -nographic -m 2048 \
+    -drive file=disk-image.qcow2,format=qcow2,cache=none,if=virtio</code></pre>
+
+This will boot into the freshly installed system and you should be able to log in as ubuntu/ubuntu.

--- a/documentation/autoinstall-quickstart.md
+++ b/documentation/autoinstall-quickstart.md
@@ -1,0 +1,121 @@
+# Autoinstall Quick Start
+
+The intent of this page is to provide simple instructions to perform an autoinstall in a VM on your machine.
+
+This page assumes that you are willing to install the latest Ubuntu release available i.e., 22.10 at the time of writing. For other releases, you would need to substitute the name of the ISO image but the instructions should otherwise remain the same.
+
+This page also assumes you are on the amd64 architecture. There is a version for [s390x](autoinstall-quickstart-s390x.md) too.
+
+## Providing the autoinstall data over the network
+
+This method is the one that generalizes most easily to doing an entirely network-based install, where a machine netboots and then is automatically installed.
+
+### Download the ISO
+
+Go to the [22.10 ISO download page](https://releases.ubuntu.com/22.10/) and download the latest Ubuntu 22.10 live-server ISO.
+
+### Mount the ISO
+
+<pre><code>sudo mount -r ~/Downloads/ubuntu-22.10-live-server-amd64.iso /mnt</code></pre>
+
+### Write your autoinstall config
+
+This means creating cloud-init config as follows:
+
+<pre><code>mkdir -p ~/www
+cd ~/www
+cat > user-data << 'EOF'
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: ubuntu-server
+    password: "$6$exDY1mhS4KUYCE/2$zmn9ToZwTKLhCw.b4/b.ZRTIZM30JZ4QrOQ2aOXJ8yk96xpcCof0kxKwuX1kqLG/ygbJ1f8wxED22bTL4F46P0"
+    username: ubuntu
+EOF
+touch meta-data</code></pre>
+
+The crypted password is just "ubuntu".
+
+### Serve the cloud-init config over http
+
+Leave this running in one terminal window:
+
+<pre><code>cd ~/www
+python3 -m http.server 3003</code></pre>
+
+### Create a target disk
+
+<pre><code>truncate -s 10G image.img</code></pre>
+
+### Run the install!
+
+<pre><code>kvm -no-reboot -m 2048 \
+    -drive file=image.img,format=raw,cache=none,if=virtio \
+    -cdrom ~/Downloads/ubuntu-22.10-live-server-amd64.iso \
+    -kernel /mnt/casper/vmlinuz \
+    -initrd /mnt/casper/initrd \
+    -append 'autoinstall ds=nocloud-net;s=http://_gateway:3003/'</code></pre>
+
+This will boot, download the config from the server set up in the previous step and run the install. The installer reboots at the end but the -no-reboot flag to kvm means that kvm will exit when this happens. It should take about 5 minutes.
+
+### Boot the installed system
+
+<pre><code>kvm -no-reboot -m 2048 \
+    -drive file=image.img,format=raw,cache=none,if=virtio</code></pre>
+
+This will boot into the freshly installed system and you should be able to log in as ubuntu/ubuntu.
+
+## Using another volume to provide the autoinstall config
+
+This is the method to use when you want to create media that you can just plug into a system to have it be installed.
+
+### Download the live-server ISO
+
+Go to the [22.10 ISO download page](https://releases.ubuntu.com/22.10/) and download the latest Ubuntu 22.10 live-server ISO.
+
+### Create your user-data & meta-data files
+
+<pre><code>mkdir -p ~/cidata
+cd ~/cidata
+cat > user-data << 'EOF'
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: ubuntu-server
+    password: "$6$exDY1mhS4KUYCE/2$zmn9ToZwTKLhCw.b4/b.ZRTIZM30JZ4QrOQ2aOXJ8yk96xpcCof0kxKwuX1kqLG/ygbJ1f8wxED22bTL4F46P0"
+    username: ubuntu
+EOF
+touch meta-data</code></pre>
+
+The crypted password is just "ubuntu".
+
+### Create an ISO to use as a cloud-init data source
+
+<pre><code>sudo apt install cloud-image-utils
+cloud-localds ~/seed.iso user-data meta-data</code></pre>
+
+### Create a target disk
+
+<pre><code>truncate -s 10G image.img</code></pre>
+
+### Run the install!
+
+<pre><code>kvm -no-reboot -m 2048 \
+    -drive file=image.img,format=raw,cache=none,if=virtio \
+    -drive file=~/seed.iso,format=raw,cache=none,if=virtio \
+    -cdrom ~/Downloads/ubuntu-22.10-live-server-amd64.iso</code></pre>
+
+This will boot and run the install. Unless you interrupt boot to add 'autoinstall' to the kernel command line, the installer will prompt for confirmation before touching the disk.
+
+The installer reboots at the end but the -no-reboot flag to kvm means that kvm will exit when this happens.
+
+The whole process should take about 5 minutes.
+
+### Boot the installed system
+
+<pre><code>kvm -no-reboot -m 2048 \
+    -drive file=image.img,format=raw,cache=none,if=virtio</code></pre>
+
+This will boot into the freshly installed system and you should be able to log in as ubuntu/ubuntu.

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -1,0 +1,598 @@
+# Automated Server Installs Config File Reference
+
+## Overall format
+
+The autoinstall file is YAML. At top level it must be a mapping containing the keys described in this document. Unrecognized keys are ignored.
+
+## Schema
+
+Autoinstall configs [are validated against a JSON schema](autoinstall-schema.md) before they are used.
+
+<a name="commandlist"></a>
+
+## Command lists
+
+Several config keys are lists of commands to be executed. Each command can be a string (in which case it is executed via "sh -c") or a list, in which case it is executed directly. Any command exiting with a non-zero return code is considered an error and aborts the install (except for error-commands, where it is ignored).
+
+## Top-level keys
+
+<a name="version"></a>
+
+### version
+
+**type:** integer
+**default:** no default
+
+A future-proofing config file version field. Currently this must be "1".
+
+<a name="interactive-sections"></a>
+
+### interactive-sections
+
+**type:** list of strings
+**default:** []
+
+A list of config keys to still show in the UI. So for example:
+
+    version: 1
+    interactive-sections:
+     - network
+    identity:
+     username: ubuntu
+     password: $crypted_pass
+
+Would stop on the network screen and allow the user to change the defaults. If a value is provided for an interactive section it is used as the default.
+
+You can use the special section name of "\*" to indicate that the installer should ask all the usual questions -- in this case, the `autoinstall.yaml` file is not really an "autoinstall" file at all, instead just a way to change the defaults in the UI.
+
+Not all config keys correspond to screens in the UI. This documentation indicates if a given section can be interactive or not.
+
+If there are any interactive sections at all, the [reporting](#reporting) key is ignored.
+
+<a name="early-commands"></a>
+
+### early-commands
+
+**type:** [command list](#commandlist)
+**default:** no commands
+**can be interactive:** no
+
+A list of shell commands to invoke as soon as the installer starts, in particular before probing for block and network devices. The autoinstall config is available at `/autoinstall.yaml` (irrespective of how it was provided) and the file will be re-read after the `early-commands` have run to allow them to alter the config if necessary.
+
+<a name="locale"></a>
+
+### locale
+
+**type:** string
+**default:** `en_US.UTF-8`
+**can be interactive:** yes, always interactive if any section is
+
+The locale to configure for the installed system.
+
+<a name="refresh-installer"></a>
+
+### refresh-installer
+
+**type:** mapping
+**default:** see below
+**can be interactive:** yes
+
+Controls whether the installer updates to a new version available in the given channel before continuing.
+
+The mapping contains keys:
+
+#### update
+
+**type:** boolean
+**default:** `no`
+
+Whether to update or not.
+
+#### channel
+
+**type:** string
+**default:** `"stable/ubuntu-$REL"`
+
+The channel to check for updates.
+
+<a name="keyboard"></a>
+
+### keyboard
+
+**type:** mapping, see below
+**default:** US English keyboard
+**can be interactive:** yes
+
+The layout of any attached keyboard. Often systems being automatically installed will not have a keyboard at all in which case the value used here does not matter.
+
+The mapping's keys correspond to settings in the `/etc/default/keyboard` configuration file. See [its manual page](http://manpages.ubuntu.com/manpages/bionic/en/man5/keyboard.5.html) for more details.
+
+The mapping contains keys:
+
+#### layout
+
+**type:** string
+**default:** `"us"`
+
+Corresponds to the `XKBLAYOUT` setting.
+
+#### variant
+
+**type:** string
+**default:** `""`
+
+Corresponds to the `XKBVARIANT` setting.
+
+#### toggle
+
+**type:** string or null
+**default:** `null`
+
+Corresponds to the value of `grp:` option from the `XKBOPTIONS` setting. Acceptable values are (but note that the installer does not validate these): `caps_toggle`, `toggle`, `rctrl_toggle`, `rshift_toggle`, `rwin_toggle`, `menu_toggle`, `alt_shift_toggle`, `ctrl_shift_toggle`, `ctrl_alt_toggle`, `alt_caps_toggle`, `lctrl_lshift_toggle`, `lalt_toggle`, `lctrl_toggle`, `lshift_toggle`, `lwin_toggle`, `sclk_toggle`
+
+The version of subiquity released with 20.04 GA does not accept `null` for this field due to a bug.
+
+### source
+**type:** mapping, see below
+**default:** see below
+**can be interactive:** yes
+
+#### search_drivers
+**type:** boolean
+**default:** `true`
+
+Whether the installer should search for available third-party drivers. When set to `false`, it disables the drivers screen and [section](#drivers).
+
+#### id
+**type:** string
+**default:** identifier of the first available source.
+
+Identifier of the source to install (e.g., `"ubuntu-server-minimized"`).
+
+<a name="network"></a>
+
+### network
+
+**type:** netplan-format mapping, see below
+**default:** DHCP on interfaces named eth\* or en\*
+**can be interactive:** yes
+
+[netplan](https://netplan.io/reference) formatted network configuration. This will be applied during installation as well as in the installed system. The default is to interpret the config for the install media, which runs DHCPv4 on any interface with a name matching "eth\*" or "en\*" but then disables any interface that does not receive an address.
+
+For example, to run dhcp6 on a particular NIC:
+
+    network:
+      version: 2
+      ethernets:
+        enp0s31f6:
+          dhcp6: yes
+
+Note that thanks to a bug, the version of subiquity released with 20.04 GA forces you to write this with an extra "network:" key like so:
+
+    network:
+      network:
+        version: 2
+        ethernets:
+          enp0s31f6:
+            dhcp6: yes
+
+Later versions support this syntax too for compatibility but if you can assume a newer version you should use the former.
+
+<a name="proxy"></a>
+
+### proxy
+
+**type:** URL or `null`
+**default:** no proxy
+**can be interactive:** yes
+
+The proxy to configure both during installation and for apt and for snapd in the target system.
+
+<a name="apt"></a>
+
+### apt
+
+**type:** mapping
+**default:** see below
+**can be interactive:** yes
+
+Apt configuration, used both during the install and once booted into the target system.
+
+This uses the same format as curtin which is documented at https://curtin.readthedocs.io/en/latest/topics/apt_source.html, with one extension: the `geoip` key controls whether a geoip lookup is done.
+
+The default is:
+
+    apt:
+        preserve_sources_list: false
+        primary:
+            - arches: [i386, amd64]
+              uri: "http://archive.ubuntu.com/ubuntu"
+            - arches: [default]
+              uri: "http://ports.ubuntu.com/ubuntu-ports"
+        geoip: true
+
+If geoip is true and the mirror to be used is the default, a request is made to `https://geoip.ubuntu.com/lookup` and the mirror uri to be used changed to be `http://CC.archive.ubuntu.com/ubuntu` where `CC` is the country code returned by the lookup (or similar for ports). If this section is not interactive, the request is timed out after 10 seconds.
+
+Any supplied config is merged with the default rather than replacing it.
+
+If you just want to set a mirror, use a config like this:
+
+    apt:
+        primary:
+            - arches: [default]
+              uri: YOUR_MIRROR_GOES_HERE
+
+To add a ppa:
+
+    apt:
+        sources:
+            curtin-ppa:
+                source: ppa:curtin-dev/test-archive
+
+<a name="storage"></a>
+
+### storage
+
+**type:** mapping, see below
+**default:** use "lvm" layout in a single disk system, no default in a multiple disk system
+**can be interactive:** yes
+
+Storage configuration is a complex topic and the description of the desired configuration in the autoinstall file can necessarily also be complex. The installer supports "layouts", simple ways of expressing common configurations.
+
+#### Supported layouts
+
+The two supported layouts at the time of writing are "lvm" and "direct".
+
+    storage:
+      layout:
+        name: lvm
+    storage:
+      layout:
+        name: direct
+
+By default these will install to the largest disk in a system, but you can supply a match spec (see below) to indicate which disk to use:
+
+    storage:
+      layout:
+        name: lvm
+        match:
+          serial: CT*
+    storage:
+      layout:
+        name: disk
+        match:
+          ssd: yes
+
+(you can just say "`match: {}`" to match an arbitrary disk)
+
+The default is to use the lvm layout.
+
+#### action-based config
+
+For full flexibility, the installer allows storage configuration to be done using a syntax which is a superset of that supported by curtin, described at https://curtin.readthedocs.io/en/latest/topics/storage.html. 
+
+If the "layout" feature is used to configure the disks, the "config" section will not be used.
+
+As well as putting the list of actions under the 'config' key, the [grub](https://curtin.readthedocs.io/en/latest/topics/config.html#grub) and [swap](https://curtin.readthedocs.io/en/latest/topics/config.html#swap) curtin config items can be put here. So a storage section might look like:
+
+    storage:
+        swap:
+            size: 0
+        config:
+            - type: disk
+              id: disk0
+              serial: ADATA_SX8200PNP_XXXXXXXXXXX
+            - type: partition
+              ...
+
+The extensions to the curtin syntax are around disk selection and partition/logical volume sizing. 
+
+##### Disk selection extensions
+
+Curtin supported identifying disks by serial (e.g. `Crucial_CT512MX100SSD1_14250C57FECE`) or by path (e.g. `/dev/sdc`) and the server installer supports this as well. The installer additionally supports a ''match spec'' on a disk action that supports more flexible matching.
+
+The actions in the storage config are processed in the order they are in the autoinstall file. Any disk action is assigned a matching disk -- chosen arbitrarily from the set of unassigned disks if there is more than one, and causing the installation to fail if there is no unassigned matching disk.
+
+A match spec supports the following keys:
+
+ * `model: foo`: matches a disk where ID_VENDOR=foo in udev, supporting globbing
+ * `path: foo`: matches a disk where DEVPATH=foo in udev, supporting globbing (the globbing support distinguishes this from specifying path: foo directly in the disk action)
+ * `serial: foo`: matches a disk where ID_SERIAL=foo in udev, supporting globbing (the globbing support distinguishes this from specifying serial: foo directly in the disk action)
+ * `ssd: yes|no`: matches a disk that is or is not an SSD (vs a rotating drive)
+ * `size: largest|smallest`: take the largest or smallest disk rather than an arbitrary one if there are multiple matches (support for `smallest` added in version 20.06.1)
+
+So for example, to match an arbitrary disk it is simply:
+
+     - type: disk
+       id: disk0
+
+To match the largest ssd:
+
+<pre><code> - type: disk
+   id: big-fast-disk
+   match:
+     ssd: yes
+     size: largest</code></pre>
+
+To match a Seagate drive:
+
+<pre><code> - type: disk
+   id: data-disk
+   match:
+     model: Seagate</code></pre>
+
+##### partition/logical volume extensions
+
+The size of a partition or logical volume in curtin is specified as a number of bytes. The autoinstall config is more flexible:
+
+ * You can specify the size using the "1G", "512M" syntax supported in the installer UI
+ * You can specify the size as a percentage of the containing disk (or RAID), e.g. "50%"
+ * For the last partition specified for a particular device, you can specify the size as "-1" to indicate that the partition should fill the remaining space.
+
+<pre><code> - type: partition
+   id: boot-partition
+   device: root-disk
+   size: 10%
+ - type: partition
+   id: root-partition
+   size: 20G
+ - type: partition
+   id: data-partition
+   device: root-disk
+   size: -1</code></pre>
+
+<a name="identity"></a>
+
+### identity
+
+**type:** mapping, see below
+**default:** no default
+**can be interactive:** yes
+
+Configure the initial user for the system. This is the only config key that must be present (unless the [user-data section](#user-data) is present, in which case it is optional).
+
+A mapping that can contain keys, all of which take string values:
+
+#### realname
+
+The real name for the user. This field is optional.
+
+#### username
+
+The user name to create.
+
+#### hostname
+
+The hostname for the system.
+
+#### password
+
+The password for the new user, crypted. This is required for use with sudo, even if SSH access is configured.
+
+### ubuntu-pro
+
+**type:** mapping, see below
+**default:** see below
+**can be interactive:** yes
+
+#### token
+
+**type:** string
+**default:** no token
+
+A contract token to attach to an existing Ubuntu Pro subscription.
+
+<a name="ssh"></a>
+
+### ssh
+
+**type:** mapping, see below
+**default:** see below
+**can be interactive:** yes
+
+Configure ssh for the installed system. A mapping that can contain keys:
+
+#### install-server
+
+**type:** boolean
+**default:** `false`
+
+Whether to install OpenSSH server in the target system.
+
+#### authorized-keys
+
+**type:** list of strings
+**default:** `[]`
+
+A list of SSH public keys to install in the initial user's account.
+
+#### allow-pw
+
+**type:** boolean
+**default:** `true` if `authorized_keys` is empty, `false` otherwise
+
+<a name="drivers"></a>
+
+### drivers
+
+**type:** mapping, see below
+**default:** see below
+**can be interactive:** yes
+
+#### install
+
+**type:** boolean
+**default:** `false`
+
+Whether to install the available third-party drivers.
+
+<a name="snaps"></a>
+
+### snaps
+
+**type:** list
+**default:** install no extra snaps
+**can be interactive:** yes
+
+A list of snaps to install. Each snap is represented as a mapping with required `name` and optional `channel` (defaulting to `stable`) and classic (defaulting to `false`) keys. For example:
+
+<pre><code>snaps:
+    - name: etcd
+      channel: edge
+      classic: false</code></pre>
+
+<a name="debconf-selections"></a>
+
+### debconf-selections
+
+**type:** string
+**default:** no config
+**can be interactive:** no
+
+The installer will update the target with debconf set-selection values. Users will need to be familiar with the package debconf options.
+
+<a name="packages"></a>
+
+### packages
+
+**type:** list
+**default:** no packages
+**can be interactive:** no
+
+A list of packages to install into the target system. More precisely, a list of strings to pass to "`apt-get install`", so this includes things like task selection (`dns-server^`) and installing particular versions of a package (`my-package=1-1`).
+
+### kernel
+
+**type:** mapping (mutually exclusive), see below
+**default:** default kernel
+**can be interactive:** no
+
+Which kernel gets installed. Either the name of the package or the name of the flavor must be specified.
+
+#### package
+
+**type:** string
+
+The name of the package, e.g., `linux-image-5.13.0-40-generic`
+
+#### flavor
+
+**type:** string
+
+The flavor of the kernel, e.g., `generic` or `hwe`.
+
+### timezone
+
+**type:** string
+**default:** no timezone
+**can be interactive:** no
+
+The timezone to configure on the system. The special value "geoip" can be used to query the timezone automatically over the network.
+
+### updates
+
+**type:** string (enumeration)
+**default:** `security`
+**can be interactive:** no
+
+The type of updates that will be downloaded and installed after the system install.
+Supported values are:
+
+ * `security` -> download and install updates from the -security pocket
+ * `all` -> also download and install updates from the -updates pocket
+
+### shutdown
+
+**type:** string (enumeration)
+**default:** `reboot`
+**can be interactive:** no
+
+Request the system to poweroff or reboot automatically after the installation has finished.
+Supported values are:
+
+ * `reboot`
+ * `poweroff`
+
+<a name="late-commands"></a>
+
+### late-commands
+
+**type:** [command list](#commandlist)
+**default:** no commands
+**can be interactive:** no
+
+Shell commands to run after the install has completed successfully and any updates and packages installed, just before the system reboots. They are run in the installer environment with the installed system mounted at `/target`. You can run `curtin in-target -- $shell_command` (with the version of subiquity released with 20.04 GA you need to specify this as `curtin in-target --target=/target -- $shell_command`) to run in the target system (similar to how plain `in-target` can be used in `d-i preseed/late_command`).
+
+<a name="error-commands"></a>
+
+### error-commands
+
+**type:** [command list](#commandlist)
+**default:** no commands
+**can be interactive:** no
+
+Shell commands to run after the install has failed. They are run in the installer environment, and the target system (or as much of it as the installer managed to configure) will be mounted at /target. Logs will be available at `/var/log/installer` in the live session.
+
+<a name="reporting"></a>
+
+### reporting
+
+**type:** mapping
+**default:** `type: print` which causes output on tty1 and any configured serial consoles
+**can be interactive:** no
+
+The installer supports reporting progress to a variety of destinations.  Note that this section is ignored if there are any [interactive sections](#interactive-sections); it only applies to fully automated installs.
+
+The config, and indeed the implementation, is 90% the same as [that used by curtin](https://curtin.readthedocs.io/en/latest/topics/reporting.html).
+
+Each key in the `reporting` mapping in the config defines a destination, where the `type` sub-key is one of:
+
+**The rsyslog reporter does not yet exist**
+
+ * **print**: print progress information on tty1 and any configured serial console. There is no other configuration.
+ * **rsyslog**: report progress via rsyslog. The **destination** key specifies where to send output.
+ * **webhook**: report progress via POSTing JSON reports to a URL. Accepts the same configuration as [curtin](https://curtin.readthedocs.io/en/latest/topics/reporting.html#webhook-reporter).
+ * **none**: do not report progress. Only useful to inhibit the default output.
+
+Examples:
+
+The default configuration is:
+
+<pre><code>reporting:
+ builtin:
+  type: print</code></pre>
+
+Report to rsyslog:
+
+<pre><code>reporting:
+ central:
+  type: rsyslog
+  destination: @192.168.0.1</code></pre>
+
+Suppress the default output:
+
+<pre><code>reporting:
+ builtin:
+  type: none</code></pre>
+
+Report to a curtin-style webhook:
+
+<pre><code>reporting:
+ hook:
+  type: webhook
+  endpoint: http://example.com/endpoint/path
+  consumer_key: "ck_foo"
+  consumer_secret: "cs_foo"
+  token_key: "tk_foo"
+  token_secret: "tk_secret"
+  level: INFO</code></pre>
+
+<a name="user-data"></a>
+
+### user-data
+
+**type:** mapping
+**default:** `{}`
+**can be interactive:** no
+
+Provide cloud-init user-data which will be merged with the user-data the installer produces. If you supply this, you don't need to supply an [identity section](#identity) (but then it's your responsibility to make sure that you can log into the installed system!).

--- a/documentation/autoinstall-schema.md
+++ b/documentation/autoinstall-schema.md
@@ -1,0 +1,492 @@
+# JSON Schema for autoinstall config
+
+## Introduction
+
+The server installer validates the provided autoinstall config against a [JSON Schema](#Schema).
+
+## How the config is validated
+
+Although the schema is presented below as a single document, and if you want to pre-validate your config you should validate it against this document, the config is not actually validated against this document at run time. What happens instead is that some sections are loaded, validated and applied first, before all other sections are validated. In detail:
+
+ 1. The reporting section is loaded, validated and applied.
+ 2. The error commands are loaded and validated.
+ 3. The early commands are loaded and validated.
+ 4. The early commands, if any, are run.
+ 5. The config is reloaded, and now all sections are loaded and validated.
+
+This is so that validation errors in most sections can be reported via the reporting and error-commands configuration, as all other errors are.
+
+## Schema
+
+The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
+
+<pre><code>{
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1
+        },
+        "early-commands": {
+            "type": "array",
+            "items": {
+                "type": [
+                    "string",
+                    "array"
+                ],
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "reporting": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type"
+                ],
+                "additionalProperties": true
+            }
+        },
+        "error-commands": {
+            "type": "array",
+            "items": {
+                "type": [
+                    "string",
+                    "array"
+                ],
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "user-data": {
+            "type": "object"
+        },
+        "packages": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "debconf-selections": {
+            "type": "string"
+        },
+        "locale": {
+            "type": "string"
+        },
+        "refresh-installer": {
+            "type": "object",
+            "properties": {
+                "update": {
+                    "type": "boolean"
+                },
+                "channel": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "kernel": {
+            "type": "object",
+            "properties": {
+                "package": {
+                    "type": "string"
+                },
+                "flavor": {
+                    "type": "string"
+                }
+            },
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "package"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "flavor"
+                    ]
+                }
+            ]
+        },
+        "keyboard": {
+            "type": "object",
+            "properties": {
+                "layout": {
+                    "type": "string"
+                },
+                "variant": {
+                    "type": "string"
+                },
+                "toggle": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "layout"
+            ],
+            "additionalProperties": false
+        },
+        "source": {
+            "type": "object",
+            "properties": {
+                "search_drivers": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "network": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "integer",
+                            "minimum": 2,
+                            "maximum": 2
+                        },
+                        "ethernets": {
+                            "type": "object",
+                            "properties": {
+                                "match": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "macaddress": {
+                                            "type": "string"
+                                        },
+                                        "driver": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "wifis": {
+                            "type": "object",
+                            "properties": {
+                                "match": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "macaddress": {
+                                            "type": "string"
+                                        },
+                                        "driver": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "bridges": {
+                            "type": "object"
+                        },
+                        "bonds": {
+                            "type": "object"
+                        },
+                        "tunnels": {
+                            "type": "object"
+                        },
+                        "vlans": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "version"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "network": {
+                            "type": "object",
+                            "properties": {
+                                "version": {
+                                    "type": "integer",
+                                    "minimum": 2,
+                                    "maximum": 2
+                                },
+                                "ethernets": {
+                                    "type": "object",
+                                    "properties": {
+                                        "match": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "macaddress": {
+                                                    "type": "string"
+                                                },
+                                                "driver": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                },
+                                "wifis": {
+                                    "type": "object",
+                                    "properties": {
+                                        "match": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "macaddress": {
+                                                    "type": "string"
+                                                },
+                                                "driver": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                },
+                                "bridges": {
+                                    "type": "object"
+                                },
+                                "bonds": {
+                                    "type": "object"
+                                },
+                                "tunnels": {
+                                    "type": "object"
+                                },
+                                "vlans": {
+                                    "type": "object"
+                                }
+                            },
+                            "required": [
+                                "version"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "network"
+                    ]
+                }
+            ]
+        },
+        "ubuntu-pro": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "minLength": 24,
+                    "maxLength": 30,
+                    "pattern": "^C[1-9A-HJ-NP-Za-km-z]+$",
+                    "description": "A valid token starts with a C and is followed by 23 to 29 Base58 characters.\nSee https://pkg.go.dev/github.com/btcsuite/btcutil/base58#CheckEncode"
+                }
+            }
+        },
+        "ubuntu-advantage": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "minLength": 24,
+                    "maxLength": 30,
+                    "pattern": "^C[1-9A-HJ-NP-Za-km-z]+$",
+                    "description": "A valid token starts with a C and is followed by 23 to 29 Base58 characters.\nSee https://pkg.go.dev/github.com/btcsuite/btcutil/base58#CheckEncode"
+                }
+            },
+            "deprecated": true,
+            "description": "Compatibility only - use ubuntu-pro instead"
+        },
+        "proxy": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "format": "uri"
+        },
+        "apt": {
+            "type": "object",
+            "properties": {
+                "preserve_sources_list": {
+                    "type": "boolean"
+                },
+                "primary": {
+                    "type": "array"
+                },
+                "geoip": {
+                    "type": "boolean"
+                },
+                "sources": {
+                    "type": "object"
+                },
+                "disable_components": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "universe",
+                            "multiverse",
+                            "restricted",
+                            "contrib",
+                            "non-free"
+                        ]
+                    }
+                },
+                "preferences": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "package": {
+                                "type": "string"
+                            },
+                            "pin": {
+                                "type": "string"
+                            },
+                            "pin-priority": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "package",
+                            "pin",
+                            "pin-priority"
+                        ]
+                    }
+                }
+            }
+        },
+        "storage": {
+            "type": "object"
+        },
+        "identity": {
+            "type": "object",
+            "properties": {
+                "realname": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "hostname": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "username",
+                "hostname",
+                "password"
+            ],
+            "additionalProperties": false
+        },
+        "ssh": {
+            "type": "object",
+            "properties": {
+                "install-server": {
+                    "type": "boolean"
+                },
+                "authorized-keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allow-pw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "snaps": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "channel": {
+                        "type": "string"
+                    },
+                    "classic": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "drivers": {
+            "type": "object",
+            "properties": {
+                "install": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "timezone": {
+            "type": "string"
+        },
+        "updates": {
+            "type": "string",
+            "enum": [
+                "security",
+                "all"
+            ]
+        },
+        "late-commands": {
+            "type": "array",
+            "items": {
+                "type": [
+                    "string",
+                    "array"
+                ],
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "shutdown": {
+            "type": "string",
+            "enum": [
+                "reboot",
+                "poweroff"
+            ]
+        }
+    },
+    "required": [
+        "version"
+    ],
+    "additionalProperties": true
+}
+</code></pre>
+
+## Regeneration
+
+The schema above can be regenerated by running "make schema" in a subiquity source checkout.

--- a/documentation/autoinstall.md
+++ b/documentation/autoinstall.md
@@ -1,0 +1,156 @@
+# Automated Server Installs
+
+## Introduction
+
+Since version 20.04, the server installer supports the automated installation mode, autoinstallation for short. You might also know this feature as unattended or handsoff or preseeded installation.
+
+Autoinstallation lets you answer all those configuration questions ahead of time with an *autoinstall config* and lets the installation process run without any interaction.
+
+## Differences from debian-installer preseeding
+
+*preseeds* are the way to automate an installer based on debian-installer (aka d-i).
+
+autoinstalls for the new server installer differ from preseeds in the following main ways:
+
+ * the format is completely different (cloud-init config, usually yaml, vs debconf-set-selections format)
+ * when the answer to a question is not present in a preseed, d-i   stops and asks the user for input. autoinstalls are not like this:   by default, if there is any autoinstall config at all, the   installer takes the default for any unanswered question (and fails if there is no default).
+    * You can designate particular sections in   the config as "interactive", which means the installer will still stop and ask about those.
+
+## Providing the autoinstall config
+
+The autoinstall config is provided via cloud-init configuration, which is almost endlessly flexible. In most scenarios the easiest way will be to provide user-data via the [nocloud](https://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html) data source.
+
+The autoinstall config should be provided under the `autoinstall` key in the config. For example:
+
+    #cloud-config
+    autoinstall:
+      version: 1
+      ...
+
+## Running a truly automatic autoinstall
+
+Even if a fully noninteractive autoinstall config is found, the server installer will ask for confirmation before writing to the disks unless `autoinstall` is present on the kernel command line. This is to make it harder to accidentally create a USB stick that will reformat a machine it is plugged into at boot. Many autoinstalls will be done via netboot, where the kernel command line is controlled by the netboot config -- just remember to put `autoinstall` in there!
+
+## Quick start
+
+So you just want to try it out? Well we have [the page for you](autoinstall-quickstart.md).
+
+## Creating an autoinstall config
+
+When any system is installed using the server installer, an autoinstall file for repeating the install is created  at `/var/log/installer/autoinstall-user-data`.
+
+# Translating a preseed file
+
+If you have a preseed file already, the [autoinstall-generator](https://snapcraft.io/autoinstall-generator) snap can assist in translating that preseed data to an autoinstall file.  See this [discussion](https://discourse.ubuntu.com/t/autoinstall-generator-tool-to-help-with-creation-of-autoinstall-files-based-on-preseed/21334) for more details.
+
+# The structure of an autoinstall config
+
+The autoinstall config has [full documentation](autoinstall-reference.md).
+
+Technically speaking the config is not defined as a textual format, but cloud-init config is usually provided as YAML so that is the syntax the documentation uses.
+
+A minimal config is:
+
+    version: 1
+    identity:
+        hostname: hostname
+        username: username
+        password: $crypted_pass
+
+Here is an example file that shows off most features:
+
+<pre><code><a href="autoinstall-reference.md#version">version</a>: 1
+<a href="autoinstall-reference.md#reporting">reporting</a>:
+    hook:
+        type: webhook
+        endpoint: http://example.com/endpoint/path
+<a href="autoinstall-reference.md#early-commands">early-commands</a>:
+    - ping -c1 198.162.1.1
+<a href="autoinstall-reference.md#locale">locale</a>: en_US
+<a href="autoinstall-reference.md#keyboard">keyboard</a>:
+    layout: gb
+    variant: dvorak
+<a href="autoinstall-reference.md#network">network</a>:
+    network:
+        version: 2
+        ethernets:
+            enp0s25:
+               dhcp4: yes
+            enp3s0: {}
+            enp4s0: {}
+        bonds:
+            bond0:
+                dhcp4: yes
+                interfaces:
+                    - enp3s0
+                    - enp4s0
+                parameters:
+                    mode: active-backup
+                    primary: enp3s0
+<a href="autoinstall-reference.md#proxy">proxy</a>: http://squid.internal:3128/
+<a href="autoinstall-reference.md#apt">apt</a>:
+    primary:
+        - arches: [default]
+          uri: http://repo.internal/
+    sources:
+        my-ppa.list:
+            source: "deb http://ppa.launchpad.net/curtin-dev/test-archive/ubuntu $RELEASE main"
+            keyid: B59D 5F15 97A5 04B7 E230  6DCA 0620 BBCF 0368 3F77
+<a href="autoinstall-reference.md#storage">storage</a>:
+    layout:
+        name: lvm
+<a href="autoinstall-reference.md#identity">identity</a>:
+    hostname: hostname
+    username: username
+    password: $crypted_pass
+<a href="autoinstall-reference.md#ssh">ssh</a>:
+    install-server: yes
+    authorized-keys:
+      - $key
+    allow-pw: no
+<a href="autoinstall-reference.md#snaps">snaps</a>:
+    - name: go
+      channel: 1.14/stable
+      classic: true
+<a href="autoinstall-reference.md#debconf-selections">debconf-selections</a>: |
+    bind9      bind9/run-resolvconf    boolean false
+<a href="autoinstall-reference.md#packages">packages</a>:
+    - libreoffice
+    - dns-server^
+<a href="autoinstall-reference.md#user-data">user-data</a>:
+    disable_root: false
+<a href="autoinstall-reference.md#late-commands">late-commands</a>:
+    - sed -ie 's/GRUB_TIMEOUT=.\*/GRUB_TIMEOUT=30/' /target/etc/default/grub
+<a href="autoinstall-reference.md#error-commands">error-commands</a>:
+    - tar c /var/log/installer | nc 192.168.0.1 1000
+</code></pre>
+
+Many keys and values correspond straightforwardly to questions the installer asks (e.g. keyboard selection). See the reference for details of those that do not.
+
+# Error handling
+
+Progress through the installer is reported via the [`reporting`](autoinstall-reference.md#reporting) system, including errors. In addition, when a fatal error occurs, the [`error-commands`](autoinstall-reference.md#error-commands) are executed and the traceback printed to the console. The server then just waits.
+
+# Interactions between Autoinstall and Cloud-init
+
+## Delivery of Autoinstall
+
+Cloud-config can be used to deliver the Autoinstall data to the installation environment. The [autoinstall quickstart](autoinstall-quickstart.md) has an [example](autoinstall-quickstart.md#write-your-autoinstall-config) demonstrating this.
+
+Note that Autoinstall is processed by Subiquity (not Cloud-init), so please direct defects in Autoinstall behavior to [Subiquity](https://bugs.launchpad.net/subiquity/+filebug).
+
+## The installation environment
+
+At install time, the live-server environment is just that, a live but ephemeral copy of Ubuntu Server.  This means that Cloud-init is present and running in that environment, and existing methods of interacting with Cloud-init can be used to configure the live-server ephemeral environment.  For example, any #cloud-config user-data keys are presented to the live-server containing [`ssh_import_id`](https://cloudinit.readthedocs.io/en/latest/topics/modules.html?highlight=ssh#ssh-import-id), then ssh keys will be added to the authorized_keys list for the ephemeral environment.
+
+## First boot configuation of the target system
+
+Autoinstall data may optionally contain a [user-data](autoinstall-reference.md#user-data) sub-section, which is cloud-config data that is used to configure the target system on first boot.
+
+Subiquity itself delegates some configuration items to Cloud-init, and these items are processed on first boot.
+
+Starting with Ubuntu 22.10, once Cloud-init has performed this first boot configuration, it will disable itself as cloud-init completes configuration in the target system on first boot.
+
+# Possible future directions
+
+We might want to extend the 'match specs' for disks to cover other ways of selecting disks.

--- a/documentation/substitute-links.py
+++ b/documentation/substitute-links.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import argparse
+from typing import List, Tuple
+
+discourse_substitutions = [
+    ("autoinstall.md", "/t/automated-server-installs/16612"),
+    ("autoinstall-reference.md", "/t/automated-server-install-reference/16613"),
+    ("autoinstall-quickstart.md", "/t/automated-server-install-quickstart/16614"),
+    ("autoinstall-schema.md", "/t/automated-server-install-schema/16615"),
+    ("autoinstall-quickstart-s390x.md", "/t/automated-server-install-schema/16616"),
+]
+md_to_html_substitutions = [
+    ("autoinstall.md", "autoinstall.html"),
+    ("autoinstall-reference.md", "autoinstall-reference.html"),
+    ("autoinstall-quickstart.md", "autoinstall-quickstart.html"),
+    ("autoinstall-schema.md", "autoinstall-schema.html"),
+    ("autoinstall-quickstart-s390x.md", "autoinstall-quickstart-s390x.html"),
+]
+
+def perform_substitutions(content: str, substitutions: List[Tuple[str, str]]) -> str:
+    for old, new in substitutions:
+        content = content.replace(old, new)
+    return content
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--input", "-i", type=argparse.FileType(mode="r"), default="-")
+    parser.add_argument("--output", "-o", type=argparse.FileType(mode="w"), default="-")
+    parser.add_argument("action", choices=("md-to-discourse", "md-to-html"))
+
+    args = vars(parser.parse_args())
+
+    if args["action"] == "md-to-discourse":
+        substitutions = discourse_substitutions
+    else:
+        substitutions = md_to_html_substitutions
+
+    print(perform_substitutions(
+            args["input"].read(),
+            substitutions=substitutions),
+        file=args["output"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Before we start adding or extending existing autoinstall sections, we should keep a copy of the autoinstall doc in the ubuntu/kinetic branch. 

--

This patch is an aggregate of all the following documentation updates from the main branch as of 66a55ad39bbb9e81e6e76775b3ee00d1e4be9a2a.

 doc: import autoinstall markdown documents from discourse
 doc: make links to anchors work with pandoc
 doc: build with pandoc
 doc: use better links in s390x page
 doc: implement link substitution mechanism
 doc: escape asterisks in markdown
 doc: import latest JSON schema in autoinstall doc
 doc: consistency fixes for autoinstall doc
 doc: document "source" section in autoinstall-reference
 doc: document "drivers" section to autoinstall-reference
 doc: document "ubuntu-pro" section in autoinstall-reference
 doc: document "timezone" section in autoinstall-reference
 doc: document "updates" section in autoinstall-reference
 doc: document "shutdown" section in autoinstall-reference
 doc: document "kernel" section in autonistall-reference
 doc: clarify cloud-init interactions
 doc: improve cloud-init interaction wording
 doc: reword autoinstall introduction that still mentions 20.04
 doc: fix default shutdown action which is to reboot
 doc: update quickstart guide for 22.10 release
 doc: double the memory allocated to kvm in quickstart guide
 doc: fix missing leading / before some discourse links
 doc: fix shutdown