### PR TITLE
Bump curtin rev for recovery key on systems using zkey

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: a7640fdcac396f9f09044dc7ca7553043ce4231c
+    source-commit: 64ea5fbe827aa98ddc63ea87de2de45689180c82
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
```
$ git log a7640fd..64ea5fbe --oneline --no-decorate
64ea5fbe block_meta: also add recovery key if zkey is used
13c1b8ad vmtests: make loading error verbose
4595c03d vmtests: +python3-debian dep
abebab1e vmtests: add mantic after jammy
91f147b0 vmtests: add jammy after focal
2a45c899 vmtests: remove hirsute
6c5ad6aa vmtests: remove impish
```