### PR TITLE
storage: autoinstall_applied long poll endpoint

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -274,6 +274,11 @@ class API:
         class has_bitlocker:
             def GET() -> List[Disk]: ...
 
+        class autoinstall_applied:
+            def GET(wait: bool = False) -> bool:
+                """Poll or wait for storage autoinstall to be applied to the
+                model."""
+
         class v2:
             def GET(wait: bool = False) -> StorageResponseV2: ...
             def POST() -> StorageResponseV2: ...


### PR DESCRIPTION
Ubuntu-desktop-installer would like to know when the storage autoinstall has been processed, so that it can show the preview information about disk changes.

The existing storage wait methods are insufficient, because that answers a different question - has block probing completed?