### PR TITLE
Make unattended upgrades run faster by disabling minimal steps

### DIFF
--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -811,6 +811,14 @@ uu_apt_conf = b"""\
 # a metered connection.
 Unattended-Upgrade::OnlyOnACPower "false";
 Unattended-Upgrade::Skip-Updates-On-Metered-Connections "true";
+
+# Set MinimalSteps to false to speedup install times. "true", the default, will
+# atmoize updates to enable interrupts between downloads, but this causes the
+# install to slow down considerably. This is a major bottleneck of the install.
+# Some testing shows a 3-4x speedup on the unattended-upgrades section of the
+# install when this is set to false. However, this will make interrupting
+# this section of the install process difficult.
+Unattended-Upgrade::MinimalSteps "false";
 """
 
 uu_apt_conf_update_security = b"""\


### PR DESCRIPTION
Testing shows minimal steps causes unattended-upgrades to take ~14 minutes, and ~4 minutes without. 

Tested using `ubuntu-22.04.1-live-server-amd64`

Relevant portions of `subiquity-server-debug.log`:

With minimal steps:
```
2023-09-14 23:25:21,035 DEBUG root:39 start: subiquity/Install/install/postinstall/run_unattended_upgrades: downloading and installing all updates
2023-09-14 23:25:21,035 DEBUG subiquitycore.utils:112 astart_command called: ['systemd-run', '--wait', '--same-dir', '--property', 'SyslogIdentifier=subiquity_log.1776', '--property', 'PrivateMounts=yes', '--setenv', 'PATH=/snap/subiquity/3698/bin:/snap/subiquity/3698/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/subiquity/3698/bin', '--setenv', 'PYTHONPATH=:/snap/subiquity/3698/lib/python3.8/site-packages', '--setenv', 'PYTHON=/snap/subiquity/3698/usr/bin/python3.8', '--setenv', 'SNAP=/snap/subiquity/3698', '--', '/snap/subiquity/3698/usr/bin/python3.8', '-m', 'curtin', '--showtrace', '-vvv', '--set', 'json:reporting={"subiquity": {"type": "journald", "identifier": "curtin_event.1776.5"}}', 'in-target', '-t', '/target', '--', 'unattended-upgrades', '-v']
2023-09-14 23:25:21,740 DEBUG root:39 start: subiquity/Install/install/postinstall/run_unattended_upgrades/cmd-in-target: curtin command in-target
2023-09-14 23:39:08,491 DEBUG root:39 finish: subiquity/Install/install/postinstall/run_unattended_upgrades/cmd-in-target: SUCCESS: curtin command in-target
2023-09-14 23:39:08,591 DEBUG root:39 finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing all updates
```

Without minimal steps:
```
2023-09-14 23:59:16,537 DEBUG root:30 start: subiquity/Install/install/postinstall/run_unattended_upgrades: downloading and installing all updates
2023-09-14 23:59:16,539 DEBUG subiquitycore.utils:151 astart_command called: ['systemd-run', '--wait', '--same-dir', '--property', 'SyslogIdentifier=subiquity_log.1775', '--property', 'PrivateMounts=yes', '--setenv', 'PATH=/snap/subiquity/x1/bin:/snap/subiquity/x1/usr/bin:/snap/subiquity/x1/usr/sbin:/snap/subiquity/x1/usr/bin:/snap/subiquity/x1/sbin:/snap/subiquity/x1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/subiquity/x1/bin:/snap/subiquity/x1/sbin', '--setenv', 'PYTHONPATH=:/snap/subiquity/x1/lib/python3.10/site-packages', '--setenv', 'PYTHON=/snap/subiquity/x1/usr/bin/python3.10', '--setenv', 'SNAP=/snap/subiquity/x1', '--', '/snap/subiquity/x1/usr/bin/python3.10', '-m', 'curtin', '--showtrace', '-vvv', '--set', 'json:reporting={"subiquity": {"type": "journald", "identifier": "curtin_event.1775.10"}}', 'in-target', '-t', '/target', '--', 'unattended-upgrades', '-v']
2023-09-14 23:59:17,197 DEBUG root:30 start: subiquity/Install/install/postinstall/run_unattended_upgrades/cmd-in-target: curtin command in-target
2023-09-15 00:03:38,198 DEBUG root:30 finish: subiquity/Install/install/postinstall/run_unattended_upgrades/cmd-in-target: SUCCESS: curtin command in-target
2023-09-15 00:03:38,226 DEBUG root:30 finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing all updates
```