### PR TITLE
apt: force downloads to be unsandboxed when running mirror testing

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -168,7 +168,13 @@ class AptConfigurer:
         except (PermissionError, LookupError) as exc:
             log.warning("could to set owner of file %s: %r", partial_dir, exc)
 
-        apt_cmd = ["apt-get", "update", "-oAPT::Update::Error-Mode=any"]
+        apt_cmd = [
+            "apt-get", "update",
+            "-oAPT::Update::Error-Mode=any",
+            # Workaround because the default sandbox user (i.e., _apt) does not
+            # have access to the overlay.
+            "-oAPT::Sandbox::User=root",
+        ]
 
         for key, path in apt_dirs.items():
             value = "" if path is None else str(path)


### PR DESCRIPTION
When apt-get is run as root, it tries to drop privileges by setuid-ing to the APT::Sandbox::User user (i.e., _apt by default). This does not work for us when doing mirror testing because the default sandbox user does not have access to the overlay. Therefore, APT produces a warning and reverts to unsandboxed downloads.

Let's force apt to use unsandboxed downloads by setting root as the sandbox user. This has the same result but avoids showing a warning in the APT output during mirror testing.