### PR TITLE
make sure mirror selection does not cause timeouts on CI

### DIFF
--- a/examples/dr-config-apt-local-mirror.yaml
+++ b/examples/dr-config-apt-local-mirror.yaml
@@ -1,0 +1,7 @@
+apt_mirrors_known:
+  - url: http://mymirror.local/repository/Apt/ubuntu/
+    strategy: failure
+  - pattern: 'https?://[a-z]{2,}\.archive\.ubuntu\.com/ubuntu/?'
+    strategy: success
+  - url: http://archive.ubuntu.com/ubuntu
+    strategy: failure

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -215,6 +215,7 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --machine-config examples/existing-partitions.json \
     --bootloader bios \
     --autoinstall examples/autoinstall.yaml \
+    --dry-run-config examples/dr-config-apt-local-mirror.yaml \
     --kernel-cmdline autoinstall \
     --source-catalog examples/install-sources.yaml
 validate

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -202,7 +202,7 @@ class MirrorController(SubiquityController):
             if idx != 0:
                 # Sleep before testing the next candidate..
                 log.debug("Will check next candiate mirror after 10 seconds.")
-                await asyncio.sleep(10)
+                await asyncio.sleep(10 / self.app.scale_factor)
             if candidate.uri is None:
                 log.debug("Skipping unresolved country mirror")
                 continue
@@ -213,7 +213,7 @@ class MirrorController(SubiquityController):
                 log.debug("Retrying in 10 seconds...")
             else:
                 break
-            await asyncio.sleep(10)
+            await asyncio.sleep(10 / self.app.scale_factor)
             # If the test fails a second time, give up on this mirror.
             try:
                 await self.try_mirror_checking_once()


### PR DESCRIPTION
Two changes:
1. do not run apt-get update on host when running autoinstall.yaml as part of the CI
2. when sleeping after a failed mirror candidates, make the sleep call be affected by SUBIQUITY_REPLAY_TIMESCALE