### PR TITLE
Active Directory - Split the domain validation endpoint in two

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -426,8 +426,15 @@ class API:
             def GET() -> bool: ...
 
         class check_domain_name:
+            """ Applies basic validation to the candidate domain name,
+                without calling the domain network. """
             def POST(domain_name: Payload[str]) \
                 -> List[AdDomainNameValidation]: ...
+
+        class ping_domain_controller:
+            """ Attempts to contact the controller of the provided domain. """
+            def POST(domain_name: Payload[str]) \
+                -> AdDomainNameValidation: ...
 
         class check_admin_name:
             def POST(admin_name: Payload[str]) -> AdAdminNameValidation: ...

--- a/subiquity/server/controllers/ad.py
+++ b/subiquity/server/controllers/ad.py
@@ -130,12 +130,12 @@ class ADController(SubiquityController):
     async def check_domain_name_POST(self, domain_name: str) \
             -> List[AdDomainNameValidation]:
         result = AdValidators.domain_name(domain_name)
-        if AdDomainNameValidation.OK in result:
-            ping = await AdValidators.ping_domain_controller(domain_name,
-                                                             self.ping_strgy)
-            return [ping]
-
         return list(result)
+
+    async def ping_domain_controller_POST(self, domain_name: str) \
+            -> AdDomainNameValidation:
+        return await AdValidators.ping_domain_controller(domain_name,
+                                                         self.ping_strgy)
 
     async def check_password_POST(self, password: str) -> AdPasswordValidation:
         return AdValidators.password(password)

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -1682,11 +1682,6 @@ class TestActiveDirectory(TestAPI):
 
             self.assertIn('MULTIPLE_DOTS', result)
 
-            # Leverages the stub ping strategy
-            result = await instance.post(endpoint + '/check_domain_name',
-                                         data='rockbuntu.com')
-            self.assertIn('REALM_NOT_FOUND', result)
-
             # Rejects invalid usernames.
             result = await instance.post(endpoint + '/check_admin_name',
                                          data='ubuntu;pro')
@@ -1696,6 +1691,12 @@ class TestActiveDirectory(TestAPI):
             result = await instance.post(endpoint + '/check_admin_name',
                                          data='$Ubuntu')
             self.assertEqual('OK', result)
+
+            # Leverages the stub ping strategy
+            result = await instance.post(endpoint + '/ping_domain_controller',
+                                         data='rockbuntu.com')
+            self.assertEqual('REALM_NOT_FOUND', result)
+
             # Attempts to join with the info supplied above.
             ad_dict = {
                 'admin_name': 'Ubuntu',


### PR DESCRIPTION
Ref: https://github.com/canonical/ubuntu-desktop-installer/pull/1522#discussion_r1124397775

GUI could face performance issues in calling the validation on each char the user type.

Having two separate endpoints prevent such issue to ever happen, because we provide more granular control. Regex validation goes at each char typed and pinging the domain controller can happen when whe user leaves the text field or hits the "Test Connection" buttont.