### PR TITLE
meta: add interactive_sections endpoint

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -135,6 +135,9 @@ class API:
                 the list of components.  free-only choice must be made prior to
                 confirmation of filesystem changes"""
 
+        class interactive_sections:
+            def GET() -> Optional[List[str]]: ...
+
     class errors:
         class wait:
             def GET(error_ref: ErrorReportRef) -> ErrorReportRef:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -181,7 +181,16 @@ class MetaController:
     async def interactive_sections_GET(self) -> Optional[List[str]]:
         if self.app.autoinstall_config is None:
             return None
-        return self.app.autoinstall_config.get('interactive-sections', None)
+
+        i_sections = self.app.autoinstall_config.get(
+                'interactive-sections', None)
+        if i_sections == ['*']:
+            # expand the asterisk to the actual controller key names
+            return [controller.autoinstall_key
+                    for controller in self.app.controllers.instances
+                    if controller.interactive()]
+
+        return i_sections
 
 
 def get_installer_password_from_cloudinit_log():

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -178,6 +178,11 @@ class MetaController:
         # enabling free only mode means disabling components
         self.app.base_model.mirror.disable_components(to_disable, enable)
 
+    async def interactive_sections_GET(self) -> Optional[List[str]]:
+        if self.app.autoinstall_config is None:
+            return None
+        return self.app.autoinstall_config.get('interactive-sections', None)
+
 
 def get_installer_password_from_cloudinit_log():
     try:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -188,7 +188,8 @@ class MetaController:
             # expand the asterisk to the actual controller key names
             return [controller.autoinstall_key
                     for controller in self.app.controllers.instances
-                    if controller.interactive()]
+                    if controller.interactive()
+                    if controller.autoinstall_key is not None]
 
         return i_sections
 

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -19,7 +19,9 @@ from unittest.mock import Mock
 
 from subiquitycore.utils import run_command
 from subiquitycore.tests import SubiTestCase
+from subiquitycore.tests.mocks import make_app
 from subiquity.server.server import (
+    MetaController,
     SubiquityServer,
     cloud_autoinstall_path,
     iso_autoinstall_path,
@@ -121,3 +123,25 @@ early-commands: ["{cmd}"]
                        'early-commands': [cmd],
                        'stuff': 'things'}
         self.assertEqual(after_early, self.server.autoinstall_config)
+
+
+class TestMetaController(SubiTestCase):
+    async def test_interactive_sections_not_present(self):
+        mc = MetaController(make_app())
+        mc.app.autoinstall_config = None
+        self.assertIsNone(await mc.interactive_sections_GET())
+
+    async def test_interactive_sections_empty(self):
+        mc = MetaController(make_app())
+        mc.app.autoinstall_config['interactive-sections'] = []
+        self.assertEqual([], await mc.interactive_sections_GET())
+
+    async def test_interactive_sections_all(self):
+        mc = MetaController(make_app())
+        mc.app.autoinstall_config['interactive-sections'] = ['*']
+        self.assertEqual(['*'], await mc.interactive_sections_GET())
+
+    async def test_interactive_sections_one(self):
+        mc = MetaController(make_app())
+        mc.app.autoinstall_config['interactive-sections'] = ['network']
+        self.assertEqual(['network'], await mc.interactive_sections_GET())

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -141,6 +141,7 @@ class TestMetaController(SubiTestCase):
         mc.app.autoinstall_config['interactive-sections'] = ['*']
         mc.app.controllers.instances = [
             Mock(autoinstall_key='f', interactive=Mock(return_value=False)),
+            Mock(autoinstall_key=None, interactive=Mock(return_value=True)),
             Mock(autoinstall_key='t', interactive=Mock(return_value=True)),
         ]
         self.assertEqual(['t'], await mc.interactive_sections_GET())

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -139,7 +139,11 @@ class TestMetaController(SubiTestCase):
     async def test_interactive_sections_all(self):
         mc = MetaController(make_app())
         mc.app.autoinstall_config['interactive-sections'] = ['*']
-        self.assertEqual(['*'], await mc.interactive_sections_GET())
+        mc.app.controllers.instances = [
+            Mock(autoinstall_key='f', interactive=Mock(return_value=False)),
+            Mock(autoinstall_key='t', interactive=Mock(return_value=True)),
+        ]
+        self.assertEqual(['t'], await mc.interactive_sections_GET())
 
     async def test_interactive_sections_one(self):
         mc = MetaController(make_app())

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -1818,6 +1818,26 @@ class TestAutoinstallServer(TestAPI):
             self.assertIsNone(view_request_yes)
             self.assertEqual('skip', resp.headers['x-status'])
 
+    @timeout()
+    async def test_interactive(self):
+        cfg = 'examples/simple.json'
+        with tempfile.NamedTemporaryFile(mode='w') as tf:
+            tf.write('''
+                version: 1
+                interactive-sections: ['*']
+            ''')
+            tf.flush()
+            extra = ['--autoinstall', tf.name]
+            async with start_server(cfg, extra_args=extra) as inst:
+                resp = await inst.get('/meta/interactive_sections')
+                expected = set([
+                    'locale', 'refresh-installer', 'keyboard', 'source',
+                    'network', 'ubuntu-pro', 'proxy', 'apt', 'storage',
+                    'identity', 'ssh', 'snaps', 'codecs', 'drivers',
+                    'timezone', 'updates', 'shutdown',
+                ])
+                self.assertTrue(expected.issubset(resp))
+
 
 class TestWSLSetupOptions(TestAPI):
     @timeout()


### PR DESCRIPTION
A feature request for Desktop was to add the ability to retrieve, all at once, the raw interactive-sections value from autoinstall.