### PR TITLE
MagicAttach: add ability to test in dry-run against the staging environment & demo web portal

### DIFF
--- a/examples/dr-config-magic-attach.yaml
+++ b/examples/dr-config-magic-attach.yaml
@@ -1,0 +1,1 @@
+pro_magic_attach_run_locally: true

--- a/subiquity/cmd/schema.py
+++ b/subiquity/cmd/schema.py
@@ -22,6 +22,7 @@ import sys
 import jsonschema
 
 from subiquity.cmd.server import make_server_args_parser
+from subiquity.server.dryrun import DRConfig
 from subiquity.server.server import SubiquityServer
 
 
@@ -54,6 +55,9 @@ def make_app():
     parser = make_server_args_parser()
     opts, unknown = parser.parse_known_args(['--dry-run'])
     app = SubiquityServer(opts, '')
+    # This is needed because the ubuntu-pro server controller accesses dr_cfg
+    # in the initializer.
+    app.dr_cfg = DRConfig()
     app.base_model = app.make_model()
     app.controllers.load_all()
     return app

--- a/subiquity/server/controllers/tests/test_ubuntu_pro.py
+++ b/subiquity/server/controllers/tests/test_ubuntu_pro.py
@@ -18,12 +18,15 @@ import unittest
 from subiquity.server.controllers.ubuntu_pro import (
     UbuntuProController,
 )
+from subiquity.server.dryrun import DRConfig
 from subiquitycore.tests.mocks import make_app
 
 
 class TestUbuntuProController(unittest.TestCase):
     def setUp(self):
-        self.controller = UbuntuProController(make_app())
+        app = make_app()
+        app.dr_cfg = DRConfig()
+        self.controller = UbuntuProController(app)
 
     def test_serialize(self):
         self.controller.model.token = "1a2b3C"

--- a/subiquity/server/controllers/ubuntu_pro.py
+++ b/subiquity/server/controllers/ubuntu_pro.py
@@ -90,7 +90,12 @@ class UbuntuProController(SubiquityController):
         """ Initializer for server-side Ubuntu Pro controller. """
         strategy: UAInterfaceStrategy
         if app.opts.dry_run:
-            strategy = MockedUAInterfaceStrategy(scale_factor=app.scale_factor)
+            if app.dr_cfg.pro_magic_attach_run_locally:
+                executable = "/usr/bin/ubuntu-advantage"
+                strategy = UAClientUAInterfaceStrategy(executable=executable)
+            else:
+                strategy = MockedUAInterfaceStrategy(
+                        scale_factor=app.scale_factor)
         else:
             # Make sure we execute `$PYTHON "$SNAP/usr/bin/ubuntu-advantage"`.
             executable = (

--- a/subiquity/server/controllers/ubuntu_pro.py
+++ b/subiquity/server/controllers/ubuntu_pro.py
@@ -90,9 +90,12 @@ class UbuntuProController(SubiquityController):
         """ Initializer for server-side Ubuntu Pro controller. """
         strategy: UAInterfaceStrategy
         if app.opts.dry_run:
+            contracts_url = app.dr_cfg.pro_ua_contracts_url
             if app.dr_cfg.pro_magic_attach_run_locally:
                 executable = "/usr/bin/ubuntu-advantage"
                 strategy = UAClientUAInterfaceStrategy(executable=executable)
+                strategy.load_default_uaclient_config()
+                strategy.uaclient_config["contract_url"] = contracts_url
             else:
                 strategy = MockedUAInterfaceStrategy(
                         scale_factor=app.scale_factor)

--- a/subiquity/server/dryrun.py
+++ b/subiquity/server/dryrun.py
@@ -36,6 +36,12 @@ class DRConfig:
 
     # Tells whether "$source"/var/lib/snapd/seed/systems exists on the source.
     systems_dir_exists: bool = False
+    # Tells whether we should run /usr/bin/ubuntu-advantage instead of using
+    # Mock objects.
+    pro_magic_attach_run_locally: bool = False
+    # When running /usr/bin/ubuntu-advantage locally, do not use the production
+    # ua-contrats.
+    pro_ua_contracts_url: str = "https://contracts.staging.canonical.com"
 
     @classmethod
     def load(cls, stream):

--- a/subiquity/server/tests/test_ubuntu_advantage.py
+++ b/subiquity/server/tests/test_ubuntu_advantage.py
@@ -15,7 +15,7 @@
 
 from subprocess import CompletedProcess
 import unittest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, ANY
 
 from subiquity.common.types import UbuntuProService
 from subiquity.server.ubuntu_advantage import (
@@ -87,7 +87,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
             mock_arun.return_value = CompletedProcess([], 0)
             mock_arun.return_value.stdout = "{}"
             await strategy.query_info(token="123456789")
-            mock_arun.assert_called_once_with(command, check=False)
+            mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_query_info_unknown_error(self):
         strategy = UAClientUAInterfaceStrategy()
@@ -103,7 +103,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
             mock_arun.return_value.stdout = "{}"
             with self.assertRaises(CheckSubscriptionError):
                 await strategy.query_info(token="123456789")
-            mock_arun.assert_called_once_with(command, check=False)
+            mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_query_info_invalid_token(self):
         strategy = UAClientUAInterfaceStrategy()
@@ -134,7 +134,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
 """
             with self.assertRaises(InvalidTokenError):
                 await strategy.query_info(token="123456789")
-            mock_arun.assert_called_once_with(command, check=False)
+            mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_query_info_invalid_json(self):
         strategy = UAClientUAInterfaceStrategy()
@@ -150,7 +150,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
             mock_arun.return_value.stdout = "invalid-json"
             with self.assertRaises(CheckSubscriptionError):
                 await strategy.query_info(token="123456789")
-            mock_arun.assert_called_once_with(command, check=False)
+            mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_api_call(self):
         strategy = UAClientUAInterfaceStrategy()
@@ -168,7 +168,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
             "u.pro.attach.magic.wait.v1",
             "--args", "magic_token=132456",
         )
-        mock_arun.assert_called_once_with(command, check=False)
+        mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_magic_initiate_v1(self):
         strategy = UAClientUAInterfaceStrategy()


### PR DESCRIPTION
This PR adds the ability to test Subiquity with magic-attach in dry-run mode against the staging (or another) environment.

As part of https://github.com/canonical/ubuntu.com/pull/11974, the web and design team deployed a demo web portal that connects to the staging environment.

To test Subiquity with magic-attach in dry-run mode, one simply needs to:

* pass the `--dry-run-config examples/dr-config-magic-attach.yaml` option
* navigate to https://ubuntu-com-11974.demos.haus/pro/attach instead of https://ubuntu.com/pro/attach when instructed to.

When testing, I noticed a crash when going back. I will investigate and fix the issue as part of a different PR.