### PR TITLE
add a target/capability for manual partitioning

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -29,6 +29,7 @@ from subiquity.common.types import (
     GuidedCapability,
     GuidedChoiceV2,
     GuidedStorageResponseV2,
+    GuidedStorageTargetManual,
     GuidedStorageTargetReformat,
     StorageResponseV2,
     )
@@ -177,7 +178,10 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
                 await asyncio.sleep(0.1)
             self.finish()
         elif self.answers['manual']:
-            await self._guided_choice(None)
+            await self._guided_choice(
+                GuidedChoiceV2(
+                    target=GuidedStorageTargetManual(),
+                    capability=GuidedCapability.MANUAL))
             await self._run_actions(self.answers['manual'])
             self.answers['manual'] = []
 
@@ -287,10 +291,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         else:
             raise Exception("could not process action {}".format(action))
 
-    async def _guided_choice(self, choice: Optional[GuidedChoiceV2]):
-        if self.core_boot_capability is not None:
-            self.app.next_screen(self.endpoint.guided.POST(choice))
-            return
+    async def _guided_choice(self, choice: GuidedChoiceV2):
         # FIXME It would seem natural here to pass the wait=true flag to the
         # below HTTP calls, especially because we wrap the coroutine in
         # wait_with_progress.
@@ -298,10 +299,10 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         # the least risky option to address https://launchpad.net/bugs/1993257
         # before the kinetic release. This is also similar to what we did for
         # https://launchpad.net/bugs/1962205
-        if choice is not None:
-            coro = self.endpoint.guided.POST(choice)
-        else:
-            coro = self.endpoint.GET(use_cached_result=True)
+        coro = self.endpoint.guided.POST(choice)
+        if self.core_boot_capability is not None:
+            self.app.next_screen(coro)
+            return
         status = await self.app.wait_with_progress(coro)
         self.model = FilesystemModel(status.bootloader)
         self.model.load_server_data(status)

--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -292,13 +292,6 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
             raise Exception("could not process action {}".format(action))
 
     async def _guided_choice(self, choice: GuidedChoiceV2):
-        # FIXME It would seem natural here to pass the wait=true flag to the
-        # below HTTP calls, especially because we wrap the coroutine in
-        # wait_with_progress.
-        # Having said that, making the server return a cached result seems like
-        # the least risky option to address https://launchpad.net/bugs/1993257
-        # before the kinetic release. This is also similar to what we did for
-        # https://launchpad.net/bugs/1962205
         coro = self.endpoint.guided.POST(choice)
         if not choice.capability.supports_manual_customization():
             self.app.next_screen(coro)

--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -300,7 +300,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         # before the kinetic release. This is also similar to what we did for
         # https://launchpad.net/bugs/1962205
         coro = self.endpoint.guided.POST(choice)
-        if self.core_boot_capability is not None:
+        if not choice.capability.supports_manual_customization():
             self.app.next_screen(coro)
             return
         status = await self.app.wait_with_progress(coro)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -341,6 +341,14 @@ class GuidedCapability(enum.Enum):
                         GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED,
                         GuidedCapability.CORE_BOOT_PREFER_UNENCRYPTED]
 
+    def supports_manual_customization(self) -> bool:
+        # After posting this capability to guided_POST, is it possible
+        # for the user to customize the layout further?
+        return self in [GuidedCapability.MANUAL,
+                        GuidedCapability.DIRECT,
+                        GuidedCapability.LVM,
+                        GuidedCapability.LVM_LUKS]
+
 
 class GuidedDisallowedCapabilityReason(enum.Enum):
     TOO_SMALL = enum.auto()

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -321,6 +321,7 @@ class Disk:
 
 
 class GuidedCapability(enum.Enum):
+    MANUAL = enum.auto()
     DIRECT = enum.auto()
     LVM = enum.auto()
     LVM_LUKS = enum.auto()
@@ -437,9 +438,17 @@ class GuidedStorageTargetUseGap:
     disallowed: List[GuidedDisallowedCapability] = attr.Factory(list)
 
 
+@attr.s(auto_attribs=True)
+class GuidedStorageTargetManual:
+    allowed: List[GuidedCapability] = attr.Factory(
+        lambda: [GuidedCapability.MANUAL])
+    disallowed: List[GuidedDisallowedCapability] = attr.Factory(list)
+
+
 GuidedStorageTarget = Union[GuidedStorageTargetReformat,
                             GuidedStorageTargetResize,
-                            GuidedStorageTargetUseGap]
+                            GuidedStorageTargetUseGap,
+                            GuidedStorageTargetManual]
 
 
 @attr.s(auto_attribs=True)
