### PR TITLE
Fix how we pass an alternative apt configuration file for mirror testing

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -152,12 +152,7 @@ class AptConfigurer:
         apt_config = apt_pkg.Configuration()
 
         apt_dirs = {
-            "Etc::SourceList": pfx / "etc/apt/sources.list",
-            "Etc::SourceParts": pfx / "etc/apt/sources.list.d",
-            "Etc::Main": pfx / "etc/apt/apt.conf",
-            "Etc::Parts": pfx / "etc/apt/apt.conf.d",
-            "Etc::Preferences": pfx / "etc/apt/preferences",
-            "Etc::PreferencesParts": pfx / "etc/apt/preferences.d",
+            "Etc": pfx / "etc/apt",
             "Cache::Archives": pfx / "var/lib/apt/archives",
             "State::Lists": pfx / "var/lib/apt/lists",
             "Cache::PkgCache": None,


### PR DESCRIPTION
Sadly, passing an alternative config file to apt using -o CLI options does not work because apt:
    
    1) Reads the configuration file first
    2) Reads CLI options (and override specified settings) second
    
Therefore, the default configuration file is always read, instead of the one we supply.
 
To specify an alternative configuration file, the recommendation from the apt maintainer is to supply an APT_CONFIG variable, hinting apt to read said file instead of the default.
    
We now generate a temporary file, write the directives we need to it using the python apt library, and then execute apt-get with a path to this temporary file set in APT_CONFIG.