### PR TITLE
specialize how fs model objects are sent across API

### DIFF
--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -363,11 +363,10 @@ def _is_esp_partition(partition):
     if partition.device.ptable == "gpt":
         return partition.flag == "boot"
     elif isinstance(partition.device, Disk):
-        blockdev_raw = partition._m._probe_data['blockdev'].get(
-            partition._path())
-        if blockdev_raw is None:
+        info = partition._info
+        if info is None:
             return False
-        typecode = blockdev_raw.get("ID_PART_ENTRY_TYPE")
+        typecode = info.raw.get("ID_PART_ENTRY_TYPE")
         if typecode is None:
             return False
         try:

--- a/subiquity/common/filesystem/tests/test_actions.py
+++ b/subiquity/common/filesystem/tests/test_actions.py
@@ -297,8 +297,7 @@ class TestActions(unittest.TestCase):
         model.add_volgroup('vg0', {raid1p1})
         self.assertActionNotPossible(raid1, DeviceAction.REFORMAT)
 
-        raid2 = make_raid(model)
-        raid2.preserve = True
+        raid2 = make_raid(model, preserve=True)
         self.assertActionNotPossible(raid2, DeviceAction.REFORMAT)
         raid2p1 = make_partition(model, raid2, preserve=True)
         self.assertActionPossible(raid2, DeviceAction.REFORMAT)

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -671,7 +671,6 @@ class TestFilesystemManipulator(unittest.TestCase):
     def test_logical_no_esp_in_gap(self):
         manipulator = make_manipulator(Bootloader.UEFI, storage_version=2)
         m = manipulator.model
-        m._probe_data.setdefault('blockdev', {})
         d1 = make_disk(m, preserve=True, ptable='msdos')
         size = gaps.largest_gap_size(d1)
         make_partition(m, d1, flag='extended', preserve=True, size=size)
@@ -683,7 +682,6 @@ class TestFilesystemManipulator(unittest.TestCase):
     def test_logical_no_esp_by_resize(self):
         manipulator = make_manipulator(Bootloader.UEFI, storage_version=2)
         m = manipulator.model
-        m._probe_data.setdefault('blockdev', {})
         d1 = make_disk(m, preserve=True, ptable='msdos')
         size = gaps.largest_gap_size(d1)
         make_partition(m, d1, flag='extended', preserve=True, size=size)
@@ -694,7 +692,6 @@ class TestFilesystemManipulator(unittest.TestCase):
     def test_logical_no_esp_in_new_part(self):
         manipulator = make_manipulator(Bootloader.UEFI, storage_version=2)
         m = manipulator.model
-        m._probe_data.setdefault('blockdev', {})
         d1 = make_disk(m, preserve=True, ptable='msdos')
         size = gaps.largest_gap_size(d1)
         make_partition(m, d1, flag='extended', size=size)
@@ -706,7 +703,6 @@ class TestFilesystemManipulator(unittest.TestCase):
     def test_too_many_primaries(self, bl):
         manipulator = make_manipulator(bl, storage_version=2)
         m = manipulator.model
-        m._probe_data.setdefault('blockdev', {})
         d1 = make_disk(m, preserve=True, ptable='msdos', size=100 << 30)
         tenth = 10 << 30
         for i in range(4):
@@ -719,7 +715,6 @@ class TestFilesystemManipulator(unittest.TestCase):
     def test_logical_when_in_extended(self):
         manipulator = make_manipulator(storage_version=2)
         m = manipulator.model
-        m._probe_data.setdefault('blockdev', {})
         d1 = make_disk(m, preserve=True, ptable='msdos')
         size = gaps.largest_gap_size(d1)
         make_partition(m, d1, flag='extended', size=size)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -369,7 +369,6 @@ class StorageResponse:
     bootloader: Optional[Bootloader] = None
     orig_config: Optional[list] = None
     config: Optional[list] = None
-    blockdev: Optional[dict] = None
     dasd: Optional[dict] = None
     storage_version: int = 1
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -865,12 +865,8 @@ class Raid(_Device):
 
     @property
     def size(self):
-        if self.preserve and self._m._probe_data:
-            bd = self._m._probe_data['blockdev'].get('/dev/' + self.name)
-            if bd:
-                s = int(bd['attrs']['size'])
-                if s > 0:
-                    return s
+        if self.preserve:
+            return self._info.size
         return get_raid_size(self.raidlevel, self.devices)
 
     def alignment_data(self):

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1212,12 +1212,11 @@ class FilesystemModel(object):
         self.storage_version = status.storage_version
         self._orig_config = status.orig_config
         self._probe_data = {
-            'blockdev': status.blockdev,
             'dasd': status.dasd,
             }
         self._actions, self._exclusions = self._actions_from_config(
             status.config,
-            blockdevs=status.blockdev,
+            blockdevs=None,
             is_probe_data=False)
 
     def _make_matchers(self, match):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -993,7 +993,7 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertTrue(disk2.id not in rendered_ids)
         self.assertTrue(disk2p1.id not in rendered_ids)
 
