### PR TITLE
Install (and optionally upgrade) available OEM meta-packages

### DIFF
--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -306,6 +306,36 @@ class InstallController(SubiquityController):
                 source=source,
                 )
             await self.setup_target(context=context)
+
+            # For OEM, we basically mimic what ubuntu-drivers does:
+            # 1. Install each package with apt-get install
+            # 2. For each package, run apt-get update using only the source
+            # installed by said package.
+            # 3. Run apt-get install again for each package. This will upgrade
+            # them to the version found in the OEM archive.
+
+            # NOTE In ubuntu-drivers, this is done in a single call to apt-get
+            # install.
+            for pkg in self.model.oem.metapkgs:
+                await self.install_package(package=pkg)
+
+            if self.model.network.has_network:
+                for pkg in self.model.oem.metapkgs:
+                    source_list = f"/etc/apt/sources.list.d/{pkg}.list"
+                    await run_curtin_command(
+                        self.app, context,
+                        "in-target", "-t", self.tpath(), "--",
+                        "apt-get", "update",
+                        "-o", f"Dir::Etc::SourceList={source_list}",
+                        "-o", "Dir::Etc::SourceParts=/dev/null",
+                        "--no-list-cleanup",
+                        private_mounts=False)
+
+                # NOTE In ubuntu-drivers, this is done in a single call to
+                # apt-get install.
+                for pkg in self.model.oem.metapkgs:
+                    await self.install_package(package=pkg)
+
             await run_curtin_step(
                 name="curthooks", stages=["curthooks"],
                 step_config=self.generic_config(),

--- a/subiquity/server/tests/test_ubuntu_drivers.py
+++ b/subiquity/server/tests/test_ubuntu_drivers.py
@@ -42,7 +42,7 @@ class TestUbuntuDriversInterface(unittest.IsolatedAsyncioTestCase):
             "--recommended",
             ])
         self.assertEqual(ubuntu_drivers.install_drivers_cmd, [
-            "ubuntu-drivers", "install"])
+            "ubuntu-drivers", "install", "--no-oem"])
 
         ubuntu_drivers = UbuntuDriversInterface(self.app, gpgpu=True)
         self.assertEqual(ubuntu_drivers.list_drivers_cmd, [
@@ -50,7 +50,7 @@ class TestUbuntuDriversInterface(unittest.IsolatedAsyncioTestCase):
             "--recommended", "--gpgpu",
             ])
         self.assertEqual(ubuntu_drivers.install_drivers_cmd, [
-            "ubuntu-drivers", "install", "--gpgpu"])
+            "ubuntu-drivers", "install", "--no-oem", "--gpgpu"])
 
     @patch.multiple(UbuntuDriversInterface, __abstractmethods__=set())
     @patch("subiquity.server.ubuntu_drivers.run_curtin_command")
@@ -63,7 +63,7 @@ class TestUbuntuDriversInterface(unittest.IsolatedAsyncioTestCase):
                 self.app, "installing third-party drivers",
                 "in-target", "-t", "/target",
                 "--",
-                "ubuntu-drivers", "install",
+                "ubuntu-drivers", "install", "--no-oem",
                 private_mounts=True,
                 )
 

--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -44,8 +44,13 @@ class UbuntuDriversInterface(ABC):
             "ubuntu-drivers", "list",
             "--recommended",
         ]
+        # Because of LP #1966413, the following command will also install
+        # relevant OEM meta-packages on affected ubuntu-drivers-common
+        # versions (unless --gpgpu is also passed).
+        # This is not ideal but should be acceptable because we want OEM
+        # meta-packages installed unconditionally (except in autoinstall).
         self.install_drivers_cmd = [
-            "ubuntu-drivers", "install",
+            "ubuntu-drivers", "install", "--no-oem",
         ]
         if gpgpu:
             self.list_drivers_cmd.append("--gpgpu")

--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -73,7 +73,7 @@ class UbuntuDriversInterface(ABC):
         """ Parse the output of ubuntu-drivers list --recommended and return a
         list of drivers. """
         drivers: List[str] = []
-        # Drivers are listed one per line, but each driver is followed by a
+        # Drivers are listed one per line, but some drivers are followed by a
         # linux-modules-* package (which we are not interested in showing).
         # e.g.,:
         # $ ubuntu-drivers list --recommended
@@ -81,7 +81,12 @@ class UbuntuDriversInterface(ABC):
         for line in [x.strip() for x in output.split("\n")]:
             if not line:
                 continue
-            drivers.append(line.split(" ", maxsplit=1)[0])
+            package = line.split(" ", maxsplit=1)[0]
+            if package.startswith("oem-") and package.endswith("-meta"):
+                # Ignore oem-*-meta packages (this would not be needed if we
+                # had passed --no-oem but ..)
+                continue
+            drivers.append(package)
 
         return drivers
 


### PR DESCRIPTION
* Available OEM meta-packages are now installed unconditionally.
* If online, the meta-packages will also get upgraded to their version from the OEM archive - essentially pulling a kernel with it.
* We don't call `ubuntu-drivers install --no-oem` because it would also install third-party drivers on systems affected by https://bugs.launchpad.net/ubuntu/+source/ubuntu-drivers-common/+bug/1966413
* We don't call `ubuntu-drivers --no-oem install` either because it would crash on affected systems
* Instead we implement more or less the same logic as in ubuntu-drivers-common - using subsequent apt commands