### PR TITLE
snapcraft: rev curtin for deb822, large sectors

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: d5f5dde574aca60935fc9e1acf9cb669e24f22de
+    source-commit: a7640fdcac396f9f09044dc7ca7553043ce4231c
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
This curtin rev adds the following:
Dan Bungert (3):
      extract: log source information
      tests/data: 4k sector disk
      storage_config: handle partitions on 4k disk

Nick Rosbrook (1):
      apt: disable default deb822 migration