### PR TITLE
locale is not implicitly interactive with other interactive sessions

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -96,7 +96,7 @@ locale
 
 * **type:** string
 * **default:** ``en_US.UTF-8``
-* **can be interactive:** yes, always interactive if any section is
+* **can be interactive:** yes
 
 The locale to configure for the installed system.
 
@@ -779,7 +779,7 @@ install
 * **type:** boolean or string (special value ``auto``)
 * **default:**: ``auto``
 
-Whether to install the available OEM meta-packages. The special value ``auto`` 
+Whether to install the available OEM meta-packages. The special value ``auto``
 -- which is the default -- enables the installation on ubuntu-desktop but not
 on ubuntu-server. This option has no effect on core boot classic.
 

--- a/documentation/autoinstall-reference.md
+++ b/documentation/autoinstall-reference.md
@@ -65,7 +65,7 @@ A list of shell commands to invoke as soon as the installer starts, in particula
 
 **type:** string
 **default:** `en_US.UTF-8`
-**can be interactive:** yes, always interactive if any section is
+**can be interactive:** yes
 
 The locale to configure for the installed system.
 


### PR DESCRIPTION
Regarding [LP #2037133](https://bugs.launchpad.net/subiquity/+bug/2037133): The documentation incorrectly states that locale is implicitly interactive if any other session is interactive. This is not true (anymore), nor the intended behavior. 