### PR TITLE
snapcraft: bump version of curtin to pickup ventoy fix

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: b1f4da3bec92356e8ef389c1c581cfdcd1b36c42
+    source-commit: 650a5af561fed5be811e7e2d5c101334c05257ba
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Depends on https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/439863