### PR TITLE
Fix canary disk layout

### DIFF
--- a/examples/snaps/v2-systems-enhanced-secureboot-desktop.json
+++ b/examples/snaps/v2-systems-enhanced-secureboot-desktop.json
@@ -3,55 +3,100 @@
   "status-code": 200,
   "status": "OK",
   "result": {
-    "label": "prefer-encrypted",
+    "label": "enhanced-secureboot-desktop",
     "model": {
       "architecture": "amd64",
-      "authority-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "authority-id": "canonical",
       "base": "core22",
-      "brand-id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
+      "brand-id": "canonical",
       "classic": "true",
       "distribution": "ubuntu",
-      "grade": "dangerous",
-      "model": "mwhudson-22-classic-dangerous",
-      "serial-authority": [
-        "generic"
-      ],
+      "grade": "signed",
+      "model": "ubuntu-classic-2304-amd64",
       "series": "16",
-      "sign-key-sha3-384": "AWEzKBCuROAYkR0dQfdgI95Ih9sWqwxpU1yezWkKT3EUX6LgNNgXFWSNUxC1S2_v",
+      "sign-key-sha3-384": "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn",
       "snaps": [
         {
-          "default-channel": "22/edge",
+          "default-channel": "classic-23.04/stable",
           "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
           "name": "pc",
           "type": "gadget"
         },
         {
-          "default-channel": "22/edge",
+          "default-channel": "24-hwe/stable",
           "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
           "name": "pc-kernel",
           "type": "kernel"
         },
         {
-          "default-channel": "latest/edge",
+          "default-channel": "latest/stable",
           "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
           "name": "core22",
           "type": "base"
         },
         {
-          "default-channel": "latest/edge",
+          "default-channel": "latest/stable",
           "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
           "name": "snapd",
           "type": "snapd"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q",
+          "name": "core20",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "EISPgh06mRh1vordZY9OZ34QHdd7OrdR",
+          "name": "bare",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk",
+          "name": "firefox",
+          "type": "app"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "rw36mkAjdIKl13dzfwyxP87cejpyIcct",
+          "name": "gnome-3-38-2004",
+          "type": "app"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3",
+          "name": "gnome-42-2204",
+          "type": "app"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "jZLfBRzf1cYlYysIjD2bwSzNtngY0qit",
+          "name": "gtk-common-themes",
+          "type": "app"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg",
+          "name": "snap-store",
+          "type": "app"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu",
+          "name": "snapd-desktop-integration",
+          "type": "app"
         }
       ],
-      "timestamp": "2022-10-07T02:25:51+00:00",
+      "timestamp": "2023-03-19T12:00:00.0Z",
       "type": "model"
     },
     "brand": {
-      "id": "9XoOBkC2zdzx5CVZdl0ZVYuLpCo15ww0",
-      "username": "mwhudson",
-      "display-name": "Michael Hudson-Doyle",
-      "validation": "unproven"
+      "id": "canonical",
+      "username": "canonical",
+      "display-name": "Canonical",
+      "validation": "verified"
     },
     "actions": [
       {
@@ -66,68 +111,13 @@
         "id": "",
         "structure": [
           {
-            "name": "mbr",
-            "filesystem-label": "",
-            "offset": null,
-            "offset-write": null,
-            "size": 440,
-            "type": "mbr",
-            "role": "mbr",
-            "id": "",
-            "filesystem": "",
-            "content": [
-              {
-                "source": "",
-                "target": "",
-                "image": "pc-boot.img",
-                "offset": null,
-                "offset-write": null,
-                "size": 0,
-                "unpack": false
-              }
-            ],
-            "update": {
-              "edition": 1,
-              "preserve": null
-            }
-          },
-          {
-            "name": "BIOS Boot",
-            "filesystem-label": "",
-            "offset": 1048576,
-            "offset-write": {
-              "relative-to": "mbr",
-              "offset": 92
-            },
-            "size": 1048576,
-            "type": "DA,21686148-6449-6E6F-744E-656564454649",
-            "role": "",
-            "id": "",
-            "filesystem": "",
-            "content": [
-              {
-                "source": "",
-                "target": "",
-                "image": "pc-core.img",
-                "offset": null,
-                "offset-write": null,
-                "size": 0,
-                "unpack": false
-              }
-            ],
-            "update": {
-              "edition": 2,
-              "preserve": null
-            }
-          },
-          {
-            "name": "ubuntu-seed",
+            "name": "EFI System partition",
             "filesystem-label": "ubuntu-seed",
-            "offset": null,
+            "offset": 1048576,
             "offset-write": null,
-            "size": 1258291200,
-            "type": "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-            "role": "system-seed",
+            "size": 786432000,
+            "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "role": "system-seed-null",
             "id": "",
             "filesystem": "vfat",
             "content": [
@@ -158,10 +148,10 @@
           {
             "name": "ubuntu-boot",
             "filesystem-label": "ubuntu-boot",
-            "offset": null,
+            "offset": 14930673664,
             "offset-write": null,
             "size": 786432000,
-            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
             "role": "system-boot",
             "id": "",
             "filesystem": "ext4",
@@ -193,10 +183,10 @@
           {
             "name": "ubuntu-save",
             "filesystem-label": "ubuntu-save",
-            "offset": null,
+            "offset": 15717105664,
             "offset-write": null,
             "size": 33554432,
-            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
             "role": "system-save",
             "id": "",
             "filesystem": "ext4",
@@ -209,10 +199,10 @@
           {
             "name": "ubuntu-data",
             "filesystem-label": "ubuntu-data",
-            "offset": null,
+            "offset": 15750660096,
             "offset-write": null,
-            "size": 1073741824,
-            "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "size": 4294967296,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
             "role": "system-data",
             "id": "",
             "filesystem": "ext4",

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -638,8 +638,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             else:
                 if structure.role == snapdapi.Role.SYSTEM_DATA and \
                    structure == self._on_volume.structure[-1]:
-                    gap = gaps.largest_gap(disk)
-                    size = gap.size - (offset - gap.offset)
+                    gap = gaps.at_offset(disk, offset)
+                    size = gap.size
                 part = self.model.add_partition(
                     disk, offset=offset, size=size, check_alignment=False)
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -715,6 +715,13 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         disk = make_disk(self.fsc.model)
         self._add_details_for_structures([
             snapdapi.VolumeStructure(
+                type="21686148-6449-6E6F-744E-656564454649",
+                offset=1 << 20,
+                name='BIOS Boot',
+                size=1 << 20,
+                role='',
+                filesystem=''),
+            snapdapi.VolumeStructure(
                 type="0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                 offset=2 << 20,
                 name='ptname',
@@ -723,7 +730,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
                 filesystem='ext4'),
             ])
         await self.fsc.guided_core_boot(disk)
-        [part] = disk.partitions()
+        [bios_part, part] = disk.partitions()
         self.assertEqual(part.offset, 2 << 20)
         self.assertEqual(part.partition_name, 'ptname')
         self.assertEqual(part.flag, 'linux')

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -609,14 +609,12 @@ class TestCore(TestAPI):
             await inst.post('/storage/v2/guided', data)
             v2resp = await inst.get('/storage/v2')
             [d] = v2resp['disks']
-            [p1, p2, p3, p4, p5] = d['partitions']
-            e1 = dict(offset=1 << 20, size=1 << 20, mount=None)
+            [p1, p2, p3, p4] = d['partitions']
+            e1 = dict(offset=1 << 20, mount='/boot/efi')
             self.assertDictSubset(e1, p1)
-            e2 = dict(offset=2 << 20, mount='/boot/efi')
-            self.assertDictSubset(e2, p2)
-            self.assertDictSubset(dict(mount='/boot'), p3)
-            self.assertDictSubset(dict(mount=None), p4)
-            self.assertDictSubset(dict(mount='/'), p5)
+            self.assertDictSubset(dict(mount='/boot'), p2)
+            self.assertDictSubset(dict(mount=None), p3)
+            self.assertDictSubset(dict(mount='/'), p4)
 
 
 class TestAdd(TestAPI):


### PR DESCRIPTION
* Update sample systems response to match current canary ISO
* Address bug in creation of the rootfs partition for smaller disks, where code that expected a single gap to exist handled multiple gaps poorly and produced a negative size for that rootfs partition.