### PR TITLE
when installing packages, try the download operation up-to 3 times

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: cc23249707a2773ecb1f10b17de35fff4620de9a
+    source-commit: b1f4da3bec92356e8ef389c1c581cfdcd1b36c42
 
     override-pull: |
       snapcraftctl pull

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -426,10 +426,18 @@ class InstallController(SubiquityController):
         name="install_{package}",
         description="installing {package}")
     async def install_package(self, *, context, package):
-        await run_curtin_command(
-            self.app, context, 'system-install', '-t', self.tpath(),
-            '--', package,
-            private_mounts=False)
+        with context.child('retrieving', f'retrieving {package}'):
+            await run_curtin_command(
+                self.app, context, 'system-install', '-t', self.tpath(),
+                '--download-only',
+                '--', package,
+                private_mounts=False)
+        with context.child('unpacking', f'unpacking {package}'):
+            await run_curtin_command(
+                self.app, context, 'system-install', '-t', self.tpath(),
+                '--assume-downloaded',
+                '--', package,
+                private_mounts=False)
 
     @with_context(description="restoring apt configuration")
     async def restore_apt_config(self, context):

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import subprocess
 import tempfile
 from typing import Any, Callable, Dict, List
 
@@ -426,12 +427,26 @@ class InstallController(SubiquityController):
         name="install_{package}",
         description="installing {package}")
     async def install_package(self, *, context, package):
-        with context.child('retrieving', f'retrieving {package}'):
-            await run_curtin_command(
-                self.app, context, 'system-install', '-t', self.tpath(),
-                '--download-only',
-                '--', package,
-                private_mounts=False)
+        """ Attempt to download the package up-to three times, then install it.
+        """
+        for attempt, attempts_remaining in enumerate(reversed(range(3))):
+            try:
+                with context.child('retrieving', f'retrieving {package}'):
+                    await run_curtin_command(
+                        self.app, context, 'system-install', '-t',
+                        self.tpath(),
+                        '--download-only',
+                        '--', package,
+                        private_mounts=False)
+            except subprocess.CalledProcessError:
+                log.error(f"failed to download package {package}")
+                if attempts_remaining > 0:
+                    await asyncio.sleep(1 + attempt * 3)
+                else:
+                    raise
+            else:
+                break
+
         with context.child('unpacking', f'unpacking {package}'):
             await run_curtin_command(
                 self.app, context, 'system-install', '-t', self.tpath(),


### PR DESCRIPTION
When installing a package, instead of using a single call to `curtin system-install [package]`, we now call:
* `curtin system-install --download-only [package]` (up to three times with a delay between iterations)
* `curtin system-install --assume-downloaded [package]`

curtin's merge request: https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/437897