### PR TITLE
workflow: run both linters always

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         image:
           - ubuntu-daily:jammy    # match the core snap we're running against


### PR DESCRIPTION
If the linter is broken in the distro in the devel series but not the LTS, such as right now, it's interesting to allow the LTS linter to finish.