### PR TITLE
snapcraft: upgrade to core22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         image:
-          - ubuntu-daily:focal    # match the core snap we're running against
+          - ubuntu-daily:jammy    # match the core snap we're running against
           - ubuntu-daily:lunar    # latest
     steps:
     - uses: actions/checkout@v2

--- a/bin/subiquity-cmd
+++ b/bin/subiquity-cmd
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export PYTHONPATH=$PYTHONPATH:$SNAP/lib/python3.8/site-packages
+export PYTHONPATH=$PYTHONPATH:$SNAP/lib/python3.10/site-packages
 $PYTHON -m subiquity "$@"

--- a/bin/subiquity-server
+++ b/bin/subiquity-server
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export PYTHONPATH=$PYTHONPATH:$SNAP/lib/python3.8/site-packages
+export PYTHONPATH=$PYTHONPATH:$SNAP/lib/python3.10/site-packages
 $PYTHON -m subiquity.cmd.server

--- a/bin/subiquity-service
+++ b/bin/subiquity-service
@@ -1,6 +1,6 @@
 #!/bin/sh
 port=tty1
-export PYTHONPATH=$SNAP/lib/python3.8/site-packages
+export PYTHONPATH=$SNAP/lib/python3.10/site-packages
 
 if [ -n "$1" ]; then
    port=$1

--- a/scripts/slimy-update-snap.sh
+++ b/scripts/slimy-update-snap.sh
@@ -52,12 +52,12 @@ do_mount $old old
 
 add_overlay old new
 
-rm -rf new/lib/python3.8/site-packages/curtin
-rm -rf new/lib/python3.8/site-packages/subiquity
-rm -rf new/lib/python3.8/site-packages/subiquitycore
+rm -rf new/lib/python3.10/site-packages/curtin
+rm -rf new/lib/python3.10/site-packages/subiquity
+rm -rf new/lib/python3.10/site-packages/subiquitycore
 
 (cd "${src}" && ./scripts/update-part.py curtin)
 
-rsync -a --chown 0:0 $src/subiquity $src/subiquitycore $src/curtin/curtin new/lib/python3.8/site-packages
+rsync -a --chown 0:0 $src/subiquity $src/subiquitycore $src/curtin/curtin new/lib/python3.10/site-packages
 
 snapcraft pack new --output $new

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: subiquity
-base: core20
+base: core22
 version: git
 summary: Ubuntu installer
 description: The Ubuntu server installer
@@ -21,7 +21,7 @@ apps:
       SUBIQUITY_ROOT_ORIG: $SUBIQUITY_ROOT
       SUBIQUITY_ROOT: $SNAP
       PYTHON_ORIG: $PYTHON
-      PYTHON: $SNAP/usr/bin/python3.8
+      PYTHON: $SNAP/usr/bin/python3.10
   probert:
     command: bin/probert
   subiquity-server:
@@ -31,8 +31,8 @@ apps:
     environment:
       PYTHONIOENCODING: utf-8
       SUBIQUITY_ROOT: $SNAP
-      PYTHON: $SNAP/usr/bin/python3.8
-      PY3OR2_PYTHON: $SNAP/usr/bin/python3.8
+      PYTHON: $SNAP/usr/bin/python3.10
+      PY3OR2_PYTHON: $SNAP/usr/bin/python3.10
       PATH: $PATH:$SNAP/bin:$SNAP/sbin
   subiquity-service:
     command: usr/bin/subiquity-service
@@ -48,7 +48,7 @@ apps:
       SUBIQUITY_ROOT_ORIG: $SUBIQUITY_ROOT
       SUBIQUITY_ROOT: $SNAP
       PYTHON_ORIG: $PYTHON
-      PYTHON: $SNAP/usr/bin/python3.8
+      PYTHON: $SNAP/usr/bin/python3.10
   os-prober:
     command: usr/bin/os-prober
     environment:
@@ -64,13 +64,19 @@ parts:
     source-commit: b1f4da3bec92356e8ef389c1c581cfdcd1b36c42
 
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"
       sed -e "s,@@PACKAGED_VERSION@@,$PACKAGED_VERSION,g" -i curtin/version.py
     override-build: &pyinstall |
       # We install without dependencies because all dependencies come from
       # archive packages.
-      pip3 install --prefix=$SNAPCRAFT_PART_INSTALL --no-dependencies .
+      # XXX: On core22, running `pip3 install --prefix xxx` does not do the
+      # right thing. The package ends up installed in xxx/local and the modules
+      # get installed to dist-packages instead of site-packages.
+      # See https://discuss.python.org/t/18240
+      # As a workaround, we use a fake user install to get the package
+      # installed in the expected place.
+      PYTHONUSERBASE="$CRAFT_PART_INSTALL" pip3 install --user --no-dependencies .
 
     build-packages:
       - python3-pip
