### PR TITLE
install: create autoinstall-user-data 0400

### DIFF
--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -689,7 +689,9 @@ class InstallController(SubiquityController):
         autoinstall_config = "#cloud-config\n" + yaml.dump(
             {"autoinstall": self.app.make_autoinstall()}
         )
-        write_file(autoinstall_path, autoinstall_config)
+        # As autoinstall-user-data contains a password hash, we want this file
+        # to have a very restrictive mode and ownership.
+        write_file(autoinstall_path, autoinstall_config, mode=0o400, group="root")
         try:
             if self.supports_apt():
                 packages = await self.get_target_packages(context=context)


### PR DESCRIPTION
CVE-2023-5182

As autoinstall-user-data contains a password hash hash for a user with sudo access, create the autoinstall-user-data as 0400 root:root.

The old permissions are 0640 root:adm, and the adm group does not by default have sudo access, so cracking that hash could lead to privilege escallation for someone in the adm group.

Thanks to Patric Åhlin and Johan Hortling for identifying and reporting the issue.