### PR TITLE
Fix crash when /var/lib/snapd/seed/systems does not exist on source

### DIFF
--- a/examples/answers-tpm.yaml
+++ b/examples/answers-tpm.yaml
@@ -1,4 +1,5 @@
 #source-catalog: examples/tpm-sources.yaml
+#dr-config: examples/tpm-dr-config.yaml
 Source:
   source: src-prefer-encrypted
 Serial:

--- a/examples/tpm-dr-config.yaml
+++ b/examples/tpm-dr-config.yaml
@@ -1,0 +1,1 @@
+systems_dir_exists: true

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -159,6 +159,7 @@ for answers in examples/answers*.yaml; do
     if echo $answers|grep -vq system-setup; then
         config=$(sed -n 's/^#machine-config: \(.*\)/\1/p' $answers || true)
         catalog=$(sed -n 's/^#source-catalog: \(.*\)/\1/p' $answers || true)
+        dr_config=$(sed -n 's/^#dr-config: \(.*\)/\1/p' "$answers" || true)
         if [ -z "$config" ]; then
             config=examples/simple.json
         fi
@@ -169,6 +170,9 @@ for answers in examples/answers*.yaml; do
         opts=()
         if [ -n "$serial" ]; then
             opts+=(--serial)
+        fi
+        if [ -n "$dr_config" ]; then
+            opts+=(--dry-run-config "$dr_config")
         fi
         # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
         LANG=C.UTF-8 timeout --foreground 60 \

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -38,6 +38,7 @@ from subiquity.models.tests.test_filesystem import (
     )
 from subiquity.server import snapdapi
 from subiquity.server.controllers.filesystem import FilesystemController
+from subiquity.server.dryrun import DRConfig
 
 bootloaders = [(bl, ) for bl in list(Bootloader)]
 bootloaders_and_ptables = [(bl, pt)
@@ -472,6 +473,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.app.prober = mock.Mock()
         self.app.snapdapi = snapdapi.make_api_client(
             AsyncSnapd(get_fake_connection()))
+        self.app.dr_cfg = DRConfig()
         self.fsc = FilesystemController(app=self.app)
         self.fsc._configured = True
         self.fsc.model = make_model(Bootloader.UEFI)
@@ -565,6 +567,9 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.app.base_model.source.current.snapd_system_label = \
             'prefer-encrypted'
         self.app.controllers.Source.source_path = ''
+
+        self.app.dr_cfg.systems_dir_exists = True
+
         await self.fsc._get_system_task.start()
         await self.fsc._get_system_task.wait()
 

--- a/subiquity/server/dryrun.py
+++ b/subiquity/server/dryrun.py
@@ -13,6 +13,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import yaml
+
+import attr
+
 
 class DryRunController:
 
@@ -22,3 +26,15 @@ class DryRunController:
 
     async def crash_GET(self) -> None:
         1/0
+
+
+@attr.s(auto_attribs=True)
+class DRConfig:
+    """ Configuration for dry-run-only executions.
+    All variables here should have default values ; to indicate the behavior we
+    want by default in dry-run mode. """
+
+    @classmethod
+    def load(cls, stream):
+        data = yaml.safe_load(stream)
+        return cls(**data)

--- a/subiquity/server/dryrun.py
+++ b/subiquity/server/dryrun.py
@@ -34,6 +34,9 @@ class DRConfig:
     All variables here should have default values ; to indicate the behavior we
     want by default in dry-run mode. """
 
+    # Tells whether "$source"/var/lib/snapd/seed/systems exists on the source.
+    systems_dir_exists: bool = False
+
     @classmethod
     def load(cls, stream):
         data = yaml.safe_load(stream)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -68,6 +68,7 @@ from subiquity.models.subiquity import (
     ModelNames,
     SubiquityModel,
     )
+from subiquity.server.dryrun import DRConfig
 from subiquity.server.controller import SubiquityController
 from subiquity.server.geoip import (
     GeoIP,
@@ -274,6 +275,7 @@ class SubiquityServer(Application):
 
     def __init__(self, opts, block_log_dir):
         super().__init__(opts)
+        self.dr_cfg: Optional[DRConfig] = None
         self.set_source_variant(self.supported_variants[0])
         self.block_log_dir = block_log_dir
         self.cloud = None


### PR DESCRIPTION
Subiquity attempts to bind-mount `/var/lib/snapd/seed/systems` from the source to the host. Unfortunately, in standard ubuntu-server installs, the directory does not exist so the install crashes early with a `CalledProcessError` (mount: No such file or directory). 

https://bugs.launchpad.net/subiquity/+bug/1997538

This PR essentially checks if the directory exists before trying to bind-mount it.

Unfortunately, adding this check impacts dry-run executions (and unit tests) because the behavior becomes dependent on the presence of `/var/lib/snapd/seed/systems` on the host (in dry-run mode, the source path is set to `/` so we look for the `systems` directory on the host).

I took the opportunity to introduce a configuration object that controls what Subiquity does in dry-run mode (I have wanted to do this for some time). This object is meant to contain default values for what a typical dry-run execution would do. For now it contains a single variable named `systems_directory_exists` but we can add more going forward. The values in the object can be overridden in unit tests (i.e.: `self.app.dr_cfg.systems_directory_exists = True`) and values can also be loaded from a YAML file passed to the subiquity server process via the `--dry-run-config` argument.

I am sure it feels over-engineered for now with only a single configuration item available. That said, it is the kind of architecture I wanted to have so we can cover many more use-cases in ubuntu-pro, ubuntu-drivers, etc. Here's a list of potential ideas I would like to use this mechanism for:

* drivers:
    * to tell Subiquity the list of third-party drivers it should suggest (or none)
    * to request Subiquity to run ubuntu-drivers on the host
    * to specify an alternative sysfs directory containing predefined modalias files
* ubuntu-pro:
    * to specify the ua-contracts test environment URL 
    * to specify automatic replies for the server
* to specify the Ubuntu release that is returned by `lsb_release` which we can be used to test behavior on LTS vs non LTS releases.
* to specify the current Subiquity version number and the version number that we would offer as a refresh (or not offer if it is lower)