### PR TITLE
apt: restore unmount

### DIFF
--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -156,10 +156,9 @@ class MirrorController(SubiquityController):
             self.model.set_country(self.app.geoip.countrycode)
         self.cc_event.set()
 
-    def on_source(self):
-        # FIXME disabled until we can sort out umount
-        # if self.apt_configurer is not None:
-        #     await self.apt_configurer.cleanup()
+    async def on_source(self):
+        if self.apt_configurer is not None:
+            await self.apt_configurer.cleanup()
         self.apt_configurer = get_apt_configurer(
             self.app, self.app.controllers.Source.source_path)
         self._apply_apt_config_task.start_sync()


### PR DESCRIPTION
This unmount is needed, as otherwise the sources.list only points to the /cdrom during curthooks.