### PR TITLE
remove PREFERRED capabilities

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -350,13 +350,12 @@ class GuidedCapability(enum.Enum):
 
     CORE_BOOT_ENCRYPTED = enum.auto()
     CORE_BOOT_UNENCRYPTED = enum.auto()
-    # These two are not valid as GuidedChoiceV2.capability:
-    CORE_BOOT_PREFER_ENCRYPTED = enum.auto()
-    CORE_BOOT_PREFER_UNENCRYPTED = enum.auto()
 
     DD = enum.auto()
 
     def __lt__(self, other) -> bool:
+        if self.is_core_boot() and other.is_core_boot():
+            return False
         return self.value < other.value
 
     def is_lvm(self) -> bool:
@@ -366,8 +365,6 @@ class GuidedCapability(enum.Enum):
         return self in [
             GuidedCapability.CORE_BOOT_ENCRYPTED,
             GuidedCapability.CORE_BOOT_UNENCRYPTED,
-            GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED,
-            GuidedCapability.CORE_BOOT_PREFER_UNENCRYPTED,
         ]
 
     def supports_manual_customization(self) -> bool:

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -696,7 +696,9 @@ class TestLayout(IsolatedAsyncioTestCase):
 
 
 class TestGuidedV2(IsolatedAsyncioTestCase):
-    async def _setup(self, bootloader, ptable, fix_bios=True, **kw):
+    async def _setup(
+        self, bootloader, ptable, fix_bios=True, snapd_system_labels=(None,), **kw
+    ):
         self.app = make_app()
         self.app.opts.bootloader = bootloader.value
         self.fsc = FilesystemController(app=self.app)
@@ -704,11 +706,16 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.fsc.calculate_suggested_install_min.return_value = 10 << 30
         self.fsc.model = self.model = make_model(bootloader)
         self.fsc._examine_systems_task.start_sync()
+        self.app.snapdapi = snapdapi.make_api_client(AsyncSnapd(get_fake_connection()))
         self.app.dr_cfg = DRConfig()
+        self.app.dr_cfg.systems_dir_exists = True
+        self.app.base_model.source.search_drivers = False
         self.app.base_model.source.current.type = "fsimage"
-        self.app.base_model.source.current.variations = {
-            "default": CatalogEntryVariation(path="", size=1),
-        }
+        variations = self.app.base_model.source.current.variations = {}
+        for label in snapd_system_labels:
+            variations["var" + str(label)] = CatalogEntryVariation(
+                path="", size=1, snapd_system_label=label
+            )
         self.app.controllers.Source.get_handler.return_value = TrivialSourceHandler("")
         await self.fsc._examine_systems_task.wait()
         self.disk = make_disk(self.model, ptable=ptable, **kw)
@@ -719,7 +726,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             "filesystem": self.fs_probe,
         }
         self.fsc._probe_task.task = mock.Mock()
-        self.fsc._examine_systems_task.task = mock.Mock()
+        # self.fsc._examine_systems_task.task = mock.Mock()
         if bootloader == Bootloader.BIOS and ptable != "msdos" and fix_bios:
             make_partition(
                 self.model,
@@ -1152,6 +1159,29 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         resp = await self.fsc.v2_guided_GET()
         self.assertEqual(expected, resp.targets)
         self.assertEqual(ProbeStatus.DONE, resp.status)
+
+    @parameterized.expand(
+        [
+            ("mandatory", ["ENCRYPTED"]),
+            ("prefer-encrypted", ["ENCRYPTED", "UNENCRYPTED"]),
+            ("prefer-unencrypted", ["UNENCRYPTED", "ENCRYPTED"]),
+            ("unavailable", ["UNENCRYPTED"]),
+        ]
+    )
+    async def test_core_boot_and_classic(self, label, core_boot_cap_names):
+        expected_core_boot_caps = [
+            getattr(GuidedCapability, f"CORE_BOOT_{cap_name}")
+            for cap_name in core_boot_cap_names
+        ]
+        await self._setup(
+            Bootloader.UEFI,
+            "gpt",
+            snapd_system_labels=[None, label],
+        )
+        resp = await self.fsc.v2_guided_GET()
+        [target, man] = resp.targets
+        got_core_boot_caps = [cap for cap in target.allowed if cap.is_core_boot()]
+        self.assertEqual(got_core_boot_caps, expected_core_boot_caps)
 
 
 class TestManualBoot(IsolatedAsyncioTestCase):

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -629,7 +629,7 @@ class TestCore(TestAPI):
             await inst.post("/source", source_id="ubuntu-desktop")
             resp = await inst.get("/storage/v2/guided", wait=True)
             [reformat, manual] = resp["targets"]
-            self.assertIn("CORE_BOOT_PREFER_ENCRYPTED", reformat["allowed"])
+            self.assertIn("CORE_BOOT_ENCRYPTED", reformat["allowed"])
             data = dict(target=reformat, capability="CORE_BOOT_ENCRYPTED")
             await inst.post("/storage/v2/guided", data)
             v2resp = await inst.get("/storage/v2")


### PR DESCRIPTION
Way back when I added support for core boot classic installs, we did not have a way to indicate whether the installed model preferred to be installed encrypted or unencrypted. Roll time on 9 months or so and our API now supports a list of capabilites and we can define that we can indicate which is preferred by putting it first in the list.

One part of the  implementation is a bit delicate really -- relying on list.sort() being stable -- so maybe we should clean that up. But I think the other changes make everything nicer.