### PR TITLE
keyboard: fix use of multi-layout keyboard layout

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -156,6 +156,12 @@ AnyStep = Union[StepPressKey, StepKeyPresent, StepResult]
 
 @attr.s(auto_attribs=True)
 class KeyboardSetting:
+    # This data structure represents a subset of the XKB options.
+    # As explained in the XKB configuration guide, XkbLayout and
+    # XkbVariant can hold multiple comma-separated values.
+    # http://www.xfree86.org/current/XKB-Config2.html#4
+    # Ideally, we would internally represent a keyboard setting as a
+    # toggle + a list of [layout, variant].
     layout: str
     variant: str = ''
     toggle: Optional[str] = None

--- a/subiquity/models/tests/test_keyboard.py
+++ b/subiquity/models/tests/test_keyboard.py
@@ -18,7 +18,10 @@ from subiquitycore.tests.parameterized import parameterized
 from subiquitycore.tests import SubiTestCase
 
 from subiquity.common.types import KeyboardSetting
-from subiquity.models.keyboard import KeyboardModel
+from subiquity.models.keyboard import (
+    InconsistentMultiLayoutError,
+    KeyboardModel,
+)
 
 
 class TestKeyboardModel(SubiTestCase):
@@ -44,6 +47,25 @@ class TestKeyboardModel(SubiTestCase):
         with self.assertRaises(ValueError):
             self.model.setting = val
         self.assertEqual(initial, self.model.setting)
+
+    def testMultiLayout(self):
+        val = KeyboardSetting(layout='us,ara', variant=',')
+        self.model.setting = val
+        self.assertEqual(self.model.setting, val)
+
+    def testInconsistentMultiLayout(self):
+        initial = self.model.setting
+        val = KeyboardSetting(layout='us,ara', variant='')
+        with self.assertRaises(InconsistentMultiLayoutError):
+            self.model.setting = val
+        self.assertEqual(self.model.setting, initial)
+
+    def testInvalidMultiLayout(self):
+        initial = self.model.setting
+        val = KeyboardSetting(layout='us,ara', variant='zz,')
+        with self.assertRaises(ValueError):
+            self.model.setting = val
+        self.assertEqual(self.model.setting, initial)
 
     @parameterized.expand([
         ['ast_ES.UTF-8', 'es', 'ast'],

--- a/subiquity/server/controllers/keyboard.py
+++ b/subiquity/server/controllers/keyboard.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Tuple
 import os
 import pwd
 
@@ -48,7 +48,7 @@ standard_non_latin_layouts = set(
 default_desktop_user = 'ubuntu'
 
 
-def latinizable(layout_code, variant_code):
+def latinizable(layout_code, variant_code) -> Optional[Tuple[str, str]]:
     """
     If this setting does not allow the typing of latin characters,
     return a setting that can be switched to one that can.


### PR DESCRIPTION
The XKB configuration guide shows that multi-layout configuration is possible, as in the following example:

    Option "XkbLayout" "us,cz,de"
    Option "XkbVariant" ",bksl,"

which translates to:
 * layout "us" with no variant
 * layout "cz" with variant "bksl"
 * layout "de" with no variant

The same applies to /etc/default/keyboard.

We do make use of this ability to automatically set an alternative keyboard layout for non latin keyboard layouts (e.g., Arabic "ara" becomes "us,ara" so that users can toggle between American and Arabic keyboard layouts.

In the following commit:

  13cae2488 keyboard: validate layout and variant

.. we started implementing early validation of the keyboard layout, but we did not consider that multi-layouts are supported.

As a result, subiquity fails at keyboard selection when a non latin keyboard layout is selected.

Fixed by making sure the validation expects possible multi-layout setups.

Launchpad bug: https://bugs.launchpad.net/subiquity/+bug/2015028