### PR TITLE
autoinstall: Don't use snap env when invoking early and late commands

### DIFF
--- a/subiquity/server/controllers/tests/test_cmdlist.py
+++ b/subiquity/server/controllers/tests/test_cmdlist.py
@@ -1,0 +1,84 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import IsolatedAsyncioTestCase, mock
+
+from subiquity.server.controllers import cmdlist
+from subiquity.server.controllers.cmdlist import (
+    CmdListController,
+    Command,
+    EarlyController,
+    LateController,
+)
+from subiquitycore.tests.mocks import make_app
+from subiquitycore.utils import orig_environ
+
+
+@mock.patch.object(cmdlist, "orig_environ", side_effect=orig_environ)
+@mock.patch.object(cmdlist, "arun_command")
+class TestCmdListController(IsolatedAsyncioTestCase):
+    controller_type = CmdListController
+
+    def setUp(self):
+        self.controller = self.controller_type(make_app())
+        self.controller.cmds = [Command(args="some-command", check=False)]
+        snap_env = {
+            "LD_LIBRARY_PATH": "/var/lib/snapd/lib/gl",
+        }
+        self.mocked_os_environ = mock.patch.dict("os.environ", snap_env)
+
+    @mock.patch("shutil.which", return_value="/usr/bin/path/to/bin")
+    async def test_no_snap_env_on_call(
+        self,
+        mocked_shutil,
+        mocked_arun,
+        mocked_orig_environ,
+    ):
+        with self.mocked_os_environ:
+            await self.controller.run()
+            args, kwargs = mocked_arun.call_args
+            call_env = kwargs["env"]
+
+            mocked_orig_environ.assert_called()
+            self.assertNotIn("LD_LIBRARY_PATH", call_env)
+
+    @mock.patch("shutil.which", return_value="/snap/path/to/bin")
+    async def test_with_snap_env_on_call(
+        self,
+        mocked_shutil,
+        mocked_arun,
+        mocked_orig_environ,
+    ):
+        with self.mocked_os_environ:
+            await self.controller.run()
+            args, kwargs = mocked_arun.call_args
+            call_env = kwargs["env"]
+
+            mocked_orig_environ.assert_not_called()
+            self.assertIn("LD_LIBRARY_PATH", call_env)
+
+
+class TestEarlyController(TestCmdListController):
+    controller_type = EarlyController
+
+    def setUp(self):
+        super().setUp()
+
+
+class TestLateController(TestCmdListController):
+    controller_type = LateController
+
+    def setUp(self):
+        super().setUp()

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -91,8 +91,6 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.app = make_app()
         self.app.opts.bootloader = "UEFI"
         self.app.command_runner = mock.AsyncMock()
-        self.app.report_start_event = mock.Mock()
-        self.app.report_finish_event = mock.Mock()
         self.app.prober = mock.Mock()
         self.app.prober.get_storage = mock.AsyncMock()
         self.app.block_log_dir = "/inexistent"
@@ -1177,8 +1175,6 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.app = make_app()
         self.app.command_runner = mock.AsyncMock()
         self.app.opts.bootloader = "UEFI"
-        self.app.report_start_event = mock.Mock()
-        self.app.report_finish_event = mock.Mock()
         self.app.prober = mock.Mock()
         self.app.prober.get_storage = mock.AsyncMock()
         self.app.snapdapi = snapdapi.make_api_client(AsyncSnapd(get_fake_connection()))

--- a/subiquity/server/controllers/tests/test_install.py
+++ b/subiquity/server/controllers/tests/test_install.py
@@ -34,8 +34,6 @@ class TestWriteConfig(unittest.IsolatedAsyncioTestCase):
         self.controller = InstallController(make_app())
         self.controller.write_config = unittest.mock.Mock()
         self.controller.app.note_file_for_apport = Mock()
-        self.controller.app.report_start_event = Mock()
-        self.controller.app.report_finish_event = Mock()
 
         self.controller.model.target = "/target"
 
