### PR TITLE
Cosmetic fixes for asynchronous probert runs fix

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -160,7 +160,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self._role_to_device: Dict[str: _Device] = {}
         self._device_to_structure: Dict[_Device: snapdapi.OnVolume] = {}
         self.use_tpm: bool = False
-        self.locked_probe_data = False
+        self.locked_probe_data: bool = False
         # If probe data come in while we are doing partitioning, store it in
         # this variable. It will be picked up on next reset will pick it up.
         self.queued_probe_data: Optional[Dict[str, Any]] = None

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -162,7 +162,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.use_tpm: bool = False
         self.locked_probe_data: bool = False
         # If probe data come in while we are doing partitioning, store it in
-        # this variable. It will be picked up on next reset will pick it up.
+        # this variable. It will be picked up on next reset.
         self.queued_probe_data: Optional[Dict[str, Any]] = None
 
     def is_core_boot_classic(self):

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -1535,13 +1535,13 @@ class TestRegression(TestAPI):
 
     @timeout()
     async def test_probert_result_during_partitioning(self):
-        '''If a probert run finished during manual partition, we used to
-        load the probing data, essentially discarding changes made by the user
-        so far.  This test creates a new partition, simulates the end of a
-        probert run, and then tries to edit the previously created partition.
-        The edit operation would fail in earlier versions, because the new
-        partition would be discarded.
-        '''
+        '''LP: #2016901 - when a probert run finishes during manual
+        partitioning, we used to load the probing data automatically ;
+        essentially discarding any change made by the user so far. This test
+        creates a new partition, simulates the end of a probert run, and then
+        tries to edit the previously created partition.  The edit operation
+        would fail in earlier versions because the new partition would have
+        been discarded. '''
         cfg = 'examples/simple.json'
         extra = ['--storage-version', '2']
         async with start_server(cfg, extra_args=extra) as inst:


### PR DESCRIPTION
This is just a follow-on PR for: https://github.com/canonical/subiquity/pull/1660 addressing a requested change, and improving the wording of some comment/docstring.