### PR TITLE
utils: fix unused stdin parameter in astart_command

### DIFF
--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -114,7 +114,7 @@ async def astart_command(cmd: Sequence[str], *, stdout=subprocess.PIPE,
                          env=None, **kw) -> asyncio.subprocess.Process:
     log.debug("astart_command called: %s", cmd)
     return await asyncio.create_subprocess_exec(
-        *cmd, stdout=stdout, stderr=stderr,
+        *cmd, stdout=stdout, stderr=stderr, stdin=stdin,
         env=_clean_env(env), **kw)
 
 


### PR DESCRIPTION
Specifying the value of `subprocess.PIPE` as the `stdin` argument of `astart_command` did not have any effect. This happened because the parameter was not forwarded to the subprocess function. The parameter was effectively unused.