### PR TITLE
network: fix crash upon accessing Help menu after creating a bond

### DIFF
--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -255,6 +255,8 @@ class NetworkController(BaseNetworkController, SubiquityController):
     async def global_addresses_GET(self) -> List[str]:
         ips: List[str] = []
         for dev in self.model.get_all_netdevs():
+            if dev.info is None:
+                continue
             ips.extend(map(str, dev.actual_global_ip_addresses))
         return ips
 

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -114,6 +114,8 @@ class MetaController:
         ips: List[str] = []
         if self.app.base_model.network:
             for dev in self.app.base_model.network.get_all_netdevs():
+                if dev.info is None:
+                    continue
                 ips.extend(map(str, dev.actual_global_ip_addresses))
         if not ips:
             return None

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -21,6 +21,7 @@ from socket import AF_INET, AF_INET6
 from typing import Dict, List, Optional
 
 import attr
+import probert.network
 import yaml
 
 from subiquitycore import netplan
@@ -189,13 +190,16 @@ class BondParameters:
     ]
 
 
-class NetworkDev(object):
+class NetworkDev:
     def __init__(self, model, name, typ):
         self._model = model
         self._name = name
         self.type = typ
         self.config = {}
-        self.info = None
+        # Devices that have been configured in Subiquity but do not (yet) exist
+        # on the system have their "info" field set to None. Once they exist,
+        # probert should pass on the information through a call to new_link().
+        self.info: Optional[probert.network.Link] = None
         self.disabled_reason = None
         self.dhcp_events = {}
         self._dhcp_state = {


### PR DESCRIPTION
Steps to reproduce (works in dry-run mode too):

1. Navigate to the network page.
2. Create a bond
3. Go to the help menu

```python
 Traceback (most recent call last):
   File "subiquity/common/api/server.py", line 164, in handler
     result = await implementation(**args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "subiquity/server/server.py", line 117, in ssh_info_GET
     ips.extend(map(str, dev.actual_global_ip_addresses))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "subiquitycore/models/network.py", line 394, in actual_global_ip_addresses
     for _, addr in sorted(self.info.addresses.items())
                           ^^^^^^^^^^^^^^^^^^^
 AttributeError: 'NoneType' object has no attribute 'addresses'
```