### PR TITLE
oem+drivers: fix wrong order or lower layers when building overlays

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -268,9 +268,9 @@ class AptConfigurer:
     async def overlay(self):
         overlay = await self.mounter.setup_overlay(
             [
-                self.install_tree.upperdir,
-                self.configured_tree.upperdir,
                 self.source_path,
+                self.configured_tree.upperdir,
+                self.install_tree.upperdir,
             ]
         )
         try:

--- a/subiquity/server/mounter.py
+++ b/subiquity/server/mounter.py
@@ -155,6 +155,15 @@ class Mounter:
                 path.unlink(missing_ok=True)
 
     async def setup_overlay(self, lowers: List[Lower]) -> OverlayMountpoint:
+        """Setup a RW overlay FS over one or more lower layers.
+        Be careful, when multiple lower layers are specified, they are stacked
+        from the leftmost one and going right. This is the opposite of what the
+        lowerdir mount option expects.
+        Therefore, when calling setup_overlay([x, y, z]), the corresponding
+        mount command will look something like:
+        $ mount [...] -o lowerdir=z:y:x
+        Which means z will be top, y will be middle and x will be bottom.
+        """
         tdir = self.tmpfiles.tdir()
         target = f"{tdir}/mount"
         lowerdir = lowerdir_for(lowers)


### PR DESCRIPTION
When doing an offline install, ubuntu-drivers would sometimes list a package that is available in the archive but not present in the pool. This would lead to a failed install when trying to download/install such package.

This is not something we would expect since we run apt-get update (with only the pool configured when offline) in the install tree.

However, it turned out that we create the overlay with the lower layers specified in the wrong order - which essentially makes APT indexes visible in the source tree also visible in the OEM/third-party driver overlay.

When calling `setup_overlay(lowers=[a, b, c])`, Subiquity invokes mount with `lowerdir=c:b:a` (in the reverse order).

This means that c is top, b is middle and a is bottom.

For the OEM and third-party drivers, we build overlays that are based on:

 * the source tree
 * the configured tree
 * the install tree

Unfortunately, we were doing the opposite. Fixed by reversing the order of the lower layers.