### PR TITLE
 Sizing policy

### DIFF
--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -311,6 +311,24 @@ When using the "lvm" layout, LUKS encryption can be enabled by supplying a passw
 
 The default is to use the lvm layout.
 
+#### sizing-policy
+
+The lvm layout will, by default, attempt to leave room for snapshots and further expansion.  A sizing-policy key may be supplied to control this behavior.
+
+**type:** string (enumeration)
+**default:** scaled
+
+Supported values are:
+
+ * `scaled` -> adjust space allocated to the root LV based on space available to the VG
+ * `all` -> allocate all remaining VG space to the root LV
+
+The scaling system is currently as follows:
+ * Less than 10 GiB: use all remaining space for root filesystem
+ * Between 10-20 GiB: 10 GiB root filesystem
+ * Between 20-200 GiB: use half of remaining space for root filesystem
+ * Greater than 200 GiB: 100 GiB root filesystem
+
 #### action-based config
 
 For full flexibility, the installer allows storage configuration to be done using a syntax which is a superset of that supported by curtin, described at https://curtin.readthedocs.io/en/latest/topics/storage.html.

--- a/subiquity/common/filesystem/sizes.py
+++ b/subiquity/common/filesystem/sizes.py
@@ -149,3 +149,21 @@ def calculate_suggested_install_min(source_min: int,
     room_for_swap = swap.suggested_swapsize()
     total = source_min + room_for_boot + room_to_grow + room_for_swap
     return align_up(total, part_align)
+
+
+# Scale the usage of the vg to leave room for snapshots and such. We should
+# use more of a smaller disk to avoid the user running into out of space errors
+# earlier than they probably expect to.
+def scaled_rootfs_size(available: int):
+    if available < 10 * (1 << 30):
+        # Use all of a small (<10G) disk.
+        return available
+    elif available < 20 * (1 << 30):
+        # Use 10G of a smallish (<20G) disk.
+        return 10 * (1 << 30)
+    elif available < 200 * (1 << 30):
+        # Use half of a larger (<200G) disk.
+        return available // 2
+    else:
+        # Use at most 100G of a large disk.
+        return 100 * (1 << 30)

--- a/subiquity/common/tests/test_types.py
+++ b/subiquity/common/tests/test_types.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from subiquity.common.types import SizingPolicy
+
+
+class TestSizingPolicy(unittest.TestCase):
+    def test_all(self):
+        actual = SizingPolicy.from_string('all')
+        self.assertEqual(SizingPolicy.ALL, actual)
+
+    def test_scaled_size(self):
+        actual = SizingPolicy.from_string('scaled')
+        self.assertEqual(SizingPolicy.SCALED, actual)
+
+    def test_default(self):
+        actual = SizingPolicy.from_string(None)
+        self.assertEqual(SizingPolicy.SCALED, actual)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -323,6 +323,10 @@ class GuidedCapability(enum.Enum):
     CORE_BOOT_PREFER_ENCRYPTED = enum.auto()
     CORE_BOOT_PREFER_UNENCRYPTED = enum.auto()
 
+    def is_lvm(self) -> bool:
+        return self in [GuidedCapability.LVM,
+                        GuidedCapability.LVM_LUKS]
+
     def is_core_boot(self) -> bool:
         return self in [GuidedCapability.CORE_BOOT_ENCRYPTED,
                         GuidedCapability.CORE_BOOT_UNENCRYPTED,
@@ -369,6 +373,11 @@ class StorageResponseV2:
     # if need_boot == True, there is not yet a boot partition
     need_boot: Optional[bool] = None
     install_minimum_size: Optional[int] = None
+
+
+class SizingPolicy(enum.Enum):
+    SCALED = enum.auto()
+    ALL = enum.auto()
 
 
 @attr.s(auto_attribs=True)
@@ -425,6 +434,8 @@ class GuidedChoiceV2:
     target: GuidedStorageTarget
     capability: GuidedCapability
     password: Optional[str] = attr.ib(default=None, repr=False)
+    sizing_policy: Optional[SizingPolicy] = \
+        attr.ib(default=SizingPolicy.SCALED)
 
     @staticmethod
     def from_guided_choice(choice: GuidedChoice):
@@ -433,6 +444,7 @@ class GuidedChoiceV2:
                     disk_id=choice.disk_id, capabilities=[choice.capability]),
                 capability=choice.capability,
                 password=choice.password,
+                sizing_policy=SizingPolicy.SCALED,
                 )
 
 

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -379,6 +379,14 @@ class SizingPolicy(enum.Enum):
     SCALED = enum.auto()
     ALL = enum.auto()
 
+    @classmethod
+    def from_string(cls, value):
+        if value is None or value == 'scaled':
+            return cls.SCALED
+        if value == 'all':
+            return cls.ALL
+        raise Exception(f'Unknown SizingPolicy value {value}')
+
 
 @attr.s(auto_attribs=True)
 class GuidedResizeValues:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -71,6 +71,7 @@ from subiquity.common.types import (
     ModifyPartitionV2,
     ProbeStatus,
     ReformatDisk,
+    SizingPolicy,
     StorageResponse,
     StorageResponseV2,
     )
@@ -278,7 +279,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         spec = dict(fstype="ext4", mount="/")
         self.create_partition(device=gap.device, gap=gap, spec=spec)
 
-    def guided_lvm(self, gap, lvm_options=None):
+    def guided_lvm(self, gap, choice: GuidedChoiceV2):
         device = gap.device
         part_align = device.alignment_data().part_align
         bootfs_size = align_up(sizes.get_bootfs_size(gap.size), part_align)
@@ -293,11 +294,17 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             i += 1
             vg_name = 'ubuntu-vg-{}'.format(i)
         spec = dict(name=vg_name, devices=set([part]))
