### PR TITLE
filesystem: fix crash when editing swap partition in v2

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -68,9 +68,10 @@ class FilesystemManipulator:
                 volume.flag = ""
         if spec.get('fstype') == "swap":
             self.model.add_mount(fs, "")
-        if spec.get('fstype') is None and spec.get('use_swap'):
+        elif spec.get('fstype') is None and spec.get('use_swap'):
             self.model.add_mount(fs, "")
-        self.create_mount(fs, spec)
+        else:
+            self.create_mount(fs, spec)
         return fs
 
     def delete_filesystem(self, fs):


### PR DESCRIPTION
When we create a swap partition using v2_add_partition, the mount parameter always has the value of None.

We do however, create a fake mountpoint object and assign it the value of "" (empty string) so we know the swap partition is used although it's not really mounted anywhere in the filesystem hierarchy.

Subsequently, when editing the swap partition, the mount parameter is set to the empty string, not None.

This causes trouble in the create_mount function, which normally returns immediately upon encountering None as the mountpoint.

Fixed by skipping the call to create_mount for a swap partition.

https://bugs.launchpad.net/subiquity/+bug/2002413