### PR TITLE
Revert "Enable tracemalloc in integration tests with at most 3 frames" to speed up integration tests

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -2,7 +2,6 @@
 set -eux
 
 export PYTHONPATH=$PWD:$PWD/probert:$PWD/curtin
-export PYTHONTRACEMALLOC=3
 
 RELEASE=$(lsb_release -rs)
 


### PR DESCRIPTION
Integration tests are becoming very slow to run. 
At least for the test using autoinstall.yaml, disabling tracemalloc yields to a 5-fold runtime speed improvement.

This reverts commit 813448683c971cf6acdc998b684d5ddea83aabe3.