### PR TITLE
snapcraft: update curtin for the efivarfs statfs workaround

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 7c18bf6a24297ed465a341a1f53875b61c878d6b
+    source-commit: a349105809af6188cb394e300a99846df3d117f0
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Full changelog:

* canonical/curtin@64b2744dc4c7c57e18beb46423cf6b563ccd76ab
* canonical/curtin@a349105809af6188cb394e300a99846df3d117f0