### PR TITLE
generalize the way screens are skipped when installing desktop

### DIFF
--- a/subiquity/server/controllers/identity.py
+++ b/subiquity/server/controllers/identity.py
@@ -62,6 +62,8 @@ class IdentityController(SubiquityController):
         'additionalProperties': False,
         }
 
+    interactive_for_variants = {'desktop', 'server'}
+
     def __init__(self, app):
         super().__init__(app)
         core_reserved_path = resource_path("reserved-usernames")

--- a/subiquity/server/controllers/snaplist.py
+++ b/subiquity/server/controllers/snaplist.py
@@ -160,6 +160,8 @@ class SnapListController(SubiquityController):
         }
     model_name = "snaplist"
 
+    interactive_for_variants = {'server'}
+
     def _make_loader(self):
         return SnapdSnapInfoLoader(
             self.model, self.app.snapd, self.opts.snap_section,
@@ -170,20 +172,6 @@ class SnapListController(SubiquityController):
         self.loader = self._make_loader()
         self.app.hub.subscribe(
             InstallerChannels.SNAPD_NETWORK_CHANGE, self.snapd_network_changed)
-        self.app.hub.subscribe(
-            InstallerChannels.INSTALL_CONFIRMED, self._confirmed)
-        self._active = True
-
-    async def _confirmed(self):
-        if self.app.base_model.source.current.variant == 'desktop':
-            await self.configured()
-            self._active = False
-            self.loader.stop()
-
-    def interactive(self):
-        if super().interactive():
-            return self._active
-        return False
 
     def load_autoinstall_data(self, ai_data):
         to_install = []

--- a/subiquity/server/controllers/ssh.py
+++ b/subiquity/server/controllers/ssh.py
@@ -29,7 +29,6 @@ from subiquity.server.ssh import (
     SSHKeyFetcher,
     DryRunSSHKeyFetcher,
     )
-from subiquity.server.types import InstallerChannels
 
 log = logging.getLogger('subiquity.server.controllers.ssh')
 
@@ -51,25 +50,14 @@ class SSHController(SubiquityController):
         },
     }
 
+    interactive_for_variants = {'server'}
+
     def __init__(self, app):
         super().__init__(app)
-        self.app.hub.subscribe(
-            InstallerChannels.INSTALL_CONFIRMED, self._confirmed)
-        self._active = True
         if app.opts.dry_run:
             self.fetcher = DryRunSSHKeyFetcher(app)
         else:
             self.fetcher = SSHKeyFetcher(app)
-
-    async def _confirmed(self):
-        if self.app.base_model.source.current.variant == 'desktop':
-            await self.configured()
-            self._active = False
-
-    def interactive(self):
-        if super().interactive():
-            return self._active
-        return False
 
     def load_autoinstall_data(self, data):
         if data is None:


### PR DESCRIPTION
Also skip identity screen when installing neither server nor desktop (i.e. core).