### PR TITLE
console_conf: identity: use snapd unix socket

### DIFF
--- a/console_conf/core.py
+++ b/console_conf/core.py
@@ -19,6 +19,7 @@ from console_conf.models.console_conf import ConsoleConfModel
 from console_conf.models.systems import RecoverySystemsModel
 from subiquitycore.prober import Prober
 from subiquitycore.snap import snap_name
+from subiquitycore.snapd import SnapdConnection
 from subiquitycore.tui import TuiApplication
 
 log = logging.getLogger("console_conf.core")
@@ -46,6 +47,9 @@ class ConsoleConf(TuiApplication):
     def __init__(self, opts):
         super().__init__(opts)
         self.prober = Prober(opts.machine_config, self.debug_flags)
+        # we're talking to snapd over the main socket, this may require
+        # snapd-control if executing inside a snap
+        self.snapdcon = SnapdConnection(self.root, "/run/snapd.socket")
 
 
 class RecoveryChooser(TuiApplication):

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -121,6 +121,19 @@ class ResponseSet:
         return _FakeFileResponse(f)
 
 
+class MemoryResponseSet:
+    """Set of response for an endpoint which returns data stored in memory."""
+
+    def __init__(self, data):
+        self.data = data
+        self.index = 0
+
+    def next(self):
+        d = self.data[self.index]
+        self.index += 1
+        return _FakeMemoryResponse(d)
+
+
 class FakeSnapdConnection:
     def __init__(self, snap_data_dir, scale_factor, output_base):
         self.snap_data_dir = snap_data_dir

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -127,6 +127,7 @@ class FakeSnapdConnection:
         self.scale_factor = scale_factor
         self.response_sets = {}
         self.output_base = output_base
+        self.post_cb = {}
 
     def configure_proxy(self, proxy):
         log.debug("pretending to restart snapd to pick up proxy config")
@@ -167,6 +168,9 @@ class FakeSnapdConnection:
                     "status": "Accepted",
                 }
             )
+        if path in self.post_cb:
+            return _FakeMemoryResponse(self.post_cb[path](path, body, **args))
+
         raise Exception(
             "Don't know how to fake POST response to {}".format((path, args))
         )


### PR DESCRIPTION
When running in strict snap confinement `snap` client binary is not accessible.
Additionally, the output format of `snap` client binary is not guaranteed not to change.
snapd REST API should be used instead when communicating to the snapd and expecting a parsable response.
This also improves error handling for this call.