### PR TITLE
create source handlers and apt configurers more on-demand

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -106,10 +106,11 @@ class AptConfigurer:
     #    system, or if it is not, just copy /var/lib/apt/lists from the
     #    'configured_tree' overlay.
 
-    def __init__(self, app, mounter: Mounter, handler: AbstractSourceHandler):
+    def __init__(self, app, mounter: Mounter,
+                 source_handler: AbstractSourceHandler):
         self.app = app
         self.mounter = mounter
-        self.source_handler: str = handler
+        self.source_handler: AbstractSourceHandler = source_handler
         self._source_path: Optional[str] = None
         self.configured_tree: Optional[OverlayMountpoint] = None
         self.install_tree: Optional[OverlayMountpoint] = None

--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -30,6 +30,7 @@ from typing import List, Optional
 import apt_pkg
 
 from curtin.config import merge_config
+from curtin.commands.extract import AbstractSourceHandler
 
 from subiquitycore.file_util import write_file, generate_config_yaml
 from subiquitycore.lsb_release import lsb_release
@@ -105,13 +106,20 @@ class AptConfigurer:
     #    system, or if it is not, just copy /var/lib/apt/lists from the
     #    'configured_tree' overlay.
 
-    def __init__(self, app, mounter: Mounter, source: str):
+    def __init__(self, app, mounter: Mounter, handler: AbstractSourceHandler):
         self.app = app
         self.mounter = mounter
-        self.source: str = source
+        self.source_handler: str = handler
+        self._source_path: Optional[str] = None
         self.configured_tree: Optional[OverlayMountpoint] = None
         self.install_tree: Optional[OverlayMountpoint] = None
         self.install_mount = None
+
+    @property
+    def source_path(self):
+        if self._source_path is None:
+            self._source_path = self.source_handler.setup()
+        return self._source_path
 
     def apt_config(self, final: bool):
         cfg = {}
@@ -127,7 +135,8 @@ class AptConfigurer:
         return {'apt': cfg}
 
     async def apply_apt_config(self, context, final: bool):
-        self.configured_tree = await self.mounter.setup_overlay([self.source])
+        self.configured_tree = await self.mounter.setup_overlay(
+            [self.source_path])
 
         config_location = os.path.join(
             self.app.root, 'var/log/installer/subiquity-curtin-apt.conf')
@@ -245,7 +254,7 @@ class AptConfigurer:
         overlay = await self.mounter.setup_overlay([
                 self.install_tree.upperdir,
                 self.configured_tree.upperdir,
-                self.source
+                self.source_path,
             ])
         try:
             yield overlay
@@ -263,7 +272,11 @@ class AptConfigurer:
                 raise OverlayCleanupError from exc
 
     async def cleanup(self):
-        await self.mounter.cleanup()
+        # FIXME disabled until we can sort out umount
+        # await self.mounter.cleanup()
+        if self._source_path is not None:
+            self.source_handler.cleanup()
+            self._source_path = None
 
     async def deconfigure(self, context, target: str) -> None:
         target_mnt = Mountpoint(mountpoint=target)

--- a/subiquity/server/controllers/drivers.py
+++ b/subiquity/server/controllers/drivers.py
@@ -104,7 +104,7 @@ class DriversController(SubiquityController):
             self.drivers = []
             self.list_drivers_done_event.set()
             return
-        apt = self.app.controllers.Mirror.apt_configurer
+        apt = self.app.controllers.Mirror.final_apt_configurer
         try:
             async with apt.overlay() as d:
                 try:

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -217,7 +217,7 @@ class InstallController(SubiquityController):
 
     async def setup_target(self, context):
         mirror = self.app.controllers.Mirror
-        await mirror.apt_configurer.setup_target(context, self.tpath())
+        await mirror.final_apt_configurer.setup_target(context, self.tpath())
 
     @with_context(
         description="installing system", level="INFO", childlevel="DEBUG")
@@ -456,7 +456,7 @@ class InstallController(SubiquityController):
 
     @with_context(description="restoring apt configuration")
     async def restore_apt_config(self, context):
-        configurer = self.app.controllers.Mirror.apt_configurer
+        configurer = self.app.controllers.Mirror.final_apt_configurer
         await configurer.deconfigure(context, self.tpath())
 
     @with_context(description="downloading and installing {policy} updates")

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -280,12 +280,11 @@ class MirrorController(SubiquityController):
             self.model.set_country(self.app.geoip.countrycode)
         self.cc_event.set()
 
