### PR TITLE
Override requested kernel flavor on certified hardware

### DIFF
--- a/subiquity/models/kernel.py
+++ b/subiquity/models/kernel.py
@@ -25,6 +25,10 @@ class KernelModel:
     # name.
     metapkg_name_override: Optional[str] = None
 
+    # If we explicitly request a kernel through autoinstall, this attribute
+    # should be True.
+    explicitly_requested: bool = False
+
     def render(self):
         if self.metapkg_name_override is not None:
             metapkg = self.metapkg_name_override

--- a/subiquity/models/kernel.py
+++ b/subiquity/models/kernel.py
@@ -13,14 +13,25 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
+
 
 class KernelModel:
 
-    metapkg_name = None
+    # The name of the kernel metapackage that we intend to install.
+    metapkg_name: Optional[str] = None
+    # During the installation, if we detect that a different kernel version is
+    # needed (OEM being a common use-case), we can override the metapackage
+    # name.
+    metapkg_name_override: Optional[str] = None
 
     def render(self):
+        if self.metapkg_name_override is not None:
+            metapkg = self.metapkg_name_override
+        else:
+            metapkg = self.metapkg_name
         return {
             'kernel': {
-                'package': self.metapkg_name,
+                'package': metapkg,
                 },
             }

--- a/subiquity/models/oem.py
+++ b/subiquity/models/oem.py
@@ -16,11 +16,19 @@
 import logging
 from typing import List, Optional
 
+import attr
+
 log = logging.getLogger('subiquity.models.oem')
+
+
+@attr.s(auto_attribs=True)
+class OEMMetaPkg:
+    name: str
+    wants_oem_kernel: bool
 
 
 class OEMModel:
     def __init__(self):
         # List of OEM metapackages relevant to the current hardware.
         # When the list is None, it has not yet been retrieved.
-        self.metapkgs: Optional[List[str]] = None
+        self.metapkgs: Optional[List[OEMMetaPkg]] = None

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -324,11 +324,11 @@ class InstallController(SubiquityController):
             # NOTE In ubuntu-drivers, this is done in a single call to apt-get
             # install.
             for pkg in self.model.oem.metapkgs:
-                await self.install_package(package=pkg)
+                await self.install_package(package=pkg.name)
 
             if self.model.network.has_network:
                 for pkg in self.model.oem.metapkgs:
