### PR TITLE
Zfs action ordering

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -158,7 +158,19 @@ class FilesystemManipulator:
     delete_lvm_partition = delete_logical_volume
 
     def create_zpool(self, device, pool, mountpoint):
-        self.model.add_zpool(device, pool, mountpoint)
+        fs_properties = dict(
+            acltype='posixacl',
+            relatime='on',
+            canmount='on',
+            compression='gzip',
+            devices='off',
+            xattr='sa',
+        )
+        pool_properties = dict(ashift=12)
+
+        self.model.add_zpool(
+            device, pool, mountpoint,
+            fs_properties=fs_properties, pool_properties=pool_properties)
 
     def delete(self, obj):
         if obj is None:

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1929,21 +1929,14 @@ class FilesystemModel(object):
                 return False
         return True
 
-    def add_zpool(self, device, pool, mountpoint):
-        fs_properties = dict(
-            acltype='posixacl',
-            relatime='on',
-            canmount='on',
-            compression='gzip',
-            devices='off',
-            xattr='sa',
-        )
+    def add_zpool(self, device, pool, mountpoint, *,
+                  fs_properties=None, pool_properties=None):
         zpool = ZPool(
             m=self,
             vdevs=[device],
             pool=pool,
             mountpoint=mountpoint,
-            pool_properties=dict(ashift=12),
+            pool_properties=pool_properties,
             fs_properties=fs_properties)
         self._actions.append(zpool)
         return zpool

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1623,7 +1623,7 @@ class FilesystemModel(object):
                         if dep.type in ['disk', 'raid']:
                             ensure_partitions(dep)
                     return False
-            if obj.type in MountlikeNames:
+            if obj.type in MountlikeNames and obj.path is not None:
                 # Any mount actions for a parent of this one have to be emitted
                 # first.
                 for parent in pathlib.Path(obj.path).parents:

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1100,7 +1100,10 @@ class ZPool:
         return self.pool
 
     @property
-    def mount(self):
+    def path(self):
+        if self.fs_properties is not None:
+            if not yaml.safe_load(self.fs_properties.get('canmount', 'off')):
+                return None
         return self.mountpoint
 
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -28,6 +28,7 @@ import tempfile
 from typing import List, Optional, Set, Union
 
 import more_itertools
+import yaml
 
 from curtin import storage_config
 from curtin.block import partition_kname
@@ -1109,6 +1110,21 @@ class ZFS:
     volume: str
     # options to pass to zfs dataset creation
     properties: Optional[dict] = None
+
+    @property
+    def fstype(self):
+        return 'zfs'
+
+    @property
+    def path(self):
+        if self.properties is None:
+            return self.volume
+        if not yaml.safe_load(self.properties.get('canmount', 'on')):
+            return None
+        mountpoint = self.properties.get('mountpoint', None)
+        if mountpoint is not None:
+            return mountpoint
+        return self.volume
 
 
 ConstructedDevice = Union[Raid, LVM_VolGroup, ZPool]

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1310,10 +1310,11 @@ class TestZPool(SubiTestCase):
             dict(type='disk', id=d2.id, path=d2.path, ptable=d2.ptable,
                  serial=d2.serial, info={d2.path: blockdevs[d2.path]}),
             dict(type='zpool', id='zpool-1', vdevs=[d1.id], pool='p1',
-                 mountpoint='/'),
+                 mountpoint='/', fs_properties=dict(canmount='on')),
             dict(type='zpool', id='zpool-2', vdevs=[d2.id], pool='p2',
                  mountpoint='/srv', fs_properties=dict(canmount='off')),
-            dict(type='zfs', id='zfs-1', volume='/ROOT', pool='zpool-1'),
+            dict(type='zfs', id='zfs-1', volume='/ROOT', pool='zpool-1',
+                 properties=dict(canmount='off')),
             dict(type='zfs', id='zfs-2', volume='/SRV/srv', pool='zpool-2',
                  properties=dict(mountpoint='/srv', canmount='on')),
         ]
@@ -1340,6 +1341,7 @@ class TestZPool(SubiTestCase):
         self.assertEqual('zfs-1', zfs_zp1.id)
         self.assertEqual(zp1, zfs_zp1.pool)
         self.assertEqual('/ROOT', zfs_zp1.volume)
+        self.assertEqual(None, zfs_zp1.path)
 
         self.assertTrue(isinstance(zfs_zp2, ZFS))
         self.assertEqual('zfs-2', zfs_zp2.id)
@@ -1361,19 +1363,14 @@ class TestRootfs(SubiTestCase):
         m.add_mount(fs, '/srv')
         self.assertFalse(m.is_root_mounted())
 
-    def test_zpool_may_provide_rootfs(self):
-        m = make_model()
-        make_zpool(model=m, mountpoint='/')
-        self.assertTrue(m.is_root_mounted())
-
     def test_zpool_not_rootfs_because_not_canmount(self):
         m = make_model()
-        make_zpool(model=m, mountpoint='/', fs_properties=dict(canmount='no'))
+        make_zpool(model=m, mountpoint='/', fs_properties=dict(canmount='off'))
         self.assertFalse(m.is_root_mounted())
 
     def test_zpool_rootfs_because_canmount(self):
         m = make_model()
-        make_zpool(model=m, mountpoint='/', fs_properties=dict(canmount='yes'))
+        make_zpool(model=m, mountpoint='/', fs_properties=dict(canmount='on'))
         self.assertTrue(m.is_root_mounted())
 
     def test_zpool_nonrootfs_mountpoint(self):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1299,30 +1299,52 @@ class TestZPool(SubiTestCase):
 
     def test_zpool_from_action(self):
         m = make_model()
