### PR TITLE
snapcraft: add pkg_resources to the snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -109,6 +109,7 @@ parts:
       - python3-jsonschema
       - python3-minimal
       - python3-oauthlib
+      - python3-pkg-resources
       - python3-pyrsistent
       - python3-pyudev
       - python3-requests


### PR DESCRIPTION
From subiquity, we sometimes execute entry point python scripts such as:

 * `usr/bin/ubuntu-advantage`
 * `usr/bin/ssh-import-id`

Those scripts require pkg_resources on core20 to run properly:

```python
from pkg_resources import load_entry_point
```

On core22, the scripts will be a bit more flexible but for now, we need python3-pkg-resources in the snap.