### PR TITLE
mirror: set default fallback method to OFFLINE_INSTALL on desktop

### DIFF
--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -301,6 +301,7 @@ class MirrorController(SubiquityController):
             self.test_apt_configurer = get_apt_configurer(
                 self.app, self.app.controllers.Source.get_handler()
             )
+        self.model.source_is_desktop = source_entry.variant == "desktop"
         self.source_configured_event.set()
 
     def serialize(self):


### PR DESCRIPTION
This is a POC of a change that we could end up landing to make ubuntu-desktop-installer fallback to an offline install by default. This hasn't yet been tested and we need to decide if we want to land something similar or not.