### PR TITLE
keyboard: validate layout and variant

### DIFF
--- a/subiquity/models/tests/test_keyboard.py
+++ b/subiquity/models/tests/test_keyboard.py
@@ -29,11 +29,21 @@ class TestKeyboardModel(SubiTestCase):
         self.assertIsNone(self.model._setting)
         self.assertEqual('us', self.model.setting.layout)
 
-    def testSetToZZ(self):
-        val = KeyboardSetting(layout='zz')
-        self.model.setting = val
-        self.assertEqual(val, self.model.setting)
-        self.assertEqual(val, self.model._setting)
+    @parameterized.expand((['zz'], ['en']))
+    def testSetToInvalidLayout(self, layout):
+        initial = self.model.setting
+        val = KeyboardSetting(layout=layout)
+        with self.assertRaises(ValueError):
+            self.model.setting = val
+        self.assertEqual(initial, self.model.setting)
+
+    @parameterized.expand((['zz']))
+    def testSetToInvalidVariant(self, variant):
+        initial = self.model.setting
+        val = KeyboardSetting(layout='us', variant=variant)
+        with self.assertRaises(ValueError):
+            self.model.setting = val
+        self.assertEqual(initial, self.model.setting)
 
     @parameterized.expand([
         ['ast_ES.UTF-8', 'es', 'ast'],


### PR DESCRIPTION
In LP: #2008271, an invalid but reasonable-looking layout was supplied in autoinstall, which makes it all the way to curthooks before failing ckbcomp in a way that makes it look like files are missing.

Validate ahead of time these values.

