### PR TITLE
storage/v2: endpoint for boot-plausible disks

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -300,7 +300,16 @@ class API:
                 def POST(data: Payload[ReformatDisk]) \
                     -> StorageResponseV2: ...
 
+            class potential_boot_disks:
+                """Obtain the list of disks which can be made bootable.
+                This list can be empty if there are no disks or if none of them
+                are plausible sources of a boot disk."""
+                def GET() -> List[str]: ...
+
             class add_boot_partition:
+                """Mark a given disk as bootable, which may cause a partition
+                to be added to the disk.  It is an error to call this for a
+                disk not in the list from potential_boot_disks."""
                 def POST(disk_id: str) -> StorageResponseV2: ...
 
             class add_partition:

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -345,7 +345,10 @@ class FilesystemManipulator:
         if not self.supports_resilient_boot:
             for disk in boot.all_boot_devices(self.model):
                 self.remove_boot_disk(disk)
-        boot.get_boot_device_plan(new_boot_disk).apply(self)
+        plan = boot.get_boot_device_plan(new_boot_disk)
+        if plan is None:
+            raise ValueError(f'No known plan to make {new_boot_disk} bootable')
+        plan.apply(self)
         if not new_boot_disk._has_preexisting_partition():
             if new_boot_disk.type == "disk":
                 new_boot_disk.preserve = False

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -731,6 +731,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.reformat(self.model._one(id=data.disk_id), data.ptable)
         return await self.v2_GET()
 
+    async def v2_potential_boot_disks_GET(self) -> List[str]:
+        disks = self.get_guided_disks(check_boot=True,
+                                      with_reformatting=False)
+        return [disk.id for disk in disks]
+
     async def v2_add_boot_partition_POST(self, disk_id: str) \
             -> StorageResponseV2:
         disk = self.model._one(id=disk_id)


### PR DESCRIPTION
Provide a list of disk IDs that are plausible boot targets.
This could also be full disk objects if that makes things simpler.