### PR TITLE
snapcraft: pickup curtin's 'kernel: null' fix

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 6412598919202072d0d8b57827a120c963478d35
+    source-commit: 168c4fd3241e449ec5fb685f9f26edd86bdad8da
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Updating curtin to address https://bugs.launchpad.net/curtin/+bug/2026225. Sadly, I didn't manage to test the fix because of https://bugs.launchpad.net/subiquity/+bug/2025535 but I think it will at least be an improvement.

canonical/curtin@168c4fd3 curthooks: fix exception when passing 'kernel: null'

This will also pull the following changes:

canonical/curtin@4587fd40 extend grub config object to handle all config under the 'grub' key
canonical/curtin@6386240f swap: API improvement, fixes, and tests for can_use_swapfile
canonical/curtin@b4ff4c37 version to 23.1.1
canonical/curtin@58b0c50d use a config object in uefi boot entry code
canonical/curtin@3b353cac modernize efi boot entry handling code
canonical/curtin@96ab8c1d tox.ini: update pylint
