### PR TITLE
Fix crash when switching sources having different variations

### DIFF
--- a/examples/answers/desktop.yaml
+++ b/examples/answers/desktop.yaml
@@ -1,4 +1,4 @@
-#source-catalog: examples/sources/desktop.yaml
+#source-catalog: examples/sources/desktop-standard.yaml
 Source:
   source: ubuntu-desktop
 Welcome:

--- a/examples/sources/desktop-standard.yaml
+++ b/examples/sources/desktop-standard.yaml
@@ -1,0 +1,29 @@
+- default: true
+  description:
+    en: A full featured Ubuntu Desktop.
+  id: ubuntu-desktop
+  locale_support: langpack
+  name:
+    en: Ubuntu Desktop
+  path: standard.squashfs
+  preinstalled_langs:
+  - de
+  - en
+  - es
+  - fr
+  - it
+  - pt
+  - ru
+  - zh
+  - ''
+  size: 4033826816
+  type: fsimage-layered
+  variant: desktop
+  variations:
+    enhanced-secureboot:
+      path: standard.enhanced-secureboot.squashfs
+      size: 4336062464
+      snapd_system_label: enhanced-secureboot-desktop
+    standard:
+      path: standard.squashfs
+      size: 4033826816

--- a/examples/sources/desktop.yaml
+++ b/examples/sources/desktop.yaml
@@ -1,11 +1,11 @@
 - default: true
   description:
-    en: A full featured Ubuntu Desktop.
-  id: ubuntu-desktop
+    en: A minimal but usable Ubuntu Desktop.
+  id: ubuntu-desktop-minimal
   locale_support: langpack
   name:
-    en: Ubuntu Desktop
-  path: standard.squashfs
+    en: Ubuntu Desktop (minimized)
+  path: minimal.squashfs
   preinstalled_langs:
   - de
   - en
@@ -16,14 +16,42 @@
   - ru
   - zh
   - ''
-  size: 4033826816
+  size: 4015337472
+  type: fsimage-layered
+  variant: desktop
+  variations:
+    minimal:
+      path: minimal.squashfs
+      size: 4015337472
+    minimal-enhanced-secureboot:
+      path: minimal.enhanced-secureboot.squashfs
+      size: 4319010816
+      snapd_system_label: enhanced-secureboot-desktop
+- description:
+    en: A full featured Ubuntu Desktop.
+  id: ubuntu-desktop
+  locale_support: langpack
+  name:
+    en: Ubuntu Desktop
+  path: minimal.standard.squashfs
+  preinstalled_langs:
+  - de
+  - en
+  - es
+  - fr
+  - it
+  - pt
+  - ru
+  - zh
+  - ''
+  size: 5735194624
   type: fsimage-layered
   variant: desktop
   variations:
     enhanced-secureboot:
-      path: standard.enhanced-secureboot.squashfs
-      size: 4336062464
+      path: minimal.standard.enhanced-secureboot.squashfs
+      size: 6006235136
       snapd_system_label: enhanced-secureboot-desktop
     standard:
-      path: standard.squashfs
-      size: 4033826816
+      path: minimal.standard.squashfs
+      size: 5735194624

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -404,6 +404,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         return info
 
     async def _examine_systems(self):
+        self._variation_info.clear()
         catalog_entry = self.app.base_model.source.current
         for name, variation in catalog_entry.variations.items():
             system = None


### PR DESCRIPTION
When the source changes, the available variations should change as well. If we keep the old variations in the FilesystemController._variations_info dictionary, we end up with a crash later in the install, showing something like:

```
2023-09-29 12:10:36,383 INFO subiquity.common.errorreport:415 saving crash report 'install failed crashed with KeyError' to /var/crash/1695989436.283925295.install_fail.crash
2023-09-29 12:10:36,383 ERROR root:30 finish: subiquity/Install/install: FAIL: 'minimal'
```