### PR TITLE
many: s/create_task/run_bg_task/

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 from typing import Callable, Optional
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.lsb_release import lsb_release
 from subiquitycore.view import BaseView
 
@@ -67,7 +68,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
 
         status = await self.endpoint.guided.GET()
         if status.status == ProbeStatus.PROBING:
-            asyncio.create_task(self._wait_for_probing())
+            run_bg_task(self._wait_for_probing())
             self.current_view = SlowProbing(self)
         else:
             self.current_view = self.make_guided_ui(status)
@@ -273,18 +274,18 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         self.ui.set_body(FilesystemView(self.model, self))
 
     def guided_choice(self, choice):
-        asyncio.create_task(self._guided_choice(choice))
+        run_bg_task(self._guided_choice(choice))
 
     async def _guided(self):
         self.ui.set_body((await self.make_ui())())
 
     def guided(self):
-        asyncio.create_task(self._guided())
+        run_bg_task(self._guided())
 
     def reset(self, refresh_view):
         log.info("Resetting Filesystem model")
         self.app.ui.block_input = True
-        asyncio.create_task(self._reset(refresh_view))
+        run_bg_task(self._reset(refresh_view))
 
     async def _reset(self, refresh_view):
         status = await self.endpoint.reset.POST()

--- a/subiquity/client/controllers/network.py
+++ b/subiquity/client/controllers/network.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import logging
 import os
 import shutil
