### PR TITLE
refresh: fix crash during autoinstall

### DIFF
--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -229,7 +229,7 @@ class RefreshController(SubiquityController):
         return change
 
     async def GET(self, wait: bool = False) -> RefreshStatus:
-        if wait:
+        if self.active and wait:
             await self.check_task.wait()
         return self.status
 


### PR DESCRIPTION
Controllers have started, but we have decided that no refresh check is needed, so no check_task was started (or assigned).

GET /refresh is called, resulting in:
DEBUG subiquity.server.server:446 request to /refresh?wait=true crashed Traceback (most recent call last):
  File "subiquity/server/controllers/refresh.py", line 233, in GET
    await self.check_task.wait()
AttributeError: 'NoneType' object has no attribute 'wait'