### PR TITLE
[WSL] WslConfigAdvanced only on reconfiguration variant

### DIFF
--- a/examples/answers-system-setup-init.yaml
+++ b/examples/answers-system-setup-init.yaml
@@ -7,10 +7,5 @@ WSLIdentity:
   username: ubuntu
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
-WSLConfigurationBase:
-  automount_root: '/custom_mnt_path'
-  automount_options: 'metadata'
-  network_generatehosts: false
-  network_generateresolvconf: false
 Summary:
   reboot: yes

--- a/system_setup/client/client.py
+++ b/system_setup/client/client.py
@@ -63,7 +63,6 @@ class SystemSetupClient(SubiquityClient):
         "Welcome",
         "WSLSetupOptions",
         "WSLIdentity",
-        "WSLConfigurationBase",
         "Summary",
     ]
 

--- a/system_setup/common/wsl_conf.py
+++ b/system_setup/common/wsl_conf.py
@@ -120,12 +120,14 @@ def wsl_config_update(config_class, root_dir):
     """
     temp_conf_default = {}
     temp_confname = config_class.__str__()
-    if temp_confname.startswith("WSLConfigurationBase"):
+    if temp_confname.startswith("None"):
+        return
+    elif temp_confname.startswith("WSLConfigurationBase"):
         temp_conf_default = config_base_default
     elif temp_confname.startswith("WSLConfigurationAdvanced"):
         temp_conf_default = config_adv_default
     else:
-        raise TypeError("Invalid type name.")
+        raise TypeError("Invalid type: {}".format(config_class))
 
     # update the config file
     for config_type in temp_conf_default:

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -413,17 +413,12 @@ class ConfigureController(SubiquityController):
                 await self.create_user(root_dir, envcp)
                 await self.apply_locale(lang, envcp)
 
-            else:
+            # update wsl.conf when it is in autoinstall mode or reconf variant.
+            if variant == "wsl_configuration" or \
+                    self.app.opts.autoinstall is not None:
+                wsl_config_update(self.model.wslconfbase.wslconfbase, root_dir)
                 wsl_config_update(self.model.wslconfadvanced.wslconfadvanced,
                                   root_dir)
-
-            # update advanced config when it is in autoinstall mode
-            if self.app.opts.autoinstall is not None and \
-               self.model.wslconfadvanced.wslconfadvanced is not None:
-                wsl_config_update(self.model.wslconfadvanced.wslconfadvanced,
-                                  root_dir)
-
-            wsl_config_update(self.model.wslconfbase.wslconfbase, root_dir)
 
             self.app.update_state(ApplicationState.DONE)
 

--- a/system_setup/server/server.py
+++ b/system_setup/server/server.py
@@ -28,12 +28,12 @@ log = logging.getLogger('system_setup.server.server')
 
 INSTALL_MODEL_NAMES = ModelNames({
         "locale",
-        "wslconfbase",
     },
     wsl_setup={
         "identity",
     },
     wsl_configuration={
+        "wslconfbase",
         "wslconfadvanced",
     })
 

--- a/system_setup/tests/golden/answers/wsl.conf
+++ b/system_setup/tests/golden/answers/wsl.conf
@@ -1,7 +1,0 @@
-[automount]
-options = metadata
-root = /custom_mnt_path
-
-[network]
-generatehosts = false
-generateresolvconf = false


### PR DESCRIPTION
This pull request addresses the feedback we received that most users won't interact with the WSL configuration knobs during setup, but later if their workflows reveal the need for customisation.
With the set of changes herein proposed the advanced configuration screen is no longer shown in the setup variant of the TUI client and the integration tests are updated to reflect that.