### PR TITLE
Allow for specifying the autoinstall file over the kernel command line

### DIFF
--- a/doc/intro-to-autoinstall.rst
+++ b/doc/intro-to-autoinstall.rst
@@ -78,24 +78,47 @@ Autoinstall on the install media
 Another option for supplying autoinstall to the Ubuntu installer is to place a
 file named :code:`autoinstall.yaml` on the install media itself.
 
-There are two potential locations for the :code:`autoinstall.yaml` file:
- * At the root of the "CD-ROM". When you write the installation ISO to a USB
-   Flash Drive, this can be done by copying the :code:`autoinstall.yaml` to the
-   partition containing the contents of the ISO - i.e.,
-   in the directory containing the ``casper`` sub-directory.
- * On the rootfs of the installation system - this option will typically
-   require modifying the installation ISO and is not suggested, but is
-   supported.
+There are two potential locations that subiquity will check for the
+:code:`autoinstall.yaml` file:
 
-Directly specifying autoinstall as a :code:`autoinstall.yaml` file does not
-require a :code:`#cloud-config` header, and does not use a top level
-``autoinstall:`` key. The autoinstall directives are placed at the top
-level. For example:
+* At the root of the "CD-ROM". When you write the installation ISO to a USB
+  Flash Drive, this can be done by copying the :code:`autoinstall.yaml` to the
+  partition containing the contents of the ISO - i.e.,
+  in the directory containing the ``casper`` sub-directory.
+* On the rootfs of the installation system - this option will typically
+  require modifying the installation ISO and is not suggested, but is
+  supported.
 
-.. code-block:: yaml
+Alternatively, you can pass the location of the autoinstall file on the kernel
+command line via the :code:`subiquity.autoinstallpath` parameter, where the
+path is relative to the rootfs of the installation system. For example:
 
-    version: 1
-    ....
+* :code:`subiquity.autoinstallpath=path/to/autoinstall.yaml`
+
+.. note::
+
+    Directly specifying autoinstall as a :code:`autoinstall.yaml` file does not
+    require a :code:`#cloud-config` header, and does not use a top level
+    ``autoinstall:`` key. The autoinstall directives are placed at the top
+    level. For example:
+
+    .. code-block:: yaml
+
+        version: 1
+        ....
+
+
+Order precedence of the autoinstall locations
+======================================
+
+Since there are many ways to specify the autoinstall file, it may happen that
+multiple locations are specified at once. Subiquity will look for the
+autoinstall file in the following order and pick the first existing one:
+
+1. Kernel command line
+2. Root of the installation system
+3. Cloud Config
+4. Root of the CD-ROM (ISO)
 
 
 Cloud-init and autoinstall interaction

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -574,10 +574,11 @@ class SubiquityServer(Application):
 
     def select_autoinstall(self):
         # precedence
-        # 1. autoinstall at root of drive
-        # 2. command line argument autoinstall
-        # 3. autoinstall supplied by cloud config
-        # 4. autoinstall baked into the iso, found at /cdrom/autoinstall.yaml
+        # 1. command line argument autoinstall
+        # 2. kernel command line argument subiquity.autoinstallpath
+        # 3. autoinstall at root of drive
+        # 4. autoinstall supplied by cloud config
+        # 5. autoinstall baked into the iso, found at /cdrom/autoinstall.yaml
 
         # if opts.autoinstall is set and empty, that means
         # autoinstall has been explicitly disabled.
@@ -588,9 +589,12 @@ class SubiquityServer(Application):
         ):
             raise Exception(f"Autoinstall argument {self.opts.autoinstall} not found")
 
+        kernel_install_path = self.kernel_cmdline.get("subiquity.autoinstallpath", None)
+
         locations = (
-            self.base_relative(root_autoinstall_path),
             self.opts.autoinstall,
+            kernel_install_path,
+            self.base_relative(root_autoinstall_path),
             self.base_relative(cloud_autoinstall_path),
             self.base_relative(iso_autoinstall_path),
         )


### PR DESCRIPTION
This change allows for specifying the location of the autoinstall.yaml file in the kernel command line via `subiquity.autoinstallpath`. So, something like `subiquity.autoinstallpath=path/to/autoinstall.yaml`.

I have additionally changed the precedence for the various ways the autoinstall file may be passed from:
```
1. root of the drive
2. subiquity cmdline
3. cloud config
4. root of cdrom
```

To:
```
1. subiquity cmdline
2. kernel cmdline
3. root of the drive
4. cloud config
5. root of the cdrom
```

For the tests:
1. I've added a test for the kernel command line case.
1. Reordered them to align with precedence changes
1. Used explicit "missing" values where possible (e.g., `None` for the subiquity arg when the case is no arg is passed), instead of simply leaving them undefined.
