### PR TITLE
add a new member of the snapdapi.Role enum

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -142,7 +142,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self._system: Optional[snapdapi.SystemDetails] = None
         self._core_boot_classic_error: str = ''
         self._system_mounter: Optional[Mounter] = None
-        self._role_to_device: Dict[snapdapi.Role: _Device] = {}
+        self._role_to_device: Dict[str: _Device] = {}
         self.use_tpm: bool = False
 
     def is_core_boot_classic(self):
@@ -536,7 +536,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 on_volumes=self._on_volumes()))
         role_to_encrypted_device = result['encrypted-devices']
         for role, enc_path in role_to_encrypted_device.items():
-            role = snapdapi.Role(role)
             arb_device = ArbitraryDevice(m=self.model, path=enc_path)
             self.model._actions.append(arb_device)
             part = self._role_to_device[role]

--- a/subiquity/server/snapdapi.py
+++ b/subiquity/server/snapdapi.py
@@ -91,7 +91,7 @@ class Response:
     status: str
 
 
-class Role(enum.Enum):
+class Role:
 
     NONE = ''
     MBR = 'mbr'
@@ -136,7 +136,7 @@ class VolumeStructure:
     offset_write: Optional[RelativeOffset] = named_field('offset-write', None)
     size: int = 0
     type: str = ''
-    role: Role = Role.NONE
+    role: str = Role.NONE
     id: Optional[str] = None
     filesystem: str = ''
     content: Optional[List[VolumeContent]] = None

--- a/subiquity/server/snapdapi.py
+++ b/subiquity/server/snapdapi.py
@@ -102,6 +102,7 @@ class Role(enum.Enum):
     SYSTEM_RECOVERY_SELECT = 'system-recovery-select'
     SYSTEM_SAVE = 'system-save'
     SYSTEM_SEED = 'system-seed'
+    SYSTEM_SEED_NULL = 'system-seed-null'
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
This kind of change is a bit of a problem with the current approach to talking to snapd I guess -- deserialization will fail if we encounter a new value for one of these fields.