### PR TITLE
Cherry-pick Ubuntu Pro patches for 23.02.1

### DIFF
--- a/examples/dr-config-magic-attach.yaml
+++ b/examples/dr-config-magic-attach.yaml
@@ -1,0 +1,1 @@
+pro_magic_attach_run_locally: true

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -151,6 +151,7 @@ export SUBIQUITY_REPLAY_TIMESCALE=100
 for answers in examples/answers*.yaml; do
     if echo $answers|grep -vq system-setup; then
         config=$(sed -n 's/^#machine-config: \(.*\)/\1/p' $answers || true)
+        dr_config=$(sed -n 's/^#dr-config: \(.*\)/\1/p' "$answers" || true)
         if [ -z "$config" ]; then
             config=examples/simple.json
         fi
@@ -158,6 +159,9 @@ for answers in examples/answers*.yaml; do
         opts=()
         if [ -n "$serial" ]; then
             opts+=(--serial)
+        fi
+        if [ -n "$dr_config" ]; then
+            opts+=(--dry-run-config "$dr_config")
         fi
         # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
         LANG=C.UTF-8 timeout --foreground 60 \

--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -69,12 +69,6 @@ class UbuntuProController(SubiquityTuiController):
             await self.endpoint.skip.POST()
             raise Skip("Not running LTS version")
 
-        # TODO remove these three lines when all dependencies for Ubuntu Pro
-        # are available in focal-updates.
-        if not self.app.opts.dry_run:
-            await self.endpoint.skip.POST()
-            raise Skip("Skipping Ubuntu Pro for now")
-
         ubuntu_pro_info: UbuntuProResponse = await self.endpoint.GET()
         return UbuntuProView(self,
                              token=ubuntu_pro_info.token,

--- a/subiquity/cmd/schema.py
+++ b/subiquity/cmd/schema.py
@@ -21,6 +21,7 @@ import sys
 import jsonschema
 
 from subiquity.cmd.server import make_server_args_parser
+from subiquity.server.dryrun import DRConfig
 from subiquity.server.server import SubiquityServer
 
 
@@ -53,6 +54,9 @@ def make_app():
     parser = make_server_args_parser()
     opts, unknown = parser.parse_known_args(['--dry-run'])
     app = SubiquityServer(opts, '')
+    # This is needed because the ubuntu-pro server controller accesses dr_cfg
+    # in the initializer.
+    app.dr_cfg = DRConfig()
     app.base_model = app.make_model()
     app.controllers.load_all()
     return app

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -61,6 +61,7 @@ def make_server_args_parser():
     parser.add_argument('--dry-run', action='store_true',
                         dest='dry_run',
                         help='menu-only, do not call installer function')
+    parser.add_argument('--dry-run-config', type=argparse.FileType())
     parser.add_argument('--socket')
     parser.add_argument('--machine-config', metavar='CONFIG',
                         dest='machine_config',
@@ -117,6 +118,7 @@ def main():
     # setup_environment sets $APPORT_DATA_DIR which must be set before
     # apport is imported, which is done by this import:
     from subiquity.server.server import SubiquityServer
+    from subiquity.server.dryrun import DRConfig
     parser = make_server_args_parser()
     opts = parser.parse_args(sys.argv[1:])
     if opts.storage_version is None:
@@ -124,9 +126,16 @@ def main():
             'subiquity-storage-version', 1))
     logdir = LOGDIR
     if opts.dry_run:
+        if opts.dry_run_config:
+            dr_cfg = DRConfig.load(opts.dry_run_config)
+        else:
+            dr_cfg = DRConfig()
+
         if opts.snaps_from_examples is None:
             opts.snaps_from_examples = True
         logdir = opts.output_base
+    else:
+        dr_cfg = None
     if opts.socket is None:
         if opts.dry_run:
             opts.socket = opts.output_base + '/socket'
@@ -155,6 +164,7 @@ def main():
     logger.debug("Storage version: {}".format(opts.storage_version))
 
     server = SubiquityServer(opts, block_log_dir)
