### PR TITLE
Single instance task wait

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ flake8:
 
 .PHONY: unit
 unit: gitdeps
+	timeout 120 \
 	$(PYTHON) -m pytest --ignore curtin --ignore probert \
 		--ignore subiquity/tests/api
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -384,7 +384,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             self.guided_direct(gap)
 
     async def _probe_response(self, wait, resp_cls):
-        if self._probe_task.task is None or not self._probe_task.task.done():
+        if not self._probe_task.done():
             if wait:
                 await self._start_task
                 await self._probe_task.wait()
@@ -394,8 +394,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             return resp_cls(
                 status=ProbeStatus.FAILED,
                 error_report=self._errors[True][1].ref())
-        if self._get_system_task.task is None or \
-           not self._get_system_task.task.done():
+        if not self._get_system_task.done():
             if wait:
                 await self._get_system_task.wait()
             else:

--- a/subiquitycore/async_helpers.py
+++ b/subiquitycore/async_helpers.py
@@ -113,3 +113,8 @@ class SingleInstanceTask:
                 return await self.task
             except asyncio.CancelledError:
                 pass
+
+    def done(self):
+        if self.task is None:
+            return False
+        return self.task.done()

--- a/subiquitycore/tests/test_async_helpers.py
+++ b/subiquitycore/tests/test_async_helpers.py
@@ -56,10 +56,13 @@ class TestSITWait(unittest.IsolatedAsyncioTestCase):
         sit = SingleInstanceTask(fn)
         await sit.start()
         await asyncio.wait_for(sit.wait(), timeout=1.0)
+        self.assertTrue(sit.done())
 
     async def test_wait_not_started(self):
         async def fn():
             self.fail('not supposed to be called')
         sit = SingleInstanceTask(fn)
+        self.assertFalse(sit.done())
         with self.assertRaises(asyncio.TimeoutError):
             await asyncio.wait_for(sit.wait(), timeout=0.1)
+        self.assertFalse(sit.done())


### PR DESCRIPTION
LP: #[2009797](https://bugs.launchpad.net/subiquity/+bug/2009797) has the following backtrace:

```
2023-03-09 06:54:49,973 DEBUG subiquity.server.server:456 request to /storage/v2?wait=true crashed
Traceback (most recent call last):
  File "/snap/ubuntu-desktop-installer/820/bin/subiquity/subiquity/common/api/server.py", line 134, in handler
    result = await implementation(**args)
  File "/snap/ubuntu-desktop-installer/820/bin/subiquity/subiquity/server/controllers/filesystem.py", line 656, in v2_GET
    return await self.get_v2_storage_response(self.model, wait)
  File "/snap/ubuntu-desktop-installer/820/bin/subiquity/subiquity/server/controllers/filesystem.py", line 642, in get_v2_storage_response
    probe_resp = await self._probe_response(wait, StorageResponseV2)
  File "/snap/ubuntu-desktop-installer/820/bin/subiquity/subiquity/server/controllers/filesystem.py", line 389, in _probe_response
    await self._start_task
AttributeError: 'FilesystemController' object has no attribute '_start_task'
```

What's happening here is that we lost the race and the installer client asked for filesystem information before the controller itself ran the `start()` method.

While working on that, I realized the behavior around `SingleInstanceTask.wait()` was more complicated than I liked for the callers, and improving that will help the fix for the above.


SingleInstanceTask has distinct steps for creation of the object, and starting the task.  If a different coroutine is waiting on the SingleInstanceTask, it isn't safe to directly call SingleInstanceTask.wait() as the task may or may not have been created yet.
    
Existing code usage of SingleInstanceTask is in 4 categories, with regards to SingleInstanceTask.wait():
1) using SingleInstanceTask without using SingleInstanceTask.wait(). This is unchanged.
2) using SingleInstanceTask.wait without a check on task is not None. This may be safe now, but is fragile in the face of innocent-looking refactors around the SingleInstanceTask.
3) using SingleInstanceTask.wait after confirming that the task is not None.  This is fine but a leaky abstraction.
4) directly waiting on the SingleInstanceTask.task.  Another leaky abstraction, but it's solving a cancellation problem.  Leaving this alone.
    
By enhancing SingleInstanceTask.wait(), cases 2 and 3 are improved.  The code not checking the task today is made safer, and the code checking the task today can be simplified.

Marking some tests async is about giving the FilesystemController an active event loop.