### PR TITLE
Fix unittest using timedatectl failing in chroot

### DIFF
--- a/subiquity/tests/test_timezonecontroller.py
+++ b/subiquity/tests/test_timezonecontroller.py
@@ -46,7 +46,10 @@ class TestTimeZoneController(SubiTestCase):
 
     @mock.patch('subiquity.server.controllers.timezone.timedatectl_settz')
     @mock.patch('subiquity.server.controllers.timezone.timedatectl_gettz')
-    async def test_good_tzs(self, tdc_gettz, tdc_settz):
+    @mock.patch('subiquity.server.controllers.timezone.generate_possible_tzs')
+    async def test_good_tzs(self, generate_possible_tzs, tdc_gettz, tdc_settz):
+        generate_possible_tzs.return_value = \
+            ['', 'geoip', 'Pacific/Auckland', 'America/Denver']
         tdc_gettz.return_value = tz_utc
         goods = [
             # val - autoinstall value


### PR DESCRIPTION
I've upgraded my desktop to lunar and sadly this broke all the async unittests that use parameterized.

Until what needs fixing is fixed, I will run unittests in a chroot. Sadly, there is one test that fails because its behavior is dependent on the presence of /run/systemd/system ; so I'm making sure to does not.