### PR TITLE
lunar: security archive

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -41,6 +41,18 @@ validate () {
             echo "password leaked into log file"
             exit 1
         fi
+        # After the lunar release and the introduction of mirror testing, it
+        # came to our attention that new Ubuntu installations have the security
+        # repository configured with the primary mirror URL (i.e.,
+        # http://<cc>.archive.ubuntu.com/ubuntu) instead of
+        # http://security.ubuntu.com/ubuntu. Let's ensure we instruct curtin
+        # not to do that.
+        # If we run an autoinstall that customizes the security section as part
+        # of the test-suite, we will need to adapt this test.
+        python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/subiquity-curtin-apt.conf \
+            apt.security[0].uri='"http://security.ubuntu.com/ubuntu/"' \
+            apt.security[0].arches='["amd64", "i386"]' \
+            apt.security[1].uri='"http://ports.ubuntu.com/ubuntu-ports"'
         netplan generate --root $tmpdir
     elif [ "${mode}" = "system_setup" ]; then
         setup_mode="$2"

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -321,7 +321,15 @@ class MirrorModel(object):
 
     def get_apt_config_staged(self) -> Dict[str, Any]:
         assert self.primary_staged is not None
-        return self._get_apt_config_using_candidate(self.primary_staged)
+        config = self._get_apt_config_using_candidate(self.primary_staged)
+
+        # For mirror testing, we disable the -security suite - so that we only
+        # test the primary mirror, not the security archive.
+        if "disable_suites" not in config:
+            config["disable_suites"]: List[str] = []
+        if "security" not in config["disable_suites"]:
+            config["disable_suites"].append("security")
+        return config
 
     def get_apt_config_elected(self) -> Dict[str, Any]:
         assert self.primary_elected is not None

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -89,7 +89,9 @@ from curtin.commands.apt_config import (
     get_arch_mirrorconfig,
     get_mirror,
     PORTS_ARCHES,
+    PORTS_MIRRORS,
     PRIMARY_ARCHES,
+    PRIMARY_ARCH_MIRRORS,
     )
 from curtin.config import merge_config
 
@@ -100,8 +102,8 @@ except ImportError:
 
 log = logging.getLogger('subiquity.models.mirror')
 
-DEFAULT_SUPPORTED_ARCHES_URI = "http://archive.ubuntu.com/ubuntu"
-DEFAULT_PORTS_ARCHES_URI = "http://ports.ubuntu.com/ubuntu-ports"
+DEFAULT_SUPPORTED_ARCHES_URI = PRIMARY_ARCH_MIRRORS["PRIMARY"]
+DEFAULT_PORTS_ARCHES_URI = PORTS_MIRRORS["PRIMARY"]
 
 LEGACY_DEFAULT_PRIMARY_SECTION = [
     {
@@ -110,6 +112,17 @@ LEGACY_DEFAULT_PRIMARY_SECTION = [
     }, {
         "arches": ["default"],
         "uri": DEFAULT_PORTS_ARCHES_URI,
+    },
+]
+
+DEFAULT_SECURITY_SECTION = [
+    {
+        "arches": PRIMARY_ARCHES,
+        "uri": PRIMARY_ARCH_MIRRORS["SECURITY"],
+    },
+    {
+        "arches": PORTS_ARCHES,
+        "uri": PORTS_MIRRORS["SECURITY"],
     },
 ]
 
@@ -311,6 +324,10 @@ class MirrorModel(object):
 
         config = copy.deepcopy(self.config)
         config["disable_components"] = sorted(self.disabled_components)
+
+        if "security" not in config:
+            config["security"] = DEFAULT_SECURITY_SECTION
+
         return config
 
     def _get_apt_config_using_candidate(

--- a/subiquity/models/tests/test_mirror.py
+++ b/subiquity/models/tests/test_mirror.py
@@ -288,3 +288,52 @@ class TestMirrorModel(unittest.TestCase):
                 return_value=iter([PrimaryEntry(parent=self.model)]))
         with country_mirror_candidates:
             self.assertTrue(self.model.wants_geoip())
+
+    def test_get_apt_config_staged_default_config(self):
+        self.model.legacy_primary = False
+        self.model.primary_candidates = [
+            PrimaryEntry(
+                uri="http://mirror.local/ubuntu", arches=None, parent=self.model
+            ),
+        ]
+        self.model.primary_candidates[0].stage()
+        config = self.model.get_apt_config_staged()
+        self.assertEqual(
+            config["primary"],
+            [
+                {
+                    "uri": "http://mirror.local/ubuntu",
+                    "arches": ["default"],
+                }
+            ],
+        )
+        self.assertEqual(
+            set(config["disable_components"]), set(self.model.disabled_components)
+        )
+        self.assertEqual(set(config["disable_suites"]), {"security"})
+
+    def test_get_apt_config_staged_with_config(self):
+        self.model.legacy_primary = False
+        self.model.primary_candidates = [
+            PrimaryEntry(
+                uri="http://mirror.local/ubuntu", arches=None, parent=self.model
+            ),
+        ]
+        self.model.primary_candidates[0].stage()
+        self.model.config = {
+            "disable_suites": ["updates"],
+        }
+        config = self.model.get_apt_config_staged()
+        self.assertEqual(
+            config["primary"],
+            [
+                {
+                    "uri": "http://mirror.local/ubuntu",
+                    "arches": ["default"],
+                }
+            ],
+        )
+        self.assertEqual(
+            set(config["disable_components"]), set(self.model.disabled_components)
+        )
+        self.assertEqual(set(config["disable_suites"]), {"security", "updates"})


### PR DESCRIPTION
backport of PR: #1790 to ubuntu/lunar with intention to do one last stable release for that branch.
The curtin portion of that PR is related to Deb822 handling, so not critical.