### PR TITLE
Update apport reporting 

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -62,7 +62,7 @@ validate () {
                 # not to do that.
                 # If we run an autoinstall that customizes the security section as part
                 # of the test-suite, we will need to adapt this test.
-                python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/subiquity-curtin-apt.conf \
+                python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/curtin-install/subiquity-curtin-apt.conf \
                     apt.security[0].uri='"http://security.ubuntu.com/ubuntu/"' \
                     apt.security[0].arches='["amd64", "i386"]' \
                     apt.security[1].uri='"http://ports.ubuntu.com/ubuntu-ports"'
@@ -259,7 +259,7 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --kernel-cmdline autoinstall \
     --source-catalog examples/sources/install.yaml
 validate
-python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/subiquity-curtin-apt.conf \
+python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/curtin-install/subiquity-curtin-apt.conf \
         apt.disable_components='[non-free, restricted]' \
         apt.preferences[0].pin-priority=200 \
         apt.preferences[0].pin='"origin *ubuntu.com*"' \

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -194,9 +194,13 @@ def main():
     logfiles = setup_logger(dir=logdir, base="subiquity-server")
 
     logger = logging.getLogger("subiquity")
-    version = os.environ.get("SNAP_REVISION", "unknown")
+    revision = os.environ.get("SNAP_REVISION", "unknown")
+    version = os.environ.get("SNAP_VERSION", "unknown")
     snap = os.environ.get("SNAP", "unknown")
-    logger.info(f"Starting Subiquity server revision {version} of snap {snap}")
+    logger.info(
+        f"Starting Subiquity server revision {revision} of snap {snap} "
+        f"of version {version}"
+    )
     logger.info(f"Arguments passed: {sys.argv}")
     logger.debug(f"Kernel commandline: {opts.kernel_cmdline}")
     logger.debug(f"Environment: {os.environ}")

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -146,8 +146,12 @@ def main():
 
     async def run_with_loop():
         subiquity_interface = SubiquityClient(opts)
-        subiquity_interface.note_file_for_apport("InstallerLog", logfiles["debug"])
-        subiquity_interface.note_file_for_apport("InstallerLogInfo", logfiles["info"])
+        subiquity_interface.note_file_for_apport(
+            "InstallerClientLog", logfiles["debug"]
+        )
+        subiquity_interface.note_file_for_apport(
+            "InstallerClientLogInfo", logfiles["info"]
+        )
         await subiquity_interface.run()
 
     asyncio.run(run_with_loop())

--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -148,7 +148,7 @@ class AptConfigurer:
         self.configured_tree = await self.mounter.setup_overlay([self.source_path])
 
         config_location = os.path.join(
-            self.app.root, "var/log/installer/subiquity-curtin-apt.conf"
+            self.app.root, "var/log/installer/curtin-install/subiquity-curtin-apt.conf"
         )
         generate_config_yaml(config_location, self.apt_config(final))
         self.app.note_data_for_apport("CurtinAptConfig", config_location)

--- a/system_setup/cmd/tui.py
+++ b/system_setup/cmd/tui.py
@@ -155,8 +155,12 @@ def main():
 
     async def run_with_loop():
         subiquity_interface = SystemSetupClient(opts)
-        subiquity_interface.note_file_for_apport("InstallerLog", logfiles["debug"])
-        subiquity_interface.note_file_for_apport("InstallerLogInfo", logfiles["info"])
+        subiquity_interface.note_file_for_apport(
+            "InstallerClientLog", logfiles["debug"]
+        )
+        subiquity_interface.note_file_for_apport(
+            "InstallerClientLogInfo", logfiles["info"]
+        )
         await subiquity_interface.run()
 
     asyncio.run(run_with_loop())


### PR DESCRIPTION
Some name and file location changes to be consistent with the (to be upload) updated subiquity hook in apport.

The only source of the traceback - if any - is the one in memory that we grab and manually attach to the report. We also need to explicitly write out the traceback information when we crash, otherwise a call to `ubuntu-bug` or similar won't be able to pick it up.