### PR TITLE
codecs: skip installation when running an offline install

### DIFF
--- a/examples/autoinstall/fallback-offline.yaml
+++ b/examples/autoinstall/fallback-offline.yaml
@@ -1,0 +1,21 @@
+version: 1
+locale: en_GB.UTF-8
+network:
+  version: 2
+  ethernets:
+    all-eth:
+      match:
+        name: "en*"
+      dhcp6: yes
+apt:
+  mirror-selection:
+    primary:
+    - uri: http://localhost/failed
+  fallback: offline-install
+codecs:
+  install: true
+identity:
+  realname: ''
+  username: ubuntu
+  password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+  hostname: ubuntu

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -68,6 +68,9 @@ validate () {
                     apt.security[1].uri='"http://ports.ubuntu.com/ubuntu-ports"'
                 ;;
         esac
+        if [ "$testname" == autoinstall-fallback-offline ]; then
+            grep -F -- 'skipping installation of package ubuntu-restricted-addons' "$tmpdir"/subiquity-server-debug.log
+        fi
         netplan generate --root $tmpdir
     elif [ "${mode}" = "system_setup" ]; then
         setup_mode="$2"
@@ -315,6 +318,18 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --output-base "$tmpdir" \
     --machine-config examples/machines/simple.json \
     --autoinstall examples/autoinstall/reset-only.yaml \
+    --kernel-cmdline autoinstall \
+    --source-catalog examples/sources/install.yaml
+validate install
+
+clean
+testname=autoinstall-fallback-offline
+LANG=C.UTF-8 timeout --foreground 60 \
+    python3 -m subiquity.cmd.tui \
+    --dry-run \
+    --output-base "$tmpdir" \
+    --machine-config examples/machines/simple.json \
+    --autoinstall examples/autoinstall/fallback-offline.yaml \
     --kernel-cmdline autoinstall \
     --source-catalog examples/sources/install.yaml
 validate install

--- a/subiquity/common/pkg.py
+++ b/subiquity/common/pkg.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Canonical, Ltd.
+# Copyright 2023 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,20 +13,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from subiquity.common.pkg import TargetPkg
-from subiquity.server.controller import NonInteractiveController
+import attr
 
 
-class PackageController(NonInteractiveController):
-    model_name = autoinstall_key = "packages"
-    autoinstall_default = []
-    autoinstall_schema = {
-        "type": "array",
-        "items": {"type": "string"},
-    }
-
-    def load_autoinstall_data(self, data):
-        self.model[:] = [TargetPkg(name=pkg, skip_when_offline=False) for pkg in data]
-
-    def make_autoinstall(self):
-        return [pkg.name for pkg in self.model]
+@attr.s(auto_attribs=True)
+class TargetPkg:
+    name: str
+    # Some packages are not present in the pool and require a working network
+    # connection to be downloaded. By marking them with "skip_when_offline", we
+    # can skip them when running an offline install.
+    skip_when_offline: bool

--- a/subiquity/models/ad.py
+++ b/subiquity/models/ad.py
@@ -14,8 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
+from subiquity.common.pkg import TargetPkg
 from subiquity.common.types import AdConnectionInfo
 
 log = logging.getLogger("subiquity.models.ad")
@@ -42,10 +43,14 @@ class AdModel:
         else:
             self.conn_info = AdConnectionInfo(domain_name=domain)
 
-    async def target_packages(self):
+    async def target_packages(self) -> List[TargetPkg]:
         # NOTE Those packages must be present in the target system to allow
         # joining to a domain.
         if self.do_join:
-            return ["adcli", "realmd", "sssd"]
+            return [
+                TargetPkg(name="adcli", skip_when_offline=False),
+                TargetPkg(name="realmd", skip_when_offline=False),
+                TargetPkg(name="sssd", skip_when_offline=False),
+            ]
 
         return []

--- a/subiquity/models/codecs.py
+++ b/subiquity/models/codecs.py
@@ -14,6 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import List
+
+from subiquity.common.pkg import TargetPkg
 
 log = logging.getLogger("subiquity.models.codecs")
 
@@ -21,9 +24,12 @@ log = logging.getLogger("subiquity.models.codecs")
 class CodecsModel:
     do_install = False
 
-    async def target_packages(self):
+    async def target_packages(self) -> List[TargetPkg]:
         # NOTE currently, ubuntu-restricted-addons is an empty package that
         # pulls relevant packages through Recommends: Ideally, we should make
         # sure to run the APT command for this package with the
         # --install-recommends option.
-        return ["ubuntu-restricted-addons"] if self.do_install else []
+        if not self.do_install:
+            return []
+
+        return [TargetPkg(name="ubuntu-restricted-addons", skip_when_offline=True)]

--- a/subiquity/models/locale.py
+++ b/subiquity/models/locale.py
@@ -16,7 +16,9 @@
 import locale
 import logging
 import subprocess
+from typing import List
 
+from subiquity.common.pkg import TargetPkg
 from subiquitycore.utils import arun_command, split_cmd_output
 
 log = logging.getLogger("subiquity.models.locale")
@@ -60,7 +62,7 @@ class LocaleModel:
             locale += ".UTF-8"
         return {"locale": locale}
 
-    async def target_packages(self):
+    async def target_packages(self) -> List[TargetPkg]:
         if self.selected_language is None:
             return []
         if self.locale_support != "langpack":
@@ -69,6 +71,7 @@ class LocaleModel:
         if lang == "C":
             return []
 
-        return await split_cmd_output(
+        pkgs = await split_cmd_output(
             self.chroot_prefix + ["check-language-support", "-l", lang], None
         )
+        return [TargetPkg(name=pkg, skip_when_offline=False) for pkg in pkgs]

--- a/subiquity/models/network.py
+++ b/subiquity/models/network.py
@@ -15,8 +15,10 @@
 
 import logging
 import subprocess
+from typing import List
 
 from subiquity import cloudinit
+from subiquity.common.pkg import TargetPkg
 from subiquitycore.models.network import NetworkModel as CoreNetworkModel
 from subiquitycore.utils import arun_command
 
@@ -93,11 +95,11 @@ class NetworkModel(CoreNetworkModel):
                 }
         return r
 
-    async def target_packages(self):
-        if self.needs_wpasupplicant:
-            return ["wpasupplicant"]
-        else:
+    async def target_packages(self) -> List[TargetPkg]:
+        if not self.needs_wpasupplicant:
             return []
+
+        return [TargetPkg(name="wpasupplicant", skip_when_offline=False)]
 
     async def is_nm_enabled(self):
         try:

--- a/subiquity/models/ssh.py
+++ b/subiquity/models/ssh.py
@@ -16,6 +16,8 @@
 import logging
 from typing import List
 
+from subiquity.common.pkg import TargetPkg
+
 log = logging.getLogger("subiquity.models.ssh")
 
 
@@ -29,8 +31,8 @@ class SSHModel:
         # we go back to it.
         self.ssh_import_id = ""
 
-    async def target_packages(self):
-        if self.install_server:
-            return ["openssh-server"]
-        else:
+    async def target_packages(self) -> List[TargetPkg]:
+        if not self.install_server:
             return []
+
+        return [TargetPkg(name="openssh-server", skip_when_offline=False)]

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -2133,7 +2133,7 @@ class TestActiveDirectory(TestAPI):
         to be installed in the target system and whether they were
         referred to or not in the server log."""
         expected_packages = await self.target_packages()
-        packages_lookup = {p: False for p in expected_packages}
+        packages_lookup = {p.name: False for p in expected_packages}
         log_path = os.path.join(log_dir, "subiquity-server-debug.log")
         find_start = "finish: subiquity/Install/install/postinstall/install_{}:"
         log_status = " SUCCESS: installing {}"


### PR DESCRIPTION
ubuntu-restricted-addons is a multiverse package and is not included in the pool. Therefore, trying to get it installed when offline leads to an obvious error.

Instead of making the whole Ubuntu installation fail, we now warn and skip installation of the package when performing an offline install. In a perfect world, we should not have offered to install the package in the first place, but in practice, we can run an offline installation as the result of failed mirror testing (bad network for instance).

NOTE: I've reused what I did for https://github.com/canonical/subiquity/pull/1795 so no wonder if the code looks similar :)