### PR TITLE
Disallow core boot if searching for third party drivers

### DIFF
--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -139,9 +139,15 @@ The version of Subiquity released with 20.04 GA does not accept `null` for this 
 
 #### search_drivers
 **type:** boolean
-**default:** `true`
+**default:** `true` (mostly, see below)
 
-Whether the installer should search for available third-party drivers. When set to `false`, it disables the drivers screen and [section](#drivers).
+Whether the installer should search for available third-party
+drivers. When set to `false`, it disables the drivers screen and
+[section](#drivers).
+
+The default is true for most installs but false when a "core boot" or
+"enhanced secure boot" method is selected (where third-party drivers
+cannot currently be installed).
 
 #### id
 **type:** string

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -387,6 +387,7 @@ class GuidedCapability(enum.Enum):
 class GuidedDisallowedCapabilityReason(enum.Enum):
     TOO_SMALL = enum.auto()
     CORE_BOOT_ENCRYPTION_UNAVAILABLE = enum.auto()
+    NOT_UEFI = enum.auto()
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -388,6 +388,7 @@ class GuidedDisallowedCapabilityReason(enum.Enum):
     TOO_SMALL = enum.auto()
     CORE_BOOT_ENCRYPTION_UNAVAILABLE = enum.auto()
     NOT_UEFI = enum.auto()
+    THIRD_PARTY_DRIVERS = enum.auto()
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/server/controllers/drivers.py
+++ b/subiquity/server/controllers/drivers.py
@@ -21,6 +21,7 @@ from subiquity.common.apidef import API
 from subiquity.common.types import DriversPayload, DriversResponse
 from subiquity.server.apt import OverlayCleanupError
 from subiquity.server.controller import SubiquityController
+from subiquity.server.controllers.source import SEARCH_DRIVERS_AUTOINSTALL_DEFAULT
 from subiquity.server.types import InstallerChannels
 from subiquity.server.ubuntu_drivers import (
     CommandNotFoundError,
@@ -123,6 +124,8 @@ class DriversController(SubiquityController):
             await self.list_drivers_done_event.wait()
 
         search_drivers = self.app.controllers.Source.model.search_drivers
+        if search_drivers is SEARCH_DRIVERS_AUTOINSTALL_DEFAULT:
+            search_drivers = True
 
         return DriversResponse(
             install=self.model.do_install,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -419,7 +419,23 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                     info.capability_info.disallow_if(
                         lambda cap: cap.is_core_boot(),
                         GuidedDisallowedCapabilityReason.NOT_UEFI,
-                        "Enhanced secure boot options only available on UEFI systems.",
+                        _(
+                            "Enhanced secure boot options only available on UEFI "
+                            "systems."
+                        ),
+                    )
+                if self.app.base_model.source.search_drivers:
+                    log.debug(
+                        "Disabling core boot based install options as third-party "
+                        "drivers selected"
+                    )
+                    info.capability_info.disallow_if(
+                        lambda cap: cap.is_core_boot(),
+                        GuidedDisallowedCapabilityReason.THIRD_PARTY_DRIVERS,
+                        _(
+                            "Enhanced secure boot options cannot currently install "
+                            "third party drivers."
+                        ),
                     )
                 self._variation_info[name] = info
             elif catalog_entry.type.startswith("dd-"):

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -74,6 +74,7 @@ from subiquity.models.filesystem import (
 )
 from subiquity.server import snapdapi
 from subiquity.server.controller import SubiquityController
+from subiquity.server.controllers.source import SEARCH_DRIVERS_AUTOINSTALL_DEFAULT
 from subiquity.server.mounter import Mounter
 from subiquity.server.snapdapi import (
     StorageEncryptionSupport,
@@ -292,6 +293,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self._configured = True
         if self._info is None:
             self.set_info_for_capability(GuidedCapability.DIRECT)
+        if (
+            self.app.base_model.source.search_drivers
+            is SEARCH_DRIVERS_AUTOINSTALL_DEFAULT
+        ):
+            self.app.base_model.source.search_drivers = not self.is_core_boot_classic()
         await super().configured()
         self.stop_listening_udev()
 
@@ -424,7 +430,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                             "systems."
                         ),
                     )
-                if self.app.base_model.source.search_drivers:
+                search_drivers = self.app.base_model.source.search_drivers
+                if (
+                    search_drivers is not SEARCH_DRIVERS_AUTOINSTALL_DEFAULT
+                    and search_drivers
+                ):
                     log.debug(
                         "Disabling core boot based install options as third-party "
                         "drivers selected"

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -419,6 +419,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                     info.capability_info.disallow_if(
                         lambda cap: cap.is_core_boot(),
                         GuidedDisallowedCapabilityReason.NOT_UEFI,
+                        "Enhanced secure boot options only available on UEFI systems.",
                     )
                 self._variation_info[name] = info
             elif catalog_entry.type.startswith("dd-"):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -1144,6 +1144,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.app.dr_cfg = DRConfig()
         self.app.dr_cfg.systems_dir_exists = True
         self.app.controllers.Source.get_handler.return_value = TrivialSourceHandler("")
+        self.app.base_model.source.search_drivers = False
         self.fsc = FilesystemController(app=self.app)
         self.fsc._configured = True
         self.fsc.model = make_model(Bootloader.UEFI)

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -235,6 +235,15 @@ class GuidedChoiceForm(SubForm):
             self.use_tpm.help = self.tpm_choice.help
             self.use_tpm.help = self.tpm_choice.help.format(reason=reason)
         else:
+            self.use_tpm.enabled = False
+            core_boot_disallowed = [
+                d for d in val.disallowed if d.capability.is_core_boot()
+            ]
+            if core_boot_disallowed:
+                self.use_tpm.help = core_boot_disallowed[0].message
+            else:
+                self.use_tpm.help = ""
+
             self.tpm_choice = None
 
     def _toggle_lvm(self, sender, val):


### PR DESCRIPTION
This disables core boot options if the user selected "search for third party drivers".

It also adapts the recent fix to not offer core boot options on non-UEFI systems to indicate that this is happening via a disallowed guided option.