### PR TITLE
logging: replace deprecated calls to log.warn by log.warning

### DIFF
--- a/subiquity/server/contract_selection.py
+++ b/subiquity/server/contract_selection.py
@@ -111,7 +111,7 @@ class ContractSelection:
                         magic_token=self.magic_token)
 
             except APIUsageError as e:
-                log.warn("failed to revoke magic-token: %r", e)
+                log.warning("failed to revoke magic-token: %r", e)
             else:
                 if answer["result"] != "success":
                     log.debug("successfully revoked magic-token")

--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -225,7 +225,7 @@ class SnapListController(SubiquityController):
             except SnapListFetchError:
                 return SnapListResponse(status=SnapCheckState.FAILED)
             except asyncio.CancelledError:
-                log.warn("load list snaps task was cancelled, retrying...")
+                log.warning("load list snaps task was cancelled, retrying...")
             else:
                 break
         return SnapListResponse(

--- a/subiquity/server/geoip.py
+++ b/subiquity/server/geoip.py
@@ -109,7 +109,7 @@ class GeoIP:
         try:
             self.response_text = await self.strategy.get_response()
         except aiohttp.ClientError as le:
-            log.warn("geoip lookup failed: %r", le)
+            log.warning("geoip lookup failed: %r", le)
             return False
         try:
             self.element = ElementTree.fromstring(self.response_text)


### PR DESCRIPTION
Since Python 3.3, log.warn has been deprecated in favor of log.warning. Running the unit tests raises the following warning:

subiquity/server/tests/test_geoip.py::TestGeoIPBadData::test_lookup_error
  /home/olivier/dev/canonical/subiquity/subiquity/server/geoip.py:112:
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn("geoip lookup failed: %r", le)

I replaced all the calls to log.warn by calls to log.warning

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>