-    def test_render_all_does_include_unreferenced(self):
+    def test_render_for_api_does_include_unreferenced(self):
         model = make_model(Bootloader.NONE)
         disk1 = make_disk(model, preserve=True)
         disk2 = make_disk(model, preserve=True)
@@ -1003,7 +1003,7 @@ class TestAutoInstallConfig(unittest.TestCase):
         model.add_mount(fs, '/')
         rendered_ids = {
             action['id']
-            for action in model._render_actions(ActionRenderMode.ALL)
+            for action in model._render_actions(ActionRenderMode.FOR_API)
             }
         self.assertTrue(disk1.id in rendered_ids)
         self.assertTrue(disk1p1.id in rendered_ids)

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1272,12 +1272,12 @@ class TestZPool(SubiTestCase):
         blockdevs = m._probe_data['blockdev']
         config = [
             dict(type='disk', id=d.id, path=d.path, ptable=d.ptable,
-                 serial=d.serial),
+                 serial=d.serial, info={d.path: blockdevs[d.path]}),
             dict(type='zpool', id='zpool-1', vdevs=[d.id], pool='p1',
                  mountpoint='/'),
             dict(type='zfs', id='zfs-1', volume='/ROOT', pool='zpool-1'),
         ]
-        objs, _exclusions = m._actions_from_config(config, blockdevs=blockdevs,
+        objs, _exclusions = m._actions_from_config(config, blockdevs=None,
                                                    is_probe_data=False)
         actual_disk, zpool, zfs = objs
         self.assertTrue(isinstance(zpool, ZPool))

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -624,7 +624,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             bootloader=self.model.bootloader,
             error_report=self.full_probe_error(),
             orig_config=self.model._orig_config,
-            config=self.model._render_actions(mode=ActionRenderMode.ALL),
+            config=self.model._render_actions(mode=ActionRenderMode.FOR_API),
             blockdev=self.model._probe_data['blockdev'],
             dasd=self.model._probe_data.get('dasd', {}),
             storage_version=self.model.storage_version)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -625,7 +625,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             error_report=self.full_probe_error(),
             orig_config=self.model._orig_config,
             config=self.model._render_actions(mode=ActionRenderMode.FOR_API),
-            blockdev=self.model._probe_data['blockdev'],
             dasd=self.model._probe_data.get('dasd', {}),
             storage_version=self.model.storage_version)
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -641,7 +641,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         log.debug(config)
         self.model._actions, self.model._exclusions = \
             self.model._actions_from_config(
-                config, self.model._probe_data['blockdev'],
+                config, blockdevs=self.model._probe_data['blockdev'],
                 is_probe_data=False)
         await self.configured()
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -49,6 +49,7 @@ from subiquity.common.types import (
 from subiquity.models.filesystem import dehumanize_size
 from subiquity.models.source import CatalogEntryVariation
 from subiquity.models.tests.test_filesystem import (
+    FakeStorageInfo,
     make_disk,
     make_model,
     make_partition,
@@ -325,7 +326,6 @@ class TestGuided(IsolatedAsyncioTestCase):
         await self.controller._examine_systems_task.wait()
         self.model = make_model(bootloader, storage_version)
         self.controller.model = self.model
-        self.model._probe_data = {'blockdev': {}}
         self.d1 = make_disk(self.model, ptable=ptable)
 
     @parameterized.expand(boot_expectations)
@@ -425,9 +425,8 @@ class TestGuided(IsolatedAsyncioTestCase):
             p.preserve = True
             if bl == Bootloader.UEFI:
                 # let it pass the is_esp check
-                self.model._probe_data['blockdev'][p._path()] = {
-                    "ID_PART_ENTRY_TYPE": str(0xef)
-                }
+                p._info = FakeStorageInfo(size=p.size)
+                p._info.raw["ID_PART_ENTRY_TYPE"] = str(0xef)
         # Make it more interesting with other partitions.
         # Also create the extended part if needed.
         g = gaps.largest_gap(self.d1)


### PR DESCRIPTION
The way the client server split was done for the server tui's filesystem screens was pretty hackish, basically repeating the conversion from what probert + curtin gives us to model objects in the client. This cleans this up ever so slightly by adding a way to indicate that particular attributes should be serialized over the client/server API (and not when rendering the curtin config) and using that mechanism to transfer the udev information associated with disks, partitions and raids to the client.