### PR TITLE
several: add --no-enhanced-secureboot flag

### DIFF
--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -129,6 +129,13 @@ def make_server_args_parser():
         default=".subiquity",
         help="in dryrun, control basedir of files",
     )
+    parser.add_argument(
+        "--no-enhanced-secureboot",
+        dest="enhanced_secureboot",
+        action="store_false",
+        default=True,
+    )
+
     parser.add_argument("--storage-version", action="store", type=int)
     parser.add_argument("--use-os-prober", action="store_true", default=False)
     parser.add_argument(

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -373,6 +373,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 system = await self._get_system(name, label)
             log.debug("got system %s for variation %s", system, name)
             if system is not None and len(system.volumes) > 0:
+                if not self.app.opts.enhanced_secureboot:
+                    log.debug("Not offering enhanced_secureboot: commandline disabled")
+                    continue
                 info = self.info_for_system(name, label, system)
                 if info is not None:
                     self._variation_info[name] = info
@@ -607,6 +610,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         disk = self.model._one(id=choice.target.disk_id)
 
         if self.is_core_boot_classic():
+            if not self.app.opts.enhanced_secureboot:
+                raise ValueError(
+                    "Not using enhanced_secureboot: disabled on commandline"
+                )
             assert isinstance(choice.target, GuidedStorageTargetReformat)
             self.use_tpm = choice.capability == GuidedCapability.CORE_BOOT_ENCRYPTED
             await self.guided_core_boot(disk)


### PR DESCRIPTION
It disables all core boot types really.  But this is the only planned core boot type at this point.

LP: #2030852