### PR TITLE
network: fix check of wlan network state

### DIFF
--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -364,7 +364,7 @@ class NetworkController(BaseNetworkController, SubiquityController):
             if state == WLANSupportInstallState.INSTALLING:
                 self.pending_wlan_devices.add(dev)
                 return
-            elif state in [WLANSupportInstallState.FAILED.
+            elif state in [WLANSupportInstallState.FAILED,
                            WLANSupportInstallState.NOT_AVAILABLE]:
                 return
             # WLANSupportInstallState.DONE falls through


### PR DESCRIPTION
The following stack is visible in https://bugs.launchpad.net/subiquity/+bug/2012128

```python
  File "/snap/ubuntu-desktop-installer/860/lib/python3.10/site-packages/probert/network.py", line 713, in link_change
    self.receiver.new_link(ifindex, link)
  File "/snap/ubuntu-desktop-installer/860/bin/subiquity/subiquitycore/controllers/network.py", line 65, in new_link
    self.controller.new_link(netdev)
  File "/snap/ubuntu-desktop-installer/860/bin/subiquity/subiquity/server/controllers/network.py", line 368, in new_link
    WLANSupportInstallState.NOT_AVAILABLE]:
AttributeError: 'WLANSupportInstallState' object has no attribute 'WLANSupportInstallState'
2023-03-18 11:52:36,816 DEBUG subiquity.common.errorreport:384 generating crash report
```

I feel like static analysis tools could help us for this kind of error but this is something I hope we get on the long run.