### PR TITLE
mirror: clean environment before running apt-get

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -34,7 +34,7 @@ from curtin.commands.extract import AbstractSourceHandler
 
 from subiquitycore.file_util import write_file, generate_config_yaml
 from subiquitycore.lsb_release import lsb_release
-from subiquitycore.utils import astart_command
+from subiquitycore.utils import astart_command, orig_environ
 
 from subiquity.server.curtin import run_curtin_command
 from subiquity.server.mounter import (
@@ -193,7 +193,7 @@ class AptConfigurer:
         for target in get_index_targets():
             apt_cmd.append(f"-o{target}::DefaultEnabled=false")
 
-        env = os.environ.copy()
+        env = orig_environ(None)
         env["LANG"] = self.app.base_model.locale.selected_language
         with tempfile.NamedTemporaryFile(mode="w+") as config_file:
             env["APT_CONFIG"] = config_file.name


### PR DESCRIPTION
For mirror testing, we run apt-get update on the host. By default, external commands run by subiquity inherit the environment variables set by the snap (including LD_LIBRARY_PATH).

We don't ship apt-get or its dependencies in the subiquity snap, so we want to reset LD_LIBRARY_PATH and other variables when running the command.

Not doing so leads to the following error when running the subiquity snap on a focal-based system:
```
apt-get: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /snap/subiquity/4675/usr/lib/x86_64-linux-gnu/libsystemd.so.0)
apt-get: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /snap/subiquity/4675/usr/lib/x86_64-linux-gnu/libsystemd.so.0)
apt-get: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /snap/subiquity/4675/usr/lib/x86_64-linux-gnu/libsystemd.so.0)
apt-get: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /snap/core22/current/lib/x86_64-linux-gnu/libcap.so.2)
```

Tested on lunar, jammy and focal.

https://bugs.launchpad.net/subiquity/+bug/2016280