### PR TITLE
Fetch SSH keys through the configured proxy

### DIFF
--- a/subiquity/client/controllers/ssh.py
+++ b/subiquity/client/controllers/ssh.py
@@ -107,13 +107,14 @@ class SSHController(SubiquityTuiController):
                 "# ssh-import-id {}".format(ssh_import_id),
                 "").strip().splitlines()
 
+            authorized_keys = [key for key in key_material.splitlines() if key]
             if 'ssh-import-id' in self.app.answers.get("Identity", {}):
-                ssh_data.authorized_keys = key_material.splitlines()
+                ssh_data.authorized_keys = authorized_keys
                 self.done(ssh_data)
             else:
                 if isinstance(self.ui.body, SSHView):
                     self.ui.body.confirm_ssh_keys(
-                        ssh_data, ssh_import_id, key_material, fingerprints)
+                        ssh_data, ssh_import_id, authorized_keys, fingerprints)
                 else:
                     log.debug("ui.body of unexpected instance: %s",
                               type(self.ui.body).__name__)

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -52,6 +52,7 @@ from subiquity.common.types import (
     SnapSelection,
     SourceSelectionAndSetting,
     SSHData,
+    SSHFetchIdResponse,
     LiveSessionSSHInfo,
     StorageResponse,
     StorageResponseV2,
@@ -75,7 +76,6 @@ class API:
     """The API offered by the subiquity installer process."""
     locale = simple_endpoint(str)
     proxy = simple_endpoint(str)
-    ssh = simple_endpoint(SSHData)
     updates = simple_endpoint(str)
     wslconfbase = simple_endpoint(WSLConfigurationBase)
     wslconfadvanced = simple_endpoint(WSLConfigurationAdvanced)
@@ -374,6 +374,13 @@ class API:
 
         class validate_username:
             def GET(username: str) -> UsernameValidation: ...
+
+    class ssh:
+        def GET() -> SSHData: ...
+        def POST(data: Payload[SSHData]) -> None: ...
+
+        class fetch_id:
+            def GET(user_id: str) -> SSHFetchIdResponse: ...
 
 
 class LinkAction(enum.Enum):

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -496,6 +496,31 @@ class SSHData:
     authorized_keys: List[str] = attr.Factory(list)
 
 
+@attr.s(auto_attribs=True)
+class SSHIdentity:
+    """ Represents a SSH identity (public key + fingerprint). """
+    key_type: str
+    key: str
+    key_comment: str
+    key_fingerprint: str
+
+    def to_authorized_key(self):
+        return f"{self.key_type} {self.key} {self.key_comment}"
+
+
+class SSHFetchIdStatus(enum.Enum):
+    OK = enum.auto()
+    IMPORT_ERROR = enum.auto()
+    FINGERPRINT_ERROR = enum.auto()
+
+
+@attr.s(auto_attribs=True)
+class SSHFetchIdResponse:
+    status: SSHFetchIdStatus
+    identities: Optional[List[SSHIdentity]]
+    error: Optional[str]
+
+
 class SnapCheckState(enum.Enum):
     FAILED = enum.auto()
     LOADING = enum.auto()

--- a/subiquity/server/controllers/ssh.py
+++ b/subiquity/server/controllers/ssh.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 import subprocess
 from typing import List
 
@@ -77,8 +78,13 @@ class SSHController(SubiquityController):
         identities: List[SSHIdentity] = []
 
         import_command = ('ssh-import-id', '--output', '-', '--', user_id)
+        env = None
+        if self.app.base_model.proxy.proxy:
+            env = os.environ.copy()
+            env["https_proxy"] = self.app.base_model.proxy.proxy
+
         try:
-            cp = await arun_command(import_command, check=True)
+            cp = await arun_command(import_command, check=True, env=env)
         except subprocess.CalledProcessError as e:
             log.exception("ssh-import-id failed. stderr: %s", e.stderr)
             return SSHFetchIdResponse(status=SSHFetchIdStatus.IMPORT_ERROR,

--- a/subiquity/server/controllers/tests/test_ssh.py
+++ b/subiquity/server/controllers/tests/test_ssh.py
@@ -1,0 +1,156 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest import mock
+from subprocess import CompletedProcess, CalledProcessError
+
+from subiquity.common.types import SSHFetchIdStatus, SSHIdentity
+from subiquity.server.controllers.ssh import (
+    SSHController,
+    SSHFetchError,
+    SSHFetchIdResponse,
+)
+from subiquitycore.tests.mocks import make_app
+
+
+class TestSSHController(unittest.IsolatedAsyncioTestCase):
+    arun_command_sym = "subiquity.server.controllers.ssh.arun_command"
+
+    def setUp(self):
+        self.controller = SSHController(make_app())
+
+    async def test_fetch_keys_for_id_one_key_ok(self):
+        with mock.patch(self.arun_command_sym) as mock_arun:
+            mock_arun.return_value = CompletedProcess([], 0)
+            mock_arun.return_value.stdout = """
+ssh-rsa AAAAC3NzaC1lZ test@gh/335797 # ssh-import-id gh:test
+"""
+            keys = await self.controller.fetch_keys_for_id(user_id="gh:test")
+        self.assertEqual(keys, [
+                "ssh-rsa AAAAC3NzaC1lZ test@gh/335797 # ssh-import-id gh:test",
+                ])
+
+    async def test_fetch_keys_for_id_two_key_ok(self):
+        with mock.patch(self.arun_command_sym) as mock_arun:
+            mock_arun.return_value = CompletedProcess([], 0)
+            mock_arun.return_value.stdout = """\
+ssh-rsa AAAAC3NzaC1lZ test@host # ssh-import-id lp:test
+
+ssh-ed25519 AAAAAC3N test@host # ssh-import-id lp:test
+"""
+            keys = await self.controller.fetch_keys_for_id(user_id="lp:test")
+        self.assertEqual(keys, [
+            "ssh-rsa AAAAC3NzaC1lZ test@host # ssh-import-id lp:test",
+            "ssh-ed25519 AAAAAC3N test@host # ssh-import-id lp:test",
+                ])
+
+    async def test_fetch_keys_for_id_error(self):
+        with mock.patch(self.arun_command_sym) as mock_arun:
+            stderr = """\
+2022-11-22 14:00:12,336 INFO [0] SSH keys [Authorized]
+2022-11-22 14:00:12,337 ERROR No matching keys found for [lp:test2]
+"""
+            mock_arun.side_effect = CalledProcessError(1, [], None, stderr)
+            with self.assertRaises(SSHFetchError) as cm:
+                await self.controller.fetch_keys_for_id(user_id="lp:test2")
+
+            self.assertEqual(cm.exception.reason, stderr)
+            self.assertEqual(cm.exception.status,
+                             SSHFetchIdStatus.IMPORT_ERROR)
+
+    async def test_gen_fingerprint_for_key_ok(self):
+        with mock.patch(self.arun_command_sym) as mock_arun:
+            mock_arun.return_value = CompletedProcess([], 0)
+            mock_arun.return_value.stdout = """\
+256 SHA256:rIR9UVRKspl7+KF75s test@host # ssh-import-id lp:test (ED25519)
+"""
+            fp = await self.controller.gen_fingerprint_for_key(
+                    "ssh-ed25519 AAAAAC3N test@host # ssh-import-id lp:test")
+
+            self.assertEqual(fp, """\
+256 SHA256:rIR9UVRKspl7+KF75s test@host # ssh-import-id lp:test (ED25519)\
+""")
+
+    async def test_gen_fingerprint_for_key_error(self):
+        stderr = "(stdin) is not a public key file.\n"
+        with mock.patch(self.arun_command_sym) as mock_arun:
+            mock_arun.side_effect = CalledProcessError(1, [], None, stderr)
+            with self.assertRaises(SSHFetchError) as cm:
+                await self.controller.gen_fingerprint_for_key(
+                    "ssh-nsa AAAAAC3N test@host # ssh-import-id lp:test")
+
+            self.assertEqual(cm.exception.reason, stderr)
+            self.assertEqual(cm.exception.status,
+                             SSHFetchIdStatus.FINGERPRINT_ERROR)
+
+    async def test_fetch_id_GET_ok(self):
+        key = "ssh-rsa AAAAA[..] user@host # ssh-import-id lp:user"
+        mock_fetch_keys = mock.patch.object(
+                self.controller, "fetch_keys_for_id", return_value=[key])
+
+        fp = "256 SHA256:rIR9[..] user@host # ssh-import-id lp:user (ED25519)"
+        mock_gen_fingerprint = mock.patch.object(
+                self.controller, "gen_fingerprint_for_key", return_value=fp)
+
+        with mock_fetch_keys, mock_gen_fingerprint:
+            response = await self.controller.fetch_id_GET(user_id="lp:user")
+
+            self.assertIsInstance(response, SSHFetchIdResponse)
+            self.assertEqual(response.status, SSHFetchIdStatus.OK)
+            self.assertEqual(response.identities, [SSHIdentity(
+                key_type="ssh-rsa",
+                key="AAAAA[..]",
+                key_comment="user@host # ssh-import-id lp:user",
+                key_fingerprint="256 SHA256:rIR9[..] user@host  (ED25519)",
+            )])
+            self.assertIsNone(response.error)
+
+    async def test_fetch_id_GET_import_error(self):
+        stderr = "ERROR No matching keys found for [lp=test2]\n"
+
+        mock_fetch_keys = mock.patch.object(
+                self.controller, "fetch_keys_for_id",
+                side_effect=SSHFetchError(
+                    status=SSHFetchIdStatus.IMPORT_ERROR,
+                    reason=stderr))
+
+        with mock_fetch_keys:
+            response = await self.controller.fetch_id_GET(user_id="test2")
+
+            self.assertEqual(response.status, SSHFetchIdStatus.IMPORT_ERROR)
+            self.assertEqual(response.error, stderr)
+            self.assertIsNone(response.identities)
+
+    async def test_fetch_id_GET_fingerprint_error(self):
+        key = "ssh-rsa AAAAA[..] user@host # ssh-import-id lp:user"
+        mock_fetch_keys = mock.patch.object(
+                self.controller, "fetch_keys_for_id", return_value=[key])
+
+        stderr = "(stdin) is not a public key file\n"
+
+        mock_gen_fingerprint = mock.patch.object(
+                self.controller, "gen_fingerprint_for_key",
+                side_effect=SSHFetchError(
+                    status=SSHFetchIdStatus.FINGERPRINT_ERROR,
+                    reason=stderr))
+
+        with mock_fetch_keys, mock_gen_fingerprint:
+            response = await self.controller.fetch_id_GET(user_id="test2")
+
+            self.assertEqual(response.status,
+                             SSHFetchIdStatus.FINGERPRINT_ERROR)
+            self.assertEqual(response.error, stderr)
+            self.assertIsNone(response.identities)

--- a/subiquity/ui/views/ssh.py
+++ b/subiquity/ui/views/ssh.py
@@ -15,6 +15,7 @@
 
 import logging
 import re
+from typing import List
 
 from urwid import (
     connect_signal,
@@ -177,10 +178,11 @@ class FetchingSSHKeys(WidgetWrap):
 
 
 class ConfirmSSHKeys(Stretchy):
-    def __init__(self, parent, ssh_data, key_material, fingerprints):
+    def __init__(self, parent, ssh_data, authorized_keys: List[str],
+                 fingerprints: List[str]):
         self.parent = parent
         self.ssh_data = ssh_data
-        self.key_material = key_material
+        self.authorized_keys: List[str] = authorized_keys
 
         ok = ok_btn(label=_("Yes"), on_press=self.ok)
         cancel = cancel_btn(label=_("No"), on_press=self.cancel)
@@ -211,7 +213,7 @@ class ConfirmSSHKeys(Stretchy):
         self.parent.remove_overlay()
 
     def ok(self, sender):
-        self.ssh_data.authorized_keys = self.key_material.splitlines()
+        self.ssh_data.authorized_keys = self.authorized_keys
         self.parent.controller.done(self.ssh_data)
 
 
@@ -288,10 +290,11 @@ class SSHView(BaseView):
     def cancel(self, result=None):
         self.controller.cancel()
 
-    def confirm_ssh_keys(self, ssh_data, ssh_import_id, ssh_key, fingerprints):
+    def confirm_ssh_keys(self, ssh_data, ssh_import_id,
+                         authorized_keys: List[str], fingerprints):
         self.remove_overlay()
         self.show_stretchy_overlay(
-            ConfirmSSHKeys(self, ssh_data, ssh_key, fingerprints))
+            ConfirmSSHKeys(self, ssh_data, authorized_keys, fingerprints))
 
     def fetching_ssh_keys_failed(self, msg, stderr):
         self.remove_overlay()


### PR DESCRIPTION
The proxy settings specified by the user were ignored when importing SSH keys from github / launchpad. This PR fixes the issue by explicitly passing the https_proxy environment variable when a proxy is set.

The calls to `ssh-import-id` used to be done on the client side of Subiquity. Our design makes it difficult to know in a given screen what proxy settings are required to access the network.

I decided to move the calls to `ssh-import-id` on the server side and expose an API to do it. Not only does it allow us to pass the relevant proxy variables in the environment, it could also be used to pass locale-related variables (e.g., LC_MESSAGES) which we are not doing as part of this PR.

From the client's standpoint, the behavior should be identical to status quo when no proxy is needed. The screens should look exactly the same.

Also, I noticed that when importing multiple keys from Github / Launchpad, we did not discard empty lines. This resulted in python objects and yaml objects having empty strings. e.g.:

```python
      authorized_keys = [
        'ssh-rsa AAAA[...] user@hostname',
        '',
        'ssh-ed255129 AAAA[...] user@hostname2',
      ]
```
I added some logic to discard these empty lines /  keys.

I haven't yet been able to test in a VM because of an unrelated issue when bind-mounting /var/lib/snapd/seed/systems so I'm leaving the PR as a draft for now. Also, the PR depends on https://github.com/canonical/subiquity/pull/1489 - which we use to display the error message from `ssh-import-id` and `ssh-keygen`. I'll rebase on top of main once this other PR is merged.
