### PR TITLE
workflow: produce a diff of the mypy errors before/after a PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,3 +30,23 @@ jobs:
     - uses: actions/checkout@v2
     - name: lint
       run: sudo ./scripts/test-in-lxd.sh ${{ matrix.image }} "make lint"
+
+  static-typing:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install mypy and typeshed
+        run: sudo apt-get install -y python3-mypy python3-typeshed
+      - name: Checkout the source branch
+        uses: actions/checkout@v3
+      - name: Run mypy on source branch
+        run: python3 -m mypy --ignore-missing-imports --check-untyped-defs subiquity subiquitycore system_setup console_conf scripts/replay-curtin-log.py | tee /tmp/mypy-source.out
+      - name: Checkout the target/base branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Run mypy on target/base branch
+        run: python3 -m mypy --ignore-missing-imports --check-untyped-defs subiquity subiquitycore system_setup console_conf scripts/replay-curtin-log.py | tee /tmp/mypy-target.out
+      - name: Produce the diff between the two mypy runs
+        run: diff --color=always --unified=0 /tmp/mypy-target.out /tmp/mypy-source.out
+        continue-on-error: true


### PR DESCRIPTION
A new job now runs on PRs. It will automatically run mypy on the target branch and on the source branch. It will generate a diff of the errors, showing the new ones and showing the ones that have been fixed.

It will also show a summary with the number of errors before/after the PR.

Because we have so many false positive, it makes no sense to mark this job red. So we always make it green (unless mypy can't run).

As for now, it's up to developers to go check if any new error is introduced.

If a line that used to produce a mypy error gets moved, it will be reported as:

 * a fixed error
 * a newly introduced error

This is suboptimal and ideally we should have a way to detect moves.

_NOTE: I don't think this is ideal but I'm sure we can iterate on it to make it better_