### PR TITLE
Drivers: make sure we suggest non-GPGPU drivers to the desktop installer

### DIFF
--- a/examples/mixed-sources.yaml
+++ b/examples/mixed-sources.yaml
@@ -1,0 +1,23 @@
+- description:
+    en: This version has been customized to have a small runtime footprint in environments
+      where humans are not expected to log in.
+  id: ubuntu-server-minimal
+  locale_support: none
+  name:
+    en: Ubuntu Server (minimized)
+  path: ubuntu-server-minimal.squashfs
+  size: 530485248
+  type: fsimage
+  variant: server
+- default: true
+  description:
+    en: The default install contains a curated set of packages that provide a comfortable
+      experience for operating your desktop.
+  id: ubuntu-desktop
+  locale_support: locale-only
+  name:
+    en: Ubuntu Desktop
+  path: ubuntu-desktop-minimal.ubuntu-desktop.squashfs
+  size: 1066115072
+  type: fsimage-layered
+  variant: desktop

--- a/subiquity/client/controllers/drivers.py
+++ b/subiquity/client/controllers/drivers.py
@@ -34,6 +34,7 @@ class DriversController(SubiquityTuiController):
         response: DriversResponse = await self.endpoint.GET()
 
         if not response.search_drivers:
+            await self.endpoint.POST(DriversPayload(install=False))
             raise Skip
 
         return DriversView(self, response.drivers,

--- a/subiquity/server/controllers/drivers.py
+++ b/subiquity/server/controllers/drivers.py
@@ -52,8 +52,12 @@ class DriversController(SubiquityController):
 
     def __init__(self, app) -> None:
         super().__init__(app)
-        self.ubuntu_drivers: UbuntuDriversInterface = \
-            get_ubuntu_drivers_interface(app)
+        self.ubuntu_drivers: Optional[UbuntuDriversInterface] = None
+
+        self._list_drivers_task: Optional[asyncio.Task] = None
+        self.list_drivers_done_event = asyncio.Event()
+
+        self.drivers: List[str] = []
 
     def make_autoinstall(self):
         return {
@@ -69,7 +73,24 @@ class DriversController(SubiquityController):
         self.app.hub.subscribe(
             InstallerChannels.APT_CONFIGURED,
             self._wait_apt.set)
-        self._drivers_task = asyncio.create_task(self._list_drivers())
+        self.app.hub.subscribe(
+            (InstallerChannels.CONFIGURED, "source"),
+            self.restart_querying_drivers_list)
+
+    def restart_querying_drivers_list(self):
+        """ Start querying the list of available drivers. This method can be
+        invoked multiple times so we need to stop ongoing operations if the
+        variant changes. """
+
+        self.ubuntu_drivers = get_ubuntu_drivers_interface(self.app)
+
+        self.drivers = []
+        self.list_drivers_done_event.clear()
+        if self._list_drivers_task is not None:
+            self._list_drivers_task.cancel()
+
+        log.debug("source variant has been set. Querying list of drivers.")
+        self._list_drivers_task = asyncio.create_task(self._list_drivers())
 
     @with_context()
     async def _list_drivers(self, context):
@@ -81,6 +102,7 @@ class DriversController(SubiquityController):
         # the source screen to enable/disable the "search drivers" checkbox.
         if not self.app.controllers.Source.model.search_drivers:
             self.drivers = []
+            self.list_drivers_done_event.set()
             return
         apt = self.app.controllers.Mirror.apt_configurer
         try:
@@ -96,12 +118,13 @@ class DriversController(SubiquityController):
                         context=context)
         except OverlayCleanupError:
             log.exception("Failed to cleanup overlay. Continuing anyway.")
+        self.list_drivers_done_event.set()
         log.debug("Available drivers to install: %s", self.drivers)
 
     async def GET(self, wait: bool = False) -> DriversResponse:
         local_only = not self.app.base_model.network.has_network
         if wait:
-            await asyncio.shield(self._drivers_task)
+            await self.list_drivers_done_event.wait()
 
         search_drivers = self.app.controllers.Source.model.search_drivers
 

--- a/subiquity/server/controllers/drivers.py
+++ b/subiquity/server/controllers/drivers.py
@@ -81,7 +81,6 @@ class DriversController(SubiquityController):
         # the source screen to enable/disable the "search drivers" checkbox.
         if not self.app.controllers.Source.model.search_drivers:
             self.drivers = []
-            await self.configured()
             return
         apt = self.app.controllers.Mirror.apt_configurer
         try:
@@ -98,8 +97,6 @@ class DriversController(SubiquityController):
         except OverlayCleanupError:
             log.exception("Failed to cleanup overlay. Continuing anyway.")
         log.debug("Available drivers to install: %s", self.drivers)
-        if not self.drivers:
-            await self.configured()
 
     async def GET(self, wait: bool = False) -> DriversResponse:
         local_only = not self.app.base_model.network.has_network

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -326,6 +326,7 @@ class TestFlow(TestAPI):
             }
             await inst.post('/ssh', ssh)
             await inst.post('/snaplist', [])
+            await inst.post('/drivers', {'install': False})
             ua_params = {
                 "token": "a1b2c3d4e6f7g8h9I0K1",
             }


### PR DESCRIPTION
The list of drivers suggested to the user may vary based on whether we are installing a server or desktop image.

In the current implementation of the drivers controller, the value of the source variant (e.g., server or desktop) is read early in the initializer.

This is a problem because it happens before the client gets the opportunity to tell us what we are installing.

As the result, we always suggest drivers for the server variant because it is the default value in Subiquity.

This PR makes sure to query the list of drivers when the source variant is set (or set again).

Launchpad bug: https://bugs.launchpad.net/subiquity/+bug/1998376