### PR TITLE
apt: in dry-run code, also copy etc/apt/sources.list.d

### DIFF
--- a/subiquity/server/mounter.py
+++ b/subiquity/server/mounter.py
@@ -199,7 +199,11 @@ class DryRunMounter(Mounter):
             ], check=True)
         if os.path.isdir(f'{target}/etc/apt/sources.list.d'):
             shutil.rmtree(f'{target}/etc/apt/sources.list.d')
-        os.mkdir(f'{target}/etc/apt/sources.list.d')
+        await arun_command([
+            'cp', '-aT',
+            f'{source}/etc/apt/sources.list.d',
+            f'{target}/etc/apt/sources.list.d',
+            ], check=True)
         return OverlayMountpoint(
             lowers=[source],
             mountpoint=target,


### PR DESCRIPTION
In dry-run mode, we used to only copy `etc/apt/sources.list` to the fake overlay. However, if the host uses deb822, the sources.list file is usually empty.

This patch also makes sure to copy the deb822 sources from `etc/apt/sources.list.d/`