### PR TITLE
ubuntu-pro: cancel any contract selection before initiating a new one

### DIFF
--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -602,9 +602,18 @@ class UbuntuProView(BaseView):
         if form.skip.value:
             self.controller.done("")
         else:
+            def initiate() -> None:
+                self.controller.contract_selection_initiate(
+                        on_initiated=self.cs_initiated)
+
             self._w = self.upgrade_mode_screen()
-            self.controller.contract_selection_initiate(
-                    on_initiated=self.cs_initiated)
+            if self.controller.cs_initiated:
+                # Cancel the existing contract selection before initiating a
+                # new one.
+                self.controller.contract_selection_cancel(
+                        on_cancelled=initiate)
+            else:
+                initiate()
 
     def cancel(self) -> None:
         """ Called when the user presses the Back button. """


### PR DESCRIPTION
Upon reaching the Ubuntu Pro screen that shows the user-code, we need to initiate a contract selection. If we are navigating to the screen a second time though, we need to cancel existing contract selections before initiating a new one.

Failing to do so results in a UPCSAlreadyInitiatedError.

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>