### PR TITLE
Log

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 64ea5fbe827aa98ddc63ea87de2de45689180c82
+    source-commit: 7c18bf6a24297ed465a341a1f53875b61c878d6b
 
     override-pull: |
       craftctl default

--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -221,7 +221,7 @@ def bind(router, endpoint, controller, serializer=None, _depth=None):
 async def make_server_at_path(socket_path, endpoint, controller, **kw):
     app = web.Application(**kw)
     bind(app.router, endpoint, controller)
-    runner = web.AppRunner(app)
+    runner = web.AppRunner(app, access_log=None)
     await runner.setup()
     site = web.UnixSite(runner, socket_path)
     await site.start()

--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -310,7 +310,8 @@ class NetworkController(BaseNetworkController, SubiquityController):
 
     def _send_update(self, act, dev):
         with self.context.child("_send_update", "{} {}".format(act.name, dev.name)):
-            log.debug("dev_info {} {}".format(dev.name, dev.config))
+            # disable log - can contain PSK
+            # log.debug("dev_info {} {}".format(dev.name, dev.config))
             dev_info = dev.netdev_info()
             self._call_clients("update_link", act, dev_info)
 

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -497,7 +497,7 @@ class SubiquityServer(Application):
             bind(app.router, API.dry_run, DryRunController(self))
         for controller in self.controllers.instances:
             controller.add_routes(app)
-        runner = web.AppRunner(app, keepalive_timeout=0xFFFFFFFF)
+        runner = web.AppRunner(app, keepalive_timeout=0xFFFFFFFF, access_log=None)
         await runner.setup()
         await self.start_site(runner)
 

--- a/subiquitycore/file_util.py
+++ b/subiquitycore/file_util.py
@@ -23,8 +23,8 @@ import tempfile
 
 import yaml
 
-_DEF_PERMS_FILE = 0o640
-_DEF_GROUP = "adm"
+_DEF_PERMS_FILE = 0o600
+_DEF_GROUP = "root"
 
 log = logging.getLogger("subiquitycore.file_util")
 

--- a/subiquitycore/log.py
+++ b/subiquitycore/log.py
@@ -23,7 +23,7 @@ def setup_logger(dir, base="subiquity"):
     os.makedirs(dir, exist_ok=True)
     # Create the log directory in such a way that users in the group may
     # write to this directory in the installation environment.
-    set_log_perms(dir, group_write=True)
+    set_log_perms(dir, mode=0o700)
 
     logger = logging.getLogger("")
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Do further logfile lockdowns

* default group now root, group adm is now and may otherwise cause future leaks
* access logs can be a problem, so turn those off
* disable the dev_info log, which is redundant with the previous but is unneeded
* disable curtin "merged config" log