### PR TITLE
remove any support for a desktop installer without a source catalog

### DIFF
--- a/subiquity/models/source.py
+++ b/subiquity/models/source.py
@@ -38,35 +38,23 @@ class CatalogEntry:
     snapd_system_label: typing.Optional[str] = None
 
 
-fake_entries = {
-    'server': CatalogEntry(
-        variant='server',
-        id='synthesized',
-        name={'en': 'Ubuntu Server'},
-        description={'en': 'the default'},
-        path='/media/filesystem',
-        type='cp',
-        default=True,
-        size=2 << 30,
-        locale_support="locale-only"),
-    'desktop': CatalogEntry(
-        variant='desktop',
-        id='synthesized',
-        name={'en': 'Ubuntu Desktop'},
-        description={'en': 'the default'},
-        path='/media/filesystem',
-        type='cp',
-        default=True,
-        size=5 << 30,
-        locale_support="langpack"),
-    }
+legacy_server_entry = CatalogEntry(
+    variant='server',
+    id='synthesized',
+    name={'en': 'Ubuntu Server'},
+    description={'en': 'the default'},
+    path='/media/filesystem',
+    type='cp',
+    default=True,
+    size=2 << 30,
+    locale_support="locale-only")
 
 
 class SourceModel:
 
     def __init__(self):
         self._dir = '/cdrom/casper'
-        self.current = fake_entries['server']
+        self.current = legacy_server_entry
         self.sources = [self.current]
         self.lang = None
         self.search_drivers = False

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -130,13 +130,7 @@ class MetaController:
     async def client_variant_POST(self, variant: str) -> None:
         if variant not in self.app.supported_variants:
             raise ValueError(f'unrecognized client variant {variant}')
-        from subiquity.models.source import fake_entries
-        if variant in fake_entries:
-            if self.app.base_model.source.current.variant != variant:
-                self.app.base_model.source.current = fake_entries[variant]
-            await self.app.controllers.Source.configured()
-        else:
-            self.app.base_model.set_source_variant(variant)
+        self.app.base_model.set_source_variant(variant)
         self.app.set_source_variant(variant)
 
     async def client_variant_GET(self) -> str:


### PR DESCRIPTION
The code in subiquity main could plausibly be offered as an upgrade to users installing focal server and focal server ISOs do not have a source catalog so we need to support that. But we will never support a desktop ISO that does not have a source catalog so we can remove some slightly confusing code that attempted to cover that case.