### PR TITLE
integration-tests: import SSH keys from LP instead of GH

### DIFF
--- a/examples/answers.yaml
+++ b/examples/answers.yaml
@@ -23,7 +23,7 @@ Identity:
   hostname: ubuntu-server
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
-  ssh-import-id: gh:mwhudson
+  ssh-import-id: lp:mwhudson
 UbuntuPro:
   token: ""
 SnapList:


### PR DESCRIPTION
As part of our integrations tests, we import mwhudson's public SSH key(s) from GitHub. At the moment, however, the GitHub API is rate limiting the number of queries from our CI.

Upon exceeding the rate limit, our HTTP queries are responded with a 403:
```
┌────────────────────────────────────────────────────────────────────────┐
│  Importing keys failed:                                                │
│                                                                        │
│  2023-01-08 23:43:40,562 ERROR GitHub REST API rate-limited this IP    │
│  address. See https://developer.github.com/v3/#rate-limiting .         │
│  status_code=403 user=mwhudson                                         │
└────────────────────────────────────────────────────────────────────────┘
```
Currently, upon pushing to GitHub, the CI runs the integrations tests against 4 different Ubuntu images (focal, jammy, kinetic, lunar).

This ends up doing 4 SSH import queries at roughly the same time ; which often exceeds the rate limit and makes some of the tests fail.

This patch makes integration tests import SSH keys from Launchpad instead of GitHub. Maybe a better approach would be to mock the calls to ssh-import-id in the CI instead,  but we can do that later.