@@ -447,8 +456,7 @@ class GuidedChoiceV2:
     target: GuidedStorageTarget
     capability: GuidedCapability
     password: Optional[str] = attr.ib(default=None, repr=False)
-    sizing_policy: Optional[SizingPolicy] = \
-        attr.ib(default=SizingPolicy.SCALED)
+    sizing_policy: Optional[SizingPolicy] = SizingPolicy.SCALED
     reset_partition: bool = False
 
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -545,6 +545,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             choice: GuidedChoiceV2,
             reset_partition_only: bool = False
             ) -> None:
+        if choice.capability == GuidedCapability.MANUAL:
+            return
+
         self.model.guided_configuration = choice
 
         self.set_info_for_capability(choice.capability)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -788,7 +788,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def guided_POST(self, data: GuidedChoiceV2) -> StorageResponse:
         log.debug(data)
         await self.guided(data)
-        if data.capability.is_core_boot():
+        if not data.capability.supports_manual_customization():
             await self.configured()
         return self._done_response()
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -560,6 +560,11 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         guided_get_resp = await self.fsc.v2_guided_GET()
         [reformat, manual] = guided_get_resp.targets
         self.assertEqual(manual, GuidedStorageTargetManual())
+        data = GuidedChoiceV2(target=reformat, capability=manual.allowed[0])
+        # POSTing the manual choice doesn't change anything
+        await self.fsc.v2_guided_POST(data=data)
+        guided_get_resp = await self.fsc.v2_guided_GET()
+        self.assertEqual([reformat, manual], guided_get_resp.targets)
 
     @parameterized.expand(bootloaders_and_ptables)
     async def test_small_blank_disk(self, bootloader, ptable):

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -332,7 +332,7 @@ class TestFlow(TestAPI):
                             {'elected': 'http://us.archive.ubuntu.com/ubuntu'})
 
             resp = await inst.get('/storage/v2/guided?wait=true')
-            [reformat] = resp['targets']
+            [reformat, manual] = resp['targets']
             await inst.post(
                 '/storage/v2/guided',
                 {
@@ -605,7 +605,7 @@ class TestCore(TestAPI):
         async with start_server(cfg, **kw) as inst:
             await inst.post('/source', source_id='ubuntu-desktop')
             resp = await inst.get('/storage/v2/guided', wait=True)
-            [reformat] = resp['targets']
+            [reformat, manual] = resp['targets']
             self.assertIn('CORE_BOOT_PREFER_ENCRYPTED',
                           reformat['allowed'])
             data = dict(target=reformat, capability='CORE_BOOT_ENCRYPTED')
@@ -1042,7 +1042,7 @@ class TestTodos(TestAPI):  # server indicators of required client actions
             self.assertTrue(resp['need_boot'])
 
             resp = await inst.get('/storage/v2/guided')
-            [reformat] = resp['targets']
+            [reformat, manual] = resp['targets']
             data = {
                 'target': reformat,
                 'capability': reformat['allowed'][0],

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -50,6 +50,7 @@ from subiquity.common.types import (
     Gap,
     GuidedCapability,
     GuidedChoiceV2,
+    GuidedStorageTargetManual,
     GuidedStorageTargetReformat,
     Partition,
 )
@@ -313,12 +314,11 @@ class GuidedDiskSelectionView(BaseView):
     def done(self, sender):
         results = sender.as_data()
         password = None
+        capability = None
         disk_id = None
         if self.controller.core_boot_capability is not None:
             if results.get('use_tpm', sender.tpm_choice.default):
                 capability = GuidedCapability.CORE_BOOT_ENCRYPTED
-            else:
-                capability = GuidedCapability.CORE_BOOT_UNENCRYPTED
             disk_id = results['disk'].id
         elif results['guided']:
             if results['guided_choice']['use_lvm']:
@@ -341,11 +341,17 @@ class GuidedDiskSelectionView(BaseView):
                 password=password,
                 )
         else:
-            choice = None
+            choice = GuidedChoiceV2(
+                target=GuidedStorageTargetManual(),
+                capability=GuidedCapability.MANUAL,
+                )
         self.controller.guided_choice(choice)
 
     def manual(self, sender):
-        self.controller.guided_choice(None)
+        self.controller.guided_choice(GuidedChoiceV2(
+            target=GuidedStorageTargetManual(),
+            capability=GuidedCapability.MANUAL,
+            ))
 
     def cancel(self, btn=None):
         self.controller.cancel()


### PR DESCRIPTION
Currently the client special cases the core boot capabilities and does not offer manual partitioning for them. This change makes things a bit more regular, and also prepares the ground for other install methods that cannot be customized.

Next up: a major rewrite of subiquity/ui/views/filesystem/guided.py!