-                    source_list = f"/etc/apt/sources.list.d/{pkg}.list"
+                    source_list = f"/etc/apt/sources.list.d/{pkg.name}.list"
                     await run_curtin_command(
                         self.app, context,
                         "in-target", "-t", self.tpath(), "--",
@@ -341,7 +341,7 @@ class InstallController(SubiquityController):
                 # NOTE In ubuntu-drivers, this is done in a single call to
                 # apt-get install.
                 for pkg in self.model.oem.metapkgs:
-                    await self.install_package(package=pkg)
+                    await self.install_package(package=pkg.name)
 
             await run_curtin_step(
                 name="curthooks", stages=["curthooks"],

--- a/subiquity/server/controllers/kernel.py
+++ b/subiquity/server/controllers/kernel.py
@@ -80,6 +80,7 @@ class KernelController(NonInteractiveController):
             package = flavor_to_pkgname(flavor, dry_run=dry_run)
         log.debug(f'Using kernel {package} due to autoinstall')
         self.model.metapkg_name = package
+        self.model.explicitly_requested = True
 
     def make_autoinstall(self):
         return {'package': self.model.metapkg_name}

--- a/subiquity/server/controllers/kernel.py
+++ b/subiquity/server/controllers/kernel.py
@@ -16,9 +16,8 @@
 import logging
 import os
 
-from subiquitycore.lsb_release import lsb_release
-
 from subiquity.server.controller import NonInteractiveController
+from subiquity.server.kernel import flavor_to_pkgname
 
 log = logging.getLogger("subiquity.server.controllers.kernel")
 
@@ -75,18 +74,10 @@ class KernelController(NonInteractiveController):
         package = data.get('package')
         flavor = data.get('flavor')
         if package is None:
-            if flavor is None or flavor == 'generic':
-                package = 'linux-generic'
-            else:
-                if flavor == 'hwe':
-                    flavor = 'generic-hwe'
-                # Should check this package exists really but
-                # that's a bit tricky until we get cleverer about
-                # the apt config in general.
-                dry_run: bool = self.app.opts.dry_run
-                package = 'linux-{flavor}-{release}'.format(
-                    flavor=flavor,
-                    release=lsb_release(dry_run=dry_run)['release'])
+            dry_run: bool = self.app.opts.dry_run
+            if flavor is None:
+                flavor = 'generic'
+            package = flavor_to_pkgname(flavor, dry_run=dry_run)
         log.debug(f'Using kernel {package} due to autoinstall')
         self.model.metapkg_name = package
 

--- a/subiquity/server/controllers/oem.py
+++ b/subiquity/server/controllers/oem.py
@@ -94,6 +94,16 @@ class OEMController(SubiquityController):
     async def load_metapackages_list(self, context) -> None:
         with context.child("wait_apt"):
             await self._wait_apt.wait()
+
+        # Skip looking for OEM meta-packages if we are running ubuntu-server.
+        # OEM meta-packages expect the default kernel flavor to be HWE (which
+        # is only true for ubuntu-desktop).
+        if self.app.base_model.source.current.variant == "server":
+            log.debug("not listing OEM meta-packages since we are installing"
+                      " ubuntu-server")
+            self.model.metapkgs = []
+            return
+
         apt = self.app.controllers.Mirror.final_apt_configurer
         try:
             async with apt.overlay() as d:

--- a/subiquity/server/kernel.py
+++ b/subiquity/server/kernel.py
@@ -1,0 +1,29 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from subiquitycore.lsb_release import lsb_release
+
+
+def flavor_to_pkgname(flavor: str, *, dry_run: bool) -> str:
+    if flavor == 'generic':
+        return 'linux-generic'
+    if flavor == 'hwe':
+        flavor = 'generic-hwe'
+
+    release = lsb_release(dry_run=dry_run)['release']
+    # Should check this package exists really but
+    # that's a bit tricky until we get cleverer about
+    # the apt config in general.
+    return f'linux-{flavor}-{release}'

--- a/subiquity/server/tests/test_kernel.py
+++ b/subiquity/server/tests/test_kernel.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from subiquity.server.kernel import flavor_to_pkgname
+
+
+class TestFlavorToPkgname(unittest.TestCase):
+    def test_flavor_generic(self):
+        self.assertEqual('linux-generic',
+                         flavor_to_pkgname('generic', dry_run=True))
+
+    def test_flavor_oem(self):
+        self.assertEqual('linux-oem-20.04',
+                         flavor_to_pkgname('oem', dry_run=True))
+
+    def test_flavor_hwe(self):
+        self.assertEqual('linux-generic-hwe-20.04',
+                         flavor_to_pkgname('hwe', dry_run=True))
+
+        self.assertEqual('linux-generic-hwe-20.04',
+                         flavor_to_pkgname('generic-hwe', dry_run=True))


### PR DESCRIPTION
On certified hardware, we now honor the Ubuntu-Oem-Kernel-Flavour attribute. If the value is "oem", then we install the OEM kernel flavor. If the value if "default", then we install the kernel flavor that was originally requested.

This was a problem on ubuntu-server because the OEM meta-packages that have `Ubuntu-Oem-Kernel-Flavor: default` have a Depends on `linux-hwe-generic` whereas in ubuntu server, the default is to use the `generic` flavor (not hwe). We decided to disable listing and installation of OEM meta-packages in the server installer (and also if we're running on core boot classic).

Depends: #1700 