### PR TITLE
Add controller + model listing OEM meta-packages

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -63,6 +63,7 @@ from subiquity.common.types import (
     CodecsData,
     DriversResponse,
     DriversPayload,
+    OEMResponse,
     SnapInfo,
     SnapListResponse,
     SnapSelection,
@@ -365,6 +366,9 @@ class API:
     class drivers:
         def GET(wait: bool = False) -> DriversResponse: ...
         def POST(data: Payload[DriversPayload]) -> None: ...
+
+    class oem:
+        def GET(wait: bool = False) -> OEMResponse: ...
 
     class snaplist:
         def GET(wait: bool = False) -> SnapListResponse: ...

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -586,6 +586,11 @@ class DriversResponse:
 
 
 @attr.s(auto_attribs=True)
+class OEMResponse:
+    metapackages: Optional[List[str]]
+
+
+@attr.s(auto_attribs=True)
 class CodecsData:
     install: bool
 

--- a/subiquity/models/oem.py
+++ b/subiquity/models/oem.py
@@ -1,0 +1,26 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from typing import List, Optional
+
+log = logging.getLogger('subiquity.models.oem')
+
+
+class OEMModel:
+    def __init__(self):
+        # List of OEM metapackages relevant to the current hardware.
+        # When the list is None, it has not yet been retrieved.
+        self.metapkgs: Optional[List[str]] = None

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -57,6 +57,7 @@ from .keyboard import KeyboardModel
 from .locale import LocaleModel
 from .mirror import MirrorModel
 from .network import NetworkModel
+from .oem import OEMModel
 from .proxy import ProxyModel
 from .snaplist import SnapListModel
 from .source import SourceModel
@@ -192,6 +193,7 @@ class SubiquityModel:
         self.locale = LocaleModel(self.chroot_prefix)
         self.mirror = MirrorModel()
         self.network = NetworkModel()
+        self.oem = OEMModel()
         self.packages = []
         self.proxy = ProxyModel()
         self.snaplist = SnapListModel()

--- a/subiquity/server/controllers/__init__.py
+++ b/subiquity/server/controllers/__init__.py
@@ -27,6 +27,7 @@ from .kernel import KernelController
 from .locale import LocaleController
 from .mirror import MirrorController
 from .network import NetworkController
+from .oem import OEMController
 from .package import PackageController
 from .proxy import ProxyController
 from .refresh import RefreshController
@@ -58,6 +59,7 @@ __all__ = [
     'LocaleController',
     'MirrorController',
     'NetworkController',
+    'OEMController',
     'PackageController',
     'ProxyController',
     'RefreshController',

--- a/subiquity/server/controllers/oem.py
+++ b/subiquity/server/controllers/oem.py
@@ -1,0 +1,76 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import logging
+from typing import Optional
+
+from subiquitycore.context import with_context
+
+from subiquity.server.apt import OverlayCleanupError
+from subiquity.server.controller import SubiquityController
+from subiquity.server.types import InstallerChannels
+from subiquity.server.ubuntu_drivers import (
+    CommandNotFoundError,
+    get_ubuntu_drivers_interface,
+    )
+
+log = logging.getLogger('subiquity.server.controllers.oem')
+
+
+class OEMController(SubiquityController):
+
+    model_name = "oem"
+
+    def __init__(self, app) -> None:
+        super().__init__(app)
+        # At this point, the source variant has not been selected but it only
+        # has an impact if we're listing drivers, not OEM metapackages.
+        self.ubuntu_drivers = get_ubuntu_drivers_interface(self.app)
+
+        self.load_metapkgs_task: Optional[asyncio.Task] = None
+
+    def start(self) -> None:
+        self._wait_apt = asyncio.Event()
+        self.app.hub.subscribe(
+            InstallerChannels.APT_CONFIGURED,
+            self._wait_apt.set)
+
+        async def list_and_mark_configured() -> None:
+            await self.load_metapackages_list()
+            await self.configured()
+
+        self.load_metapkgs_task = asyncio.create_task(
+                list_and_mark_configured())
+
+    @with_context()
+    async def load_metapackages_list(self, context) -> None:
+        with context.child("wait_apt"):
+            await self._wait_apt.wait()
+        apt = self.app.controllers.Mirror.final_apt_configurer
+        try:
+            async with apt.overlay() as d:
+                try:
+                    # Make sure ubuntu-drivers is available.
+                    await self.ubuntu_drivers.ensure_cmd_exists(d.mountpoint)
+                except CommandNotFoundError:
+                    self.model.metapkgs = []
+                else:
+                    self.model.metapkgs = await self.ubuntu_drivers.list_oem(
+                        root_dir=d.mountpoint,
+                        context=context)
+        except OverlayCleanupError:
+            log.exception("Failed to cleanup overlay. Continuing anyway.")
+        log.debug("OEM meta-packages to install: %s", self.model.metapkgs)

--- a/subiquity/server/controllers/oem.py
+++ b/subiquity/server/controllers/oem.py
@@ -19,6 +19,8 @@ from typing import Optional
 
 from subiquitycore.context import with_context
 
+from subiquity.common.apidef import API
+from subiquity.common.types import OEMResponse
 from subiquity.server.apt import OverlayCleanupError
 from subiquity.server.controller import SubiquityController
 from subiquity.server.types import InstallerChannels
@@ -31,6 +33,8 @@ log = logging.getLogger('subiquity.server.controllers.oem')
 
 
 class OEMController(SubiquityController):
+
+    endpoint = API.oem
 
     model_name = "oem"
 
@@ -74,3 +78,8 @@ class OEMController(SubiquityController):
         except OverlayCleanupError:
             log.exception("Failed to cleanup overlay. Continuing anyway.")
         log.debug("OEM meta-packages to install: %s", self.model.metapkgs)
+
+    async def GET(self, wait: bool = False) -> OEMResponse:
+        if wait:
+            await asyncio.shield(self.load_metapkgs_task)
+        return OEMResponse(metapackages=self.model.metapkgs)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -277,6 +277,7 @@ class SubiquityServer(Application):
         "Ad",
         "Codecs",
         "Drivers",
+        "OEM",
         "TimeZone",
         "Install",
         "Updates",

--- a/subiquity/server/tests/test_ubuntu_drivers.py
+++ b/subiquity/server/tests/test_ubuntu_drivers.py
@@ -135,6 +135,25 @@ nvidia-driver-510 linux-modules-nvidia-510-generic-hwe-20.04
 
         self.assertEqual(drivers, ["nvidia-driver-510"])
 
+    @patch("subiquity.server.ubuntu_drivers.run_curtin_command")
+    async def test_list_oem(self, mock_run_curtin_command):
+        # Make sure this gets decoded as utf-8.
+        mock_run_curtin_command.return_value = Mock(stdout=b"""\
+oem-somerville-tentacool-meta
+""")
+        drivers = await self.ubuntu_drivers.list_oem(
+            root_dir="/target",
+            context="listing OEM meta-packages")
+
+        mock_run_curtin_command.assert_called_once_with(
+                self.app, "listing OEM meta-packages",
+                "in-target", "-t", "/target",
+                "--",
+                "ubuntu-drivers", "list-oem",
+                capture=True, private_mounts=True)
+
+        self.assertEqual(drivers, ["oem-somerville-tentacool-meta"])
+
 
 class TestUbuntuDriversRunDriversInterface(unittest.IsolatedAsyncioTestCase):
     def setUp(self):

--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -195,11 +195,11 @@ def get_ubuntu_drivers_interface(app) -> UbuntuDriversInterface:
     is_server = app.base_model.source.current.variant == "server"
     cls: Type[UbuntuDriversInterface] = UbuntuDriversClientInterface
     if app.opts.dry_run:
-        if 'has-drivers' in app.debug_flags:
-            cls = UbuntuDriversHasDriversInterface
+        if 'no-drivers' in app.debug_flags:
+            cls = UbuntuDriversNoDriversInterface
         elif 'run-drivers' in app.debug_flags:
             cls = UbuntuDriversRunDriversInterface
         else:
-            cls = UbuntuDriversNoDriversInterface
+            cls = UbuntuDriversHasDriversInterface
 
     return cls(app, gpgpu=is_server)

--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -37,6 +37,9 @@ class UbuntuDriversInterface(ABC):
     def __init__(self, app, gpgpu: bool) -> None:
         self.app = app
 
+        self.list_oem_cmd = [
+            "ubuntu-drivers", "list-oem",
+        ]
         self.list_drivers_cmd = [
             "ubuntu-drivers", "list",
             "--recommended",
@@ -54,6 +57,10 @@ class UbuntuDriversInterface(ABC):
 
     @abstractmethod
     async def list_drivers(self, root_dir: str, context) -> List[str]:
+        pass
+
+    @abstractmethod
+    async def list_oem(self, root_dir: str, context) -> List[str]:
         pass
 
     async def install_drivers(self, root_dir: str, context) -> None:
@@ -77,6 +84,18 @@ class UbuntuDriversInterface(ABC):
             drivers.append(line.split(" ", maxsplit=1)[0])
 
         return drivers
+
+    def _oem_metapackages_from_output(self, output: str) -> List[str]:
+        """ Parse the output of ubuntu-drivers list-oem and return a list of
+        packages. """
+        metapackages: List[str] = []
+        # Packages are listed one per line.
+        for line in [x.strip() for x in output.split("\n")]:
+            if not line:
+                continue
+            metapackages.append(line)
+
+        return metapackages
 
 
 class UbuntuDriversClientInterface(UbuntuDriversInterface):
@@ -105,12 +124,24 @@ class UbuntuDriversClientInterface(UbuntuDriversInterface):
         # output.
         return self._drivers_from_output(result.stdout.decode("utf-8"))
 
+    async def list_oem(self, root_dir: str, context) -> List[str]:
+        result = await run_curtin_command(
+            self.app, context,
+            "in-target", "-t", root_dir, "--", *self.list_oem_cmd,
+            capture=True, private_mounts=True)
+        # Currently we have no way to specify universal_newlines=True or
+        # encoding="utf-8" to run_curtin_command so we need to decode the
+        # output.
+        return self._oem_metapackages_from_output(
+                result.stdout.decode("utf-8"))
+
 
 class UbuntuDriversHasDriversInterface(UbuntuDriversInterface):
     """ A dry-run implementation of ubuntu-drivers that returns a hard-coded
     list of drivers. """
     gpgpu_drivers: List[str] = ["nvidia-driver-470-server"]
     not_gpgpu_drivers: List[str] = ["nvidia-driver-510"]
+    oem_metapackages: List[str] = ["oem-somerville-tentacool-meta"]
 
     def __init__(self, app, gpgpu: bool) -> None:
         super().__init__(app, gpgpu)
@@ -122,6 +153,9 @@ class UbuntuDriversHasDriversInterface(UbuntuDriversInterface):
     async def list_drivers(self, root_dir: str, context) -> List[str]:
         return self.drivers
 
+    async def list_oem(self, root_dir: str, context) -> List[str]:
+        return self.oem_metapackages
+
 
 class UbuntuDriversNoDriversInterface(UbuntuDriversHasDriversInterface):
     """ A dry-run implementation of ubuntu-drivers that returns a hard-coded
@@ -129,6 +163,7 @@ class UbuntuDriversNoDriversInterface(UbuntuDriversHasDriversInterface):
 
     gpgpu_drivers: List[str] = []
     not_gpgpu_drivers: List[str] = []
+    oem_metapackages: List[str] = []
 
 
 class UbuntuDriversRunDriversInterface(UbuntuDriversInterface):
@@ -149,6 +184,11 @@ class UbuntuDriversRunDriversInterface(UbuntuDriversInterface):
         # We run the command locally - ignoring the root_dir.
         result = await arun_command(self.list_drivers_cmd)
         return self._drivers_from_output(result.stdout)
+
+    async def list_oem(self, root_dir: str, context) -> List[str]:
+        # We run the command locally - ignoring the root_dir.
+        result = await arun_command(self.list_oem_cmd)
+        return self._oem_metapackages_from_output(result.stdout)
 
 
 def get_ubuntu_drivers_interface(app) -> UbuntuDriversInterface:


### PR DESCRIPTION
This is one step towards what we need for OEM. Natural next steps are:

* Making sure that the drivers screen does not list OEM meta-packages (metapackages are not drivers and should be installed unconditionally).
  * the `--no-oem` option could come to the rescue but currently we use the ubuntu-drivers command from the target rootfs. Old ISOs will not have it and will fail on installer refresh.
* Installing the OEM meta-packages. This is tricky because:
  * running `ubuntu-drivers install oem-somerville-tentacool-meta` or alike does not work - the package does not get installed
  * running `ubuntu-drivers install` will install third-party drivers even if the user decided not to do so.