### PR TITLE
refresh: remove the cancel update button since it is broken

### DIFF
--- a/subiquity/ui/views/refresh.py
+++ b/subiquity/ui/views/refresh.py
@@ -238,13 +238,11 @@ class RefreshView(BaseView):
         self.lb_tasks = ListBox([])
         self.task_to_bar = {}
 
-        buttons = [
-            other_btn(_("Cancel update"), on_press=self.check_state_available),
-            ]
-
         self.controller.ui.set_header(_(self.progress_title))
-        self._w = screen(
-            self.lb_tasks, buttons, excerpt=_(self.progress_excerpt))
+        # TODO Cancellation of an ongoing self-refresh is not currently
+        # implemented on the server side. Let's include a cancel button when we
+        # have an API for it.
+        self._w = screen(self.lb_tasks, [], excerpt=_(self.progress_excerpt))
         schedule_task(self._update())
 
     async def _update(self):


### PR DESCRIPTION
Cancelling the installer self refresh does not work. Clicking on the button simply goes back to the screen asking the user if they want to update ; but the refresh operation still continues in the background.

Since we do not have a simple way to implement refresh cancellation at the moment, we are just removing the button.