### PR TITLE
console_conf: identity: use prepared fingerprints

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -19,7 +19,6 @@ import os
 import pwd
 import shlex
 import sys
-from pathlib import Path
 
 from console_conf.ui.views import IdentityView, LoginView
 from subiquitycore.snapd import SnapdConnection
@@ -117,17 +116,7 @@ def write_login_details(fp, username, ips):
         )
     else:
         first_ip = ips[0]
-        key_info = None
-        if os.getenv("SNAP_CONFINEMENT", "classic") == "strict":
-            # if we run in confinement, we have no direct accesss to host
-            # keys info use prepared finger prints if exist
-            host_fingerprints_path = "/run/console-conf/host-fingerprints.txt"
-            host_fingerprints = Path(host_fingerprints_path)
-            if host_fingerprints.is_file():
-                fingerprints = open(host_fingerprints_path, "r")
-                key_info = fingerprints.read()
-        else:
-            key_info = host_key_info()
+        key_info = host_key_info()
         fp.write(
             login_details_tmpl.format(
                 sshcommands=sshcommands,

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -19,6 +19,7 @@ import os
 import pwd
 import shlex
 import sys
+from pathlib import Path
 
 from console_conf.ui.views import IdentityView, LoginView
 from subiquitycore.snapd import SnapdConnection
@@ -116,10 +117,21 @@ def write_login_details(fp, username, ips):
         )
     else:
         first_ip = ips[0]
+        key_info = None
+        if os.getenv("SNAP_CONFINEMENT", "classic") == "strict":
+            # if we run in confinement, we have no direct accesss to host
+            # keys info use prepared finger prints if exist
+            host_fingerprints_path = "/run/console-conf/host-fingerprints.txt"
+            host_fingerprints = Path(host_fingerprints_path)
+            if host_fingerprints.is_file():
+                fingerprints = open(host_fingerprints_path, "r")
+                key_info = fingerprints.read()
+        else:
+            key_info = host_key_info()
         fp.write(
             login_details_tmpl.format(
                 sshcommands=sshcommands,
-                host_key_info=host_key_info(),
+                host_key_info=key_info,
                 tty_name=tty_name,
                 first_ip=first_ip,
                 version=version,

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -21,6 +21,7 @@ import shlex
 import sys
 
 from console_conf.ui.views import IdentityView, LoginView
+from subiquitycore import snap
 from subiquitycore.snapd import SnapdConnection
 from subiquitycore.ssh import get_ips_standalone, host_key_info
 from subiquitycore.tuicontroller import TuiController
@@ -102,7 +103,7 @@ Personalize your account at https://login.ubuntu.com.
 """
 
 
-def write_login_details(fp, username, ips):
+def write_login_details(fp, username, ips, state_dir=None):
     sshcommands = "\n"
     for ip in ips:
         sshcommands += "    ssh %s@%s\n" % (username, ip)
@@ -116,7 +117,7 @@ def write_login_details(fp, username, ips):
         )
     else:
         first_ip = ips[0]
-        key_info = host_key_info()
+        key_info = host_key_info(runtime_state_dir=state_dir)
         fp.write(
             login_details_tmpl.format(
                 sshcommands=sshcommands,
@@ -143,7 +144,13 @@ def write_login_details_standalone():
     if owner is None:
         print("device managed without user @ {}".format(", ".join(ips)))
     else:
-        write_login_details(sys.stdout, owner["username"], ips)
+        if snap.is_snap() and snap.is_snap_strictly_confined():
+            # normally this is set by the application context, but here we are
+            # executing standalone
+            runtime_state = os.path.join("/run", snap.snap_name())
+        else:
+            runtime_state = None
+        write_login_details(sys.stdout, owner["username"], ips, state_dir=runtime_state)
     return 0
 
 
@@ -192,7 +199,9 @@ class IdentityController(TuiController):
         for dev in net_model.get_all_netdevs():
             ips.extend(dev.actual_global_ip_addresses)
         with open(login_details_path, "w") as fp:
-            write_login_details(fp, result["username"], ips)
+            write_login_details(
+                fp, result["username"], ips, state_dir=self.app.state_dir
+            )
         self.login()
 
     def cancel(self):

--- a/subiquitycore/ssh.py
+++ b/subiquitycore/ssh.py
@@ -16,6 +16,7 @@
 import logging
 import os
 import pwd
+from pathlib import Path
 
 from subiquitycore.utils import run_command
 
@@ -77,7 +78,17 @@ The {keytype} host key fingerprint is:
 
 
 def host_key_info():
-    return summarize_host_keys(host_key_fingerprints())
+    if os.getenv("SNAP_CONFINEMENT", "classic") == "strict":
+        # if we run in confinement, we have no direct accesss to host
+        # keys info use prepared finger prints if exist
+        snap_name = os.getenv("SNAP_NAME", "classic")
+        host_fingerprints = Path("/run/" + snap_name + "/host-fingerprints.txt")
+        if host_fingerprints.is_file():
+            fingerprints = open(host_fingerprints, "r")
+            return fingerprints.read()
+        return ""
+    else:
+        return summarize_host_keys(host_key_fingerprints())
 
 
 def summarize_host_keys(fingerprints):

--- a/subiquitycore/ssh.py
+++ b/subiquitycore/ssh.py
@@ -88,8 +88,8 @@ def host_key_info(runtime_state_dir=None):
             host_fingerprints.is_file(),
         )
         if host_fingerprints.is_file():
-            fingerprints = open(host_fingerprints, "r")
-            return fingerprints.read()
+            with open(host_fingerprints, "r") as fp:
+                return fp.read()
 
     return summarize_host_keys(host_key_fingerprints())
 

--- a/subiquitycore/ssh.py
+++ b/subiquitycore/ssh.py
@@ -77,18 +77,21 @@ The {keytype} host key fingerprint is:
 )
 
 
-def host_key_info():
-    if os.getenv("SNAP_CONFINEMENT", "classic") == "strict":
-        # if we run in confinement, we have no direct accesss to host
-        # keys info use prepared finger prints if exist
-        snap_name = os.getenv("SNAP_NAME", "classic")
-        host_fingerprints = Path("/run/" + snap_name + "/host-fingerprints.txt")
+def host_key_info(runtime_state_dir=None):
+    if runtime_state_dir:
+        # host fingerprints information may have already been prepared by the
+        # platform glue
+        host_fingerprints = Path(runtime_state_dir) / "host-fingerprints.txt"
+        log.debug(
+            "pre-made host finterprints %s present: %s",
+            host_fingerprints,
+            host_fingerprints.is_file(),
+        )
         if host_fingerprints.is_file():
             fingerprints = open(host_fingerprints, "r")
             return fingerprints.read()
-        return ""
-    else:
-        return summarize_host_keys(host_key_fingerprints())
+
+    return summarize_host_keys(host_key_fingerprints())
 
 
 def summarize_host_keys(fingerprints):

--- a/subiquitycore/tests/test_ssh.py
+++ b/subiquitycore/tests/test_ssh.py
@@ -1,0 +1,53 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os.path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from subiquitycore import ssh
+
+
+class TestSSH(unittest.TestCase):
+    @patch(
+        "subiquitycore.ssh.host_key_fingerprints",
+        return_value=[("key1-type", "key1-value"), ("key2-type", "key2-value")],
+    )
+    def test_host_key_info_premade(self, hkf):
+        # premade fingerprints are present
+        with tempfile.TemporaryDirectory(suffix="subiquity-ssh") as td:
+            fpfile = os.path.join(td, "host-fingerprints.txt")
+            with open(fpfile, "w") as outf:
+                outf.write("mock host fingerprints")
+
+            # fingerprints are pulled from the pre-made file
+            self.assertEqual(
+                ssh.host_key_info(runtime_state_dir=td), "mock host fingerprints"
+            )
+
+            # but are pulled from the system if the file is not there
+            os.remove(fpfile)
+            self.assertIn(
+                "key1-type key1-value", ssh.host_key_info(runtime_state_dir=td)
+            )
+
+    @patch(
+        "subiquitycore.ssh.host_key_fingerprints",
+        return_value=[("key1-type", "key1-value"), ("key2-type", "key2-value")],
+    )
+    def test_host_key_info_query(self, hkf):
+        self.assertIn("key1-type key1-value", ssh.host_key_info())
+        self.assertIn("key2-type key2-value", ssh.host_key_info())


### PR DESCRIPTION
In strict snap confinement, sshd config or host keys are not accessible.
If strict confinement is detected, instead allow reuse of the host keys fingerprints already prepared by invoking process. Prepared fingerprints are stored in: `/run/console-conf/host-fingerprints.txt`

Additionally, in strict snap confinement, snap can not access the other user's ssh keys or authorised keys.
Do not read those, it does not seem like we are displaying them at the moment anyway.