### PR TITLE
ubuntu-pro: enable for LTS releases

### DIFF
--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -69,12 +69,6 @@ class UbuntuProController(SubiquityTuiController):
             await self.endpoint.skip.POST()
             raise Skip("Not running LTS version")
 
-        # TODO remove these three lines when all dependencies for Ubuntu Pro
-        # are available in focal-updates.
-        if not self.app.opts.dry_run:
-            await self.endpoint.skip.POST()
-            raise Skip("Skipping Ubuntu Pro for now")
-
         ubuntu_pro_info: UbuntuProResponse = await self.endpoint.GET()
         return UbuntuProView(self,
                              token=ubuntu_pro_info.token,


### PR DESCRIPTION
The version of ubuntu-advantage-tools present in focal-updates contains all we need with regard to the magic attach implementation.

Although we are still missing the ubuntu.com/pro/attach screens, they should get active in the near future. It should be enough for testing.