@@ -199,8 +197,6 @@ efi_state_with_dup_rp = EFIBootState(
 class TestInstallController(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.controller = InstallController(make_app())
-        self.controller.app.report_start_event = Mock()
-        self.controller.app.report_finish_event = Mock()
         self.controller.model.target = tempfile.mkdtemp()
         os.makedirs(os.path.join(self.controller.model.target, "etc/grub.d"))
         self.addCleanup(shutil.rmtree, self.controller.model.target)

--- a/subiquity/server/controllers/tests/test_refresh.py
+++ b/subiquity/server/controllers/tests/test_refresh.py
@@ -26,8 +26,6 @@ from subiquitycore.tests.mocks import make_app
 class TestRefreshController(SubiTestCase):
     def setUp(self):
         self.app = make_app()
-        self.app.report_start_event = mock.Mock()
-        self.app.report_finish_event = mock.Mock()
         self.app.note_data_for_apport = mock.Mock()
         self.app.prober = mock.Mock()
         self.app.snapdapi = snapdapi.make_api_client(AsyncSnapd(get_fake_connection()))

--- a/subiquity/server/controllers/tests/test_snaplist.py
+++ b/subiquity/server/controllers/tests/test_snaplist.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 import requests
 

--- a/subiquity/server/controllers/tests/test_snaplist.py
+++ b/subiquity/server/controllers/tests/test_snaplist.py
@@ -31,8 +31,6 @@ class TestSnapdSnapInfoLoader(unittest.IsolatedAsyncioTestCase):
         self.model = SnapListModel()
         self.app = make_app()
         self.app.snapd = AsyncMock()
-        self.app.report_start_event = Mock()
-        self.app.report_finish_event = Mock()
 
         self.loader = SnapdSnapInfoLoader(
             self.model, self.app.snapd, "server", self.app.context

--- a/subiquitycore/tests/mocks.py
+++ b/subiquitycore/tests/mocks.py
@@ -43,4 +43,9 @@ def make_app(model=None):
     app.opts = mock.Mock()
     app.opts.dry_run = True
     app.scale_factor = 1000
+    app.echo_syslog_id = None
+    app.log_syslog_id = None
+    app.report_start_event = mock.Mock()
+    app.report_finish_event = mock.Mock()
+
     return app

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -19,7 +19,7 @@ import logging
 import os
 import random
 import subprocess
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 log = logging.getLogger("subiquitycore.utils")
 
@@ -35,15 +35,18 @@ def _clean_env(env, *, locale=True):
     return env
 
 
-def orig_environ(env):
+def orig_environ(env: Optional[Dict[str, str]]) -> Dict[str, str]:
     """Generate an environment dict that is suitable for use for running
     programs that live outside the snap."""
+
     if env is None:
-        env = os.environ
-    ret = env.copy()
+        env: Dict[str, str] = os.environ
+
+    ret: Dict[str, str] = env.copy()
+
     for key, val in env.items():
         if key.endswith("_ORIG"):
-            key_to_restore = key[: -len("_ORIG")]
+            key_to_restore: str = key[: -len("_ORIG")]
             if val:
                 ret[key_to_restore] = val
             else:


### PR DESCRIPTION
LP [#2032961](https://pad.lv/2032961): We are not cleaning the environment provided to subprocesses correctly. When trying to invoke a program that should run outside of the snap context, the `LD_LIBRARY_PATH` variable is pointing to the linker on the snap, which causes errors like:
```
curl: /lib/x86_64-linux-gnu/libc.so/6: version `GLIBC_2.33` not found (required by /snap/subiquity/x1/usr/lib/x86_64-linux-gnu/libpsl.so.5)
```

We had a similar issue solved in #1300. This fix similarly uses `orig_environ` to clean the environment before running commands in the respective command controllers. 

I would especially appreciate some input if the license header on the new test file looks correct. It's an exact copy and paste from one of the other new tests files from this year, but I just want to be sure. 