### PR TITLE
gaps: fix gap size in extended

### DIFF
--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -150,7 +150,10 @@ def find_disk_gaps_v2(device, info=None):
         if part is None:
             gap_end = ad(device.size - info.min_end_offset)
         else:
-            gap_end = ad(part.offset)
+            if part.is_logical:
+                gap_end = ad(part.offset - info.ebr_space)
+            else:
+                gap_end = ad(part.offset)
 
         gap_start = au(prev_end)
 

--- a/subiquity/common/filesystem/tests/test_gaps.py
+++ b/subiquity/common/filesystem/tests/test_gaps.py
@@ -333,6 +333,32 @@ class TestDiskGaps(unittest.TestCase):
                 gaps.Gap(d, 50, 50, False),
             ])
 
+    def test_gap_before_primary(self):
+        # 0----10---20---30---40---50---60---70---80---90---100
+        # [        g1             ][    p1 (primary)          ]
+        info = PartitionAlignmentData(
+            part_align=5, min_gap_size=1, min_start_offset=0, min_end_offset=0,
+            ebr_space=1, primary_part_limit=10)
+        m, d = make_model_and_disk(size=100, ptable='dos')
+        p1 = make_partition(m, d, offset=50, size=50)
+        self.assertEqual(
+            gaps.find_disk_gaps_v2(d, info),
+            [gaps.Gap(d, 0, 50, False), p1])
+
+    def test_gap_in_extended_before_logical(self):
+        # 0----10---20---30---40---50---60---70---80---90---100
+        # [      p1 (extended)                                ]
+        #   [      g1            ] [    p5 (logical)          ]
+        info = PartitionAlignmentData(
+            part_align=5, min_gap_size=1, min_start_offset=0, min_end_offset=0,
+            ebr_space=1, primary_part_limit=10)
+        m, d = make_model_and_disk(size=100, ptable='dos')
+        p1 = make_partition(m, d, offset=0, size=100, flag='extended')
+        p5 = make_partition(m, d, offset=50, size=50, flag='logical')
+        self.assertEqual(
+            gaps.find_disk_gaps_v2(d, info),
+            [p1, gaps.Gap(d, 5, 40, True), p5])
+
     def test_unusable_gap_primaries(self):
         info = PartitionAlignmentData(
             part_align=10, min_gap_size=1, min_start_offset=0,

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -1469,6 +1469,38 @@ class TestRegression(TestAPI):
             v1resp = await inst.get('/storage')
             self.assertEqual([], match(v1resp['config'], type='format'))
 
+    @timeout()
+    async def test_guided_v2_resize_logical_middle_partition(self):
+        '''LP: #2015521 - a logical partition that wasn't the physically last
+        logical partition was resized to allow creation of more partitions, but
+        the 1MiB space was not left between the newly created partition and the
+        physically last partition.'''
+        cfg = 'examples/threebuntu-on-msdos.json'
+        extra = ['--storage-version', '2']
+        async with start_server(cfg, extra_args=extra) as inst:
+            resp = await inst.get('/storage/v2/guided')
+            [resize] = match(resp['possible'], partition_number=5,
+                             _type='GuidedStorageTargetResize')
+            data = {
+                'target': resize,
+                'capability': resize['capabilities'][0],
+                }
+            resp = await inst.post('/storage/v2/guided', data)
+            self.assertEqual(resize, resp['configured']['target'])
+
+            resp = await inst.get('/storage')
+            parts = match(resp['config'], type='partition', flag='logical')
+            logicals = []
+            for part in parts:
+                part['end'] = part['offset'] + part['size']
+                logicals.append(part)
+
+            logicals.sort(key=lambda p: p['offset'])
+            for i in range(len(logicals) - 1):
+                cur, nxt = logicals[i:i+2]
+                self.assertLessEqual(cur['end'] + (1 << 20), nxt['offset'],
+                                     f'partition overlap {cur} {nxt}')
+
 
 class TestCancel(TestAPI):
     @timeout()


### PR DESCRIPTION
Gap sizing in extended had a flaw when there was a partition after it.  We need the ebr space in between.

Emerged in the private bug LP: #2015521, where a user was given a guided resize option based on a logical partition that was not physically last.  The result was that the end position of the newly created partition was the same spot as the offset of the next partition.