### PR TITLE
remove --script/--click command line arguments

### DIFF
--- a/console_conf/cmd/tui.py
+++ b/console_conf/cmd/tui.py
@@ -24,11 +24,6 @@ from subiquitycore import __version__ as VERSION
 from console_conf.core import ConsoleConf, RecoveryChooser
 
 
-class ClickAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        namespace.scripts.append("c(" + repr(values) + ")")
-
-
 def parse_options(argv):
     parser = argparse.ArgumentParser(
         description=(
@@ -49,12 +44,6 @@ def parse_options(argv):
                         help="Don't Probe. Use probe data file")
     parser.add_argument('--screens', action='append', dest='screens',
                         default=[])
-    parser.add_argument('--script', metavar="SCRIPT", action='append',
-                        dest='scripts', default=[],
-                        help=('Execute SCRIPT in a namespace containing view '
-                              'helpers and "ui"'))
-    parser.add_argument('--click', metavar="PAT", action=ClickAction,
-                        help='Synthesize a click on a button matching PAT')
     parser.add_argument('--answers')
     parser.add_argument('--recovery-chooser-mode', action='store_true',
                         dest='chooser_systems',

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -31,11 +31,6 @@ from .common import (
 from .server import make_server_args_parser
 
 
-class ClickAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        namespace.scripts.append("c(" + repr(values) + ")")
-
-
 def make_client_args_parser():
     parser = argparse.ArgumentParser(
         description='Subiquity - Ubiquity for Servers',
@@ -63,12 +58,6 @@ def make_client_args_parser():
                         help='Run the installer in unicode mode.')
     parser.add_argument('--screens', action='append', dest='screens',
                         default=[])
-    parser.add_argument('--script', metavar="SCRIPT", action='append',
-                        dest='scripts', default=[],
-                        help=('Execute SCRIPT in a namespace containing view '
-                              'helpers and "ui"'))
-    parser.add_argument('--click', metavar="PAT", action=ClickAction,
-                        help='Synthesize a click on a button matching PAT')
     parser.add_argument('--answers')
     parser.add_argument('--server-pid')
     parser.add_argument('--output-base', action='store', dest='output_base',


### PR DESCRIPTION
I implemented these a long time ago to help working on parts of the ui by allowing a way to script moving past some screens. I haven't used them in ages, it's pretty bad code and probably a fragmentary answers file is a better solution to the same problem. What do you think?