### PR TITLE
mounter: handle destination not existing 

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -221,8 +221,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if not systems_dir_exists:
             raise NoSnapdSystemsOnSource
         self._system_mounter = Mounter(self.app)
-        await self._system_mounter.bind_mount_tree(
-            source_systems_dir, cur_systems_dir)
+        if not self.app.opts.dry_run:
+            await self._system_mounter.bind_mount_tree(
+                source_systems_dir, cur_systems_dir)
 
         cur_snaps_dir = '/var/lib/snapd/seed/snaps'
         source_snaps_dir = os.path.join(source_path, cur_snaps_dir[1:])


### PR DESCRIPTION
bind_mount_tree really wants to mount to places that don't exist yet,
and to unmount them later.  Simply creating these files or directories
gets weird.  Manage this process in the Mounter, so that any of these
temporary mountpoints get cleaned up on unmount.