### PR TITLE
Lunar 2023 04 03

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,8 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 650a5af561fed5be811e7e2d5c101334c05257ba
+    # We're traking the branch ubuntu/lunar here.
+    source-commit: f30a1533f88b753b6fdd3c04699dda9621b632cc
 
     override-pull: |
       craftctl default

--- a/subiquity/server/ad_joiner.py
+++ b/subiquity/server/ad_joiner.py
@@ -61,7 +61,7 @@ class AdJoinStrategy():
                 log.info("Failed to set live session hostname for adcli")
                 return AdJoinResult.JOIN_ERROR
 
-            root_dir = self.app.root
+            root_dir = self.app.base_model.target
             cp = await arun_command([self.realm, "join", "--install", root_dir,
                                      "--user", info.admin_name,
                                      "--computer-name", hostname,

--- a/subiquity/server/ad_joiner.py
+++ b/subiquity/server/ad_joiner.py
@@ -16,6 +16,7 @@
 import asyncio
 from contextlib import contextmanager
 import logging
+import os
 from socket import gethostname
 from subprocess import CalledProcessError
 from subiquitycore.utils import arun_command, run_command
@@ -29,18 +30,28 @@ log = logging.getLogger('subiquity.server.ad_joiner')
 
 
 @contextmanager
-def hostname_context(hostname: str):
-    """ Temporarily adjusts the host name to [hostname] and restores it
-        back in the end of the caller scope. """
+def joining_context(hostname: str, root_dir: str):
+    """ Temporarily adjusts the host name to [hostname] and bind-mounts
+        interesting system directories in preparation for running realm
+        in target's [root_dir], undoing it all on exit. """
     hostname_current = gethostname()
-    hostname_process = run_command(['hostname', hostname])
+    binds = ("/proc", "/sys", "/dev", "/run")
     try:
+        hostname_process = run_command(['hostname', hostname])
+        for bind in binds:
+            bound_dir = os.path.join(root_dir, bind[1:])
+            if bound_dir != bind:
+                run_command(["mount", "--bind", bind, bound_dir])
         yield hostname_process
     finally:
         # Restoring the live session hostname.
         hostname_process = run_command(['hostname', hostname_current])
         if hostname_process.returncode:
             log.info("Failed to restore live session hostname")
+        for bind in binds:
+            bound_dir = os.path.join(root_dir, bind[1:])
+            if bound_dir != bind:
+                run_command(["umount", "-f", bound_dir])
 
 
 class AdJoinStrategy():
@@ -54,14 +65,14 @@ class AdJoinStrategy():
             -> AdJoinResult:
         """ This method changes the hostname and perform a real AD join, thus
             should only run in a live session. """
+        root_dir = self.app.base_model.target
         # Set hostname for AD to determine FQDN (no FQDN option in realm join,
         # only adcli, which only understands the live system, but not chroot)
-        with hostname_context(hostname) as host_process:
+        with joining_context(hostname, root_dir) as host_process:
             if host_process.returncode:
                 log.info("Failed to set live session hostname for adcli")
                 return AdJoinResult.JOIN_ERROR
 
-            root_dir = self.app.base_model.target
             cp = await arun_command([self.realm, "join", "--install", root_dir,
                                      "--user", info.admin_name,
                                      "--computer-name", hostname,

--- a/subiquity/server/ad_joiner.py
+++ b/subiquity/server/ad_joiner.py
@@ -48,7 +48,7 @@ def joining_context(hostname: str, root_dir: str):
         hostname_process = run_command(['hostname', hostname_current])
         if hostname_process.returncode:
             log.info("Failed to restore live session hostname")
-        for bind in binds:
+        for bind in reversed(binds):
             bound_dir = os.path.join(root_dir, bind[1:])
             if bound_dir != bind:
                 run_command(["umount", "-f", bound_dir])

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -154,11 +154,16 @@ class ConfigureController(SubiquityController):
         # ever by just '.'. On the other hand in dry-run we want it pointing to
         # '/' if not properly set.
         snap_dir = snap_dir if snap_dir != '.' else '/'
-        data_dir = os.path.join(snap_dir, "usr/share/language-selector")
+        data_dir_base = "usr/share/language-selector"
+        data_dir = os.path.join(snap_dir, data_dir_base)
         if not os.path.exists(data_dir):
-            log.error("Misconfigured snap environment pointed L-S-C data dir"
-                      " to %s", data_dir)
-            return None
+            log.error("Language selector data dir %s seems not to be part"
+                      " of the snap.", data_dir)
+            # Try seeded L-S-C
+            data_dir = os.path.join(self.model.root, data_dir_base)
+            if not os.path.exists(data_dir):
+                log.error("Cannot find language selector data directory.")
+                return None
 
         cp = await arun_command([clsCommand, "-d", data_dir, "-l", clsLang])
         if cp.returncode != 0:


### PR DESCRIPTION
* cherry-picked cd6e69187a48c7d9ed1ec4b78db87d6e09756225 from https://github.com/canonical/subiquity/pull/1618
* cherry-picked 37f33481355b2e2e63b8cba5e4b7c58041aeab91 .. cda5a0f25003f7945971b2047b39fd32fdaaa8bc from https://github.com/canonical/subiquity/pull/1627
* cherry-picked 1105da2368bdbf9b9ce54641d5d5e4dd6ef1fed2 from https://github.com/canonical/subiquity/pull/1617
* cherry-picked 4c4ab16f7d3fd0b333d62b5e8cc08cfd7ef5c2b2 from https://github.com/canonical/subiquity/pull/1631 (adjusted to track curtin's ubuntu/lunar branch)

NOTE: with the comment I added in snapcraft.yaml, I expect future cherry-picks adjusting the curtin revision to conflict. This is on purpose, we don't want to pull new revisions of curtin from master (this would potentially introduce new features). To fix the conflict, we need to find the relevant revision in ubuntu/lunar.