@@ -97,8 +103,8 @@ parts:
       - cloud-init
       - iso-codes
       - libpython3-stdlib
-      - libpython3.8-minimal
-      - libpython3.8-stdlib
+      - libpython3.10-minimal
+      - libpython3.10-stdlib
       - libsystemd0
       - lsb-release
       - ntfs-3g
@@ -119,7 +125,7 @@ parts:
       - python3-urwid
       - python3-yaml
       - python3-yarl
-      - python3.8-minimal
+      - python3.10-minimal
       - ssh-import-id
       - ubuntu-advantage-tools
 
@@ -128,7 +134,10 @@ parts:
       bin/subiquity-service: usr/bin/subiquity-service
       bin/subiquity-server: usr/bin/subiquity-server
       bin/subiquity-cmd: usr/bin/subiquity-cmd
-      $SNAPCRAFT_PART_BUILD/system_setup/ubuntu-wsl-setup: bin/ubuntu-wsl-setup
+      $CRAFT_PART_BUILD/system_setup/ubuntu-wsl-setup: bin/ubuntu-wsl-setup
+
+    build-attributes:
+      - enable-patchelf
 
   users-and-groups:
     plugin: nil
@@ -138,7 +147,7 @@ parts:
     override-build: |
       echo "get passwd/user-default-groups" | \
         debconf-communicate user-setup | \
-        cut -d ' ' -f 2- > $SNAPCRAFT_PART_INSTALL/users-and-groups
+        cut -d ' ' -f 2- > $CRAFT_PART_INSTALL/users-and-groups
     stage:
       - users-and-groups
 
@@ -148,7 +157,7 @@ parts:
     source: https://git.launchpad.net/ubuntu/+source/user-setup
     source-type: git
 
-    override-build: cp -a reserved-usernames $SNAPCRAFT_PART_INSTALL/
+    override-build: cp -a reserved-usernames $CRAFT_PART_INSTALL/
     stage:
       - reserved-usernames
 
@@ -161,9 +170,9 @@ parts:
       - python3-attr
       - python3-yaml
     override-build: |
-      PYTHONPATH=$SNAPCRAFT_PROJECT_DIR/ $SNAPCRAFT_PROJECT_DIR/scripts/make-kbd-info.py
-      cp $SNAPCRAFT_PROJECT_DIR/kbds/keyboard-configuration.yaml \
-        $SNAPCRAFT_PART_INSTALL/kbds/keyboard-configuration.yaml
+      PYTHONPATH=$CRAFT_PROJECT_DIR/ $CRAFT_PROJECT_DIR/scripts/make-kbd-info.py
+      cp $CRAFT_PROJECT_DIR/kbds/keyboard-configuration.yaml \
+        $CRAFT_PART_INSTALL/kbds/keyboard-configuration.yaml
     stage:
       - kbds/
 
@@ -188,7 +197,7 @@ parts:
         sed -i 's/^path-exclude.*LC_MESSAGES.*/#\0/g' /etc/dpkg/dpkg.cfg.d/excludes
         apt-get -y install --reinstall iso-codes
       } || true
-      $SNAPCRAFT_PROJECT_DIR/scripts/make-language-lists $SNAPCRAFT_PROJECT_DIR/po > $SNAPCRAFT_PART_INSTALL/languagelist
+      $CRAFT_PROJECT_DIR/scripts/make-language-lists $CRAFT_PROJECT_DIR/po > $CRAFT_PART_INSTALL/languagelist
 
     stage:
       - languagelist
@@ -211,6 +220,9 @@ parts:
       - python3-dev
       - python3-pip
 
+    build-attributes:
+      - enable-patchelf
+
   os-prober:
     plugin: nil
 
@@ -225,4 +237,7 @@ parts:
     override-build: |
       ./debian/rules build
       fakeroot ./debian/rules install
-      cp -a debian/os-prober/{usr,var} $SNAPCRAFT_PART_INSTALL
+      cp -a debian/os-prober/{usr,var} $CRAFT_PART_INSTALL
+
+    build-attributes:
+      - enable-patchelf

