### PR TITLE
Bootable disks

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -306,16 +306,10 @@ class API:
                 def POST(data: Payload[ReformatDisk]) \
                     -> StorageResponseV2: ...
 
-            class potential_boot_disks:
-                """Obtain the list of disks which can be made bootable.
-                This list can be empty if there are no disks or if none of them
-                are plausible sources of a boot disk."""
-                def GET() -> List[str]: ...
-
             class add_boot_partition:
                 """Mark a given disk as bootable, which may cause a partition
                 to be added to the disk.  It is an error to call this for a
-                disk not in the list from potential_boot_disks."""
+                disk for which can_be_boot_device is False."""
                 def POST(disk_id: str) -> StorageResponseV2: ...
 
             class add_partition:

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -306,6 +306,7 @@ def _for_client_disk(disk, *, min_size=0):
         usage_labels=usage_labels(disk),
         partitions=[for_client(p) for p in gaps.parts_and_gaps(disk)],
         boot_device=boot.is_boot_device(disk),
+        can_be_boot_device=boot.can_be_boot_device(disk),
         ok_for_guided=disk.size >= min_size,
         model=getattr(disk, 'model', None),
         vendor=getattr(disk, 'vendor', None))

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -309,6 +309,7 @@ class Disk:
     preserve: bool
     path: Optional[str]
     boot_device: bool
+    can_be_boot_device: bool
     model: Optional[str] = None
     vendor: Optional[str] = None
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -780,11 +780,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.reformat(self.model._one(id=data.disk_id), data.ptable)
         return await self.v2_GET()
 
-    async def v2_potential_boot_disks_GET(self) -> List[str]:
-        disks = self.potential_boot_disks(check_boot=True,
-                                          with_reformatting=False)
-        return [disk.id for disk in disks]
-
     async def v2_add_boot_partition_POST(self, disk_id: str) \
             -> StorageResponseV2:
         disk = self.model._one(id=disk_id)

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -545,7 +545,12 @@ class TestManualBoot(IsolatedAsyncioTestCase):
         self.app = make_app()
         self.app.opts.bootloader = bootloader.value
         self.fsc = FilesystemController(app=self.app)
+        self.fsc.calculate_suggested_install_min = mock.Mock()
+        self.fsc.calculate_suggested_install_min.return_value = 10 << 30
         self.fsc.model = self.model = make_model(bootloader)
+        self.model.storage_version = 2
+        self.fsc._probe_task.task = mock.Mock()
+        self.fsc._get_system_task.task = mock.Mock()
 
     @parameterized.expand(bootloaders_and_ptables)
     async def test_get_boot_disks_only(self, bootloader, ptable):
@@ -553,6 +558,9 @@ class TestManualBoot(IsolatedAsyncioTestCase):
         disk = make_disk(self.model)
         self.assertEqual([disk.id],
                          await self.fsc.v2_potential_boot_disks_GET())
+        resp = await self.fsc.v2_GET()
+        [d] = resp.disks
+        self.assertTrue(d.can_be_boot_device)
 
     @parameterized.expand(bootloaders_and_ptables)
     async def test_get_boot_disks_none(self, bootloader, ptable):
@@ -566,6 +574,10 @@ class TestManualBoot(IsolatedAsyncioTestCase):
         d2 = make_disk(self.model)
         self.assertEqual(set([d1.id, d2.id]),
                          set(await self.fsc.v2_potential_boot_disks_GET()))
+        resp = await self.fsc.v2_GET()
+        [d1, d2] = resp.disks
+        self.assertTrue(d1.can_be_boot_device)
+        self.assertTrue(d2.can_be_boot_device)
 
     @parameterized.expand(bootloaders_and_ptables)
     async def test_get_boot_disks_some(self, bootloader, ptable):
@@ -582,6 +594,10 @@ class TestManualBoot(IsolatedAsyncioTestCase):
             expected = set([d2.id])
         self.assertEqual(expected,
                          set(await self.fsc.v2_potential_boot_disks_GET()))
+
+        resp = await self.fsc.v2_GET()
+        for d in resp.disks:
+            self.assertEqual(d.id in expected, d.can_be_boot_device)
 
 
 class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -555,25 +555,16 @@ class TestManualBoot(IsolatedAsyncioTestCase):
     @parameterized.expand(bootloaders_and_ptables)
     async def test_get_boot_disks_only(self, bootloader, ptable):
         self._setup(bootloader, ptable)
-        disk = make_disk(self.model)
-        self.assertEqual([disk.id],
-                         await self.fsc.v2_potential_boot_disks_GET())
+        make_disk(self.model)
         resp = await self.fsc.v2_GET()
         [d] = resp.disks
         self.assertTrue(d.can_be_boot_device)
 
     @parameterized.expand(bootloaders_and_ptables)
-    async def test_get_boot_disks_none(self, bootloader, ptable):
-        self._setup(bootloader, ptable)
-        self.assertEqual([], await self.fsc.v2_potential_boot_disks_GET())
-
-    @parameterized.expand(bootloaders_and_ptables)
     async def test_get_boot_disks_all(self, bootloader, ptable):
         self._setup(bootloader, ptable)
-        d1 = make_disk(self.model)
-        d2 = make_disk(self.model)
-        self.assertEqual(set([d1.id, d2.id]),
-                         set(await self.fsc.v2_potential_boot_disks_GET()))
+        make_disk(self.model)
+        make_disk(self.model)
         resp = await self.fsc.v2_GET()
         [d1, d2] = resp.disks
         self.assertTrue(d1.can_be_boot_device)
@@ -589,15 +580,12 @@ class TestManualBoot(IsolatedAsyncioTestCase):
                        preserve=True)
         if bootloader == Bootloader.NONE:
             # NONE will always pass the boot check, even on a full disk
-            expected = set([d1.id, d2.id])
+            bootable = set([d1.id, d2.id])
         else:
-            expected = set([d2.id])
-        self.assertEqual(expected,
-                         set(await self.fsc.v2_potential_boot_disks_GET()))
-
+            bootable = set([d2.id])
         resp = await self.fsc.v2_GET()
         for d in resp.disks:
-            self.assertEqual(d.id in expected, d.can_be_boot_device)
+            self.assertEqual(d.id in bootable, d.can_be_boot_device)
 
 
 class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):


### PR DESCRIPTION
Mark the disks as can_be_boot_disk, instead of a separate API call.