### PR TITLE
workflow: runners to 20.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       run: sudo ./scripts/test-in-lxd.sh ${{ matrix.image }} "make lint"
 
   format-black:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
@@ -47,7 +47,7 @@ jobs:
           src: "console_conf subiquity subiquitycore system_setup"
 
   format-isort:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: isort/isort-action@v1
@@ -58,7 +58,7 @@ jobs:
   static-typing:
     # In this job, we compare the output of mypy before and after the PR.
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04  # minimimum 22.04 for python3-typeshed
     steps:
       - name: Install mypy and typeshed
         run: sudo apt-get install -y python3-mypy python3-typeshed

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   snap-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
     - uses: snapcore/action-build@v1


### PR DESCRIPTION
The CI jobs today are split over 20.04 and 22.04 runners.  Some of the test setup actually fails when run against the 22.04 runners, which is why the haven't been moved all to 22.04 yet.

The 20.04 runners are consistently being run before the 22.04 ones, so move everyone to 20.04 for now.

Runner for typing left on 22.04, that one matters.