### PR TITLE
apt-deps: drop pep8 which is unused and does not exist anymore in mantic

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -14,7 +14,6 @@ libsystemd-dev
 lsb-release
 os-prober
 pandoc
-pep8
 pkg-config
 python3-aiohttp
 python3-aioresponses


### PR DESCRIPTION
The pep8 binary package was a transitional package. It would install a symlink /usr/bin/pep8 -> pycodestyle

pep8 does not exist anymore in mantic.

pycodestyle would be the right binary package going forward. That said, we stopped using the pep8 command back in 2018 with this commit:

  af9427561 Make tox and Makefile more similar.

Let's drop the dependency instead.