### PR TITLE
Make sure mirror test output is translated if translation is available

### DIFF
--- a/subiquity/models/tests/test_locale.py
+++ b/subiquity/models/tests/test_locale.py
@@ -1,0 +1,58 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+import unittest
+from unittest import mock
+
+from subiquity.models.locale import LocaleModel
+
+
+class TestLocaleModel(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.model = LocaleModel(chroot_prefix="/")
+
+    def test_switch_language(self):
+        self.model.switch_language("fr_FR.UTF-8")
+        self.assertEqual(self.model.selected_language, "fr_FR.UTF-8")
+
+    async def test_gen_localedef(self):
+        expected_cmd = [
+            "localedef",
+            "-f", "UTF-8",
+            "-i", "fr_FR",
+            "--",
+            "fr_FR.UTF-8",
+        ]
+        self.model.selected_language = "fr_FR.UTF-8"
+        with mock.patch("subiquity.models.locale.arun_command") as arun_cmd:
+            await self.model.gen_localedef()
+        arun_cmd.assert_called_once_with(expected_cmd, check=True)
+        self.model.selected_language = "fr_FR"
+        with mock.patch("subiquity.models.locale.arun_command") as arun_cmd:
+            # Currently, the default for fr_FR is fr_FR.ISO8859-1
+            with mock.patch("subiquity.models.locale.locale.normalize",
+                            return_value="fr_FR.UTF-8"):
+                await self.model.gen_localedef()
+        arun_cmd.assert_called_once_with(expected_cmd, check=True)
+
+    async def test_try_gen_localedef(self):
+        self.model.selected_language = "fr_FR.UTF-8"
+        exc = subprocess.CalledProcessError(returncode=1, cmd=["localedef"])
+        with mock.patch("subiquity.models.locale.arun_command",
+                        side_effect=exc):
+            await self.model.try_gen_localedef()
+        with mock.patch("subiquity.models.locale.arun_command"):
+            await self.model.try_gen_localedef()

--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -173,7 +173,10 @@ class AptConfigurer:
             apt_cmd.append(
                     f"-o{target}::DefaultEnabled=false")
 
-        proc = await astart_command(apt_cmd, stderr=subprocess.STDOUT)
+        env = os.environ.copy()
+        env["LANG"] = self.app.base_model.locale.selected_language
+        proc = await astart_command(apt_cmd, stderr=subprocess.STDOUT,
+                                    clean_locale=False, env=env)
 
         async def _reader():
             while not proc.stdout.at_eof():

--- a/subiquity/server/controllers/locale.py
+++ b/subiquity/server/controllers/locale.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import os
 
+from subiquitycore import async_helpers as async_helpers
 from subiquity.common.apidef import API
 from subiquity.server.controller import SubiquityController
 from subiquity.server.types import InstallerChannels
@@ -65,5 +66,7 @@ class LocaleController(SubiquityController):
         return self.model.selected_language
 
     async def POST(self, data: str):
+        log.debug(data)
         self.model.switch_language(data)
+        async_helpers.run_bg_task(self.model.try_gen_localedef())
         await self.configured()

--- a/subiquity/server/tests/test_apt.py
+++ b/subiquity/server/tests/test_apt.py
@@ -60,6 +60,7 @@ class TestAptConfigurer(SubiTestCase):
         self.model = Mock()
         self.model.mirror = MirrorModel()
         self.model.proxy = ProxyModel()
+        self.model.locale.selected_language = "en_US.UTF-8"
         self.app = make_app(self.model)
         self.configurer = AptConfigurer(self.app, AsyncMock(), '')
 


### PR DESCRIPTION
When a mirror test failure occurs, the user is expected to read the apt-get output to determine what the root cause could be. Users who don't use English as their installer's language should get the output of apt-get translated (provided there is a translation available).

I made 3 changes to make it possible:
1. when we execute a command through `arun_command` or another helper, the environment is passed to `subiquitycore.utils._clean_env()` ; which unconditionally hard-coded the value of LC_ALL to C. This behavior is still preserved by default, but the _clean_env function now takes an optional locale boolean, which can be set to False to disable the override of LC_* variables. The helpers have been updated to take an optional `clean_locale` boolean (defaulting to True).
2. in an autoinstall scenario we set the LANG env variable to the user's selected language. For some reason, we don't do that for normal interactive installs. I believe we should be more consistent but I didn't want to proceed with such a change without prior investigation. Therefore, I now explicitly set the LANG variable for the mirror check process (i.e., apt-get).
3. for translations to work, we need to have the relevant locale definition compiled. We now call the `localedef` function in the background when setting the locale. A warning is reported if this operation fails, but it does not prevent the install from pursuing.