### PR TITLE
snapcraft: bump curtin rev to fix curthooks always running apt-config

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: b08eecd68cf5f1bccf4255b3d00a77af51c159f7
+    source-commit: cc23249707a2773ecb1f10b17de35fff4620de9a
 
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
the goal is to pull the curthooks fixes:
* canonical/curtin@cc232497 apt-config: stop returning cfg object in translate_old_apt_features
* canonical/curtin@90177706 apt-config: fix wrong value printed in debug log
* canonical/curtin@ce9ca977 apt-config: fix curthooks unconditionally triggering apt-config

but it also pulls the following changes:
* canonical/curtin@5af09277 add SLES support
* canonical/curtin@a6960887 integration: use sfdisk as the source of info
* canonical/curtin@c56c51aa block/v1: handle msdos+swap
* canonical/curtin@8c5f87ed block_meta: all fields on a disk action must match with v2 config
* canonical/curtin@6d114064 apt: use string.format instead of f-string
