### PR TITLE
update curtin

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 168c4fd3241e449ec5fb685f9f26edd86bdad8da
+    source-commit: ecd94789be334c3f8e4b431b602e83c269ddbe96
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
2495681a support dd-raw:file:// urls
ecd94789 have ChrootableTarget ignore allow_daemons when target == "/"

I need the former for the core desktop installation stuff, the latter to fix integration tests in some environments.