### PR TITLE
api: delay most endpoints until controllers start

### DIFF
--- a/subiquity/common/api/defs.py
+++ b/subiquity/common/api/defs.py
@@ -99,3 +99,11 @@ def simple_endpoint(typ):
         def GET() -> typ: ...
         def POST(data: Payload[typ]): ...
     return endpoint
+
+
+def allowed_before_start(fun):
+    """An endpoint may mark themselves as allowed_before_start if they should
+    be made usable prior to the controllers starting.  Most endpoints don't
+    want this."""
+    fun.allowed_before_start = True
+    return fun

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -23,7 +23,12 @@ from subiquitycore.models.network import (
     WLANConfig,
     )
 
-from subiquity.common.api.defs import api, Payload, simple_endpoint
+from subiquity.common.api.defs import (
+    allowed_before_start,
+    api,
+    Payload,
+    simple_endpoint,
+    )
 from subiquity.common.types import (
     AdConnectionInfo,
     AdAdminNameValidation,
@@ -94,8 +99,9 @@ class API:
 
     class meta:
         class status:
+            @allowed_before_start
             def GET(cur: Optional[ApplicationState] = None) \
-              -> ApplicationStatus:
+                    -> ApplicationStatus:
                 """Get the installer state."""
 
         class mark_configured:

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -76,6 +76,7 @@ class Application:
         self.load_controllers(self.controllers)
         self.context = Context.new(self)
         self.exit_event = asyncio.Event()
+        self.controllers_have_started = asyncio.Event()
 
     def load_controllers(self, controllers):
         """ Load the corresponding list of controllers
@@ -123,6 +124,7 @@ class Application:
         for controller in self.controllers.instances:
             controller.start()
         log.debug("controllers started")
+        self.controllers_have_started.set()
 
     async def start(self):
         self.controllers.load_all()


### PR DESCRIPTION
In LP: 2009797, an exception of this form happens:
AttributeError: 'FilesystemController' object has no attribute '_start_task'

The installer client, u-d-i, is asking for storage information ASAP after the socket starts listening, and in this case that happened before all controllers were started.  The sync primitive the probe is waiting on wasn't created yet.

With one known exception, /meta/status, we really shouldn't be responding to random API calls, and the startup sequence of the controllers should be relatively quick (sub 1 second to be sure). Just delay them, except for the special one.

A more aggressive version of https://github.com/canonical/subiquity/pull/1595