### PR TITLE
filesystem: fix logical+swap or logical+boot partition not considered logical

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 33411a726532d24e982e29c62f48abd82e2bc4fe
+    source-commit: e1af11e532c1eada6a229939d9949713414817a4
 
     override-pull: |
       craftctl default

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -264,12 +264,12 @@ def _movable_trailing_partitions_and_gap_size_partition(partition: Partition) \
     pgs = parts_and_gaps(partition.device)
     part_idx = pgs.index(partition)
     trailing_partitions = []
-    in_extended = partition.flag == "logical"
+    in_extended = partition.is_logical
     for pg in pgs[part_idx + 1:]:
         if isinstance(pg, Partition):
             if pg.preserve:
                 break
-            if in_extended and pg.flag != "logical":
+            if in_extended and not pg.is_logical:
                 break
             trailing_partitions.append(pg)
         else:

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -84,9 +84,11 @@ def _annotations_partition(partition):
     elif partition.flag == "extended":
         # extended partition
         r.append(_("extended"))
-    elif partition.flag == "logical":
+
+    if partition.is_logical:
         # logical partition
         r.append(_("logical"))
+
     return r
 
 
@@ -182,7 +184,7 @@ def _label_just_name(device, *, short=False):
 
 @label.register(Partition)
 def _label_partition(partition, *, short=False):
-    if partition.flag == "logical":
+    if partition.is_logical:
         p = "  "
     else:
         p = ""

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -797,7 +797,18 @@ class Partition(_Formattable):
 
     @property
     def is_logical(self):
-        return self.flag == 'logical'
+        if self.flag == "logical":
+            return True
+
+        if self.number is None:
+            # Should only be possible during initialization.
+            return False
+
+        # There is not guarantee that a logical partition will have its flag
+        # set to 'logical'. For a swap partition, for instance, the partition's
+        # flag will be set to 'swap'.  For MSDOS partitions tables, we need to
+        # check the partition number.
+        return self.device.ptable == "msdos" and self.number > 4
 
 
 @fsobj("raid")

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1167,3 +1167,23 @@ class TestSwap(unittest.TestCase):
         with mock.patch.object(m, '_should_add_swapfile', return_value=False):
             cfg = m.render()
             self.assertEqual({'size': 0}, cfg['swap'])
+
+
+class TestPartition(unittest.TestCase):
+
+    def test_is_logical(self):
+        m = make_model(storage_version=2)
+        d = make_disk(m, ptable='msdos')
+        make_partition(m, d, flag='extended')
+        p3 = make_partition(m, d, number=3, flag='swap')
+        p4 = make_partition(m, d, number=4, flag='boot')
+
+        p5 = make_partition(m, d, number=5, flag='logical')
+        p6 = make_partition(m, d, number=6, flag='boot')
+        p7 = make_partition(m, d, number=7, flag='swap')
+
+        self.assertFalse(p3.is_logical)
+        self.assertFalse(p4.is_logical)
+        self.assertTrue(p5.is_logical)
+        self.assertTrue(p6.is_logical)
+        self.assertTrue(p7.is_logical)


### PR DESCRIPTION
Some people who installed a previous version of Ubuntu on a DOS partition table ended up with a logical, ESP partition (which is marked bootable).

This is an unsupported use-case. An ESP partition should always be a primary partition. Ideally, an ESP partition should be on a GPT.
    
 However, curtin's storage_config makes it clear that expecting the flag of a logical partition to be set to 'logical' is a bad idea.
 
```
      # if the boot flag is set, use this as the flag, logical
      # flag is not required as we can determine logical via
      # partition number
```    
Other people want to create a swap partition in an extended partition. This is a perfectly valid use-case and we set flag='swap' for those partitions.

Therefore, in subiquity code, we cannot just check if a partition has a flag set to 'logical'. We need to look at the partition number too.

Going forward, it feels better to make partitions support multiple flags.

Depends on https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/441769