+    server.dr_cfg = dr_cfg
 
     server.note_file_for_apport(
         "InstallerServerLog", logfiles['debug'])

--- a/subiquity/server/controllers/tests/test_ubuntu_pro.py
+++ b/subiquity/server/controllers/tests/test_ubuntu_pro.py
@@ -18,12 +18,15 @@ import unittest
 from subiquity.server.controllers.ubuntu_pro import (
     UbuntuProController,
 )
+from subiquity.server.dryrun import DRConfig
 from subiquitycore.tests.mocks import make_app
 
 
 class TestUbuntuProController(unittest.TestCase):
     def setUp(self):
-        self.controller = UbuntuProController(make_app())
+        app = make_app()
+        app.dr_cfg = DRConfig()
+        self.controller = UbuntuProController(app)
 
     def test_serialize(self):
         self.controller.model.token = "1a2b3C"

--- a/subiquity/server/controllers/ubuntu_pro.py
+++ b/subiquity/server/controllers/ubuntu_pro.py
@@ -90,7 +90,12 @@ class UbuntuProController(SubiquityController):
         """ Initializer for server-side Ubuntu Pro controller. """
         strategy: UAInterfaceStrategy
         if app.opts.dry_run:
-            strategy = MockedUAInterfaceStrategy(scale_factor=app.scale_factor)
+            if app.dr_cfg.pro_magic_attach_run_locally:
+                executable = "/usr/bin/ubuntu-advantage"
+                strategy = UAClientUAInterfaceStrategy(executable=executable)
+            else:
+                strategy = MockedUAInterfaceStrategy(
+                        scale_factor=app.scale_factor)
         else:
             # Make sure we execute `$PYTHON "$SNAP/usr/bin/ubuntu-advantage"`.
             executable = (

--- a/subiquity/server/controllers/ubuntu_pro.py
+++ b/subiquity/server/controllers/ubuntu_pro.py
@@ -90,9 +90,12 @@ class UbuntuProController(SubiquityController):
         """ Initializer for server-side Ubuntu Pro controller. """
         strategy: UAInterfaceStrategy
         if app.opts.dry_run:
+            contracts_url = app.dr_cfg.pro_ua_contracts_url
             if app.dr_cfg.pro_magic_attach_run_locally:
                 executable = "/usr/bin/ubuntu-advantage"
                 strategy = UAClientUAInterfaceStrategy(executable=executable)
+                strategy.load_default_uaclient_config()
+                strategy.uaclient_config["contract_url"] = contracts_url
             else:
                 strategy = MockedUAInterfaceStrategy(
                         scale_factor=app.scale_factor)

--- a/subiquity/server/dryrun.py
+++ b/subiquity/server/dryrun.py
@@ -13,6 +13,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import yaml
+
+import attr
+
 
 class DryRunController:
 
@@ -22,3 +26,15 @@ class DryRunController:
 
     async def crash_GET(self) -> None:
         1/0
+
+
+@attr.s(auto_attribs=True)
+class DRConfig:
+    """ Configuration for dry-run-only executions.
+    All variables here should have default values ; to indicate the behavior we
+    want by default in dry-run mode. """
+
+    @classmethod
+    def load(cls, stream):
+        data = yaml.safe_load(stream)
+        return cls(**data)

--- a/subiquity/server/dryrun.py
+++ b/subiquity/server/dryrun.py
@@ -34,6 +34,13 @@ class DRConfig:
     All variables here should have default values ; to indicate the behavior we
     want by default in dry-run mode. """
 
+    # Tells whether we should run /usr/bin/ubuntu-advantage instead of using
+    # Mock objects.
+    pro_magic_attach_run_locally: bool = False
+    # When running /usr/bin/ubuntu-advantage locally, do not use the production
+    # ua-contrats.
+    pro_ua_contracts_url: str = "https://contracts.staging.canonical.com"
+
     @classmethod
     def load(cls, stream):
         data = yaml.safe_load(stream)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -68,6 +68,7 @@ from subiquity.models.subiquity import (
     ModelNames,
     SubiquityModel,
     )
+from subiquity.server.dryrun import DRConfig
 from subiquity.server.controller import SubiquityController
 from subiquity.server.geoip import (
     GeoIP,
@@ -278,6 +279,7 @@ class SubiquityServer(Application):
 
     def __init__(self, opts, block_log_dir):
         super().__init__(opts)
+        self.dr_cfg: Optional[DRConfig] = None
         self.set_source_variant(self.supported_variants[0])
         self.block_log_dir = block_log_dir
         self.cloud = None

--- a/subiquity/server/tests/test_ubuntu_advantage.py
+++ b/subiquity/server/tests/test_ubuntu_advantage.py
@@ -15,7 +15,7 @@
 
 from subprocess import CompletedProcess
 import unittest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, ANY
 
 from subiquity.common.types import UbuntuProService
 from subiquity.server.ubuntu_advantage import (
@@ -87,7 +87,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
             mock_arun.return_value = CompletedProcess([], 0)
             mock_arun.return_value.stdout = "{}"
             await strategy.query_info(token="123456789")
-            mock_arun.assert_called_once_with(command, check=False)
+            mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_query_info_unknown_error(self):
         strategy = UAClientUAInterfaceStrategy()
@@ -103,7 +103,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
             mock_arun.return_value.stdout = "{}"
             with self.assertRaises(CheckSubscriptionError):
                 await strategy.query_info(token="123456789")
-            mock_arun.assert_called_once_with(command, check=False)
+            mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_query_info_invalid_token(self):
         strategy = UAClientUAInterfaceStrategy()
@@ -134,7 +134,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
 """
             with self.assertRaises(InvalidTokenError):
                 await strategy.query_info(token="123456789")
-            mock_arun.assert_called_once_with(command, check=False)
+            mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_query_info_invalid_json(self):
         strategy = UAClientUAInterfaceStrategy()
@@ -150,7 +150,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
             mock_arun.return_value.stdout = "invalid-json"
             with self.assertRaises(CheckSubscriptionError):
                 await strategy.query_info(token="123456789")
-            mock_arun.assert_called_once_with(command, check=False)
+            mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_api_call(self):
         strategy = UAClientUAInterfaceStrategy()
@@ -168,7 +168,7 @@ class TestUAClientUAInterfaceStrategy(unittest.IsolatedAsyncioTestCase):
             "u.pro.attach.magic.wait.v1",
             "--args", "magic_token=132456",
         )
