### PR TITLE
Fix assertion in autoinstall API test

### DIFF
--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -156,6 +156,7 @@ class MirrorController(SubiquityController):
         self.test_apt_configurer: Optional[AptConfigurer] = None
         self.final_apt_configurer: Optional[AptConfigurer] = None
         self.mirror_check: Optional[MirrorCheck] = None
+        self.autoinstall_apply_started = False
 
     def load_autoinstall_data(self, data):
         if data is None:
@@ -274,6 +275,7 @@ class MirrorController(SubiquityController):
 
     @with_context()
     async def apply_autoinstall_config(self, context):
+        self.autoinstall_apply_started = True
         await self.run_mirror_selection_or_fallback(context)
 
     def on_geoip(self):
@@ -282,6 +284,11 @@ class MirrorController(SubiquityController):
         self.cc_event.set()
 
     async def on_source(self):
+        if self.autoinstall_apply_started:
+            # Alternatively, we should cancel and restart the
+            # apply_autoinstall_config but this is out of scope.
+            raise RuntimeError("source model has changed but autoinstall"
+                               " configuration is already being applied")
         self.test_apt_configurer = get_apt_configurer(
             self.app, self.app.controllers.Source.get_handler())
         self.source_configured_event.set()

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -314,9 +314,14 @@ class MirrorController(SubiquityController):
 
     async def run_mirror_testing(self, output: io.StringIO) -> None:
         await self.source_configured_event.wait()
-        await self.test_apt_configurer.apply_apt_config(
+        # If the source model changes at the wrong time, there is a chance that
+        # self.test_apt_configurer will be replaced between the call to
+        # apply_apt_config and run_apt_config_check. Just make sure we still
+        # use the original one.
+        configurer = self.test_apt_configurer
+        await configurer.apply_apt_config(
             self.context, final=False)
-        await self.test_apt_configurer.run_apt_config_check(output)
+        await configurer.run_apt_config_check(output)
 
     async def wait_config(self) -> AptConfigurer:
         self.final_apt_configurer = get_apt_configurer(

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -265,13 +265,14 @@ async def start_server_factory(factory, *args, **kwargs):
 
 
 @contextlib.asynccontextmanager
-async def start_server(*args, **kwargs):
+async def start_server(*args, set_first_source=True, **kwargs):
     async with start_server_factory(Server, *args, **kwargs) as instance:
-        sources = await instance.get('/source')
-        if sources is None:
-            raise Exception('unexpected /source response')
-        await instance.post(
-            '/source', source_id=sources['sources'][0]['id'])
+        if set_first_source:
+            sources = await instance.get('/source')
+            if sources is None:
+                raise Exception('unexpected /source response')
+            await instance.post(
+                '/source', source_id=sources['sources'][0]['id'])
         while True:
             resp = await instance.get('/storage/v2')
             print(resp)
@@ -1684,7 +1685,8 @@ class TestAutoinstallServer(TestAPI):
             '--autoinstall', 'examples/autoinstall-short.yaml',
             '--source-catalog', 'examples/install-sources.yaml',
         ]
-        async with start_server(cfg, extra_args=extra) as inst:
+        async with start_server(cfg, extra_args=extra,
+                                set_first_source=False) as inst:
             view_request_unspecified, resp = await inst.get(
                     '/locale',
                     full_response=True)
@@ -1829,7 +1831,8 @@ class TestActiveDirectory(TestAPI):
             '--kernel-cmdline', 'autoinstall',
         ]
         try:
-            async with start_server(cfg, extra_args=extra) as inst:
+            async with start_server(cfg, extra_args=extra,
+                                    set_first_source=False) as inst:
                 endpoint = '/active_directory'
                 logdir = inst.output_base()
                 self.assertIsNotNone(logdir)


### PR DESCRIPTION
The API tests unconditionally did a POST request to /source.

This is fine in interactive scenarios, but for autoinstalls, it results in the source controller being "configured" twice:
 * once after the apply_autoinstall_config coroutine finishes executing
 * once after the POST request is handled

By the time the POST request is handled, other models might have started (or even finished) applying their own autoinstall configuration. If that happens, changing the source model will likely invalidate their configuration, resulting in various bugs. Subiquity does not currently support re-running the apply_autoinstall_config coroutines, so it seems fair to say that doing a POST to source in a fully automated install is a pretty bad idea, unless it's done veryyyyy early.

A recent [change](https://github.com/canonical/subiquity/pull/1639) slightly affected the timings in CI, and coupled with the above considerations, lead to a race condition to show up regularly:

* the apply_autoinstall_config coroutine from the mirror model now runs sooner in CI
* the POST request to /source gets handled during mirror testing, or more precisely between the moment we apply the apt configuration in an overlay, and the moment we run the apt-get update command

**Summary of changes**

* The race condition is something that could happen in an interactive install, and therefore the first patch in the series addresses it.
* In autoinstall scenarios though, changing the source during mirror testing is a recipe to disaster, so the second patch makes sure subiquity raises an exception if that happens.
* Doing a POST to /source in API tests if fine for interactive installs, but is wrong for autoinstalls. Added a parameter to `start_server` so that individual tests can disable the POST to /source.
