### PR TITLE
bin/console-conf-wrapper: prefer use of snapd/modeenv

### DIFF
--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -22,7 +22,14 @@ if [ -e /run/snapd-recovery-chooser-triggered ]; then
     fi
 fi
 
-if grep -q 'snapd_recovery_mode=install' /proc/cmdline ; then
+# always prefer to use modeevn if it is available
+if [ -e "/var/lib/snapd/modeenv" ]; then
+    mode="$(sed -n 's/mode=\([^[:space:]]*\)/\1/p' /var/lib/snapd/modeenv)"
+else
+    mode="$(sed 's/.*snapd_recovery_mode=\([^[:space:]]*\)[[:space:]].*/\1/' /proc/cmdline))"
+fi
+
+if [ "${mode}" = "install" ]; then
     echo "Installing the system, please wait for reboot"
     # XXX: replace with something more user friendly after the beta?
     journalctl -u snapd.service -f


### PR DESCRIPTION
Prefer use of `/var/lib/snapd/modeenv` when determining snapd recovery run mode.
`modeenv` is used by `snapd` as a source of _true_ about the device state.

This change solves the issue when install mode can be performed during a single boot, at which case the `/proc/cmdline` can hold the wrong mode information.