### PR TITLE
Fix typo in reference: minimized --> minimal

### DIFF
--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -147,7 +147,7 @@ Whether the installer should search for available third-party drivers. When set 
 **type:** string
 **default:** identifier of the first available source.
 
-Identifier of the source to install (e.g., `"ubuntu-server-minimized"`).
+Identifier of the source to install (e.g., `"ubuntu-server-minimal"`).
 
 <a name="network"></a>
 


### PR DESCRIPTION
There is no such thing as `ubuntu-server-minimized`. It should be `ubuntu-server-minimal`.

See for example here:
https://github.com/canonical/subiquity/blob/f8bf1105bf96e044b013e7c30b688e4c89de2f47/examples/sources/install.yaml#L4

Another piece of evidence is found in the Ubuntu ISO:

![image](https://github.com/canonical/subiquity/assets/7773090/4bd6671e-c0a0-4f0c-b434-81fb1786c560)
