### PR TITLE
source: do not fire a configured event again if nothing changed

### DIFF
--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -165,8 +165,9 @@ class SourceController(SubiquityController):
         try:
             new_source = self.model.get_matching_source(source_id)
         except KeyError:
-            # TODO going forward, we should probably stop silently ignoring
-            # unmatched sources.
+            # TODO going forward, we should probably stop ignoring unmatched
+            # sources.
+            log.warning("unable to find '%s' in sources catalog", source_id)
             pass
         else:
             if self.model.current != new_source:


### PR DESCRIPTION
When handling a POST request to /source, Subiquity sends a 'source configured' event. This signals other controllers / models that they need to restart their tasks that depend on the source being used.

However, if the user of the installer goes back all the way to the source page and submits it again without changing the settings, there should be no reason to restart the machinery.

If a call to source ends up doing no modification to the model (i.e., not changing the source used or the search_drivers setting), we now avoid emitting the 'source configured' event ; except if the model has not been configured yet.

NOTE: this is theoretically more of an optimization than a bug fix (unless it significantly speeds up the install) and may or may not be suitable for a merge to ubuntu/mantic.