### PR TITLE
filesystem: Use the first fitting gap for ESP, instead of the largest gap

### DIFF
--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -224,8 +224,22 @@ def get_add_part_plan(device, *, spec, args, resize_partition=None):
     # is a bad idea.  So avoid putting any sort of boot stuff on a logical -
     # it's probably a bad idea for all cases.
 
-    gap = gaps.largest_gap(device, in_extended=False)
-    if gap is not None and gap.size >= size and gap.is_usable:
+    # find the first available gap (not always the largest one)
+    gap = next(
+        iter(
+            [
+                gap
+                for gap in gaps.parts_and_gaps(device)
+                if isinstance(gap, gaps.Gap)
+                and not gap.in_extended
+                and gap.size >= size
+                and gap.is_usable
+            ]
+        ),
+        None,
+    )
+
+    if gap is not None:
         create_part_plan.gap = gap.split(size)[0]
         return create_part_plan
     elif resize_partition is not None and not resize_partition.is_logical:


### PR DESCRIPTION
This is to handle the issue, that when using recovery (reset) partition to install to the same disk, it:

  1. removes all partitions except recovery partition on the target disk, then
  2. picks the largest gap to install ESP, usually after the recovery partition.

This should not affect disk installation where the disk partitions are all removed, but affects installations where there are some partitions exist but not removed.