### PR TITLE
[Active Directory] [WIP] fix `pam-auth-update`

### DIFF
--- a/subiquity/server/controllers/ad.py
+++ b/subiquity/server/controllers/ad.py
@@ -194,11 +194,10 @@ class AdController(SubiquityController):
 
         return self.join_result
 
-    async def join_domain(self, hostname: str, context) -> None:
+    async def join_domain(self, hostname: str) -> None:
         """ To be called from the install controller if the user requested
         joining an AD domain """
-        await self.ad_joiner.join_domain(self.model.conn_info, hostname,
-                                         context)
+        await self.ad_joiner.join_domain(self.model.conn_info, hostname)
 
 
 # Helper out-of-class functions grouped.

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -413,7 +413,7 @@ class InstallController(SubiquityController):
                 with open(self.tpath('etc/hostname'), 'r') as f:
                     hostname = f.read().strip()
 
-            await self.app.controllers.Ad.join_domain(hostname, context)
+            await self.app.controllers.Ad.join_domain(hostname)
 
     @with_context(description="configuring cloud-init")
     async def configure_cloud_init(self, context):

--- a/subiquity/server/controllers/tests/test_ad.py
+++ b/subiquity/server/controllers/tests/test_ad.py
@@ -159,14 +159,14 @@ class TestAdJoin(IsolatedAsyncioTestCase):
         # Mimics a client requesting the join result. Blocking by default.
         result = self.controller.join_result_GET()
         # Mimics a calling from the install controller.
-        await self.controller.join_domain('this', 'AD Join')
+        await self.controller.join_domain('this')
         self.assertEqual(await result, AdJoinResult.OK)
 
     async def test_join_Join_Error(self):
         self.controller.model.set(AdConnectionInfo(domain_name='jubuntu.com',
                                                    admin_name='Helper',
                                                    password='1234'))
-        await self.controller.join_domain('this', 'AD Join')
+        await self.controller.join_domain('this')
         result = await self.controller.join_result_GET(wait=True)
         self.assertEqual(result, AdJoinResult.JOIN_ERROR)
 
@@ -174,6 +174,6 @@ class TestAdJoin(IsolatedAsyncioTestCase):
         self.controller.model.set(AdConnectionInfo(domain_name='pubuntu.com',
                                                    admin_name='Helper',
                                                    password='1234'))
-        await self.controller.join_domain('this', 'AD Join')
+        await self.controller.join_domain('this')
         result = await self.controller.join_result_GET(wait=True)
         self.assertEqual(result, AdJoinResult.PAM_ERROR)


### PR DESCRIPTION
As a follow-up to LP #2013079 I noticed enabling pam-mkhomedir failing.