### PR TITLE
Cherry-pick patch - fix answers race (maybe)

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -107,8 +107,8 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
             await asyncio.sleep(0.1)
 
         if self.answers['tpm-default']:
-            self.ui.body.done(self.ui.body.form)
             await self.app.confirm_install()
+            self.ui.body.done(self.ui.body.form)
         if self.answers['guided']:
             if 'guided-index' in self.answers:
                 disk = self.ui.body.form.disks[self.answers['guided-index']]


### PR DESCRIPTION
The integration tests with TPM answers are flaky at the moment. It causes some workflows to fail.

@mwhudson added a patch as part of https://github.com/canonical/subiquity/pull/1485 that addresses the issue:
https://github.com/canonical/subiquity/pull/1485/commits/97901a78a254ff3aa55e97a578dceae4ea2e3574

Make it part of an independent pull request so that we can merge it ASAP.

