### PR TITLE
bind mount systems from before asking snapd about them

### DIFF
--- a/subiquity/server/mounter.py
+++ b/subiquity/server/mounter.py
@@ -158,6 +158,23 @@ class Mounter:
             await self.unmount(m, remove=False)
         self.tmpfiles.cleanup()
 
+    async def bind_mount_tree(self, src, dst):
+        """bind-mount files and directories from src that are not already
+        present into dst"""
+        if not os.path.exists(dst):
+            await self.mount(src, dst, options='bind')
+            return
+        for src_dirpath, dirnames, filenames in os.walk(src):
+            dst_dirpath = src_dirpath.replace(src, dst)
+            for name in dirnames + filenames:
+                dst_path = os.path.join(dst_dirpath, name)
+                if os.path.exists(dst_path):
+                    continue
+                src_path = os.path.join(src_dirpath, name)
+                await self.mount(src_path, dst_path, options='bind')
+                if name in dirnames:
+                    dirnames.remove(name)
+
 
 class DryRunMounter(Mounter):
 

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -303,7 +303,7 @@ class TestFlow(TestAPI):
             await inst.post('/proxy', '')
             await inst.post('/mirror', 'http://us.archive.ubuntu.com/ubuntu')
 
-            resp = await inst.get('/storage/v2/guided')
+            resp = await inst.get('/storage/v2/guided?wait=true')
             [reformat] = resp['possible']
             await inst.post('/storage/v2/guided', {'target': reformat})
             await inst.post('/storage/v2')


### PR DESCRIPTION
For the systems currently being tested, the live installer environment is stacked on the one being installed and so the system definition for the system being installed is already available. That's not going to be true in full generality though, so add some helpers to make all systems defined in the source available in the live installer environment before calling into snapd to find out about them.