### PR TITLE
geoip: do not raise on geoip failure

### DIFF
--- a/subiquity/server/tests/test_geoip.py
+++ b/subiquity/server/tests/test_geoip.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import aiohttp
 from aioresponses import aioresponses
 
 from subiquitycore.tests import SubiTestCase
@@ -94,5 +95,12 @@ class TestGeoIPBadData(SubiTestCase):
     async def test_empty_tz(self):
         with aioresponses() as mocked:
             mocked.get("https://geoip.ubuntu.com/lookup", body=empty_tz)
+            self.assertFalse(await self.geoip.lookup())
+        self.assertIsNone(self.geoip.timezone)
+
+    async def test_lookup_error(self):
+        with aioresponses() as mocked:
+            mocked.get("https://geoip.ubuntu.com/lookup",
+                       exception=aiohttp.ClientError('lookup failure'))
             self.assertFalse(await self.geoip.lookup())
         self.assertIsNone(self.geoip.timezone)


### PR DESCRIPTION
This is non-fatal, and users find the Traceback confusing.

Sample log statement:
```
  2023-01-17 18:18:19,958 DEBUG subiquity.server.geoip:113 geoip lookup
  failed: ClientConnectorError(ConnectionKey(host='lmao', port=443,
  is_ssl=True, ssl=None, proxy=None, proxy_auth=None,
  proxy_headers_hash=None), gaierror(-5, 'No address associated with
  hostname'))
```