### PR TITLE
storage: don't let probing discard storage config in the middle of partitioning

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -302,6 +302,16 @@ class API:
             class reset:
                 def POST() -> StorageResponseV2: ...
 
+            class ensure_transaction:
+                """This call will ensure that a transaction is initiated.
+                During a transaction, storage probing runs are not permitted to
+                reset the partitioning configuration.
+                A transaction will also be initiated by any v2_storage POST
+                request that modifies the partitioning configuration (e.g.,
+                add_partition, edit_partition, ...) but ensure_transaction can
+                be called early if desired. """
+                def POST() -> None: ...
+
             class reformat_disk:
                 def POST(data: Payload[ReformatDisk]) \
                     -> StorageResponseV2: ...

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -277,6 +277,10 @@ class API:
 
         def POST(config: Payload[list]): ...
 
+        class dry_run_wait_probe:
+            """This endpoint only works in dry-run mode."""
+            def POST() -> None: ...
+
         class reset:
             def POST() -> StorageResponse: ...
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -22,7 +22,7 @@ import os
 import pathlib
 import select
 import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from curtin.commands.extract import AbstractSourceHandler
 from curtin.storage_config import ptable_uuid_to_flag_entry
@@ -160,6 +160,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self._role_to_device: Dict[str: _Device] = {}
         self._device_to_structure: Dict[_Device: snapdapi.OnVolume] = {}
         self.use_tpm: bool = False
+        self.locked_probe_data = False
+        # If probe data come in while we are doing partitioning, store it in
+        # this variable. It will be picked up on next reset will pick it up.
+        self.queued_probe_data: Optional[Dict[str, Any]] = None
 
     def is_core_boot_classic(self):
         return self._system is not None
@@ -680,8 +684,21 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
     async def v2_reset_POST(self) -> StorageResponseV2:
         log.info("Resetting Filesystem model")
-        self.model.reset()
+        # From the API standpoint, it seems sound to set locked_probe_data back
+        # to False after a reset. But in practise, v2_reset_POST can be called
+        # during manual partitioning ; and we don't want to reenable automatic
+        # loading of probe data. Going forward, this could be controlled by an
+        # optional parameter maybe?
+        if self.queued_probe_data is not None:
+            log.debug("using newly obtained probe data")
+            self.model.load_probe_data(self.queued_probe_data)
+            self.queued_probe_data = None
+        else:
+            self.model.reset()
         return await self.v2_GET()
+
+    async def v2_ensure_transaction_POST(self) -> None:
+        self.locked_probe_data = True
 
     def get_capabilities(self):
         if self.is_core_boot_classic():
@@ -772,16 +789,19 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def v2_guided_POST(self, data: GuidedChoiceV2) \
             -> GuidedStorageResponseV2:
         log.debug(data)
+        self.locked_probe_data = True
         await self.guided(data)
         return await self.v2_guided_GET()
 
     async def v2_reformat_disk_POST(self, data: ReformatDisk) \
             -> StorageResponseV2:
+        self.locked_probe_data = True
         self.reformat(self.model._one(id=data.disk_id), data.ptable)
         return await self.v2_GET()
 
     async def v2_add_boot_partition_POST(self, disk_id: str) \
             -> StorageResponseV2:
+        self.locked_probe_data = True
         disk = self.model._one(id=disk_id)
         if boot.is_boot_device(disk):
             raise ValueError('device already has bootloader partition')
@@ -793,6 +813,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def v2_add_partition_POST(self, data: AddPartitionV2) \
             -> StorageResponseV2:
         log.debug(data)
+        self.locked_probe_data = True
         if data.partition.boot is not None:
             raise ValueError('add_partition does not support changing boot')
         disk = self.model._one(id=data.disk_id)
@@ -814,6 +835,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def v2_delete_partition_POST(self, data: ModifyPartitionV2) \
             -> StorageResponseV2:
         log.debug(data)
+        self.locked_probe_data = True
         disk = self.model._one(id=data.disk_id)
         partition = self.get_partition(disk, data.partition.number)
         self.delete_partition(partition)
@@ -822,6 +844,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def v2_edit_partition_POST(self, data: ModifyPartitionV2) \
             -> StorageResponseV2:
         log.debug(data)
+        self.locked_probe_data = True
         disk = self.model._one(id=data.disk_id)
         partition = self.get_partition(disk, data.partition.number)
         if data.partition.size not in (None, partition.size) \
@@ -867,7 +890,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         with open(fpath, 'w') as fp:
             json.dump(storage, fp, indent=4)
         self.app.note_file_for_apport(key, fpath)
-        self.model.load_probe_data(storage)
+        if not self.locked_probe_data:
+            self.queued_probe_data = None
+            self.model.load_probe_data(storage)
+        else:
+            self.queued_probe_data = storage
 
     @with_context()
     async def _probe(self, *, context=None):


### PR DESCRIPTION
At least in the desktop installer with storage v2, things go bad if a probert storage run finishes during partitioning. Unless storage is already configured, we automatically discard any change done so far upon receiving a response from a probert storage run. This leads to various problems.

This PR aims at making sure the storage configuration is not reset by a probert run while we are in the middle of partitioning.

Essentially, any request that modifies the partitioning configuration will now ensure that a transaction is started. If we receive the result of a probert run in the middle of a transaction, the new data is not applied. Instead it is stored and will only be used if the user asks for a reset/refresh.

It also introduces a new endpoint storage/v2/ensure_transaction that a client can use before doing any modification to the partitioning configuration. This ensures that the data returned by a subsequent GET /storage/v2/ call will not be invalidated by a probert run.

TODO:

- [x] unit tests
- [x] API test(s)
- [ ] VM testing
- [ ] testing with desktop installer