### PR TITLE
FR-5673: exclude doc/ from CI and Snap checks.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 jobs:
   test:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,6 +1,12 @@
 name: Snap
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 jobs:
   snap-build:


### PR DESCRIPTION
Fixes [FR-5673](https://warthogs.atlassian.net/browse/FR-5673)

This change excludes changes in the `doc/` directory from the following GH Actions workflows:
* `ci.yaml`
* `snap.yaml`

[FR-5673]: https://warthogs.atlassian.net/browse/FR-5673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