### PR TITLE
kinetic merge - geoip, CI fix

### DIFF
--- a/examples/answers.yaml
+++ b/examples/answers.yaml
@@ -23,7 +23,7 @@ Identity:
   hostname: ubuntu-server
   # ubuntu
   password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
-  ssh-import-id: gh:mwhudson
+  ssh-import-id: lp:mwhudson
 UbuntuPro:
   token: ""
 SnapList:

--- a/subiquity/server/tests/test_geoip.py
+++ b/subiquity/server/tests/test_geoip.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import aiohttp
 from aioresponses import aioresponses
 
 from subiquitycore.tests import SubiTestCase
@@ -94,5 +95,12 @@ class TestGeoIPBadData(SubiTestCase):
     async def test_empty_tz(self):
         with aioresponses() as mocked:
             mocked.get("https://geoip.ubuntu.com/lookup", body=empty_tz)
+            self.assertFalse(await self.geoip.lookup())
+        self.assertIsNone(self.geoip.timezone)
+
+    async def test_lookup_error(self):
+        with aioresponses() as mocked:
+            mocked.get("https://geoip.ubuntu.com/lookup",
+                       exception=aiohttp.ClientError('lookup failure'))
             self.assertFalse(await self.geoip.lookup())
         self.assertIsNone(self.geoip.timezone)


### PR DESCRIPTION
* cherry-picked 11d89ec from #1535.  Users sometimes run into a Subiquity crash, see the geoip tracebacks, and mistakenly view that traceback as the cause of the crash, when the answer is later in the log.
* cherry-picked ec80a1c from #1527.  Works around CI glitch due to rate limiting