### PR TITLE
snapcraft: update curtin to fix disk lookups with wwn extensions

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 650a5af561fed5be811e7e2d5c101334c05257ba
+    source-commit: 73da3c4f47ea22d58f57371594a396c5434ab260
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Note: when backporting to ubuntu/lunar, the sha1 needs to be updated to follow what's in https://code.launchpad.net/~curtin-dev/curtin/+git/curtin/+ref/ubuntu/lunar