### PR TITLE
integration: add background runner script

### DIFF
--- a/scripts/background-runner
+++ b/scripts/background-runner
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+
+# Use screen to run a terminal program in the background until it exists.
+# This process stays around in the forground.
+# Exit code from the program being run is returned here.
+
+import argparse
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-l', '--logfile', default=None,
+                        help='append output to logfile')
+    args, program = parser.parse_known_args()
+
+    cmd = [
+        'screen',
+        '-c', '/dev/null',  # ignore any user configuration
+        '-D', '-m',         # run detached from a terminal perspective,
+                            # but the screen process doesn't background
+    ]
+    if args.logfile:
+        cmd.extend(('-L', '-Logfile', args.logfile))
+
+    with tempfile.NamedTemporaryFile() as exitfile:
+        cmd.extend(('./scripts/capture-exit-code', exitfile.name, *program))
+        subprocess.run(cmd, check=True)
+        sys.exit(int(exitfile.read()))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/capture-exit-code
+++ b/scripts/capture-exit-code
@@ -1,0 +1,11 @@
+#!/bin/sh -u
+
+# Take a filename argument. The rest of the arguments are a program to run.
+# Save the exit code of that program to the filename arg.
+
+exitfile="$1"
+shift
+"$@"
+ec=$?
+echo $ec > "$exitfile"
+exit $ec

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -174,8 +174,10 @@ for answers in examples/answers*.yaml; do
             opts+=(--dry-run-config "$dr_config")
         fi
         # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
-        LANG=C.UTF-8 timeout --foreground 60 \
-            python3 -m subiquity.cmd.tui < "$tty" \
+        ./scripts/background-runner -l $tmpdir/tui.log \
+            env LANG=C.UTF-8 \
+            timeout --foreground 60 \
+            python3 -m subiquity.cmd.tui \
             --dry-run \
             --output-base "$tmpdir" \
             --answers "$answers" \
@@ -196,8 +198,10 @@ for answers in examples/answers*.yaml; do
                 reconf_settings="true"
                 validate_subtype="answers-reconf"
             fi
-            DRYRUN_RECONFIG="$reconf_settings" LANG=C.UTF-8 timeout --foreground 60 \
-                python3 -m system_setup.cmd.tui < "$tty" \
+            ./scripts/background-runner -l $tmpdir/tui.log \
+                env DRYRUN_RECONFIG="$reconf_settings" LANG=C.UTF-8 \
+                timeout --foreground 60 \
+                python3 -m system_setup.cmd.tui \
                 --dry-run \
                 --answers "$answers" \
                 --output-base "$tmpdir"
@@ -207,7 +211,9 @@ for answers in examples/answers*.yaml; do
     clean
 done
 
-LANG=C.UTF-8 timeout --foreground 60 \
+./scripts/background-runner -l $tmpdir/tui.log \
+    env LANG=C.UTF-8 \
+    timeout --foreground 60 \
     python3 -m subiquity.cmd.tui \
     --dry-run \
     --output-base "$tmpdir" \
@@ -241,7 +247,9 @@ grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: 
     $tmpdir/subiquity-server-debug.log
 
 clean
-LANG=C.UTF-8 timeout --foreground 60 \
+./scripts/background-runner -l $tmpdir/tui.log \
+    env LANG=C.UTF-8 \
+    timeout --foreground 60 \
     python3 -m subiquity.cmd.tui \
     --dry-run \
     --output-base "$tmpdir" \
@@ -275,7 +283,9 @@ if [ "${RELEASE%.*}" -ge 20 ]; then
     # Test system_setup autoinstall.
     for mode in "" "-full" "-no-shutdown"; do
         clean
-        LANG=C.UTF-8 timeout --foreground 60 \
+        ./scripts/background-runner -l $tmpdir/tui.log \
+            env LANG=C.UTF-8 \
+            timeout --foreground 60 \
             python3 -m system_setup.cmd.tui \
             --dry-run \
             --output-base "$tmpdir" \


### PR DESCRIPTION
To eventually run these in parallel, we want to not have a single test instance hogging the console.  Add a background-runner script which uses a detached screen session that also preserves the exit code of the program we're testing.