### PR TITLE
only examine system from snapd when source is selected

### DIFF
--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -554,6 +554,9 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.app.snapdapi = snapdapi.make_api_client(
             AsyncSnapd(get_fake_connection()))
         self.app.dr_cfg = DRConfig()
+        self.app.dr_cfg.systems_dir_exists = True
+        self.app.controllers.Source.get_handler.return_value = \
+            TrivialSourceHandler('')
         self.fsc = FilesystemController(app=self.app)
         self.fsc._configured = True
         self.fsc.model = make_model(Bootloader.UEFI)
@@ -666,8 +669,6 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
             'prefer-encrypted'
         self.app.base_model.source.current.size = 1
         self.app.controllers.Source.source_path = ''
-        self.app.controllers.Source.get_handler.return_value = \
-            TrivialSourceHandler('')
 
         self.app.dr_cfg.systems_dir_exists = True
 


### PR DESCRIPTION
and only take actions (like setting storage_version to 2) when we know we are installing a core boot classic system.