### PR TITLE
console_conf: identity: handle os.ttyname() error

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -102,11 +102,22 @@ Personalize your account at https://login.ubuntu.com.
 """
 
 
+def get_tty_name():
+    # handle error if we cannot get tty, e.g. in snap confinement
+    # try to get correct tty from env, it should be ready there
+    try:
+        tty_name = os.ttyname(0)[5:]  # strip off the /dev/
+    except OSError:
+        tty_name = os.getenv("tty", "")
+    return tty_name
+
+
 def write_login_details(fp, username, ips):
     sshcommands = "\n"
     for ip in ips:
         sshcommands += "    ssh %s@%s\n" % (username, ip)
-    tty_name = os.ttyname(0)[5:]  # strip off the /dev/
+
+    tty_name = get_tty_name()
     version = get_core_version() or "16"
     if len(ips) == 0:
         fp.write(
@@ -135,7 +146,7 @@ def write_login_details_standalone():
             print("device managed without user")
             return 2
         else:
-            tty_name = os.ttyname(0)[5:]
+            tty_name = get_tty_name()
             version = get_core_version() or "16"
             print(login_details_tmpl_no_ip.format(tty_name=tty_name, version=version))
             return 2


### PR DESCRIPTION
In strict snap confinement getting tty name is not permitted and calling `os.ttyname()` fails.
Handle the error and fall back to the use of the value from env variable, this is already set by the invoking process if needed.