### PR TITLE
Make sure journalctl -b is properly captured on shutdown

### DIFF
--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -120,7 +120,10 @@ class ShutdownController(SubiquityController):
         try:
             with open_perms(journal_txt) as output:
                 await self.app.command_runner.run(
-                    ["journalctl", "-b"], stdout=output, stderr=subprocess.STDOUT
+                    ["journalctl", "-b"],
+                    capture=True,
+                    stdout=output,
+                    stderr=subprocess.STDOUT,
                 )
         except Exception:
             log.exception("saving journal failed")

--- a/subiquity/server/runner.py
+++ b/subiquity/server/runner.py
@@ -70,12 +70,17 @@ class LoggedCommandRunner:
         return prefix + cmd
 
     async def start(
-        self, cmd: List[str], *, private_mounts: bool = False, capture: bool = False
+        self,
+        cmd: List[str],
+        *,
+        private_mounts: bool = False,
+        capture: bool = False,
+        **astart_kwargs,
     ) -> asyncio.subprocess.Process:
         forged: List[str] = self._forge_systemd_cmd(
             cmd, private_mounts=private_mounts, capture=capture
         )
-        proc = await astart_command(forged)
+        proc = await astart_command(forged, **astart_kwargs)
         proc.args = forged
         return proc
 
@@ -128,10 +133,17 @@ class DryRunCommandRunner(LoggedCommandRunner):
             return self.delay
 
     async def start(
-        self, cmd: List[str], *, private_mounts: bool = False, capture: bool = False
+        self,
+        cmd: List[str],
+        *,
+        private_mounts: bool = False,
+        capture: bool = False,
+        **astart_kwargs,
     ) -> asyncio.subprocess.Process:
         delay = self._get_delay_for_cmd(cmd)
-        proc = await super().start(cmd, private_mounts=private_mounts, capture=capture)
+        proc = await super().start(
+            cmd, private_mounts=private_mounts, capture=capture, **astart_kwargs
+        )
         await asyncio.sleep(delay)
         return proc
 

--- a/subiquity/server/tests/test_runner.py
+++ b/subiquity/server/tests/test_runner.py
@@ -14,7 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from unittest.mock import patch
+import subprocess
+from unittest.mock import ANY, patch
 
 from subiquity.server.runner import DryRunCommandRunner, LoggedCommandRunner
 from subiquitycore.tests import SubiTestCase
@@ -102,6 +103,15 @@ class TestLoggedCommandRunner(SubiTestCase):
             "/root",
         ]
         self.assertEqual(cmd, expected)
+
+    async def test_start(self):
+        runner = LoggedCommandRunner(ident="my-id", use_systemd_user=False)
+
+        with patch("subiquity.server.runner.astart_command") as astart_mock:
+            await runner.start(["/bin/ls"], stdout=subprocess.PIPE)
+
+        expected_cmd = ANY
+        astart_mock.assert_called_once_with(expected_cmd, stdout=subprocess.PIPE)
 
 
 class TestDryRunCommandRunner(SubiTestCase):


### PR DESCRIPTION
With recent changes, the `journalctl -b` command would fail to run:

```python
      File "subiquity/server/controllers/shutdown.py", line 118, in copy_logs_to_target
        await self.app.command_runner.run(
      File "subiquity/server/runner.py", line 98, in run
        proc = await self.start(cmd, **opts)
                     ^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: DryRunCommandRunner.start() got an unexpected keyword argument 'stdout'
```

Fixed by making sure that:
* the output of `journalctl -b` is captured instead of going into the journal (which in itself feels like a bug).
* the command runner expects the `stdout`, `stderr` and other possible keyword arguments.