### PR TITLE
Permit ESP on Raid if PowerEdge

### DIFF
--- a/subiquity/common/dmidecode.py
+++ b/subiquity/common/dmidecode.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from subiquitycore.utils import run_command
+
+
+def dmidecode_get(key: str) -> str:
+    """Retrieve a value from `dmidecode -s`
+    :param key: dmidecode(8) KEYWORD
+    :returns: stripped string output, or empty string on failure
+    """
+    sp = run_command(["dmidecode", "-s", key], check=False, text=True)
+    if sp.returncode == 0:
+        return sp.stdout.strip()
+    return ""

--- a/subiquity/common/filesystem/tests/test_boot.py
+++ b/subiquity/common/filesystem/tests/test_boot.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import Mock
+
+from subiquity.common.filesystem import boot
+from subiquity.models.filesystem import Bootloader
+from subiquity.models.tests.test_filesystem import make_model, make_raid
+
+
+class TestBootDevRaid(unittest.TestCase):
+    def test_bios(self):
+        raid = make_raid(make_model(Bootloader.BIOS))
+        self.assertFalse(boot.can_be_boot_device(raid))
+
+    def test_UEFI_no_container(self):
+        raid = make_raid(make_model(Bootloader.UEFI))
+        raid.container = None
+        self.assertFalse(boot.can_be_boot_device(raid))
+
+    def test_UEFI_container_imsm(self):
+        raid = make_raid(make_model(Bootloader.UEFI))
+        raid.container = Mock()
+        raid.container.metadata = "imsm"
+        self.assertTrue(boot.can_be_boot_device(raid))
+
+    def test_UEFI_container_non_imsm(self):
+        raid = make_raid(make_model(Bootloader.UEFI))
+        raid.container = Mock()
+        raid.container.metadata = "something else"
+        self.assertFalse(boot.can_be_boot_device(raid))

--- a/subiquity/common/tests/test_dmidecode.py
+++ b/subiquity/common/tests/test_dmidecode.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from subprocess import CompletedProcess
+from unittest import mock
+
+from subiquity.common.dmidecode import dmidecode_get
+
+
+class TestDmidecode(unittest.TestCase):
+    @mock.patch("subiquity.common.dmidecode.run_command")
+    def test_fail(self, run_cmd):
+        run_cmd.return_value = CompletedProcess([], 1)
+        self.assertEqual("", dmidecode_get("invalid-key"))
+
+    @mock.patch("subiquity.common.dmidecode.run_command")
+    def test_poweredge(self, run_cmd):
+        expected = "PowerEdge R6525"
+        run_cmd.return_value = CompletedProcess([], 0, stdout=expected)
+        self.assertEqual(expected, dmidecode_get("system-product-name"))


### PR DESCRIPTION
Per discussion in LP: #[1961079](https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/1961079), permit bootable raid if the system appears to be a "PowerEdge".

Tested only by way of CI.