### PR TITLE
Fix missing scrip in snap.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -134,7 +134,7 @@ parts:
       bin/subiquity-service: usr/bin/subiquity-service
       bin/subiquity-server: usr/bin/subiquity-server
       bin/subiquity-cmd: usr/bin/subiquity-cmd
-      $CRAFT_PART_BUILD/system_setup/ubuntu-wsl-setup: bin/ubuntu-wsl-setup
+      $CRAFT_PROJECT_DIR/system_setup/ubuntu-wsl-setup: bin/ubuntu-wsl-setup
 
     build-attributes:
       - enable-patchelf


### PR DESCRIPTION
When testing #1597 I didn't notice that I was testing the snap with the help of `systemd` and `snapd`.

There is a missing script and the only craft variable that put it back in place was the `CRAFT_PROJECT_DIR`.