### PR TITLE
Min size revisited

### DIFF
--- a/examples/sources/desktop.yaml
+++ b/examples/sources/desktop.yaml
@@ -1,23 +1,3 @@
-- description:
-    en: A minimal but usable Ubuntu Desktop.
-  id: ubuntu-desktop-minimal
-  locale_support: langpack
-  name:
-    en: Ubuntu Desktop (minimized)
-  path: minimal.squashfs
-  preinstalled_langs:
-  - de
-  - en
-  - es
-  - fr
-  - it
-  - pt
-  - ru
-  - zh
-  - ''
-  size: 6135083008
-  type: fsimage-layered
-  variant: desktop
 - default: true
   description:
     en: A full featured Ubuntu Desktop.
@@ -25,7 +5,7 @@
   locale_support: langpack
   name:
     en: Ubuntu Desktop
-  path: minimal.standard.squashfs
+  path: standard.squashfs
   preinstalled_langs:
   - de
   - en
@@ -36,6 +16,14 @@
   - ru
   - zh
   - ''
-  size: 7604871168
+  size: 4033826816
   type: fsimage-layered
   variant: desktop
+  variations:
+    enhanced-secureboot:
+      path: standard.enhanced-secureboot.squashfs
+      size: 4336062464
+      snapd_system_label: enhanced-secureboot-desktop
+    standard:
+      path: standard.squashfs
+      size: 4033826816

--- a/subiquity/common/filesystem/tests/test_sizes.py
+++ b/subiquity/common/filesystem/tests/test_sizes.py
@@ -140,37 +140,29 @@ class TestCalculateGuidedResize(unittest.TestCase):
 
 
 class TestCalculateInstallMin(unittest.TestCase):
-    @mock.patch("subiquity.common.filesystem.sizes.swap.suggested_swapsize")
+    @mock.patch("subiquity.common.filesystem.sizes.uefi_scale")
     @mock.patch("subiquity.common.filesystem.sizes.bootfs_scale")
-    def test_small_setups(self, bootfs_scale, swapsize):
-        swapsize.return_value = 1 << 30
-        bootfs_scale.maximum = 1 << 30
+    def test_small_setups(self, bootfs_scale, uefi_scale):
+        uefi_scale.minimum = 1 << 30
+        bootfs_scale.minimum = 1 << 30
         source_min = 1 << 30
         # with a small source, we hit the default 2GiB padding
         self.assertEqual(5 << 30, calculate_suggested_install_min(source_min))
 
-    @mock.patch("subiquity.common.filesystem.sizes.swap.suggested_swapsize")
+    @mock.patch("subiquity.common.filesystem.sizes.uefi_scale")
     @mock.patch("subiquity.common.filesystem.sizes.bootfs_scale")
-    def test_small_setups_big_swap(self, bootfs_scale, swapsize):
-        swapsize.return_value = 10 << 30
-        bootfs_scale.maximum = 1 << 30
+    def test_small_setups_big_boot(self, bootfs_scale, uefi_scale):
+        uefi_scale.minimum = 1 << 30
+        bootfs_scale.minimum = 10 << 30
         source_min = 1 << 30
         self.assertEqual(14 << 30, calculate_suggested_install_min(source_min))
 
-    @mock.patch("subiquity.common.filesystem.sizes.swap.suggested_swapsize")
+    @mock.patch("subiquity.common.filesystem.sizes.uefi_scale")
     @mock.patch("subiquity.common.filesystem.sizes.bootfs_scale")
-    def test_small_setups_big_boot(self, bootfs_scale, swapsize):
-        swapsize.return_value = 1 << 30
-        bootfs_scale.maximum = 10 << 30
-        source_min = 1 << 30
-        self.assertEqual(14 << 30, calculate_suggested_install_min(source_min))
-
-    @mock.patch("subiquity.common.filesystem.sizes.swap.suggested_swapsize")
-    @mock.patch("subiquity.common.filesystem.sizes.bootfs_scale")
-    def test_big_source(self, bootfs_scale, swapsize):
-        swapsize.return_value = 1 << 30
-        bootfs_scale.maximum = 2 << 30
+    def test_big_source(self, bootfs_scale, uefi_scale):
+        uefi_scale.minimum = 1 << 30
+        bootfs_scale.minimum = 2 << 30
         source_min = 10 << 30
-        # a bigger source should hit 80% padding
-        expected = (10 + 8 + 1 + 2) << 30
+        # a bigger source should hit 50% padding
+        expected = (10 + 5 + 1 + 2) << 30
         self.assertEqual(expected, calculate_suggested_install_min(source_min))

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -157,13 +157,8 @@ class VariationInfo:
     def capability_info_for_gap(
         self,
         gap: gaps.Gap,
+        install_min: int,
     ) -> CapabilityInfo:
