### PR TITLE
filesystem: don't offer tiny partitions / disks as potential PVs

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -688,7 +688,9 @@ class Disk(_Device):
             return False
         return True
 
-    ok_for_lvm_vg = ok_for_raid
+    @property
+    def ok_for_lvm_vg(self):
+        return self.ok_for_raid and self.size > LVM_OVERHEAD
 
     @property
     def model(self):
@@ -783,6 +785,10 @@ class Partition(_Formattable):
         return True
 
     @property
+    def ok_for_lvm_vg(self):
+        return self.ok_for_raid and self.size > LVM_OVERHEAD
+
+    @property
     def os(self):
         os_data = self._m._probe_data.get('os', {}).get(self._path())
         if not os_data:
@@ -792,8 +798,6 @@ class Partition(_Formattable):
     @property
     def is_logical(self):
         return self.flag == 'logical'
-
-    ok_for_lvm_vg = ok_for_raid
 
 
 @fsobj("raid")
@@ -866,7 +870,9 @@ class Raid(_Device):
             return False
         return True
 
-    ok_for_lvm_vg = ok_for_raid
+    @property
+    def ok_for_lvm_vg(self):
+        return self.ok_for_raid and self.size > LVM_OVERHEAD
 
     # What is a device that makes up this device referred to as?
     component_name = "component"


### PR DESCRIPTION
When creating a virtual group, all disks and partitions that could be used as a raid device were also offered as a potential LVM physical volume.

However, tiny disks and partitions (i.e., < 1 MiB) are too small to store the LVM header. They make the get_lvm_size() function potentially return a negative value; which in turn causes math errors.

We now make sure to only offer disks/partitions that are big enough to store the LVM header.

Technically speaking, a 2MiB disk is still useless as a physical volume since it is not big enough to store any PE (which are 4MiB by default). We can come up with better rules later but this is good enough to prevent subiquity from crashing.

Steps to reproduce the crash:
1. `make dryrun`
2. navigate to the filesystem screen
3. select "Custom storage layout" and next
4. select the free space -> add a GPT partition
5. make the size `0G` and format: `Leave unformatted'
6. redo 4. and 5. to create a second partition
7. click on `Create volume group (LVM)`
8. try to add one of the two partition
