### PR TITLE
Update instructions to test local changes in kvm

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -521,7 +521,7 @@ Tests (and lint checks) are run by github actions using lxd.  See
 `.github/workflows/build.yaml` and `./scripts/test-in-lxd.sh` and so
 on.
 
-For "real" testing, you need to make a snap (`snapcraft snap`), mash
+For "real" testing, you need to make a snap (`snapcraft pack`), mash
 it into an existing ISO using `./scripts/inject-subiquity-snap.sh`,
 and boot the result in a VM. There is an even hackier pair of scripts
 (`./scripts/slimy-update-snap.sh` and

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ do this:
 1. Build your change into a snap:
 
    ```
-   $ snapcraft snap --output subiquity_test.snap
+   $ snapcraft pack --output subiquity_test.snap
    ```
 
 2. Grab the current version of the installer:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,38 @@ an ISO. Rather than building one from scratch, it's much easier to
 install your version of subiquity into the daily image. Here's how to
 do this:
 
-1. Build your change into a snap:
+## Commit your changes locally
+
+If you are only making a change in Subiquity itself, running `git add <modified-file...>`
+and then `git commit` should be enough.
+
+Otherwise, if you made any modification to curtin or probert, you need to ensure that:
+
+* The modification is committed inside the relevant repository (i.e., `git add` + `git commit`).
+* The relevant `source` property in snapcraft.yaml points to the local
+  repository instead of the upstream repository.
+* The relevant `source-commit` property in snapcraft.yaml is updated to reflect
+  your new revision (one must use the full SHA-1 here).
+* The above modifications to snapcraft.yaml are committed.
+
+Example:
+```
+parts:
+  curtin:
+    plugin: nil
+
+    # Comment out the original source property, pointing to the upstream repository
+    #source: https://git.launchpad.net/curtin
+    # Instead, specify the name of the directory where curtin is checked out
+    source: curtin
+    source-type: git
+    # Update the below so it points to the commit ID within the curtin repository
+    source-commit: 7c18bf6a24297ed465a341a1f53875b61c878d6b
+```
+
+## Build and inject your changes into an ISO
+
+1. Build your changes into a snap:
 
    ```
    $ snapcraft pack --output subiquity_test.snap

--- a/scripts/kvm-test.py
+++ b/scripts/kvm-test.py
@@ -306,14 +306,14 @@ def build(ctx):
             with snap_manager('subiquity_test.snap') as snap:
                 if not ctx.args.reuse:
                     run('snapcraft clean --use-lxd')
-                    run(f'snapcraft snap --use-lxd --output {snap} {snapargs}')
+                    run(f'snapcraft pack --use-lxd --output {snap} {snapargs}')
                 assert_exists(snap)
                 livefs_edit(ctx, '--add-snap-from-store', 'core20', 'stable',
                             '--inject-snap', snap)
     elif project == 'ubuntu-desktop-installer':
         with snap_manager('udi_test.snap') as snap:
             run('snapcraft clean --use-lxd')
-            run(f'snapcraft snap --use-lxd --output {snap} {snapargs}')
+            run(f'snapcraft pack --use-lxd --output {snap} {snapargs}')
             assert_exists(snap)
             run(f'sudo ./scripts/inject-snap {ctx.baseiso} {ctx.iso} {snap}')
     else:

--- a/scripts/test-this-branch.sh
+++ b/scripts/test-this-branch.sh
@@ -6,7 +6,7 @@ cd $(dirname $(dirname $(readlink -f $0)))
 
 sudo apt install -y zsync xorriso isolinux
 
-snapcraft snap --output subiquity_test.snap
+snapcraft pack --output subiquity_test.snap
 urlbase=http://cdimage.ubuntu.com/ubuntu-server/daily-live/current
 distroname=$(distro-info -d)
 isoname="${distroname}"-live-server-$(dpkg --print-architecture).iso


### PR DESCRIPTION
As reported in LP:#2039966, the instructions we provide to test local changes in KVM were not enough to cover changes in curtin or probert.

Updated README.md with some pointers and also replaced uses of `snapcraft snap` by `snapcraft pack` to avoid deprecation warnings.