-        d = make_disk(m)
+        d1 = make_disk(m)
+        d2 = make_disk(m)
         fake_up_blockdata(m)
         blockdevs = m._probe_data['blockdev']
         config = [
-            dict(type='disk', id=d.id, path=d.path, ptable=d.ptable,
-                 serial=d.serial, info={d.path: blockdevs[d.path]}),
-            dict(type='zpool', id='zpool-1', vdevs=[d.id], pool='p1',
+            dict(type='disk', id=d1.id, path=d1.path, ptable=d1.ptable,
+                 serial=d1.serial, info={d1.path: blockdevs[d1.path]}),
+            dict(type='disk', id=d2.id, path=d2.path, ptable=d2.ptable,
+                 serial=d2.serial, info={d2.path: blockdevs[d2.path]}),
+            dict(type='zpool', id='zpool-1', vdevs=[d1.id], pool='p1',
                  mountpoint='/'),
+            dict(type='zpool', id='zpool-2', vdevs=[d2.id], pool='p2',
+                 mountpoint='/srv', fs_properties=dict(canmount='off')),
             dict(type='zfs', id='zfs-1', volume='/ROOT', pool='zpool-1'),
+            dict(type='zfs', id='zfs-2', volume='/SRV/srv', pool='zpool-2',
+                 properties=dict(mountpoint='/srv', canmount='on')),
         ]
         objs = m._actions_from_config(
             config, blockdevs=None, is_probe_data=False)
-        actual_disk, zpool, zfs = objs
-        self.assertTrue(isinstance(zpool, ZPool))
-        self.assertEqual('zpool-1', zpool.id)
-        self.assertEqual([actual_disk], zpool.vdevs)
-        self.assertEqual('p1', zpool.pool)
-        self.assertEqual('/', zpool.mountpoint)
-        self.assertEqual([zfs], zpool._zfses)
+        actual_d1, actual_d2, zp1, zp2, zfs_zp1, zfs_zp2 = objs
+        self.assertTrue(isinstance(zp1, ZPool))
+        self.assertEqual('zpool-1', zp1.id)
+        self.assertEqual([actual_d1], zp1.vdevs)
+        self.assertEqual('p1', zp1.pool)
+        self.assertEqual('/', zp1.mountpoint)
+        self.assertEqual('/', zp1.path)
+        self.assertEqual([zfs_zp1], zp1._zfses)
 
-        self.assertTrue(isinstance(zfs, ZFS))
-        self.assertEqual('zfs-1', zfs.id)
-        self.assertEqual(zpool, zfs.pool)
-        self.assertEqual('/ROOT', zfs.volume)
+        self.assertTrue(isinstance(zp2, ZPool))
+        self.assertEqual('zpool-2', zp2.id)
+        self.assertEqual([actual_d2], zp2.vdevs)
+        self.assertEqual('p2', zp2.pool)
+        self.assertEqual('/srv', zp2.mountpoint)
+        self.assertEqual(None, zp2.path)
+        self.assertEqual([zfs_zp2], zp2._zfses)
+
+        self.assertTrue(isinstance(zfs_zp1, ZFS))
+        self.assertEqual('zfs-1', zfs_zp1.id)
+        self.assertEqual(zp1, zfs_zp1.pool)
+        self.assertEqual('/ROOT', zfs_zp1.volume)
+
+        self.assertTrue(isinstance(zfs_zp2, ZFS))
+        self.assertEqual('zfs-2', zfs_zp2.id)
+        self.assertEqual(zp2, zfs_zp2.pool)
+        self.assertEqual('/SRV/srv', zfs_zp2.volume)
+        self.assertEqual('/srv', zfs_zp2.path)
 
 
 class TestRootfs(SubiTestCase):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -255,10 +255,8 @@ def make_zpool(model=None, device=None, pool=None, mountpoint=None, **kw):
         device = make_disk(model)
     if pool is None:
         pool = f'pool{len(model._actions)}'
-    zpool = ZPool(m=model, vdevs=[device], pool=pool, mountpoint=mountpoint,
-                  **kw)
-    model._actions.append(zpool)
-    return zpool
+    return model.add_zpool(
+        device=device, pool=pool, mountpoint=mountpoint, **kw)
 
 
 def make_zfs(model, *, pool, **kw):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -483,9 +483,9 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertFalse(d1p2.preserve)
         self.assertFalse(d1p3.preserve)
         [rpool] = self.model._all(type='zpool', pool='rpool')
-        self.assertEqual('/', rpool.mount)
+        self.assertEqual('/', rpool.path)
         [bpool] = self.model._all(type='zpool', pool='bpool')
-        self.assertEqual('/boot', bpool.mount)
+        self.assertEqual('/boot', bpool.path)
 
     async def test_guided_zfs_BIOS_MSDOS(self):
         await self._guided_setup(Bootloader.BIOS, 'msdos')
@@ -499,9 +499,9 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertFalse(d1p1.preserve)
         self.assertFalse(d1p2.preserve)
         [rpool] = self.model._all(type='zpool', pool='rpool')
-        self.assertEqual('/', rpool.mount)
+        self.assertEqual('/', rpool.path)
         [bpool] = self.model._all(type='zpool', pool='bpool')
-        self.assertEqual('/boot', bpool.mount)
+        self.assertEqual('/boot', bpool.path)
 
     async def _guided_side_by_side(self, bl, ptable):
         await self._guided_setup(bl, ptable, storage_version=2)


### PR DESCRIPTION
Address action ordering with zpool/zfs objects - these objects are 'Mountlike' objects and may represent a viable mountpoint, which affects rootfs detection and the required ordering of curtin storage actions.
