### PR TITLE
readme: make a contributing section and point to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,40 @@
 
-Thank you for considering a contribution to Subiquity.  Here's what we like to
-see:
+Thank you for considering a contribution to Subiquity.  Here are some things to
+note:
 
-* Contributors will need to have signed the
-  [CLA](https://ubuntu.com/legal/contributors/agreement).
-* Format, lint, unit, integration, and API tests should be passing.
-  * format - either run `make format` or `pre-commit install`.
-    See [pre-commit](https://pre-commit.com/#install) for more details on that
-    tool.
+## Code of Conduct
+
+This project is subject to the [Ubuntu Code of Conduct](https://ubuntu.com/community/code-of-conduct)
+to foster an open and welcoming place to contribute. By participating in the
+project (in the form of code contributions, issues, comments, and other
+activities), you agree to abide by its terms.
+
+## Contributor License Agreement
+
+This project is subject to the
+[Canonical contributor license agreement](https://ubuntu.com/legal/contributors),
+please make sure you have [signed it](https://ubuntu.com/legal/contributors/agreement)
+before (or shortly after) submitting your first pull request.
+
+A github workflow will verify that your GitHub username or email address is
+associated with a contributor license agreement signature, but it may take
+some time after your initial signature for the check to see it. If you're
+part of [@canonical](https://github.com/canonical), you will also need to make
+sure your canonical.com email address is associated with your GitHub account.
+
+## Bugs
+Bugs are tracked on [Launchpad](https://bugs.launchpad.net/subiquity). It is
+recommended you use `ubuntu-bug` (or similar) to let apport collect relevant
+logs which are helpful for the debug process, instead of filing one directly.
+
+## Pull Requests
+Changes to this project should be proposed as pull requests on GitHub at:
+[https://github.com/canonical/subiquity/](https://github.com/canonical/subiquity/)
+
+
+ Format, lint, unit, integration, and API tests should be passing.
+  * format - run either `make format` or `pre-commit install`.
+    * Install pre-commit with `sudo apt install pre-commit`.
   * all the rest - `make lint check`.
-    Prerequisites for running these locally can be installed with
+    * Prerequisites for running these locally can be installed with
     `make aptdeps`.

--- a/README.md
+++ b/README.md
@@ -125,3 +125,7 @@ parts:
    ```
 
 The first three steps are bundled into the script ./scripts/test-this-branch.sh.
+
+# Contributing
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
I added a link in the readme to our contribution guidelines and in the contribution guidelines I included a section about the Ubuntu Code of Conduct and updated the Contributor License Agreement text. These two sections are almost entirely lifted from [ubuntu-desktop-installer's readme](https://github.com/canonical/ubuntu-desktop-installer/blob/c030903a00e3819c094efa30d89467e6071985fe/CONTRIBUTING.md#contributor-license-agreement) because it sounds nice and it'd probably be good to have something consistent across the projects. 

I also added some information about where and how to submit bugs, as well as where to submit PRs.