-    def on_source(self):
-        # FIXME disabled until we can sort out umount
-        # if self.apt_configurer is not None:
-        #     await self.apt_configurer.cleanup()
+    async def on_source(self):
+        if self.apt_configurer is not None:
+            await self.apt_configurer.cleanup()
         self.apt_configurer = get_apt_configurer(
-            self.app, self.app.controllers.Source.source_path)
+            self.app, self.app.controllers.Source.get_handler())
         self._apply_apt_config_task.start_sync()
         self.source_configured_event.set()
 

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -153,7 +153,8 @@ class MirrorController(SubiquityController):
             (InstallerChannels.CONFIGURED, 'proxy'),
             self.proxy_configured_event.set)
         self._apt_config_key = None
-        self.apt_configurer: Optional[AptConfigurer] = None
+        self.test_apt_configurer: Optional[AptConfigurer] = None
+        self.final_apt_configurer: Optional[AptConfigurer] = None
         self.mirror_check: Optional[MirrorCheck] = None
 
     def load_autoinstall_data(self, data):
@@ -281,7 +282,7 @@ class MirrorController(SubiquityController):
         self.cc_event.set()
 
     async def on_source(self):
-        self.apt_configurer = get_apt_configurer(
+        self.test_apt_configurer = get_apt_configurer(
             self.app, self.app.controllers.Source.get_handler())
         self.source_configured_event.set()
 
@@ -313,8 +314,9 @@ class MirrorController(SubiquityController):
 
     async def run_mirror_testing(self, output: io.StringIO) -> None:
         await self.source_configured_event.wait()
-        await self.apt_configurer.apply_apt_config(self.context, final=False)
-        await self.apt_configurer.run_apt_config_check(output)
+        await self.test_apt_configurer.apply_apt_config(
+            self.context, final=False)
+        await self.test_apt_configurer.run_apt_config_check(output)
 
     async def wait_config(self) -> AptConfigurer:
         self.final_apt_configurer = get_apt_configurer(

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -20,7 +20,6 @@ from typing import List, Optional
 
 import attr
 
-from subiquitycore.async_helpers import SingleInstanceTask
 from subiquitycore.context import with_context
 
 from subiquity.common.apidef import API
@@ -33,7 +32,11 @@ from subiquity.common.types import (
     MirrorSelectionFallback,
     )
 from subiquity.models.mirror import filter_candidates
-from subiquity.server.apt import get_apt_configurer, AptConfigCheckError
+from subiquity.server.apt import (
+    AptConfigCheckError,
+    AptConfigurer,
+    get_apt_configurer,
+    )
 from subiquity.server.controller import SubiquityController
 from subiquity.server.types import InstallerChannels
 
@@ -137,7 +140,6 @@ class MirrorController(SubiquityController):
         super().__init__(app)
         self.geoip_enabled = True
         self.cc_event = asyncio.Event()
-        self.configured_event = asyncio.Event()
         self.source_configured_event = asyncio.Event()
         self.network_configured_event = asyncio.Event()
         self.proxy_configured_event = asyncio.Event()
@@ -151,9 +153,7 @@ class MirrorController(SubiquityController):
             (InstallerChannels.CONFIGURED, 'proxy'),
             self.proxy_configured_event.set)
         self._apt_config_key = None
-        self._apply_apt_config_task = SingleInstanceTask(
-            self._promote_mirror)
-        self.apt_configurer = None
+        self.apt_configurer: Optional[AptConfigurer] = None
         self.mirror_check: Optional[MirrorCheck] = None
 
     def load_autoinstall_data(self, data):
@@ -281,11 +281,8 @@ class MirrorController(SubiquityController):
         self.cc_event.set()
 
     async def on_source(self):
-        if self.apt_configurer is not None:
-            await self.apt_configurer.cleanup()
         self.apt_configurer = get_apt_configurer(
             self.app, self.app.controllers.Source.get_handler())
-        self._apply_apt_config_task.start_sync()
         self.source_configured_event.set()
 
     def serialize(self):
@@ -304,30 +301,26 @@ class MirrorController(SubiquityController):
         config['geoip'] = self.geoip_enabled
         return config
 
-    async def configured(self):
-        await super().configured()
-        self._apply_apt_config_task.start_sync()
-        self.configured_event.set()
-
     async def _promote_mirror(self):
-        await asyncio.gather(self.source_configured_event.wait(),
-                             self.configured_event.wait())
         if self.model.primary_elected is None:
             # NOTE: In practice, this should only happen if the mirror was
             # marked configured using a POST to mark_configured ; which is not
             # recommended. Clients should do a POST request to /mirror with
             # null as the body instead.
             await self.run_mirror_selection_or_fallback(self.context)
-        await self.apt_configurer.apply_apt_config(self.context, final=True)
+        await self.final_apt_configurer.apply_apt_config(
+            self.context, final=True)
 
     async def run_mirror_testing(self, output: io.StringIO) -> None:
         await self.source_configured_event.wait()
         await self.apt_configurer.apply_apt_config(self.context, final=False)
         await self.apt_configurer.run_apt_config_check(output)
 
-    async def wait_config(self):
-        await self._apply_apt_config_task.wait()
-        return self.apt_configurer
+    async def wait_config(self) -> AptConfigurer:
+        self.final_apt_configurer = get_apt_configurer(
+            self.app, self.app.controllers.Source.get_handler())
+        await self._promote_mirror()
+        return self.final_apt_configurer
 
     async def GET(self) -> MirrorGet:
         elected: Optional[str] = None

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -17,6 +17,8 @@ import copy
 from unittest import mock, IsolatedAsyncioTestCase
 import uuid
 
+from curtin.commands.extract import TrivialSourceHandler
+
 from subiquitycore.tests.parameterized import parameterized
 
 from subiquitycore.snapd import AsyncSnapd, get_fake_connection
@@ -664,6 +666,8 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
             'prefer-encrypted'
         self.app.base_model.source.current.size = 1
         self.app.controllers.Source.source_path = ''
+        self.app.controllers.Source.get_handler.return_value = \
+            TrivialSourceHandler('')
 
         self.app.dr_cfg.systems_dir_exists = True
 

--- a/subiquity/server/controllers/tests/test_mirror.py
+++ b/subiquity/server/controllers/tests/test_mirror.py
@@ -51,7 +51,7 @@ class TestMirrorController(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         app = make_app()
         self.controller = MirrorController(app)
-        self.controller.apt_configurer = mock.AsyncMock()
+        self.controller.test_apt_configurer = mock.AsyncMock()
 
     def test_make_autoinstall(self):
         self.controller.model = MirrorModel()
@@ -89,7 +89,7 @@ class TestMirrorController(unittest.IsolatedAsyncioTestCase):
                 self.controller.source_configured_event, "wait")
 
         mock_run_apt_config_check = mock.patch.object(
-                self.controller.apt_configurer, "run_apt_config_check",
+                self.controller.test_apt_configurer, "run_apt_config_check",
                 side_effect=fake_mirror_check_success)
         with mock_source_configured, mock_run_apt_config_check:
             await self.controller.run_mirror_testing(output)
@@ -97,7 +97,7 @@ class TestMirrorController(unittest.IsolatedAsyncioTestCase):
 
         output = io.StringIO()
         mock_run_apt_config_check = mock.patch.object(
-                self.controller.apt_configurer, "run_apt_config_check",
+                self.controller.test_apt_configurer, "run_apt_config_check",
                 side_effect=fake_mirror_check_failure)
         with mock_source_configured, mock_run_apt_config_check:
             with self.assertRaises(AptConfigCheckError):

--- a/subiquity/server/tests/test_apt.py
+++ b/subiquity/server/tests/test_apt.py
@@ -17,6 +17,8 @@ import io
 import subprocess
 from unittest.mock import Mock, patch, AsyncMock
 
+from curtin.commands.extract import TrivialSourceHandler
+
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
 from subiquitycore.utils import astart_command
@@ -65,7 +67,8 @@ class TestAptConfigurer(SubiTestCase):
         self.model.debconf_selections = DebconfSelectionsModel()
         self.model.locale.selected_language = "en_US.UTF-8"
         self.app = make_app(self.model)
-        self.configurer = AptConfigurer(self.app, AsyncMock(), '')
+        self.configurer = AptConfigurer(
+            self.app, AsyncMock(), TrivialSourceHandler(''))
 
         self.astart_sym = "subiquity.server.apt.astart_command"
 


### PR DESCRIPTION
Coming changes for the canary image for 23.04 mean that we won't know the precise source for the install until after the storage config is confirmed, so we can't create one curtin source handler and hang on to it.