### PR TITLE
Optionally fallback to offline install if no usable mirror provided

### DIFF
--- a/autoinstall-schema.json
+++ b/autoinstall-schema.json
@@ -386,6 +386,14 @@
                             "pin-priority"
                         ]
                     }
+                },
+                "fallback": {
+                    "type": "string",
+                    "enum": [
+                        "abort",
+                        "continue-anyway",
+                        "offline-install"
+                    ]
                 }
             }
         },

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -201,6 +201,7 @@ Apt configuration, used both during the install and once booted into the target 
 This section historically used the same format as curtin, [which is documented here](https://curtin.readthedocs.io/en/latest/topics/apt_source.html). Nonetheless, some key differences with the format supported by curtin have been introduced:
 
  * Subiquity supports an alternative format for the `primary` section, allowing to configure a list of candidate primary mirrors. During installation, subiquity will automatically test the specified mirrors and select the first one that seems usable. This new behavior is only activated when the `primary` section is wrapped in the `mirror-selection` section.
+ * The `fallback` key controls what subiquity should do if no primary mirror is usable.
  * The `geoip` key controls whether a geoip lookup is done to determine the correct country mirror.
 
 The default is:
@@ -214,6 +215,7 @@ The default is:
                   uri: "http://archive.ubuntu.com/ubuntu"
                 - arches: [s390x, arm64, armhf, powerpc, ppc64el, riscv64]
                   uri: "http://ports.ubuntu.com/ubuntu-ports"
+        fallback: abort
         geoip: true
 
 #### mirror-selection
@@ -228,6 +230,17 @@ In the new format, the `primary` section expects a list of mirrors, which can be
  * a mapping with the following keys:
    * `uri`: the URI of the mirror to use, e.g., "http://fr.archive.ubuntu.com/ubuntu"
    * `arches`: an optional list of architectures supported by the mirror. By default, this list contains the current CPU architecture.
+
+#### fallback
+**type:** string (enumeration)
+**default:** abort
+
+Controls what subiquity should do if no primary mirror is usable.
+Supported values are:
+
+ * `abort` -> abort the installation
+ * `offline-install` -> revert to an offline installation
+ * `continue-anyway` -> attempt to install the system anyway (not recommended, the installation will certainly fail)
 
 #### geoip
 **type:** boolean

--- a/documentation/autoinstall-schema.md
+++ b/documentation/autoinstall-schema.md
@@ -408,6 +408,14 @@ The [JSON schema](https://json-schema.org/) for autoinstall data is as follows:
                             "pin-priority"
                         ]
                     }
