### PR TITLE
identity: do not mention SSH being the next screen

### DIFF
--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -181,7 +181,7 @@ class IdentityView(BaseView):
     title = _("Profile setup")
     excerpt = _(
         "Enter the username and password you will use to log in to "
-        "the system. You can configure SSH access on the next screen "
+        "the system. You can configure SSH access on a later screen "
         "but a password is still needed for sudo."
     )
 


### PR DESCRIPTION
The identity screen tells the user that SSH can be configured on the next screen. That said, nowadays, other screens can be presented between the identity screen and the SSH screen (including the Ubuntu Pro screen).

Reword the message accordingly.