### PR TITLE
include api-only data when sending storage objects from client to server

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -28,7 +28,12 @@ from subiquity.common.types import (
     ProbeStatus,
     StorageResponseV2,
 )
-from subiquity.models.filesystem import Bootloader, FilesystemModel, raidlevels_by_value
+from subiquity.models.filesystem import (
+    ActionRenderMode,
+    Bootloader,
+    FilesystemModel,
+    raidlevels_by_value,
+)
 from subiquity.ui.views import FilesystemView, GuidedDiskSelectionView
 from subiquity.ui.views.filesystem.probing import ProbingFailed, SlowProbing
 from subiquitycore.async_helpers import run_bg_task
@@ -288,4 +293,8 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
 
     def finish(self):
         log.debug("FilesystemController.finish next_screen")
-        self.app.next_screen(self.endpoint.POST(self.model._render_actions()))
+        self.app.next_screen(
+            self.endpoint.POST(
+                self.model._render_actions(mode=ActionRenderMode.FOR_API_CLIENT)
+            )
+        )


### PR DESCRIPTION
Making an install that used an existing RAID failed because of an attempt to log the size of the RAID when rendering the curtin config.

This turns out to be because when the client sends the storage objects back to the server it loses all the "api only" data including the udev data that is needed to display the size.

In some sense this is a bit silly, we could just drop the log statement and it would be fine but I think it's probably better to always have the full storage objects in the server (until we can get away from this hackish API anyway).