### PR TITLE
Cloud init log

### DIFF
--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -92,6 +92,7 @@ class ShutdownController(SubiquityController):
         for logfile in cloudinit_logs:
             if not os.path.exists(logfile):
                 continue
+            set_log_perms(logfile)
             await self.app.command_runner.run(
                 ["cp", "-a", logfile, "/var/log/installer"]
             )

--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -83,6 +83,19 @@ class ShutdownController(SubiquityController):
         elif self.app.state == ApplicationState.DONE:
             await self.shutdown()
 
+    async def copy_cloud_init_logs(self, target_logs):
+        # Preserve ephemeral boot cloud-init logs if applicable
+        cloudinit_logs = (
+            "/var/log/cloud-init.log",
+            "/var/log/cloud-init-output.log",
+        )
+        for logfile in cloudinit_logs:
+            if not os.path.exists(logfile):
+                continue
+            await self.app.command_runner.run(
+                ["cp", "-a", logfile, "/var/log/installer"]
+            )
+
     @with_context()
     async def copy_logs_to_target(self, context):
         if self.opts.dry_run and "copy-logs-fail" in self.app.debug_flags:
@@ -96,19 +109,7 @@ class ShutdownController(SubiquityController):
         if self.opts.dry_run:
             os.makedirs(target_logs, exist_ok=True)
         else:
-            # Preserve ephemeral boot cloud-init logs if applicable
-            cloudinit_logs = [
-                cloudinit_log
-                for cloudinit_log in (
-                    "/var/log/cloud-init.log",
-                    "/var/log/cloud-init-output.log",
-                )
-                if os.path.exists(cloudinit_log)
-            ]
-            if cloudinit_logs:
-                await self.app.command_runner.run(
-                    ["cp", "-a"] + cloudinit_logs + ["/var/log/installer"]
-                )
+            await self.copy_cloud_init_logs(target_logs)
             await self.app.command_runner.run(
                 ["cp", "-aT", "/var/log/installer", target_logs]
             )

--- a/subiquitycore/file_util.py
+++ b/subiquitycore/file_util.py
@@ -44,7 +44,7 @@ def set_log_perms(target, *, group_write=False, mode=None, group=_DEF_GROUP):
         if group_write:
             mode |= 0o020
     os.chmod(target, mode)
-    os.chown(target, -1, grp.getgrnam(group).gr_gid)
+    os.chown(target, 0, grp.getgrnam(group).gr_gid)
 
 
 @contextlib.contextmanager

--- a/subiquitycore/tests/test_file_util.py
+++ b/subiquitycore/tests/test_file_util.py
@@ -64,52 +64,52 @@ class TestLogPerms(SubiTestCase):
         Path(target).touch()
         set_log_perms(target)
         self.chmod.assert_called_once_with(target, _DEF_PERMS_FILE)
-        self.chown.assert_called_once_with(target, -1, self.mock_gid)
+        self.chown.assert_called_once_with(target, 0, self.mock_gid)
 
     def test_defaults_dir(self):
         target = self.tmp_dir()
         set_log_perms(target)
         self.chmod.assert_called_once_with(target, _DEF_PERMS_FILE | 0o110)
-        self.chown.assert_called_once_with(target, -1, self.mock_gid)
+        self.chown.assert_called_once_with(target, 0, self.mock_gid)
 
     def test_group_write_file(self):
         target = self.tmp_path("file")
         Path(target).touch()
         set_log_perms(target, group_write=True)
         self.chmod.assert_called_once_with(target, _DEF_PERMS_FILE | 0o020)
-        self.chown.assert_called_once_with(target, -1, self.mock_gid)
+        self.chown.assert_called_once_with(target, 0, self.mock_gid)
 
     def test_group_write_dir(self):
         target = self.tmp_dir()
         set_log_perms(target, group_write=True)
         self.chmod.assert_called_once_with(target, _DEF_PERMS_FILE | 0o130)
-        self.chown.assert_called_once_with(target, -1, self.mock_gid)
+        self.chown.assert_called_once_with(target, 0, self.mock_gid)
 
     def test_nogroup_write_file(self):
         target = self.tmp_path("file")
         Path(target).touch()
         set_log_perms(target, group_write=False)
         self.chmod.assert_called_once_with(target, _DEF_PERMS_FILE)
-        self.chown.assert_called_once_with(target, -1, self.mock_gid)
+        self.chown.assert_called_once_with(target, 0, self.mock_gid)
 
     def test_nogroup_write_dir(self):
         target = self.tmp_dir()
         set_log_perms(target, group_write=False)
         self.chmod.assert_called_once_with(target, _DEF_PERMS_FILE | 0o110)
-        self.chown.assert_called_once_with(target, -1, self.mock_gid)
+        self.chown.assert_called_once_with(target, 0, self.mock_gid)
 
     def test_mode_file(self):
         target = self.tmp_path("file")
         Path(target).touch()
         set_log_perms(target, mode=0o510)
         self.chmod.assert_called_once_with(target, 0o510)
-        self.chown.assert_called_once_with(target, -1, self.mock_gid)
+        self.chown.assert_called_once_with(target, 0, self.mock_gid)
 
     def test_mode_dir(self):
         target = self.tmp_dir()
         set_log_perms(target, mode=0o510)
         self.chmod.assert_called_once_with(target, 0o510)
-        self.chown.assert_called_once_with(target, -1, self.mock_gid)
+        self.chown.assert_called_once_with(target, 0, self.mock_gid)
 
     def test_group_file(self):
         self.getgrnam.return_value = Mock(gr_gid=11)
@@ -117,11 +117,11 @@ class TestLogPerms(SubiTestCase):
         Path(target).touch()
         set_log_perms(target, group="group1")
         self.chmod.assert_called_once_with(target, _DEF_PERMS_FILE)
-        self.chown.assert_called_once_with(target, -1, 11)
+        self.chown.assert_called_once_with(target, 0, 11)
 
     def test_group_dir(self):
         self.getgrnam.return_value = Mock(gr_gid=11)
         target = self.tmp_dir()
         set_log_perms(target, group="group1")
         self.chmod.assert_called_once_with(target, _DEF_PERMS_FILE | 0o110)
-        self.chown.assert_called_once_with(target, -1, 11)
+        self.chown.assert_called_once_with(target, 0, 11)


### PR DESCRIPTION
The cloud init log files are originally owned by syslog:adm, but that user ID is not necessarily the same on the target system.  Normalize that owning user id of the file to root.