-        mock_arun.assert_called_once_with(command, check=False)
+        mock_arun.assert_called_once_with(command, check=False, env=ANY)
 
     async def test_magic_initiate_v1(self):
         strategy = UAClientUAInterfaceStrategy()

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -602,9 +602,18 @@ class UbuntuProView(BaseView):
         if form.skip.value:
             self.controller.done("")
         else:
+            def initiate() -> None:
+                self.controller.contract_selection_initiate(
+                        on_initiated=self.cs_initiated)
+
             self._w = self.upgrade_mode_screen()
-            self.controller.contract_selection_initiate(
-                    on_initiated=self.cs_initiated)
+            if self.controller.cs_initiated:
+                # Cancel the existing contract selection before initiating a
+                # new one.
+                self.controller.contract_selection_cancel(
+                        on_cancelled=initiate)
+            else:
+                initiate()
 
     def cancel(self) -> None:
         """ Called when the user presses the Back button. """


### PR DESCRIPTION
The patchset includes:
* a bugfix for ubuntu pro: b070c30
* more ways to test ubuntu pro in dry-run mode: fa6fcd7 (which is not ubuntu pro specific) + cd38c06 and 1bb8f60
* the activation of the ubuntu pro screens on LTS releases: d999b7b

The addition of the dryrun machinery can feel out of place but it only affects dry-run so it should have very low risk on normal installs.