### PR TITLE
load grub config from ai_data

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1241,7 +1241,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 raise Exception(
                     "must not use config: when installing core boot classic")
             self.model.apply_autoinstall_config(self.ai_data['config'])
-            self.model.swap = self.ai_data.get('swap')
+        self.model.swap = self.ai_data.get('swap')
         self.model.grub = self.ai_data.get('grub')
 
     def start(self):

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1241,8 +1241,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 raise Exception(
                     "must not use config: when installing core boot classic")
             self.model.apply_autoinstall_config(self.ai_data['config'])
-            self.model.grub = self.ai_data.get('grub')
             self.model.swap = self.ai_data.get('swap')
+        self.model.grub = self.ai_data.get('grub')
 
     def start(self):
         if self.model.bootloader == Bootloader.PREP:

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -154,6 +154,20 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.assertEqual(self.fsc.queued_probe_data, {})
         load.assert_not_called()
 
+    @parameterized.expand(((0,), ('1G',)))
+    async def test_layout_plus_swap(self, swapsize):
+        self.fsc.model = model = make_model(Bootloader.UEFI)
+        self.fsc.run_autoinstall_guided = mock.AsyncMock()
+
+        self.fsc.ai_data = {
+            'layout': {'name': 'direct'},
+            'swap': {'size': swapsize}
+        }
+
+        await self.fsc.convert_autoinstall_config()
+        curtin_cfg = model.render()
+        self.assertEqual(swapsize, curtin_cfg['swap']['size'])
+
     @mock.patch('subiquity.server.controllers.filesystem.open',
                 mock.mock_open())
     async def test_probe_once_unlocked_probe_data(self):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -115,6 +115,33 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.assertIsNone(self.fsc.queued_probe_data)
         load.assert_not_called()
 
+    async def test_layout_no_grub_or_swap(self):
+        self.fsc.model = model = make_model(Bootloader.UEFI)
+        self.fsc.run_autoinstall_guided = mock.AsyncMock()
+
+        self.fsc.ai_data = {
+            'layout': {'name': 'direct'},
+        }
+
+        await self.fsc.convert_autoinstall_config()
+        curtin_cfg = model.render()
+        self.assertNotIn('grub', curtin_cfg)
+        self.assertNotIn('swap', curtin_cfg)
+
+    @parameterized.expand(((True,), (False,)))
+    async def test_layout_plus_grub(self, reorder_uefi):
+        self.fsc.model = model = make_model(Bootloader.UEFI)
+        self.fsc.run_autoinstall_guided = mock.AsyncMock()
+
+        self.fsc.ai_data = {
+            'layout': {'name': 'direct'},
+            'grub': {'reorder_uefi': reorder_uefi}
+        }
+
+        await self.fsc.convert_autoinstall_config()
+        curtin_cfg = model.render()
+        self.assertEqual(reorder_uefi, curtin_cfg['grub']['reorder_uefi'])
+
     @mock.patch('subiquity.server.controllers.filesystem.open',
                 mock.mock_open())
     async def test_probe_once_locked_probe_data(self):


### PR DESCRIPTION
launchpad bug: [1952926](https://bugs.launchpad.net/subiquity/+bug/1952926)

This change should make it so that user supplied grub config in the autoinstall data will be used even when the layout option is supplied.

This would allow users to supply the simpler storage configs (see launchpad bug) and disable the grub reordering (which currently moves network boot devices to the first boot item making the newly installed os not the default boot option)
