### PR TITLE
network: fix Wi-Fi interfaces not listed in dry-run

### DIFF
--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -108,23 +108,7 @@ class NetworkController(BaseNetworkController, SubiquityController):
         return self.app.package_installer.state_for_pkg("wpasupplicant")
 
     async def _install_wpasupplicant(self):
-        if self.opts.dry_run:
-
-            async def fake_install(pkgname: str) -> PackageInstallState:
-                await asyncio.sleep(10 / self.app.scale_factor)
-                a = "DONE"
-                for k in self.app.debug_flags:
-                    if k.startswith("wlan_install="):
-                        a = k.split("=", 2)[1]
-                return getattr(PackageInstallState, a)
-
-            install_coro = fake_install
-        else:
-            install_coro = None
-
-        r = await self.app.package_installer.install_pkg(
-            "wpasupplicant", install_coro=install_coro
-        )
+        r = await self.app.package_installer.install_pkg("wpasupplicant")
         log.debug("wlan_support_install_finished %s", r)
         self._call_clients("wlan_support_install_finished", r)
         if r == PackageInstallState.DONE:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -44,7 +44,7 @@ from subiquity.server.controller import SubiquityController
 from subiquity.server.dryrun import DRConfig
 from subiquity.server.errors import ErrorController
 from subiquity.server.geoip import DryRunGeoIPStrategy, GeoIP, HTTPGeoIPStrategy
-from subiquity.server.pkghelper import PackageInstaller
+from subiquity.server.pkghelper import get_package_installer
 from subiquity.server.runner import get_command_runner
 from subiquity.server.snapdapi import make_api_client
 from subiquity.server.types import InstallerChannels
@@ -291,7 +291,7 @@ class SubiquityServer(Application):
         self.event_syslog_id = "subiquity_event.{}".format(os.getpid())
         self.log_syslog_id = "subiquity_log.{}".format(os.getpid())
         self.command_runner = get_command_runner(self)
-        self.package_installer = PackageInstaller(self)
+        self.package_installer = get_package_installer(self)
 
         self.error_reporter = ErrorReporter(
             self.context.child("ErrorReporter"), self.opts.dry_run, self.root

--- a/subiquity/server/tests/test_pkghelper.py
+++ b/subiquity/server/tests/test_pkghelper.py
@@ -1,0 +1,101 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional
+from unittest.mock import Mock, patch
+
+import attr
+
+from subiquity.server.pkghelper import PackageInstaller, PackageInstallState
+from subiquitycore.tests import SubiTestCase
+from subiquitycore.tests.mocks import make_app
+
+
+@patch("apt.Cache", Mock(return_value={}))
+class TestPackageInstaller(SubiTestCase):
+    class Package:
+        @attr.s(auto_attribs=True)
+        class Candidate:
+            uri: str
+
+        def __init__(
+            self, installed: bool, name: str, candidate_uri: Optional[str] = None
+        ) -> None:
+            self.installed = installed
+            self.name = name
+            if candidate_uri is None:
+                self.candidate = None
+            else:
+                self.candidate = self.Candidate(uri=candidate_uri)
+
+    def setUp(self):
+        self.pkginstaller = PackageInstaller(make_app())
+
+    async def test_install_pkg_not_found(self):
+        self.assertEqual(
+            await self.pkginstaller.install_pkg("sysvinit-core"),
+            PackageInstallState.NOT_AVAILABLE,
+        )
+
+    async def test_install_pkg_already_installed(self):
+        with patch.dict(
+            self.pkginstaller.cache,
+            {"util-linux": self.Package(installed=True, name="util-linux")},
+        ):
+            self.assertEqual(
+                await self.pkginstaller.install_pkg("util-linux"),
+                PackageInstallState.DONE,
+            )
+
+    async def test_install_pkg_dr_install(self):
+        with patch.dict(
+            self.pkginstaller.cache,
+            {"python3-attr": self.Package(installed=False, name="python3-attr")},
+        ):
+            with patch("subiquity.server.pkghelper.asyncio.sleep") as sleep:
+                self.assertEqual(
+                    await self.pkginstaller.install_pkg("python3-attr"),
+                    PackageInstallState.DONE,
+                )
+        sleep.assert_called_once()
+
+    async def test_install_pkg_not_from_cdrom(self):
+        with patch.dict(
+            self.pkginstaller.cache,
+            {
+                "python3-attr": self.Package(
+                    installed=False,
+                    name="python3-attr",
+                    candidate_uri="http://archive.ubuntu.com",
+                )
+            },
+        ):
+            with patch.object(self.pkginstaller.app.opts, "dry_run", False):
+                self.assertEqual(
+                    await self.pkginstaller.install_pkg("python3-attr"),
+                    PackageInstallState.NOT_AVAILABLE,
+                )
+
+    async def test_install_pkg_alternative_impl(self):
+        async def impl(pkgname: str) -> PackageInstallState:
+            return PackageInstallState.FAILED
+
+        with patch.object(self.pkginstaller, "_install_pkg") as default_impl:
+            self.assertEqual(
+                await self.pkginstaller.install_pkg("python3-attr", install_coro=impl),
+                PackageInstallState.FAILED,
+            )
+
+        default_impl.assert_not_called()


### PR DESCRIPTION
When a Wi-Fi interface is present in the machine configuration (e.g., mwhudson.json), the GUI seemingly ignores it. This happens because there is a filter on the server side which only returns Wi-Fi interfaces if the wlan_support_install_state() function returns
PackageInstallState.DONE.

However, calling the /network endpoint shows that the state is set to the wrong value:

```json
 {"wlan_support_install_state": "NOT_NEEDED"}
```

This turns out to be inconsistent because:
 * we lean on a PackageInstaller instance to tell if wpasupplicant is installed (this is what the wlan_support_install_state() function reflects) ; but
 * in dry-run mode, we pretend to install wpasupplicant without actually relying on the PackageInstaller instance.

Fixed by using the PackageInstaller instance to install the wpasupplicant package - with a special implementation that only pretends to install it. This is enough to make the PackageInstaller instance think the package is installed.