### PR TITLE
snapcraft: update curtin for apt distro fix

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: bdd9069835f8e2c8e42b997c2d7a367ad7359882
+    source-commit: 307b32f7bf7eebc32f81b1f0f2f17184a7cffb22
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Includes the following changes:

Dan Bungert (2):
      swap: add logging
      docs: link to sources.list manpage for apt deb822

Michael Hudson-Doyle (2):
      distro: remove disabling of deb-src lines in apt_update
      distro: remove even more code from apt_update
