### PR TITLE
ad: add hack to fix non-autoinstall cases

### DIFF
--- a/subiquity/server/controllers/ad.py
+++ b/subiquity/server/controllers/ad.py
@@ -128,7 +128,11 @@ class AdController(SubiquityController):
     def interactive(self):
         # Since we don't accept the domain admin password in the autoinstall
         # file, this cannot be non-interactive.
-        return True
+
+        # HACK: the interactive behavior is causing some autoinstalls with
+        # desktop to block.
+        # return True
+        return False
 
     def __init__(self, app):
         super().__init__(app)


### PR DESCRIPTION
Due to how top-level interactivity is determined:
https://github.com/canonical/subiquity/blob/903299fb84bf95904bba36f9f7c615b2efc9aebb/subiquity/server/server.py#L655

Simply marking this controller as interactive is not sufficient to address the autoinstall flow.
I am proposing this change now to fix non-active directory autoinstalls being hung waiting on the ad controller.