### PR TITLE
apt: fix source.list mode

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -259,6 +259,7 @@ class AptConfigurer:
         write_file(
             self.install_tree.p("etc/apt/sources.list"),
             f"deb [check-date=no] file:///cdrom {codename} main restricted\n",
+            mode=0o644,
         )
 
         await run_curtin_command(


### PR DESCRIPTION
logfile hardening changes have resulted in a warning appearing when running c-n-f about not being able to read sources.list.  Write this file as 644.