### PR TITLE
journald: stop passing a loop

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -297,10 +297,7 @@ class SubiquityClient(TuiApplication):
                 p('\x08 \n')
 
         status = await spinning_wait("connecting", self._status_get())
-        journald_listen(
-            self.aio_loop,
-            [status.echo_syslog_id],
-            lambda e: print(e['MESSAGE']))
+        journald_listen([status.echo_syslog_id], lambda e: print(e['MESSAGE']))
         if status.state == ApplicationState.STARTING_UP:
             status = await spinning_wait(
                 "starting up", self._status_get(cur=status.state))
@@ -357,11 +354,9 @@ class SubiquityClient(TuiApplication):
             # the progress page
             if hasattr(self.controllers, "Progress"):
                 journald_listen(
-                    self.aio_loop,
                     [status.event_syslog_id],
                     self.controllers.Progress.event)
                 journald_listen(
-                    self.aio_loop,
                     [status.log_syslog_id],
                     self.controllers.Progress.log_line)
             if not status.cloud_init_ok:
@@ -382,7 +377,6 @@ class SubiquityClient(TuiApplication):
                 # prompting for confirmation will be confusing.
                 os.system('stty sane')
             journald_listen(
-                self.aio_loop,
                 [status.event_syslog_id],
                 self.subiquity_event_noninteractive,
                 seek=True)

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -145,8 +145,7 @@ class InstallController(SubiquityController):
             asyncio.create_task(self.stop_unattended_upgrades())
 
     def start(self):
-        journald_listen(
-            self.app.aio_loop, [self.app.log_syslog_id], self.log_event)
+        journald_listen([self.app.log_syslog_id], self.log_event)
         self.install_task = asyncio.create_task(self.install())
 
     def tpath(self, *path):

--- a/subiquity/server/curtin.py
+++ b/subiquity/server/curtin.py
@@ -103,8 +103,7 @@ class _CurtinCommand:
         return cmd
 
     async def start(self, context, **opts):
-        self._fd = journald_listen(
-            asyncio.get_running_loop(), [self._event_syslog_id], self._event)
+        self._fd = journald_listen([self._event_syslog_id], self._event)
         # Yield to the event loop before starting curtin to avoid missing the
         # first couple of events.
         await asyncio.sleep(0)


### PR DESCRIPTION
Per python 3.10 changelog[1], passing a loop around is no longer considered a good idea.  Remove the loop argument and request the running loop.

[1]: https://docs.python.org/3/whatsnew/3.10.html#removed