### PR TITLE
subiquitycore: do not set uid and gid in snap strict confinement

### DIFF
--- a/subiquitycore/file_util.py
+++ b/subiquitycore/file_util.py
@@ -30,6 +30,8 @@ log = logging.getLogger("subiquitycore.file_util")
 
 
 def set_log_perms(target, *, group_write=False, mode=None, group=_DEF_GROUP):
+    if os.getenv("SNAP_CONFINEMENT", "classic") == "strict":
+        return
     if os.getuid() != 0:
         log.warning(
             "set_log_perms: running as non-root - not adjusting"


### PR DESCRIPTION
Snap strict confinement does not permit uid and gid alteration.
This is also not necessary, we should be running as root anyway. If strict snap confinement is detected, skip this step.