### PR TITLE
storage/v2: allow unformatted partition creation

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -304,6 +304,7 @@ class API:
                    adding a partion when there is not yet a boot partition can
                    result in the boot partition being added automatically - see
                    add_boot_partition for more control over this.
+                   format=None means an unformatted partition
                 """
                 def POST(data: Payload[AddPartitionV2]) \
                     -> StorageResponseV2: ...

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -742,8 +742,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def v2_add_partition_POST(self, data: AddPartitionV2) \
             -> StorageResponseV2:
         log.debug(data)
-        if data.partition.format is None:
-            raise ValueError('add_partition must supply format')
         if data.partition.boot is not None:
             raise ValueError('add_partition does not support changing boot')
         disk = self.model._one(id=data.disk_id)


### PR DESCRIPTION
Previously unformatted partition creation was blocked, but supplying None does seem to do the right thing, and we want to support creation of unformatted partitions.  Allow it and add a API test to help document it as an intended feature.