### PR TITLE
Add test source catalog for desktop variants

### DIFF
--- a/examples/desktop-sources.yaml
+++ b/examples/desktop-sources.yaml
@@ -1,0 +1,41 @@
+- description:
+    en: A minimal but usable Ubuntu Desktop.
+  id: ubuntu-desktop-minimal
+  locale_support: langpack
+  name:
+    en: Ubuntu Desktop (minimized)
+  path: minimal.squashfs
+  preinstalled_langs:
+  - de
+  - en
+  - es
+  - fr
+  - it
+  - pt
+  - ru
+  - zh
+  - ''
+  size: 6135083008
+  type: fsimage-layered
+  variant: desktop
+- default: true
+  description:
+    en: A full featured Ubuntu Desktop.
+  id: ubuntu-desktop
+  locale_support: langpack
+  name:
+    en: Ubuntu Desktop
+  path: minimal.standard.squashfs
+  preinstalled_langs:
+  - de
+  - en
+  - es
+  - fr
+  - it
+  - pt
+  - ru
+  - zh
+  - ''
+  size: 7604871168
+  type: fsimage-layered
+  variant: desktop


### PR DESCRIPTION
The values were extracted from desktop daily-live 20230327.1:
```
$ curl --unix-socket /run/subiquity/socket a/source
{"sources": [{"name": "Ubuntu Desktop (minimized)", "description": "A minimal but usable Ubuntu Desktop.", "id": "ubuntu-desktop-minimal", "size": 6135083008, "variant": "desktop", "default": false}, {"name": "Ubuntu Desktop", "description": "A full featured Ubuntu Desktop.", "id": "ubuntu-desktop", "size": 7604871168, "variant": "desktop", "default": true}], "current_id": "ubuntu-desktop", "search_drivers": false}
```
and livecd-rootfs:
```python
				cat <<-EOF > config/minimal.catalog-in.yaml
					name: "Ubuntu Desktop (minimized)"
					description: >-
					  A minimal but usable Ubuntu Desktop.
					id: ubuntu-desktop-minimal
					type: fsimage-layered
					variant: desktop
					locale_support: langpack
				EOF
				cat <<-EOF > config/minimal.standard.catalog-in.yaml
					name: "Ubuntu Desktop"
					description: >-
					  A full featured Ubuntu Desktop.
					id: ubuntu-desktop
					type: fsimage-layered
					variant: desktop
					locale_support: langpack
					default: yes
				EOF
```
https://git.launchpad.net/livecd-rootfs/tree/live-build/auto/config