-        if self.label is None:
-            install_min = sizes.calculate_suggested_install_min(
-                self.min_size, gap.device.alignment_data().part_align
-            )
-        else:
-            install_min = self.min_size
         r = CapabilityInfo()
         r.disallowed = list(self.capability_info.disallowed)
         if self.capability_info.allowed and gap.size < install_min:
@@ -1015,7 +1010,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             capability_info = CapabilityInfo()
             for variation in self._variation_info.values():
                 gap = gaps.largest_gap(disk._reformatted())
-                capability_info.combine(variation.capability_info_for_gap(gap))
+                capability_info.combine(
+                    variation.capability_info_for_gap(gap, install_min)
+                )
             reformat = GuidedStorageTargetReformat(
                 disk_id=disk.id,
                 allowed=capability_info.allowed,
@@ -1042,7 +1039,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             for variation in self._variation_info.values():
                 if variation.is_core_boot_classic():
                     continue
-                capability_info.combine(variation.capability_info_for_gap(gap))
+                capability_info.combine(
+                    variation.capability_info_for_gap(gap, install_min)
+                )
             api_gap = labels.for_client(gap)
             use_gap = GuidedStorageTargetUseGap(
                 disk_id=disk.id,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -70,6 +70,7 @@ from subiquity.models.filesystem import (
     _Device,
     align_down,
     align_up,
+    humanize_size,
 )
 from subiquity.server import snapdapi
 from subiquity.server.controller import SubiquityController
@@ -926,7 +927,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         align = max(
             (pa.part_align for pa in self.model._partition_alignment_data.values())
         )
-        return sizes.calculate_suggested_install_min(source_min, align)
+        install_min = sizes.calculate_suggested_install_min(source_min, align)
+        log.debug(f"suggested install minimum size: {humanize_size(install_min)}")
+        return install_min
 
     async def get_v2_storage_response(self, model, wait, include_raid):
         probe_resp = await self._probe_response(wait, StorageResponseV2)

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -386,7 +386,7 @@ class TestFlow(TestAPI):
         cfg = self.machineConfig("examples/machines/simple.json")
         with cfg.edit() as data:
             attrs = data["storage"]["blockdev"]["/dev/sda"]["attrs"]
-            attrs["size"] = str(25 << 30)
+            attrs["size"] = str(10 << 30)
         extra_args = ["--source-catalog", "examples/sources/desktop.yaml"]
         async with start_server(cfg, extra_args=extra_args) as inst:
             disk_id = "disk-sda"


### PR DESCRIPTION
* if a source entry has variations, use the install_min of the largest of the variations
* several tweaks to suggested min install size
* clearer logging of this outcome
* refresh the desktop install sources yaml

analysis of the above

```
10G drive tests
no case here creates a swapfile

CORE_BOOT_ENCRYPTED, canary iso build 20230831.7
  $ df -h -x tmpfs
  Filesystem      Size  Used Avail Use% Mounted on
  /dev/vda2       721M   61M  609M   9% /run/mnt/ubuntu-boot
  /dev/vda1       749M  3.7M  745M   1% /run/mnt/ubuntu-seed
  /dev/dm-0       8.3G  4.4G  3.5G  56% /
  /dev/dm-1        20M  120K   18M   1% /var/lib/snapd/save

  suggested install minimum size: 8.339G
  catalog size: 4.042G
  calculated min_size (end offset of last partition): 5.497G

LVM_LUKS, canary iso build 20230831.7
  $ df -h -x tmpfs
  Filesystem                         Size  Used Avail Use% Mounted on
  /dev/mapper/ubuntu--vg-ubuntu--lv  7.5G  4.9G  2.2G  69% /
  /dev/vda2                          1.7G  137M  1.5G   9% /boot
  /dev/vda1                          537M  6.1M  531M   2% /boot/efi

  suggested install minimum size: 8.339G
  catalog size: 3.77G

LVM_LUKS, desktop iso build 20230831.4
  $ df -h -x tmpfs
  Filesystem                         Size  Used Avail Use% Mounted on
  /dev/mapper/ubuntu--vg-ubuntu--lv  7.5G  4.9G  2.3G  68% /
  /dev/vda2                          1.7G  137M  1.5G   9% /boot
  /dev/vda1                          537M  6.1M  531M   2% /boot/efi

  suggested install minimum size: 9.644G
  catalog size: 4.91G

LVM_LUKS, live-server iso build 20230831
  $ df -h -x tmpfs
  Filesystem                         Size  Used Avail Use% Mounted on
  /dev/mapper/ubuntu--vg-ubuntu--lv  7.5G  2.5G  4.7G  36% /
  /dev/vda2                          1.7G  142M  1.5G   9% /boot
  /dev/vda1                          537M  6.1M  531M   2% /boot/efi

  using source: ubuntu-server
  suggested install minimum size: 5.530G
  catalog size: 1.25G
```