### PR TITLE
install: request curthooks not to reorder UEFI boot entries

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -451,7 +451,8 @@ class SubiquityModel:
         config = {
             'grub': {
                 'terminal': 'unmodified',
-                'probe_additional_os': True
+                'probe_additional_os': True,
+                'reorder_uefi': False,
                 },
 
             'install': {


### PR DESCRIPTION
By default, curthooks will automatically reorder the UEFI boot entries so that the media used during installation is set as the first boot entry.

This is something that MAAS wants because MAAS typically boots over the network.

This is not typically something we would want for a server or desktop installer though. Most of the time, the media is a removable device. Ideally, we would want the new installed grub to be the first boot entry.

Furthermore, on some UEFI implementations, the BootCurrent does not correspond to a Boot#### entry when booting from a removable media. When this happens, curtin fails at making the media the first boot entry, resulting in the following error:

  Invalid BootOrder order entry valueXXXX
                                       ^
  efibootmgr: entry XXXX does not exist

Fixed by disabling the UEFI boot entries reordering when invoking curthooks.