### PR TITLE
server: fix when cloud-config has no default user

### DIFF
--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -629,7 +629,10 @@ class SubiquityServer(Application):
 
         self.installer_user_name = username
 
-        if self._user_has_password(username):
+        if username is None:
+            # extract_default can return None, if there is no default user
+            self.installer_user_passwd_kind = PasswordKind.NONE
+        elif self._user_has_password(username):
             # Was the password set to a random password by a version of
             # cloud-init that records the username in the log?  (This is the
             # case we hit on upgrading the subiquity snap)


### PR DESCRIPTION
If a cloud-config is sent that adjusts the users but creates no default user, Subiquity crashes with a exception while mishandling the None.

cloudinit.distros.ug_util.extract_default is documented as returning None in the event that the default user cannot be found.

Example bad from the Subiquity point of view but otherwise valid cloud-config:
```yaml
users:
- name: ubuntu-server
```