### PR TITLE
Fix snap build, and CI enforce it

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,10 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  snap-build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -21,7 +21,6 @@ from socket import AF_INET, AF_INET6
 from typing import Dict, List, Optional
 
 import attr
-import probert.network
 import yaml
 
 from subiquitycore import netplan
@@ -196,10 +195,15 @@ class NetworkDev:
         self._name = name
         self.type = typ
         self.config = {}
+
+        # import done here to break a chain where anybody importing
+        # subiquity.common.types has to have probert
+        from probert.network import Link
+
         # Devices that have been configured in Subiquity but do not (yet) exist
         # on the system have their "info" field set to None. Once they exist,
         # probert should pass on the information through a call to new_link().
-        self.info: Optional[probert.network.Link] = None
+        self.info: Optional[Link] = None
         self.disabled_reason = None
         self.dhcp_events = {}
         self._dhcp_state = {


### PR DESCRIPTION
The snap build is broken at the moment.
Fix the build, and add CI showing the build working.

Samples of current build failure:

https://github.com/dbungert/subiquity/actions/runs/6126545979/job/16630745991#step:3:89
https://launchpadlibrarian.net/686174599/buildlog_snap_ubuntu_jammy_amd64_subiquity_BUILDING.txt.gz