### PR TITLE
Fix wslsetupotions being None

### DIFF
--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -225,8 +225,8 @@ class ConfigureController(SubiquityController):
             return True
 
         cmd = []
-        if self.model.wslsetupoptions.wslsetupoptions.\
-                install_language_support_packages is True:
+        opts = self.model.wslsetupoptions.wslsetupoptions
+        if opts is None or opts.install_language_support_packages is True:
             cmd = [aptCommand, "install", "-y"]
 
         else:


### PR DESCRIPTION
Recent changes in GUI turned possible to have that field as None, leading to a crash.
This avoids the crash while preserving the default behavior of installing the language packs, unless the client sets otherwise.