### PR TITLE
filesystem: don't crash if v2/orig_config is called early

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1435,7 +1435,8 @@ class FilesystemModel:
         # use on the V2 storage API.
         orig_model = FilesystemModel(self.bootloader, root=self.root)
         orig_model.target = self.target
-        orig_model.load_probe_data(self._probe_data)
+        if self._probe_data is not None:
+            orig_model.load_probe_data(self._probe_data)
         return orig_model
 
     def process_probe_data(self):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -328,6 +328,15 @@ class TestFilesystemModel(unittest.TestCase):
         self.assertFalse(lv.ok_for_raid)
         self.assertFalse(lv.ok_for_lvm_vg)
 
+    def test_get_orig_model_no_probe_data(self):
+        # When v2/get_orig_data gets called early, model._probe_data is still
+        # None. Ensure get_orig_model() does not fail.
+        model = make_model()
+
+        model._probe_data = None
+        orig_model = model.get_orig_model()
+        self.assertIsNone(orig_model._probe_data)
+
 
 def fake_up_blockdata_disk(disk, **kw):
     model = disk._m


### PR DESCRIPTION
When v2/orig_config is called too early, the load_probe_data function will fail because probe_data is None:

```python
  Traceback (most recent call last):
    File "subiquity/common/api/server.py", line 164, in handler
      result = await implementation(**args)
    File "subiquity/server/controllers/filesystem.py", line 1029, in v2_orig_config_GET
      model = self.model.get_orig_model()
    File "subiquity/models/filesystem.py", line 1428, in get_orig_model
      orig_model.load_probe_data(self._probe_data)
    File "subiquity/models/filesystem.py", line 1894, in load_probe_data
      for devname, devdata in probe_data["blockdev"].items():
  TypeError: 'NoneType' object is not subscriptable
```

Make sure we don't dereference model._probe_data if it is None.