### PR TITLE
autoinstall: adjust x-make-view-request behavior

### DIFF
--- a/examples/autoinstall-short.yaml
+++ b/examples/autoinstall-short.yaml
@@ -1,0 +1,5 @@
+version: 1
+identity:
+    hostname: ai-test
+    password: "$y$j9T$UdY22v4Kexn/AZcIzBSUc0$2DnuvWDSwoDCFPlbk1ghZeT2qFrEBKY1bpFQoexHdw7"
+    username: ubuntu

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -432,12 +432,13 @@ class SubiquityServer(Application):
         override_status = None
         controller = await controller_for_request(request)
         if isinstance(controller, SubiquityController):
-            if not controller.interactive():
-                override_status = 'skip'
-            elif (self.state == ApplicationState.NEEDS_CONFIRMATION and
-                  request.headers.get('x-make-view-request') == 'yes'):
-                if self.base_model.is_postinstall_only(controller.model_name):
-                    override_status = 'confirm'
+            if request.headers.get('x-make-view-request') == 'yes':
+                if not controller.interactive():
+                    override_status = 'skip'
+                elif self.state == ApplicationState.NEEDS_CONFIRMATION:
+                    if self.base_model.is_postinstall_only(
+                            controller.model_name):
+                        override_status = 'confirm'
         if override_status is not None:
             resp = web.Response(headers={'x-status': override_status})
         else:


### PR DESCRIPTION
With autoinstall, a controller that was not interactive would decline
outright to provide the response to GET queries, with the notion that the
controller needed to be skipped.  Limit this behavior to only when
`x-make-view-request: yes` is set, which lets the client be able to get
the real response, or the skip info, depending on need.