### PR TITLE
Ld lib path vs cmds

### DIFF
--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -159,10 +159,11 @@ def main():
 
     logger = logging.getLogger('subiquity')
     version = os.environ.get("SNAP_REVISION", "unknown")
-    logger.info("Starting Subiquity server revision {}".format(version))
-    logger.info("Arguments passed: {}".format(sys.argv))
-    logger.debug("Kernel commandline: {}".format(opts.kernel_cmdline))
-    logger.debug("Storage version: {}".format(opts.storage_version))
+    snap = os.environ.get("SNAP", "unknown")
+    logger.info(f"Starting Subiquity server revision {version} of snap {snap}")
+    logger.info(f"Arguments passed: {sys.argv}")
+    logger.debug(f"Kernel commandline: {opts.kernel_cmdline}")
+    logger.debug(f"Environment: {os.environ}")
 
     async def run_with_loop():
         server = SubiquityServer(opts, block_log_dir)

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -113,8 +113,10 @@ def main():
 
     logger = logging.getLogger('subiquity')
     version = os.environ.get("SNAP_REVISION", "unknown")
-    logger.info("Starting Subiquity revision {}".format(version))
-    logger.info("Arguments passed: {}".format(sys.argv))
+    snap = os.environ.get("SNAP", "unknown")
+    logger.info(f"Starting Subiquity TUI revision {version} of snap {snap}")
+    logger.info(f"Arguments passed: {sys.argv}")
+    logger.debug(f"Environment: {os.environ}")
 
     if opts.answers is None and os.path.exists(AUTO_ANSWERS_FILE):
         logger.debug("Autoloading answers from %s", AUTO_ANSWERS_FILE)

--- a/subiquitycore/tests/test_utils.py
+++ b/subiquitycore/tests/test_utils.py
@@ -40,10 +40,16 @@ class TestOrigEnviron(SubiTestCase):
         expected = {}
         self.assertEqual(expected, orig_environ(env))
 
+    def test_no_ld_library_path(self):
+        env = {'LD_LIBRARY_PATH': 'a'}
+        expected = {}
+        self.assertEqual(expected, orig_environ(env))
+
     def test_practical(self):
         snap = '/snap/subiquity/1234'
         env = {
             'TERM': 'linux',
+            'LD_LIBRARY_PATH': '/var/lib/snapd/lib/gl',
             'PYTHONIOENCODING_ORIG': '',
             'PYTHONIOENCODING': 'utf-8',
             'SUBIQUITY_ROOT_ORIG': '',

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -36,6 +36,8 @@ def _clean_env(env, *, locale=True):
 
 
 def orig_environ(env):
+    """Generate an environment dict that is suitable for use for running
+    programs that live outside the snap."""
     if env is None:
         env = os.environ
     ret = env.copy()
@@ -47,6 +49,7 @@ def orig_environ(env):
             else:
                 del ret[key_to_restore]
             del ret[key]
+    ret.pop('LD_LIBRARY_PATH', None)
     return ret
 
 


### PR DESCRIPTION
LD_LIBRARY_PATH is populated with snap things, that we don't want for the commands that run orig_environ.  Saving LD_LIBRARY_PATH to an ORIG variable like I did https://github.com/canonical/ubuntu-desktop-installer/pull/1747 was not going to work, as that particular variable already has the snap things set to it, but does work as intended for PATH and PYTHONPATH.
