### PR TITLE
Ensure the security archive is set to the proper URL

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -54,6 +54,18 @@ validate () {
                 ;;
             *)
                 python3 scripts/validate-autoinstall-user-data.py < $tmpdir/var/log/installer/autoinstall-user-data
+                # After the lunar release and the introduction of mirror testing, it
+                # came to our attention that new Ubuntu installations have the security
+                # repository configured with the primary mirror URL (i.e.,
+                # http://<cc>.archive.ubuntu.com/ubuntu) instead of
+                # http://security.ubuntu.com/ubuntu. Let's ensure we instruct curtin
+                # not to do that.
+                # If we run an autoinstall that customizes the security section as part
+                # of the test-suite, we will need to adapt this test.
+                python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/subiquity-curtin-apt.conf \
+                    apt.security[0].uri='"http://security.ubuntu.com/ubuntu/"' \
+                    apt.security[0].arches='["amd64", "i386"]' \
+                    apt.security[1].uri='"http://ports.ubuntu.com/ubuntu-ports"'
                 ;;
         esac
         netplan generate --root $tmpdir

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 307b32f7bf7eebc32f81b1f0f2f17184a7cffb22
+    source-commit: d5f5dde574aca60935fc9e1acf9cb669e24f22de
 
     override-pull: |
       craftctl default

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -323,7 +323,15 @@ class MirrorModel(object):
 
     def get_apt_config_staged(self) -> Dict[str, Any]:
         assert self.primary_staged is not None
-        return self._get_apt_config_using_candidate(self.primary_staged)
+        config = self._get_apt_config_using_candidate(self.primary_staged)
+
+        # For mirror testing, we disable the -security suite - so that we only
+        # test the primary mirror, not the security archive.
+        if "disable_suites" not in config:
+            config["disable_suites"]: List[str] = []
+        if "security" not in config["disable_suites"]:
+            config["disable_suites"].append("security")
+        return config
 
     def get_apt_config_elected(self) -> Dict[str, Any]:
         assert self.primary_elected is not None

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -81,6 +81,8 @@ from urllib import parse
 import attr
 from curtin.commands.apt_config import (
     PORTS_ARCHES,
+    PORTS_MIRRORS,
+    PRIMARY_ARCH_MIRRORS,
     PRIMARY_ARCHES,
     get_arch_mirrorconfig,
     get_mirror,
@@ -96,8 +98,8 @@ except ImportError:
 
 log = logging.getLogger("subiquity.models.mirror")
 
-DEFAULT_SUPPORTED_ARCHES_URI = "http://archive.ubuntu.com/ubuntu"
-DEFAULT_PORTS_ARCHES_URI = "http://ports.ubuntu.com/ubuntu-ports"
+DEFAULT_SUPPORTED_ARCHES_URI = PRIMARY_ARCH_MIRRORS["PRIMARY"]
+DEFAULT_PORTS_ARCHES_URI = PORTS_MIRRORS["PRIMARY"]
 
 LEGACY_DEFAULT_PRIMARY_SECTION = [
     {
@@ -107,6 +109,17 @@ LEGACY_DEFAULT_PRIMARY_SECTION = [
     {
         "arches": ["default"],
         "uri": DEFAULT_PORTS_ARCHES_URI,
+    },
+]
+
+DEFAULT_SECURITY_SECTION = [
+    {
+        "arches": PRIMARY_ARCHES,
+        "uri": PRIMARY_ARCH_MIRRORS["SECURITY"],
+    },
+    {
+        "arches": PORTS_ARCHES,
+        "uri": PORTS_MIRRORS["SECURITY"],
     },
 ]
 
@@ -312,6 +325,10 @@ class MirrorModel(object):
 
         config = copy.deepcopy(self.config)
         config["disable_components"] = sorted(self.disabled_components)
+
+        if "security" not in config:
+            config["security"] = DEFAULT_SECURITY_SECTION
+
         return config
 
     def _get_apt_config_using_candidate(

--- a/subiquity/models/tests/test_mirror.py
+++ b/subiquity/models/tests/test_mirror.py
@@ -290,3 +290,52 @@ class TestMirrorModel(unittest.TestCase):
         )
         with country_mirror_candidates:
             self.assertTrue(self.model.wants_geoip())
+
+    def test_get_apt_config_staged_default_config(self):
+        self.model.legacy_primary = False
+        self.model.primary_candidates = [
+            PrimaryEntry(
+                uri="http://mirror.local/ubuntu", arches=None, parent=self.model
+            ),
+        ]
+        self.model.primary_candidates[0].stage()
+        config = self.model.get_apt_config_staged()
+        self.assertEqual(
+            config["primary"],
+            [
+                {
+                    "uri": "http://mirror.local/ubuntu",
+                    "arches": ["default"],
+                }
+            ],
+        )
+        self.assertEqual(
+            set(config["disable_components"]), set(self.model.disabled_components)
+        )
+        self.assertEqual(set(config["disable_suites"]), {"security"})
+
+    def test_get_apt_config_staged_with_config(self):
+        self.model.legacy_primary = False
+        self.model.primary_candidates = [
+            PrimaryEntry(
+                uri="http://mirror.local/ubuntu", arches=None, parent=self.model
+            ),
+        ]
+        self.model.primary_candidates[0].stage()
+        self.model.config = {
+            "disable_suites": ["updates"],
+        }
+        config = self.model.get_apt_config_staged()
+        self.assertEqual(
+            config["primary"],
+            [
+                {
+                    "uri": "http://mirror.local/ubuntu",
+                    "arches": ["default"],
+                }
+            ],
+        )
+        self.assertEqual(
+            set(config["disable_components"]), set(self.model.disabled_components)
+        )
+        self.assertEqual(set(config["disable_suites"]), {"security", "updates"})


### PR DESCRIPTION
A regression was introduced as part of mirror testing.

On new Ubuntu installations, the -security pocket is accessed through the primary mirror instead of being accessed through security.ubuntu.com/ubuntu (or ports.ubuntu.com/ubuntu-ports)

This happens because when no `security` section is provided to curtin, the value configured in the `primary` section is reused.

We now ensure that the right URI is used for the security repository.

It has a slight impact on the behavior of mirror testing though. Instead of downloading content from the primary repository only, we would download content from the primary+security repository. Therefore, we would try all the candidate mirrors without success is the security repository is unreachable. To work around this issue, we now disable the -security suite when running mirror testing. This requires a fix in curtin for releases that use deb822 sources: https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/450893