@@ -22,6 +21,7 @@ from typing import List, Optional
 
 from aiohttp import web
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.controllers.network import NetworkAnswersMixin
 from subiquitycore.models.network import (
     BondConfig,
@@ -118,7 +118,7 @@ class NetworkController(SubiquityTuiController, NetworkAnswersMixin):
     def end_ui(self):
         if self.view is not None:
             self.view = None
-            asyncio.create_task(self.unsubscribe())
+            run_bg_task(self.unsubscribe())
 
     def cancel(self):
         self.app.prev_screen()
@@ -128,36 +128,36 @@ class NetworkController(SubiquityTuiController, NetworkAnswersMixin):
 
     def set_static_config(self, dev_name: str, ip_version: int,
                           static_config: StaticConfig) -> None:
-        asyncio.create_task(
+        run_bg_task(
             self.endpoint.set_static_config.POST(
                 dev_name, ip_version, static_config))
 
     def enable_dhcp(self, dev_name, ip_version: int) -> None:
-        asyncio.create_task(
+        run_bg_task(
             self.endpoint.enable_dhcp.POST(dev_name, ip_version))
 
     def disable_network(self, dev_name: str, ip_version: int) -> None:
-        asyncio.create_task(
+        run_bg_task(
             self.endpoint.disable.POST(dev_name, ip_version))
 
     def add_vlan(self, dev_name: str, vlan_id: int):
-        asyncio.create_task(
+        run_bg_task(
             self.endpoint.vlan.PUT(dev_name, vlan_id))
 
     def set_wlan(self, dev_name: str, wlan: WLANConfig) -> None:
-        asyncio.create_task(
+        run_bg_task(
             self.endpoint.set_wlan.POST(dev_name, wlan))
 
     def start_scan(self, dev_name: str) -> None:
-        asyncio.create_task(
+        run_bg_task(
             self.endpoint.start_scan.POST(dev_name))
 
     def delete_link(self, dev_name: str):
-        asyncio.create_task(self.endpoint.delete.POST(dev_name))
+        run_bg_task(self.endpoint.delete.POST(dev_name))
 
     def add_or_update_bond(self, existing_name: Optional[str],
                            new_name: str, new_info: BondConfig) -> None:
-        asyncio.create_task(
+        run_bg_task(
             self.endpoint.add_or_edit_bond.POST(
                 existing_name, new_name, new_info))
 

--- a/subiquity/client/controllers/progress.py
+++ b/subiquity/client/controllers/progress.py
@@ -18,6 +18,7 @@ import logging
 
 import aiohttp
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.context import with_context
 
 from subiquity.client.controller import SubiquityTuiController
@@ -61,10 +62,10 @@ class ProgressController(SubiquityTuiController):
         pass
 
     def start(self):
-        asyncio.create_task(self._wait_status())
+        run_bg_task(self._wait_status())
 
     def click_reboot(self):
-        asyncio.create_task(self.send_reboot_and_wait())
+        run_bg_task(self.send_reboot_and_wait())
 
     async def send_reboot_and_wait(self):
         try:

--- a/subiquity/server/controllers/cmdlist.py
+++ b/subiquity/server/controllers/cmdlist.py
@@ -21,6 +21,7 @@ from typing import List, Sequence, Union
 import attr
 from systemd import journal
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.context import with_context
 from subiquitycore.utils import arun_command
 
@@ -132,7 +133,7 @@ class LateController(CmdListController):
         return env
 
     def start(self):
-        asyncio.create_task(self._run())
+        run_bg_task(self._run())
 
     async def _run(self):
         Install = self.app.controllers.Install

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -28,6 +28,7 @@ import attr
 import yaml
 
 from subiquitycore.async_helpers import (
+    run_bg_task,
     run_in_thread,
     )
 from subiquitycore.context import with_context
@@ -142,7 +143,7 @@ class InstallController(SubiquityController):
     def stop_uu(self):
         if self.app.state == ApplicationState.UU_RUNNING:
             self.app.update_state(ApplicationState.UU_CANCELLING)
-            asyncio.create_task(self.stop_unattended_upgrades())
+            run_bg_task(self.stop_unattended_upgrades())
 
     def start(self):
         journald_listen([self.app.log_syslog_id], self.log_event)

--- a/subiquity/server/controllers/locale.py
+++ b/subiquity/server/controllers/locale.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import logging
 import os
 
@@ -45,7 +44,7 @@ class LocaleController(SubiquityController):
             self.model.selected_language = os.environ.get("LANG") \
                 or self.autoinstall_default
 
-        asyncio.create_task(self.configured())
+        async_helpers.run_bg_task(self.configured())
         self.app.hub.subscribe(
             (InstallerChannels.CONFIGURED, 'source'), self._set_source)
 

--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -22,7 +22,10 @@ import aiohttp
 
 import apt
 
-from subiquitycore.async_helpers import schedule_task
+from subiquitycore.async_helpers import (
+    run_bg_task,
+    schedule_task,
+    )
 from subiquitycore.context import with_context
 from subiquitycore.controllers.network import BaseNetworkController
 from subiquitycore.models.network import (
@@ -302,7 +305,7 @@ class NetworkController(BaseNetworkController, SubiquityController):
         client = make_client_for_conn(NetEventAPI, conn)
         lock = asyncio.Lock()
         self.clients[socket_path] = (client, conn, lock)
-        asyncio.create_task(
+        run_bg_task(
             self._call_client(
                 client, conn, lock, "route_watch",
                 self.network_event_receiver.default_routes))
@@ -329,7 +332,7 @@ class NetworkController(BaseNetworkController, SubiquityController):
     def _call_clients(self, meth_name, *args):
         for client, conn, lock in self.clients.values():
             log.debug('creating _call_client task %s %s', conn.path, meth_name)
-            asyncio.create_task(
+            run_bg_task(
                 self._call_client(client, conn, lock, meth_name, *args))
 
     def apply_starting(self):

--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -23,6 +23,7 @@ from subiquitycore.file_util import (
     open_perms,
     set_log_perms,
 )
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.context import with_context
 from subiquitycore.utils import arun_command, run_command
 
@@ -73,8 +74,8 @@ class ShutdownController(SubiquityController):
         return self.app.interactive
 
     def start(self):
-        asyncio.create_task(self._wait_install())
-        asyncio.create_task(self._run())
+        run_bg_task(self._wait_install())
+        run_bg_task(self._run())
 
     async def _wait_install(self):
         await self.app.controllers.Install.install_task

--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -89,8 +89,7 @@ class SnapdSnapInfoLoader:
 
     async def _start(self):
         with self.context:
-            task = self.tasks[None] = \
-                    asyncio.create_task(self._load_list())
+            task = self.tasks[None] = asyncio.create_task(self._load_list())
             self.load_list_task_created.set()
             try:
                 await task

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -32,7 +32,10 @@ from systemd import journal
 
 import yaml
 
-from subiquitycore.async_helpers import run_in_thread
+from subiquitycore.async_helpers import (
+    run_bg_task,
+    run_in_thread,
+    )
 from subiquitycore.context import with_context
 from subiquitycore.core import Application
 from subiquitycore.file_util import (
@@ -426,7 +429,7 @@ class SubiquityServer(Application):
             self.update_state(ApplicationState.ERROR)
         if not self.running_error_commands:
             self.running_error_commands = True
-            asyncio.create_task(self._run_error_cmds(report))
+            run_bg_task(self._run_error_cmds(report))
 
     @web.middleware
     async def middleware(self, request, handler):

--- a/subiquity/ui/views/drivers.py
+++ b/subiquity/ui/views/drivers.py
@@ -16,7 +16,6 @@
 """ Module defining the view for third-party drivers installation.
 
 """
-import asyncio
 from enum import auto, Enum
 import logging
 from typing import List, Optional
@@ -26,6 +25,7 @@ from urwid import (
     Text,
     )
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.ui.buttons import back_btn, ok_btn
 from subiquitycore.ui.form import (
     Form,
@@ -111,7 +111,7 @@ class DriversView(BaseView):
                 _("Back"),
                 on_press=lambda sender: self.cancel())
         self._w = screen(rows, [self.back_btn])
-        asyncio.create_task(self._wait(install))
+        run_bg_task(self._wait(install))
         self.status = DriversViewStatus.WAITING
 
     async def _wait(self, install: bool) -> None:

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -24,6 +24,7 @@ from urwid import (
     Text,
     )
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.ui.buttons import other_btn
 from subiquitycore.ui.container import (
     Pile,
@@ -153,7 +154,7 @@ class ErrorReportStretchy(Stretchy):
         self.report = app.error_reporter.get(ref)
         self.pending = None
         if self.report is None:
-            asyncio.create_task(self._wait())
+            run_bg_task(self._wait())
         else:
             connect_signal(self.report, 'changed', self._report_changed)
             self.report.mark_seen()

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import logging
 import os
 
@@ -25,6 +24,7 @@ from urwid import (
     Text,
     )
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.lsb_release import lsb_release
 from subiquitycore.ssh import summarize_host_keys
 from subiquitycore.ui.buttons import (
@@ -410,7 +410,7 @@ class HelpMenu(PopUpLauncher):
 
     def _open(self, sender):
         log.debug("open help menu")
-        asyncio.create_task(self._get_ssh_info())
+        run_bg_task(self._get_ssh_info())
 
     def create_pop_up(self):
         self._menu = OpenHelpMenu(self)

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -21,6 +21,7 @@ from urwid import (
     Text,
     )
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import (
     cancel_btn,
@@ -266,7 +267,7 @@ class InstallConfirmation(Stretchy):
             self.app.ui.body.hide_continue()
         self.app.remove_global_overlay(self)
         if self.app.controllers.Progress.showing:
-            asyncio.create_task(self.app.confirm_install())
+            run_bg_task(self.app.confirm_install())
         else:
             self.app.next_screen(self.app.confirm_install())
 

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import locale
 import logging
 
@@ -24,6 +23,7 @@ from urwid import (
     Padding as UrwidPadding
     )
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.ui.buttons import (
     cancel_btn,
     ok_btn,
@@ -259,8 +259,7 @@ class Detector:
 
     def do_step(self, step_index):
         self.abort()
-        asyncio.create_task(
-            self._do_step(step_index))
+        run_bg_task(self._do_step(step_index))
 
     async def _do_step(self, step_index):
         log.debug("moving to step %s", step_index)
@@ -423,7 +422,7 @@ class KeyboardView(BaseView):
         layout = data['layout']
         variant = data.get('variant', layout.variants[0])
         setting = KeyboardSetting(layout=layout.code, variant=variant.code)
-        asyncio.create_task(self._check_toggle(setting))
+        run_bg_task(self._check_toggle(setting))
 
     async def _apply(self, setting):
         await self.controller.app.wait_with_text_dialog(
@@ -431,7 +430,7 @@ class KeyboardView(BaseView):
         self.controller.done()
 
     def really_done(self, setting):
-        asyncio.create_task(self._apply(setting))
+        run_bg_task(self._apply(setting))
 
     def cancel(self, result=None):
         self.controller.cancel()

--- a/subiquity/ui/views/zdev.py
+++ b/subiquity/ui/views/zdev.py
@@ -18,7 +18,6 @@
 Provides device activation and configuration on s390x
 
 """
-import asyncio
 import logging
 
 from urwid import (
@@ -26,6 +25,7 @@ from urwid import (
     Text,
     )
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.ui.actionmenu import (
     ActionMenu,
     )
@@ -84,8 +84,7 @@ class ZdevList(WidgetWrap):
         self.update(new_zdevinfos)
 
     def zdev_action(self, sender, action, zdevinfo):
-        asyncio.create_task(
-            self._zdev_action(action, zdevinfo))
+        run_bg_task(self._zdev_action(action, zdevinfo))
 
     def update(self, zdevinfos):
         rows = [TableRow([

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.context import (
     Context,
     )
@@ -129,7 +130,7 @@ class Application:
 
     async def run(self):
         self.base_model = self.make_model()
-        asyncio.create_task(self.start())
+        run_bg_task(self.start())
         await self.exit_event.wait()
         if self._exc:
             exc, self._exc = self._exc, None

--- a/subiquitycore/tui.py
+++ b/subiquitycore/tui.py
@@ -24,7 +24,10 @@ import urwid
 
 import yaml
 
-from subiquitycore.async_helpers import schedule_task
+from subiquitycore.async_helpers import (
+    run_bg_task,
+    schedule_task,
+    )
 from subiquitycore.core import Application
 from subiquitycore.palette import (
     PALETTE_COLOR,
@@ -247,10 +250,10 @@ class TuiApplication(Application):
             self.ui.set_body(view)
 
     def next_screen(self, coro=None):
-        asyncio.create_task(self.move_screen(1, coro))
+        run_bg_task(self.move_screen(1, coro))
 
     def prev_screen(self):
-        asyncio.create_task(self.move_screen(-1, None))
+        run_bg_task(self.move_screen(-1, None))
 
     def select_initial_screen(self):
         self.next_screen()

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -19,7 +19,6 @@ Provides network device listings and extended network information
 
 """
 
-import asyncio
 import logging
 
 from urwid import (
@@ -27,6 +26,7 @@ from urwid import (
     Text,
     )
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.models.network import (
     DHCPState,
     NetDevAction,
@@ -297,7 +297,7 @@ class NetworkView(BaseView):
         self.show_stretchy_overlay(stretchy)
 
     def _action_INFO(self, name, dev_info):
-        asyncio.create_task(
+        run_bg_task(
             self._show_INFO(dev_info.name))
     _action_INFO.opens_dialog = True
 

--- a/system_setup/client/controllers/summary.py
+++ b/system_setup/client/controllers/summary.py
@@ -2,6 +2,7 @@ import aiohttp
 import asyncio
 import logging
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.context import with_context
 
 from subiquity.client.controller import SubiquityTuiController
@@ -25,7 +26,7 @@ class SummaryController(SubiquityTuiController):
         self.summary_view = None
 
     def start(self):
-        asyncio.create_task(self._wait_status())
+        run_bg_task(self._wait_status())
 
     def cancel(self):
         self.app.cancel()
@@ -34,7 +35,7 @@ class SummaryController(SubiquityTuiController):
         pass
 
     def click_reboot(self):
-        asyncio.create_task(self.send_reboot_and_wait())
+        run_bg_task(self.send_reboot_and_wait())
 
     async def send_reboot_and_wait(self):
         try:

--- a/system_setup/server/controllers/shutdown.py
+++ b/system_setup/server/controllers/shutdown.py
@@ -13,11 +13,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import enum
 import os
 import logging
 
+from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.context import with_context
 from subiquity.common.types import ShutdownMode
 from subiquity.server.controllers import ShutdownController
@@ -40,8 +40,8 @@ class SetupShutdownController(ShutdownController):
         self.mode = WSLShutdownMode.COMPLETE  # allow the complete mode
 
     def start(self):
-        asyncio.create_task(self._wait_install())
-        asyncio.create_task(self._run())
+        run_bg_task(self._wait_install())
+        run_bg_task(self._run())
 
     async def _wait_install(self):
         await self.app.controllers.Install.install_task


### PR DESCRIPTION
create_task has the following note:
  Important: Save a reference to the result of this function, to avoid a
  task disappearing mid-execution.

Convert existing usage of create_task to run_bg_task, if that create_task is not actually storing the result.