### PR TITLE
s390x: ensure chreipl is called before unmounting /target

### DIFF
--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -16,7 +16,6 @@
 import asyncio
 import logging
 import os
-import platform
 import subprocess
 
 from subiquity.common.apidef import API
@@ -137,11 +136,6 @@ class ShutdownController(SubiquityController):
         if self.opts.dry_run:
             self.app.exit()
         else:
-            # On shutdown, it seems that the asynchronous command runners are not
-            # reliable.  Best to keep using the traditional sort.
-            if self.app.state == ApplicationState.DONE:
-                if platform.machine() == "s390x":
-                    run_command(["chreipl", "/target/boot"])
             if self.mode == ShutdownMode.REBOOT:
                 run_command(["/sbin/reboot"])
             elif self.mode == ShutdownMode.POWEROFF:


### PR DESCRIPTION
For ZFS, we recently introduced a call to `umount --recursive /target` slighly before shutting down or rebooting. Unfortunately, on s390x, we also had a very late call to `chreipl` to make the firmware boot from the installed system.

The call to `chreipl` reads data from `/target/boot`, and it fails if the filesystem is no longer mounted.

Fixed by calling `chreipl` earlier in the installation, during the postinst phase rather than after the user clicks "reboot".

[LP: #2029479](https://bugs.launchpad.net/subiquity/+bug/2029479)