### PR TITLE
Active Directory API Part 3 - Pinging the Domain Controller

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -784,6 +784,7 @@ class AdDomainNameValidation(enum.Enum):
     START_HYPHEN = 'Starts with a hyphen'
     END_HYPHEN = 'Ends with a hyphen'
     MULTIPLE_DOTS = 'Contains multiple dots'
+    REALM_NOT_FOUND = 'Could not find the domain controller'
 
 
 class AdPasswordValidation(enum.Enum):

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -1682,6 +1682,11 @@ class TestActiveDirectory(TestAPI):
 
             self.assertIn('MULTIPLE_DOTS', result)
 
+            # Leverages the stub ping strategy
+            result = await instance.get(endpoint + '/check_domain_name',
+                                        data='rockbuntu.com')
+            self.assertIn('REALM_NOT_FOUND', result)
+
             # Rejects invalid usernames.
             result = await instance.get(endpoint + '/check_admin_name',
                                         data='ubuntu;pro')


### PR DESCRIPTION
In tandem with the Ubiquity this implements a "ping" to the domain controller during validation. It allows clients to validate not only if the DC name is "syntatically" correct, but also whehter it's reachable in the network.

The "ping" relies on realmd, which is part of the minimal layer. The package is not staged in Subiquity nor UDI at this point.

Here it is the domain name validation in action (running in a locally built ubuntu desktop installer snap):

![image](https://user-images.githubusercontent.com/11138291/218847203-fbff2262-8c5e-49a6-92ca-e3df1dfa7317.png)
