### PR TITLE
Simplify systemd configuration for console-conf

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -23,7 +23,6 @@ from subiquitycore import snap
 from subiquitycore.snapd import SnapdConnection
 from subiquitycore.ssh import get_ips_standalone, host_key_info
 from subiquitycore.tuicontroller import TuiController
-from subiquitycore.utils import disable_console_conf
 
 log = logging.getLogger("console_conf.controllers.identity")
 
@@ -221,9 +220,4 @@ class IdentityController(TuiController):
         self.ui.set_body(self.make_login_view())
 
     def login_done(self):
-        if not self.opts.dry_run:
-            # stop the console-conf services (this will kill the
-            # current process).
-            disable_console_conf()
-
         self.app.exit()

--- a/debian/console-conf-serial.conf
+++ b/debian/console-conf-serial.conf
@@ -1,2 +1,2 @@
-[Service]
-ExecStartPre=/bin/systemctl start serial-console-conf@%i.service
+[Unit]
+ConditionPathExists=/var/lib/console-conf/complete

--- a/debian/console-conf.conf
+++ b/debian/console-conf.conf
@@ -1,2 +1,3 @@
-[Service]
-ExecStartPre=/bin/systemctl start console-conf@%i.service
+[Unit]
+ConditionPathExists=/var/lib/console-conf/complete
+ConditionPathExists=!/run/snapd-recovery-chooser-triggered

--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -13,12 +13,11 @@ ConditionPathExists=/dev/tty0
 ConditionPathExists=|!/var/lib/console-conf/complete
 ConditionPathExists=|/run/snapd-recovery-chooser-triggered
 StartLimitInterval=0
+Conflicts=getty@%i.service
 
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
-ExecStartPre=/bin/systemctl stop getty@%I
 ExecStart=/sbin/agetty -i -n --noclear -l /usr/share/subiquity/console-conf-wrapper %I $TERM
-ExecStopPost=/bin/systemctl start getty@%I
 Type=idle
 Restart=always
 RestartSec=0
@@ -36,3 +35,7 @@ SendSIGHUP=yes
 #StandardInput=tty-force
 #StandardOutput=tty
 #StandardError=tty
+
+[Install]
+WantedBy=getty.target
+DefaultInstance=tty1

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -11,12 +11,11 @@ After=core18.start-snapd.service core.start-snapd.service
 After=snapd.recovery-chooser-trigger.service
 ConditionPathExists=!/var/lib/console-conf/complete
 StartLimitInterval=0
+Conflicts=serial-getty@%i.service
 
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
-ExecStartPre=/bin/systemctl stop serial-getty@%I
 ExecStart=/sbin/agetty -i -n --keep-baud -l /usr/share/subiquity/console-conf-wrapper --login-options "--serial" 115200,38400,9600 %I $TERM
-ExecStopPost=/bin/systemctl start serial-getty@%I
 Type=idle
 Restart=always
 RestartSec=0

--- a/debian/rules
+++ b/debian/rules
@@ -28,6 +28,7 @@ override_dh_installinit:
 	dh_installsystemd --no-start --name=serial-console-conf@
 	install -D -m 0644 $(CURDIR)/debian/console-conf.conf $(CURDIR)/debian/console-conf/usr/lib/systemd/system/getty@.service.d/console-conf.conf
 	install -D -m 0644 $(CURDIR)/debian/console-conf-serial.conf $(CURDIR)/debian/console-conf/usr/lib/systemd/system/serial-getty@.service.d/console-conf-serial.conf
+	install -D -m 0755 -t $(CURDIR)/debian/console-conf/lib/systemd/system-generators $(CURDIR)/debian/serial-console-generator
 
 override_dh_auto_test:
 	@echo "No tests."

--- a/debian/serial-console-generator
+++ b/debian/serial-console-generator
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+NORMAL_DIR="${1}"
+EARLY_DIR="${2}"
+LATE_DIR="${3}"
+
+for tty in $(cat /sys/class/tty/console/active); do
+    case "${tty}" in
+      tty[0-9]*)
+      ;;
+      *)
+        mkdir -p "${NORMAL_DIR}/getty.target.wants"
+        ln -sf /usr/lib/systemd/system/serial-console-conf@.service "${NORMAL_DIR}/getty.target.wants/serial-console-conf@${tty}.service"
+
+      ;;
+    esac
+done

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -228,21 +228,6 @@ def crypt_password(passwd, algo="SHA-512"):
     return crypt.crypt(passwd, algos[algo] + salt)
 
 
-def disable_console_conf():
-    """Stop console-conf service; which also restores getty service"""
-    log.info("disabling console-conf service")
-    run_command(
-        [
-            "systemctl",
-            "stop",
-            "--no-block",
-            "console-conf@*.service",
-            "serial-console-conf@*.service",
-        ]
-    )
-    return
-
-
 def disable_subiquity():
     """Stop subiquity service; which also restores getty service"""
     log.info("disabling subiquity service")


### PR DESCRIPTION
Having `getty@.service` and `console-conf@.service` starting each others seem to generate errors on shut down.

```
[  115.522870] systemctl[1011]: Got message type=error sender=org.freedesktop.systemd1 destination=n/a path=n/a interface=n/a member=n/a cookie=1 reply_cookie=1 signature=s error-name=org.freedesktop.systemd1.TransactionIsDestructive error-message=Transaction for getty@tty1.service/star
[  115.524325] systemctl[1011]: t is destructive (systemd-poweroff.service has 'start' job queued, but 'stop' is included in transaction).
[  115.525067] systemctl[1011]: Failed to start getty@tty1.service: Transaction for getty@tty1.service/start is destructive (systemd-poweroff.service has 'start' job queued, but 'stop' is included in transaction).
```

Instead we should just have both `console-conf@` and `getty@` enabled and select with conditions.

Serial port services are enabled by a generator, in a similar way as `systemd-getty-generator` for `serial-getty@`.