### PR TITLE
Added python3-debian in apt-deps.txt

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -25,6 +25,7 @@ python3-async-timeout
 python3-attr
 python3-bson
 python3-coverage
+python3-debian
 python3-dev
 python3-distutils-extra
 python3-flake8


### PR DESCRIPTION
Fixes issue reported at https://github.com/canonical/ubuntu-desktop-installer/issues/2385

Based on the Log included with the ticket, the cause of the issue is "`ModuleNotFoundError: No module named 'debian.deb822`". 

This PR fixes it by including `python3-debian` in `apt-deps.text`.