### PR TITLE
storage: restricted probes must gather fs info

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -846,7 +846,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     @with_context(name='probe_once', description='restricted={restricted}')
     async def _probe_once(self, *, context, restricted):
         if restricted:
-            probe_types = {'blockdev'}
+            probe_types = {'blockdev', 'filesystem'}
             fname = 'probe-data-restricted.json'
             key = "ProbeDataRestricted"
         else:

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -72,7 +72,8 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
     async def test_probe_restricted(self):
         await self.fsc._probe_once(context=None, restricted=True)
-        self.app.prober.get_storage.assert_called_with({'blockdev'})
+        expected = {'blockdev', 'filesystem'}
+        self.app.prober.get_storage.assert_called_with(expected)
 
     async def test_probe_os_prober_false(self):
         self.app.opts.use_os_prober = False


### PR DESCRIPTION
In ubuntu-desktop-installer/issues/1772, a user formatted an existing partition as ext4, which triggered the ESP to be "mounted".  Except this mount step also formatted the ESP.

Previously, when we ran block probing, the restricted=False version failed, which caused it to run a restricted=True probe.  The restricted=True probe looks at block devices, but does not gather filesystem information.  The esp "mount" check is also willing to format the partition if it is unformatted.  (We do not have a distinction between a partition that is unformatted and one for which we have not obtained filesystem information.)

This user had block probing restricted=False fail due to LP: #2012722, where Ventoy was in use and we handled the device mapper entry poorly. While recreating the failure case, simply retesting with a build with the fix for LP: #2012722 is enough to avoid this problem.  This is because the restricted=False probe passes, which means filesystem info is gathered, which means the mount step doesn't attempt to format it.

There will inevitably be other block probing failure cases for restricted=False.  restricted=True must not leave people so vulnerable to a partition reformat.

Gather filesystem information during a restricted=True probe.