### PR TITLE
Fixes and more tests for mirror testing

### DIFF
--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -106,3 +106,6 @@ class MirrorModel(object):
 
     def render(self):
         return {}
+
+    def make_autoinstall(self):
+        return self.get_apt_config()

--- a/subiquity/models/tests/test_mirror.py
+++ b/subiquity/models/tests/test_mirror.py
@@ -99,3 +99,11 @@ class TestMirrorModel(unittest.TestCase):
         actual.sort()
         expected.sort()
         self.assertEqual(expected, actual)
+
+    def test_make_autoinstall(self):
+        primary = [{"arches": "amd64", "uri": "http://mirror"}]
+        self.model.disabled_components = set(["non-free"])
+        self.model.primary = primary
+        cfg = self.model.make_autoinstall()
+        self.assertEqual(cfg["disable_components"], ["non-free"])
+        self.assertEqual(cfg["primary"], primary)

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -233,7 +233,7 @@ class MirrorController(SubiquityController):
             return None
         if self.mirror_check.task.done():
             if self.mirror_check.task.exception():
-                log.warning("Mirror check failed: %s",
+                log.warning("Mirror check failed: %r",
                             self.mirror_check.task.exception())
                 status = MirrorCheckStatus.FAILED
             else:

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-import copy
 import io
 import logging
 from typing import List, Optional
@@ -173,9 +172,9 @@ class MirrorController(SubiquityController):
         self.model.set_mirror(data)
 
     def make_autoinstall(self):
-        r = copy.deepcopy(self.model.config)
-        r['geoip'] = self.geoip_enabled
-        return r
+        config = self.model.make_autoinstall()
+        config['geoip'] = self.geoip_enabled
+        return config
 
     async def configured(self):
         await super().configured()

--- a/subiquity/server/controllers/tests/test_mirror.py
+++ b/subiquity/server/controllers/tests/test_mirror.py
@@ -13,13 +13,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import io
 import jsonschema
 import unittest
 from unittest import mock
 
 from subiquitycore.tests.mocks import make_app
 from subiquity.models.mirror import MirrorModel
+from subiquity.server.apt import AptConfigCheckError
 from subiquity.server.controllers.mirror import MirrorController
+from subiquity.server.controllers.mirror import log as MirrorLogger
 
 
 class TestMirrorSchema(unittest.TestCase):
@@ -53,3 +56,52 @@ class TestMirrorController(unittest.IsolatedAsyncioTestCase):
         self.assertIn("disable_components", config.keys())
         self.assertIn("primary", config.keys())
         self.assertIn("geoip", config.keys())
+
+    async def test_run_mirror_testing(self):
+        def fake_mirror_check_success(output):
+            output.write("test is successful!")
+
+        def fake_mirror_check_failure(output):
+            output.write("Unable to download index")
+            raise AptConfigCheckError
+
+        output = io.StringIO()
+        mock_source_configured = mock.patch.object(
+                self.controller.source_configured_event, "wait")
+
+        mock_run_apt_config_check = mock.patch.object(
+                self.controller.apt_configurer, "run_apt_config_check",
+                side_effect=fake_mirror_check_success)
+        with mock_source_configured, mock_run_apt_config_check:
+            await self.controller.run_mirror_testing(output)
+        self.assertEqual(output.getvalue(), "test is successful!")
+
+        output = io.StringIO()
+        mock_run_apt_config_check = mock.patch.object(
+                self.controller.apt_configurer, "run_apt_config_check",
+                side_effect=fake_mirror_check_failure)
+        with mock_source_configured, mock_run_apt_config_check:
+            with self.assertRaises(AptConfigCheckError):
+                await self.controller.run_mirror_testing(output)
+        self.assertEqual(output.getvalue(), "Unable to download index")
+
+    async def test_try_mirror_checking_once(self):
+        run_test = mock.patch.object(self.controller, "run_mirror_testing")
+        with run_test:
+            with self.assertLogs(MirrorLogger, "DEBUG") as debug:
+                await self.controller.try_mirror_checking_once()
+        self.assertIn("Mirror checking successful",
+                      [record.msg for record in debug.records])
+        self.assertIn("APT output follows",
+                      [record.msg for record in debug.records])
+
+        run_test = mock.patch.object(self.controller, "run_mirror_testing",
+                                     side_effect=AptConfigCheckError)
+        with run_test:
+            with self.assertLogs(MirrorLogger, "DEBUG") as debug:
+                with self.assertRaises(AptConfigCheckError):
+                    await self.controller.try_mirror_checking_once()
+        self.assertIn("Mirror checking failed",
+                      [record.msg for record in debug.records])
+        self.assertIn("APT output follows",
+                      [record.msg for record in debug.records])

--- a/subiquity/server/controllers/tests/test_mirror.py
+++ b/subiquity/server/controllers/tests/test_mirror.py
@@ -15,7 +15,10 @@
 
 import jsonschema
 import unittest
+from unittest import mock
 
+from subiquitycore.tests.mocks import make_app
+from subiquity.models.mirror import MirrorModel
 from subiquity.server.controllers.mirror import MirrorController
 
 
@@ -36,3 +39,17 @@ class TestMirrorSchema(unittest.TestCase):
     def test_no_disable_random_junk(self):
         with self.assertRaises(jsonschema.ValidationError):
             self.validate({'disable_components': ['not-a-component']})
+
+
+class TestMirrorController(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        app = make_app()
+        self.controller = MirrorController(app)
+        self.controller.apt_configurer = mock.AsyncMock()
+
+    def test_make_autoinstall(self):
+        self.controller.model = MirrorModel()
+        config = self.controller.make_autoinstall()
+        self.assertIn("disable_components", config.keys())
+        self.assertIn("primary", config.keys())
+        self.assertIn("geoip", config.keys())

--- a/subiquity/ui/views/mirror.py
+++ b/subiquity/ui/views/mirror.py
@@ -112,7 +112,7 @@ class MirrorView(BaseView):
                 "details here.")
 
     def __init__(self, controller, mirror,
-                 check: Optional[MirrorCheckStatus], has_network: bool):
+                 check: Optional[MirrorCheckResponse], has_network: bool):
         self.controller = controller
 
         self.form = MirrorForm(initial={'url': mirror})
@@ -136,7 +136,7 @@ class MirrorView(BaseView):
         else:
             self.status_text.set_text(rewrap(_(
                 MIRROR_CHECK_STATUS_TEXTS[self.has_network, None])))
-            self.last_status = None
+            self.last_status: Optional[MirrorCheckStatus] = None
 
         rows = [
             ('pack', Text(_(self.excerpt))),


### PR DESCRIPTION
I noticed a few things:
* if a mirror check fails and the error gets logged in response to a GET /mirror/check_mirror/progress call, the type of the error is not printed. This makes exceptions that do not have a description appear as blank; which does not make the diagnostic easy. Print the type of exception as well using `%r` instead of `%s`.
* Some types hints are wrong (or not accurate) in the UI / view.
* the `primary` and `disable_components` were not present in the generated autoinstall configuration. This was a regression introduced by [c13edb07f, 8c29f3475]

I also added more tests to cover `MirrorController.run_mirror_testing`. The code only runs in autoinstall and testing in manually in dry-run is clunky.