### PR TITLE
snapcraft: update probert to get swap size fixes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -197,7 +197,7 @@ parts:
 
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: 31778895be3002422e9e8758d42940f290dc70af
+    source-commit: 40479d08fce0370a0c41a140e6d322d2846c2a8f
 
     override-build: *pyinstall
 


### PR DESCRIPTION
Pull in recent fixes on probert to avoid issues such as:
```
  File "/snap/ubuntu-desktop-installer/773/lib/python3.8/site-packages/probert/filesystem.py", line 162, in get_device_filesystem
    size_info = sizing_tools[fstype](device)
  File "/snap/ubuntu-desktop-installer/773/lib/python3.8/site-packages/probert/filesystem.py", line 141, in get_swap_sizing
    'SIZE': device['ID_PART_ENTRY_SIZE'] * 512,
  File "/snap/ubuntu-desktop-installer/773/lib/python3.8/site-packages/pyudev/device/_device.py", line 988, in __getitem__
    return self.properties.__getitem__(prop)
  File "/snap/ubuntu-desktop-installer/773/lib/python3.8/site-packages/pyudev/device/_device.py", line 1115, in __getitem__
    raise KeyError(prop)
KeyError: 'ID_PART_ENTRY_SIZE'
```