--- a/subiquity/server/tests/test_runner.py
+++ b/subiquity/server/tests/test_runner.py
@@ -46,8 +46,8 @@ class TestLoggedCommandRunner(SubiTestCase):
         runner = LoggedCommandRunner(ident="my-id", use_systemd_user=False)
         environ = {
             "PATH": "/snap/subiquity/x1/bin",
-            "PYTHONPATH": "/usr/lib/python3.8/site-packages",
-            "PYTHON": "/snap/subiquity/x1/usr/bin/python3.8",
+            "PYTHONPATH": "/usr/lib/python3.10/site-packages",
+            "PYTHON": "/snap/subiquity/x1/usr/bin/python3.10",
             "TARGET_MOUNT_POINT": "/target",
             "SNAP": "/snap/subiquity/x1",
             "SAMPLE": "should-not-be-exported",
@@ -64,8 +64,8 @@ class TestLoggedCommandRunner(SubiTestCase):
             "--property", "SyslogIdentifier=my-id",
             "--property", "PrivateMounts=yes",
             "--setenv", "PATH=/snap/subiquity/x1/bin",
-            "--setenv", "PYTHONPATH=/usr/lib/python3.8/site-packages",
-            "--setenv", "PYTHON=/snap/subiquity/x1/usr/bin/python3.8",
+            "--setenv", "PYTHONPATH=/usr/lib/python3.10/site-packages",
+            "--setenv", "PYTHON=/snap/subiquity/x1/usr/bin/python3.10",
             "--setenv", "TARGET_MOUNT_POINT=/target",
             "--setenv", "SNAP=/snap/subiquity/x1",
             "--",
@@ -76,7 +76,7 @@ class TestLoggedCommandRunner(SubiTestCase):
         runner = LoggedCommandRunner(ident="my-id", use_systemd_user=True)
         # Make sure unset variables are ignored
         environ = {
-            "PYTHONPATH": "/usr/lib/python3.8/site-packages",
+            "PYTHONPATH": "/usr/lib/python3.10/site-packages",
         }
         with patch.dict(os.environ, environ, clear=True):
             cmd = runner._forge_systemd_cmd(
@@ -89,7 +89,7 @@ class TestLoggedCommandRunner(SubiTestCase):
             "--property", "SyslogIdentifier=my-id",
             "--user",
             "--pipe",
-            "--setenv", "PYTHONPATH=/usr/lib/python3.8/site-packages",
+            "--setenv", "PYTHONPATH=/usr/lib/python3.10/site-packages",
             "--",
             "/bin/ls", "/root",
         ]

--- a/subiquitycore/tests/test_utils.py
+++ b/subiquitycore/tests/test_utils.py
@@ -49,11 +49,11 @@ class TestOrigEnviron(SubiTestCase):
             'SUBIQUITY_ROOT_ORIG': '',
             'SUBIQUITY_ROOT': snap,
             'PYTHON_ORIG': '',
-            'PYTHON': f'{snap}/usr/bin/python3.8',
+            'PYTHON': f'{snap}/usr/bin/python3.10',
             'PYTHONPATH_ORIG': '',
             'PYTHONPATH': f'{snap}/stuff/things',
             'PY3OR2_PYTHON_ORIG': '',
-            'PY3OR2_PYTHON': f'{snap}/usr/bin/python3.8',
+            'PY3OR2_PYTHON': f'{snap}/usr/bin/python3.10',
             'PATH_ORIG': '/usr/bin:/bin',
             'PATH': '/usr/bin:/bin:/snap/bin'
         }

--- a/system_setup/ubuntu-wsl-setup
+++ b/system_setup/ubuntu-wsl-setup
@@ -344,11 +344,11 @@ PATH="${PATH}:${SNAP_CORE_DIR}/usr/sbin:${SNAP_CORE_DIR}/usr/bin:${SNAP_CORE_DIR
 
 # configure python environment
 export PYTHONIOENCODING=utf-8
-PYTHONPATH=$SNAP/lib/python3.8/site-packages
+PYTHONPATH=$SNAP/lib/python3.10/site-packages
 PYTHONPATH=$SNAP/usr/lib/python3/site-packages:$PYTHONPATH
 PYTHONPATH=$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
 export PYTHONPATH
-export PYTHON=$SNAP/usr/bin/python3.8
+export PYTHON=$SNAP/usr/bin/python3.10
 export SNAP_PYTHON=$PYTHON
 # ensure curtin points at PYTHON
 export PY3OR2_PYTHON=$PYTHON


### PR DESCRIPTION
Bump the base snap to core22 so we only have a single core on live-server isos.

It took me a while to come up with a working hack for override-build. The problem is that in debian and ubuntu, we patched python3.10's sysconfig so that running `sysconfig.get_preferred_scheme('prefix')` returns `posix_local`. Unfortunately, this also affects `pip install` even when we specify a prefix.