### PR TITLE
do not round up partition size in add_partition

### DIFF
--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -171,7 +171,7 @@ def get_boot_device_plan_bios(device) -> Optional[MakeBootDevicePlan]:
             return attr_plan
 
     gap = gaps.Gap(device=device,
-                   offset=sizes.BIOS_GRUB_SIZE_BYTES,
+                   offset=device.alignment_data().min_start_offset,
                    size=sizes.BIOS_GRUB_SIZE_BYTES)
     create_part_plan = CreatePartPlan(
         gap=gap,

--- a/subiquity/common/filesystem/sizes.py
+++ b/subiquity/common/filesystem/sizes.py
@@ -101,6 +101,8 @@ def calculate_guided_resize(part_min: int, part_size: int, install_min: int,
     if part_min < 0:
         return None
 
+    part_size = align_up(part_size, part_align)
+
     other_room_to_grow = max(2 * GiB, math.ceil(.25 * part_min))
     padded_other_min = part_min + other_room_to_grow
     other_min = min(align_up(padded_other_min, part_align), part_size)

--- a/subiquity/common/filesystem/tests/test_sizes.py
+++ b/subiquity/common/filesystem/tests/test_sizes.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import random
 import unittest
 from unittest import mock
 
@@ -27,6 +28,9 @@ from subiquity.common.filesystem.sizes import (
     uefi_scale,
     )
 from subiquity.common.types import GuidedResizeValues
+from subiquity.models.filesystem import (
+    MiB,
+    )
 
 
 class TestPartitionSizeScaling(unittest.TestCase):
@@ -108,6 +112,25 @@ class TestCalculateGuidedResize(unittest.TestCase):
                 install_max=190 << 30,
                 minimum=50 << 30, recommended=200 << 30, maximum=230 << 30)
         self.assertEqual(expected, actual)
+
+    def test_unaligned_size(self):
+
+        def assertAligned(val):
+            if val % MiB != 0:
+                self.fail(
+                    "val of %s not aligned (%s) with delta %s" % (
+                        val, val % MiB, delta))
+
+        for i in range(1000):
+            delta = random.randrange(MiB)
+            actual = calculate_guided_resize(
+                part_min=40 << 30,
+                part_size=(240 << 30) + delta,
+                install_min=10 << 30)
+            assertAligned(actual.install_max)
+            assertAligned(actual.minimum)
+            assertAligned(actual.recommended)
+            assertAligned(actual.maximum)
 
 
 class TestCalculateInstallMin(unittest.TestCase):

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1588,12 +1588,10 @@ class FilesystemModel(object):
     def add_partition(self, device, *, size, offset, flag="", wipe=None,
                       grub_device=None, partition_name=None):
         from subiquity.common.filesystem import boot
-        real_size = align_up(size)
-        log.debug("add_partition: rounded size from %s to %s", size, real_size)
         if device._fs is not None:
             raise Exception("%s is already formatted" % (device,))
         p = Partition(
-            m=self, device=device, size=real_size, flag=flag, wipe=wipe,
+            m=self, device=device, size=size, flag=flag, wipe=wipe,
             grub_device=grub_device, offset=offset,
             partition_name=partition_name)
         if boot.is_bootloader_partition(p):

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1586,7 +1586,14 @@ class FilesystemModel(object):
         self._actions.remove(obj)
 
     def add_partition(self, device, *, size, offset, flag="", wipe=None,
-                      grub_device=None, partition_name=None):
+                      grub_device=None, partition_name=None,
+                      check_alignment=True):
+        align = device.alignment_data().part_align
+        if check_alignment:
+            if offset % align != 0 or size % align != 0:
+                raise Exception(
+                    "size %s or offset %s not aligned to %s",
+                    size, offset, align)
         from subiquity.common.filesystem import boot
         if device._fs is not None:
             raise Exception("%s is already formatted" % (device,))

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -510,7 +510,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                    structure == volume.structure[-1]:
                     gap = gaps.largest_gap(disk)
                     size = gap.size - (offset - gap.offset)
-                part = self.model.add_partition(disk, offset=offset, size=size)
+                part = self.model.add_partition(
+                    disk, offset=offset, size=size, check_alignment=False)
 
             type_uuid = structure.gpt_part_type_uuid()
             if type_uuid:


### PR DESCRIPTION
I'm like 99% sure that all call paths to here align the size properly, apart from the one in apply_system, which I want to be able to create improperly sized partitions.