### PR TITLE
network: reset SNAP when calling netplan in dry-run mode

### DIFF
--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -15,6 +15,7 @@
 
 import abc
 import asyncio
+import contextlib
 import logging
 import os
 import subprocess
@@ -294,10 +295,15 @@ class BaseNetworkController(BaseController):
                 if os.path.exists('/lib/netplan/generate'):
                     # If netplan appears to be installed, run generate to
                     # at least test that what we wrote is acceptable to
-                    # netplan.
+                    # netplan but clear the SNAP environment variable to
+                    # avoid that netplan thinks its running in a snap and
+                    # tries to call netplan over the system bus.
+                    env = os.environ.copy()
+                    with contextlib.suppress(KeyError):
+                        del env['SNAP']
                     await arun_command(
                         ['netplan', 'generate', '--root', self.root],
-                        check=True)
+                        check=True, env=env)
             else:
                 if devs_to_down or devs_to_delete:
                     try:


### PR DESCRIPTION
```
$ SNAP=foo netplan generate --root /bar
Call failed: Access denied
Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
  File "/usr/share/netplan/netplan/cli/core.py", line 50, in main
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 231, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/generate.py", line 46, in run
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 231, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/generate.py", line 73, in command_generate
    raise RuntimeError(
RuntimeError: failed to communicate with dbus service: error 1
```
https://github.com/canonical/netplan/blob/eb0ff44490f5d04fbf3fdabfc11513f9134e3222/netplan/cli/commands/generate.py#L49-L76