### PR TITLE
Only consider size not in use when considering disks for guided reformat

### DIFF
--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -335,9 +335,7 @@ def can_be_boot_device(device, *,
 def _can_be_boot_device_disk(disk, *,
                              resize_partition=None, with_reformatting=False):
     if with_reformatting:
-        new_disk = attr.evolve(disk)
-        new_disk._partitions = [p for p in disk.partitions() if p._is_in_use]
-        disk = new_disk
+        disk = disk._reformatted()
     plan = get_boot_device_plan(disk, resize_partition=resize_partition)
     return plan is not None
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -534,6 +534,13 @@ class _Device(_Formattable, ABC):
     _partitions: List["Partition"] = attributes.backlink(
         default=attr.Factory(list))
 
+    def _reformatted(self):
+        # Return a ephemeral copy of the device with as many partitions
+        # deleted as possible.
+        new_disk = attr.evolve(self)
+        new_disk._partitions = [p for p in self.partitions() if p._is_in_use]
+        return new_disk
+
     def dasd(self):
         return None
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -943,18 +943,14 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
     async def test_in_use_too_small(self, bootloader, ptable):
         # Disks with "in use" partitions do not allow a reformat if
         # there is not enough space on the rest of the disk.
-        await self._setup(bootloader, ptable, fix_bios=True, size=5 << 30)
+        await self._setup(bootloader, ptable, fix_bios=True, size=25 << 30)
+        print(bootloader, ptable)
         make_partition(
             self.model, self.disk, preserve=True,
-            size=4 << 30, is_in_use=True)
+            size=23 << 30, is_in_use=True)
         make_partition(
             self.model, self.disk, preserve=True,
             size=gaps.largest_gap_size(self.disk))
-        expected = [
-            GuidedStorageTargetReformat(
-                disk_id=self.disk.id, allowed=default_capabilities),
-            GuidedStorageTargetManual(),
-            ]
         resp = await self.fsc.v2_guided_GET()
         expected = [
             GuidedStorageTargetReformat(


### PR DESCRIPTION
And as a bonus make the VariationInfo nicer.