### PR TITLE
server: default uefi on dryrun

### DIFF
--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -168,6 +168,8 @@ def main():
         if opts.snaps_from_examples is None:
             opts.snaps_from_examples = True
         logdir = opts.output_base
+        if opts.bootloader is None:
+            opts.bootloader = "uefi"
     else:
         dr_cfg = None
     if opts.socket is None:


### PR DESCRIPTION
Detecting the bootloader is an obvious choice for real installs, but is a source of glitches in CI.  Default to UEFI, and if tests want something else they should pass a specific --bootloader.