### PR TITLE
snapcraft: update curtin for the efivarfs statfs workaround

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,8 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 7c18bf6a24297ed465a341a1f53875b61c878d6b
+    # We are tracking the branch ubuntu/mantic here.
+    source-commit: f96c957c756d2856889ae977677de32647a1cbc9
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
* cherry-picked a36d969745b05c93b62eee711a0c9882c5fd7fa3 from https://github.com/canonical/subiquity/pull/1860 (adjusted to track curtin's ubuntu/mantic branch)

NOTE: with the comment I added in snapcraft.yaml, I expect future cherry-picks adjusting the curtin revision to conflict. This is on purpose, we don't want to pull new revisions of curtin from master (this would potentially introduce new features). To fix the conflict, we need to find the relevant revision in ubuntu/mantic.