### PR TITLE
storage: fix crash when guided and a small disk

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -162,7 +162,11 @@ class VariationInfo:
     ) -> CapabilityInfo:
         r = CapabilityInfo()
         r.disallowed = list(self.capability_info.disallowed)
-        if self.capability_info.allowed and gap.size < install_min:
+        if gap is None:
+            gap_size = 0
+        else:
+            gap_size = gap.size
+        if self.capability_info.allowed and gap_size < install_min:
             for capability in self.capability_info.allowed:
                 r.disallowed.append(
                     GuidedDisallowedCapability(


### PR DESCRIPTION
In LP: #2034270, a 1MiB disk is present.  This is triggering a crash while attempting to decide if we can do a guided install.