### PR TITLE
tox: use skip_install to speed up black/isort

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,17 +2,18 @@
 envlist =
     black
     isort
-recreate = True
 
 [testenv]
 basepython = python3
 
 [testenv:black]
 deps = black ~= 23.0
+skip_install = True
 commands = {envpython} -m black \
     {posargs:console_conf subiquity subiquitycore system_setup}
 
 [testenv:isort]
 deps = isort == 5.12.0
+skip_install = True
 commands = {envpython} -m isort \
     {posargs:console_conf subiquity subiquitycore system_setup}


### PR DESCRIPTION
Skips the install when it's already there, does the right thing if .tox not present / old dependency / missing dependency.