### PR TITLE
console_conf: use the correct /run directory

### DIFF
--- a/console_conf/core.py
+++ b/console_conf/core.py
@@ -26,7 +26,7 @@ log = logging.getLogger("console_conf.core")
 class ConsoleConf(TuiApplication):
     from console_conf import controllers as controllers_mod
 
-    project = "console_conf"
+    project = "console-conf"
 
     make_model = ConsoleConfModel
 
@@ -44,7 +44,7 @@ class ConsoleConf(TuiApplication):
 class RecoveryChooser(TuiApplication):
     from console_conf import controllers as controllers_mod
 
-    project = "console_conf"
+    project = "console-conf"
 
     controllers = [
         "RecoveryChooserWelcome",


### PR DESCRIPTION
We should use one `/run/console_conf` directory.
As this is defined dynamically based on the package name, align
other places where `/run/console-conf` is used and use `/run/console_conf` instead, to avoid cluttering of `/run` directory.
This also complicated strict confinement.