+                },
+                "fallback": {
+                    "type": "string",
+                    "enum": [
+                        "abort",
+                        "continue-anyway",
+                        "offline-install"
+                    ]
                 }
             }
         },

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -45,6 +45,7 @@ from subiquity.common.types import (
     NetworkStatus,
     MirrorGet,
     MirrorPost,
+    MirrorPostResponse,
     MirrorCheckResponse,
     ModifyPartitionV2,
     ReformatDisk,
@@ -351,7 +352,9 @@ class API:
 
     class mirror:
         def GET() -> MirrorGet: ...
-        def POST(data: Payload[Optional[MirrorPost]]) -> None: ...
+
+        def POST(data: Payload[Optional[MirrorPost]]) \
+            -> MirrorPostResponse: ...
 
         class disable_components:
             def GET() -> List[str]: ...

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -43,6 +43,7 @@ from subiquity.common.types import (
     KeyboardSetup,
     IdentityData,
     NetworkStatus,
+    MirrorSelectionFallback,
     MirrorGet,
     MirrorPost,
     MirrorPostResponse,
@@ -369,6 +370,8 @@ class API:
 
             class abort:
                 def POST() -> None: ...
+
+        fallback = simple_endpoint(MirrorSelectionFallback)
 
     class ubuntu_pro:
         def GET() -> UbuntuProResponse: ...

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -754,6 +754,11 @@ class MirrorPost:
     staged: Optional[str] = None
 
 
+class MirrorPostResponse(enum.Enum):
+    OK = "ok"
+    NO_USABLE_MIRROR = "no-usable-mirror"
+
+
 @attr.s(auto_attribs=True)
 class MirrorGet:
     elected: Optional[str]

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -766,6 +766,12 @@ class MirrorGet:
     staged: Optional[str]
 
 
+class MirrorSelectionFallback(enum.Enum):
+    ABORT = 'abort'
+    CONTINUE_ANYWAY = 'continue-anyway'
+    OFFLINE_INSTALL = 'offline-install'
+
+
 @attr.s(auto_attribs=True)
 class ADConnectionInfo:
     admin_name: str = ""

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -75,7 +75,10 @@ import abc
 import copy
 import contextlib
 import logging
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Union
+from typing import (
+    Any, Callable, Dict, Iterator, List,
+    Optional, Sequence, Set, Union,
+    )
 from urllib import parse
 
 import attr
@@ -130,6 +133,11 @@ class BasePrimaryEntry(abc.ABC):
     def serialize_for_ai(self) -> Any:
         """ Serialize the entry for autoinstall. """
 
+    @abc.abstractmethod
+    def supports_arch(self, arch: str) -> bool:
+        """ Tells whether the mirror claims to support the architecture
+        specified. """
+
 
 @attr.s(auto_attribs=True)
 class PrimaryEntry(BasePrimaryEntry):
@@ -159,8 +167,6 @@ class PrimaryEntry(BasePrimaryEntry):
         return [{"uri": self.uri, "arches": ["default"]}]
 
     def supports_arch(self, arch: str) -> bool:
-        """ Tells whether the mirror claims to support the architecture
-        specified. """
         if self.arches is None:
             return True
         return arch in self.arches
@@ -207,12 +213,29 @@ class LegacyPrimaryEntry(BasePrimaryEntry):
     def serialize_for_ai(self) -> List[Any]:
         return self.config
 
+    def supports_arch(self, arch: str) -> bool:
+        # Curtin will always find a mirror ; albeit with the ["default"]
+        # architectures.
+        return True
+
 
 def countrify_uri(uri: str, cc: str) -> str:
     """ Return a URL where the host is prefixed with a country code. """
     parsed = parse.urlparse(uri)
     new = parsed._replace(netloc=cc + '.' + parsed.netloc)
     return parse.urlunparse(new)
+
+
+CandidateFilter = Callable[[BasePrimaryEntry], bool]
+
+
+def filter_candidates(candidates: List[BasePrimaryEntry],
+                      *, filters: Sequence[CandidateFilter]) \
+                              -> Iterator[BasePrimaryEntry]:
+    candidates_iter = iter(candidates)
+    for filt in filters:
+        candidates_iter = filter(filt, candidates_iter)
+    return candidates_iter
 
 
 class MirrorModel(object):
@@ -312,8 +335,12 @@ class MirrorModel(object):
         # install. It will be placed in etc/apt/sources.list of the target
         # system.
         with contextlib.suppress(StopIteration):
-            candidate = next(filter(lambda c: c.uri is not None,
-                                    self.compatible_primary_candidates()))
+            filters = [
+                lambda c: c.uri is not None,
+                lambda c: c.supports_arch(self.architecture),
+            ]
+            candidate = next(filter_candidates(self.primary_candidates,
+                                               filters=filters))
             return self._get_apt_config_using_candidate(candidate)
         # Our last resort is to include no primary section. Curtin will use
         # its own internal values.
@@ -357,20 +384,20 @@ class MirrorModel(object):
         return next(self.country_mirror_candidates(), None) is not None
 
     def country_mirror_candidates(self) -> Iterator[BasePrimaryEntry]:
-        for candidate in self.primary_candidates:
+        def filt(candidate):
             if self.legacy_primary and candidate.mirror_is_default():
-                yield candidate
+                return True
             elif not self.legacy_primary and candidate.country_mirror:
-                yield candidate
+                return True
+            return False
+
+        return filter_candidates(self.primary_candidates, filters=[filt])
 
     def compatible_primary_candidates(self) -> Iterator[BasePrimaryEntry]:
-        for candidate in self.primary_candidates:
-            if self.legacy_primary:
-                yield candidate
-            elif candidate.arches is None:
-                yield candidate
-            elif self.architecture in candidate.arches:
-                yield candidate
+        def filt(candidate):
+            return candidate.supports_arch(self.architecture)
+
+        return filter_candidates(self.primary_candidates, filters=[filt])
 
     def render(self):
         return {}

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -417,10 +417,11 @@ class NetworkModel(object):
         self.devices_by_name = {}  # Maps interface names to NetworkDev
         self._has_network = False
         self.project = project
+        self.force_offline = False
 
     @property
     def has_network(self):
-        return self._has_network
+        return self._has_network and not self.force_offline
 
     @has_network.setter
     def has_network(self, val):


### PR DESCRIPTION
Subiquity now supports 3 different fallback actions if the automatic mirror selection did not find any usable mirror:

* aborting the install (this is the default)
* continuing anyway (which I would hardly recommend doing)
* reverting to an offline install

The fallback action can be configured via autoinstall:
```yaml
apt:
    fallback: offline-install   # accepted values are "offline-install", "continue-anyway" and "abort"
```
and it can also be changed via the HTTP API:

```bash
curl --unix-socket socket http://a/mirror/fallback -d "offline-install"
```

If the mirror selection fails during an autoinstall, the fallback action is automatically executed.
If the mirror selection fails and the mirror model was marked configured via /meta/mark_configured, the fallback action is automatically executed.
 If the mirror selection fails during a call to POST /mirror with a null body, the fallback action is not applied. The client gets the opportunity to:
  * adjust the settings and retry
  * disable the network and retry,
  * wait and retry
  * give up on the install