### PR TITLE
skip ssh and snaplist screens for desktop install

### DIFF
--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -171,6 +171,21 @@ class SnapListController(SubiquityController):
         self.loader = self._make_loader()
         self.app.hub.subscribe(InstallerChannels.SNAPD_NETWORK_CHANGE,
                                self.snapd_network_changed)
+        self.app.hub.subscribe(
+            (InstallerChannels.CONFIGURED, 'filesystem'),
+            self._confirmed)
+        self._active = True
+
+    async def _confirmed(self):
+        if self.app.base_model.source.current.variant == 'desktop':
+            await self.configured()
+            self._active = False
+            self.loader.stop()
+
+    def interactive(self):
+        if super().interactive():
+            return self._active
+        return False
 
     def load_autoinstall_data(self, ai_data):
         to_install = []

--- a/subiquity/server/controllers/ssh.py
+++ b/subiquity/server/controllers/ssh.py
@@ -27,6 +27,7 @@ from subiquity.common.types import (
     SSHIdentity,
     )
 from subiquity.server.controller import SubiquityController
+from subiquity.server.types import InstallerChannels
 
 log = logging.getLogger('subiquity.server.controllers.ssh')
 
@@ -54,6 +55,23 @@ class SSHController(SubiquityController):
             'allow-pw': {'type': 'boolean'},
         },
     }
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.app.hub.subscribe(
+            (InstallerChannels.CONFIGURED, 'filesystem'),
+            self._confirmed)
+        self._active = True
+
+    async def _confirmed(self):
+        if self.app.base_model.source.current.variant == 'desktop':
+            await self.configured()
+            self._active = False
+
+    def interactive(self):
+        if super().interactive():
+            return self._active
+        return False
 
     def load_autoinstall_data(self, data):
         if data is None:


### PR DESCRIPTION
If and when the desktop installer adds a snaps screen, we should probably fetch information for a different set of snaps for a desktop install. But for now this is OK.