### PR TITLE
Support for Sphinx substitutions

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -142,8 +142,10 @@ custom_html_js_files = []
 # Specify a reST string that is included at the end of each file.
 # If commented out, use the default (which pulls the reuse/links.txt
 # file into each reST file).
-# custom_rst_epilog = ''
-
+custom_rst_epilog = '''
+.. include:: /reuse/substitutions.txt
+.. include:: /reuse/links.txt
+'''
 # By default, the documentation includes a feedback button at the top.
 # You can disable it by setting the following configuration to True.
 disable_feedback_button = False

--- a/doc/howto/autoinstall-quickstart-s390x.rst
+++ b/doc/howto/autoinstall-quickstart-s390x.rst
@@ -12,21 +12,19 @@ adapted for s390x.
 Download an ISO
 ===============
 
-At the time of writing (just after the Kinetic release), the best place to go
-is here:
-https://cdimage.ubuntu.com/ubuntu/releases/22.10/release/
+Download an ISO image of the latest release from the `release page <https://cdimage.ubuntu.com/ubuntu/releases/>`_ (currently |ubuntu-latest-version| (|ubuntu-latest-codename|)).
 
-..code-block:: bash
+.. parsed-literal::
 
-    wget https://cdimage.ubuntu.com/ubuntu/releases/22.10/release/ubuntu-22.10-live-server-s390x.iso -P ~/Downloads
+    wget https:\ //cdimage.ubuntu.com/ubuntu/releases/|ubuntu-latest-version|/release/ubuntu-|ubuntu-latest-version|-live-server-s390x.iso -P ~/Downloads
 
 Mount the ISO
 =============
 
-.. code-block:: bash
+.. parsed-literal::
 
     mkdir -p ~/iso
-    sudo mount -r ~/Downloads/ubuntu-22.10-live-server-s390x.iso ~/iso
+    sudo mount -r ~/Downloads/ubuntu-|ubuntu-latest-version|-live-server-s390x.iso ~/iso
 
 Write your autoinstall config
 =============================

--- a/doc/reuse/substitutions.txt
+++ b/doc/reuse/substitutions.txt
@@ -1,0 +1,2 @@
+.. |ubuntu-latest-version| replace:: 23.04
+.. |ubuntu-latest-codename| replace:: Lunar Lobster


### PR DESCRIPTION
Fixes [FR-5578](https://warthogs.atlassian.net/browse/FR-5578).

* Adds support for variable substitutions in Sphinx docs.
* Adds an initial `substitutions.txt` file with a couple of definitions.
* Modifies a sample howto to use the variables in place of version numbers and release code names.

This should be merged after #1822 as it's based off those additions (just to keep it orderly).

[FR-5578]: https://warthogs.atlassian.net/browse/FR-5578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