-        if lvm_options and lvm_options['encrypt']:
-            spec['passphrase'] = lvm_options['luks_options']['passphrase']
+        if choice.password is not None:
+            spec['passphrase'] = choice.password
         vg = self.create_volgroup(spec)
-        lv_size = sizes.scaled_rootfs_size(vg.size)
-        lv_size = align_down(lv_size, LVM_CHUNK_SIZE)
+        if choice.sizing_policy == SizingPolicy.SCALED:
+            lv_size = sizes.scaled_rootfs_size(vg.size)
+            lv_size = align_down(lv_size, LVM_CHUNK_SIZE)
+        elif choice.sizing_policy == SizingPolicy.ALL:
+            lv_size = vg.size
+        else:
+            raise Exception(f'Unhandled size policy {choice.sizing_policy}')
+        log.debug(f'lv_size {lv_size} for {choice.sizing_policy}')
         self.create_logical_volume(
             vg=vg, spec=dict(
                 size=lv_size,
@@ -347,14 +354,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             raise Exception(f'gap not found after resize, pgs={pgs}')
         return gap
 
-    def build_lvm_options(self, passphrase):
-        return {
-            'encrypt': True,
-            'luks_options': {
-                'passphrase': passphrase,
-                },
-            }
-
     async def guided(self, choice: GuidedChoiceV2):
         self.model.guided_configuration = choice
 
@@ -375,11 +374,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if gap is None:
             raise Exception('failed to locate gap after adding boot')
 
-        if choice.capability == GuidedCapability.LVM:
-            self.guided_lvm(gap, lvm_options=None)
-        elif choice.capability == GuidedCapability.LVM_LUKS:
-            lvm_options = self.build_lvm_options(choice.password)
-            self.guided_lvm(gap, lvm_options=lvm_options)
+        if choice.capability.is_lvm():
+            self.guided_lvm(gap, choice)
         elif choice.capability == GuidedCapability.DIRECT:
             self.guided_direct(gap)
         else:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -296,22 +296,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if lvm_options and lvm_options['encrypt']:
             spec['passphrase'] = lvm_options['luks_options']['passphrase']
         vg = self.create_volgroup(spec)
-        # There's no point using LVM and unconditionally filling the
-        # VG with a single LV, but we should use more of a smaller
-        # disk to avoid the user running into out of space errors
-        # earlier than they probably expect to.
-        if vg.size < 10 * (1 << 30):
-            # Use all of a small (<10G) disk.
-            lv_size = vg.size
-        elif vg.size < 20 * (1 << 30):
-            # Use 10G of a smallish (<20G) disk.
-            lv_size = 10 * (1 << 30)
-        elif vg.size < 200 * (1 << 30):
-            # Use half of a larger (<200G) disk.
-            lv_size = vg.size // 2
-        else:
-            # Use at most 100G of a large disk.
-            lv_size = 100 * (1 << 30)
+        lv_size = sizes.scaled_rootfs_size(vg.size)
         lv_size = align_down(lv_size, LVM_CHUNK_SIZE)
         self.create_logical_volume(
             vg=vg, spec=dict(

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -976,8 +976,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         else:
             capability = GuidedCapability.DIRECT
         password = layout.get('password', None)
-        await self.guided(GuidedChoiceV2(target=target, capability=capability,
-                                         password=password))
+        sizing_policy = SizingPolicy.from_string(
+                layout.get('sizing-policy', None))
+        await self.guided(
+                GuidedChoiceV2(target=target, capability=capability,
+                               password=password, sizing_policy=sizing_policy))
 
     def validate_layout_mode(self, mode):
         if mode not in ('reformat_disk', 'use_gap'):

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -28,7 +28,10 @@ from unittest.mock import patch
 from urllib.parse import unquote
 
 from subiquitycore.tests import SubiTestCase
-from subiquitycore.utils import astart_command
+from subiquitycore.utils import (
+    astart_command,
+    matching_dicts,
+    )
 
 default_timeout = 10
 
@@ -37,8 +40,7 @@ def match(items, **kw):
     typename = kw.pop('_type', None)
     if typename is not None:
         kw['$type'] = typename
-    return [item for item in items
-            if all(item.get(k) == v for k, v in kw.items())]
+    return matching_dicts(items, **kw)
 
 
 def timeout(multiplier=1):

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -176,3 +176,10 @@ def disable_subiquity():
                  "snap.subiquity.subiquity-service.service",
                  "serial-subiquity@*.service"])
     return
+
+
+def matching_dicts(items, **kw):
+    """Given an input sequence of dictionaries, return a list of dicts where
+    the supplied keyword arguments all match those items."""
+    return [item for item in items
+            if all(item.get(k) == v for k, v in kw.items())]

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -19,7 +19,7 @@ import logging
 import os
 import random
 import subprocess
-from typing import List, Sequence
+from typing import Any, Dict, List, Sequence
 
 log = logging.getLogger("subiquitycore.utils")
 
@@ -178,8 +178,8 @@ def disable_subiquity():
     return
 
 
-def matching_dicts(items, **kw):
+def matching_dicts(items: Sequence[Dict[Any, Any]], **criteria):
     """Given an input sequence of dictionaries, return a list of dicts where
     the supplied keyword arguments all match those items."""
     return [item for item in items
-            if all(item.get(k) == v for k, v in kw.items())]
+            if all(k in item and item[k] == v for k, v in criteria.items())]


### PR DESCRIPTION
Add an API that ubuntu-desktop-installer can use and an autoinstall key to control the size allocation for how much of a VG is allocated to the root LV.

Thanks to Ryan Mounce as well for the related PR #1588