### PR TITLE
allow creation and population of a recovery partition via autoinstall

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: fb70e57035375abc63c7c2c757c4c64ab928d5b4
+    source-commit: 8e74f621e1bd84f804bda280a370440b150f9f40
 
     override-pull: |
       craftctl default

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -451,6 +451,7 @@ class GuidedChoiceV2:
     password: Optional[str] = attr.ib(default=None, repr=False)
     sizing_policy: Optional[SizingPolicy] = \
         attr.ib(default=SizingPolicy.SCALED)
+    reset_partition: bool = False
 
     @staticmethod
     def from_guided_choice(choice: GuidedChoice):

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -192,7 +192,7 @@ class InstallController(SubiquityController):
             config: Dict[str, Any]):
         """Run a curtin install step."""
         self.app.note_file_for_apport(
-            f"Curtin{name}Config", str(config_file))
+            f"Curtin{name.title().replace(' ', '')}Config", str(config_file))
 
         self.write_config(config_file=config_file, config=config)
 
@@ -240,12 +240,13 @@ class InstallController(SubiquityController):
 
         async def run_curtin_step(name, stages, step_config, source=source):
             config = copy.deepcopy(base_config)
+            filename = f"subiquity-{name.replace(' ', '-')}.conf"
             merge_config(config, copy.deepcopy(step_config))
             await self.run_curtin_step(
                 context=context,
                 name=name,
                 stages=stages,
-                config_file=config_dir / f"subiquity-{name}.conf",
+                config_file=config_dir / filename,
                 source=source,
                 config=config,
                 )

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -157,6 +157,7 @@ class InstallController(SubiquityController):
             "install": {
                 "target": target,
                 "resume_data": None,
+                "extra_rsync_args": ['--no-links'],
             }
         }
 

--- a/subiquity/server/controllers/tests/test_install.py
+++ b/subiquity/server/controllers/tests/test_install.py
@@ -54,7 +54,32 @@ class TestWriteConfig(unittest.IsolatedAsyncioTestCase):
         run_cmd.assert_called_once_with(
                 self.controller.app,
                 ANY,
-                "install", "/source",
+                "install",
+                "--set", 'json:stages=["partitioning", "extract"]',
+                "/source",
+                config="/config.yaml",
+                private_mounts=False)
+
+    @patch("subiquity.server.controllers.install.run_curtin_command")
+    async def test_run_curtin_install_step_no_src(self, run_cmd):
+
+        with patch("subiquity.server.controllers.install.open",
+                   mock_open()) as m_open:
+            await self.controller.run_curtin_step(
+                name='MyStep',
+                stages=["partitioning", "extract"],
+                config_file=Path("/config.yaml"),
+                source=None,
+                config=self.controller.base_config(
+                    logs_dir=Path("/"), resume_data_file=Path("resume-data"))
+                )
+
+        m_open.assert_called_once_with("/curtin-install.log", mode="a")
+
+        run_cmd.assert_called_once_with(
+                self.controller.app,
+                ANY,
+                "install",
                 "--set", 'json:stages=["partitioning", "extract"]',
                 config="/config.yaml",
                 private_mounts=False)

--- a/subiquity/server/mounter.py
+++ b/subiquity/server/mounter.py
@@ -197,6 +197,14 @@ class Mounter:
                 if name in dirnames:
                     dirnames.remove(name)
 
+    @contextlib.asynccontextmanager
+    async def mounted(self, device, mountpoint=None, options=None, type=None):
+        mp = await self.mount(device, mountpoint, options, type)
+        try:
+            yield mp
+        finally:
+            await self.unmount(mp)
+
 
 class DryRunMounter(Mounter):
 

--- a/subiquity/server/mounter.py
+++ b/subiquity/server/mounter.py
@@ -118,13 +118,16 @@ class Mounter:
         self.tmpfiles = TmpFileSet()
         self._mounts: List[Mountpoint] = []
 
-    async def mount(self, device, mountpoint, options=None, type=None):
+    async def mount(self, device, mountpoint=None, options=None, type=None):
         opts = []
         if options is not None:
             opts.extend(['-o', options])
         if type is not None:
             opts.extend(['-t', type])
-        if os.path.exists(mountpoint):
+        if mountpoint is None:
+            mountpoint = tempfile.mkdtemp()
+            created = True
+        elif os.path.exists(mountpoint):
             created = False
         else:
             path = Path(device)


### PR DESCRIPTION
This depends on this change to curtin: https://code.launchpad.net/~mwhudson/curtin/+git/curtin/+merge/444008 as you can't copy symlinks to a vfat partition.

No idea how to test this useful in CI but maybe I'm just not being imaginative enough. I have run almost exactly this code in a VM though and it works reasonably well.