### PR TITLE
Unify UI screen titles and minor lang. fixes

### DIFF
--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -178,10 +178,10 @@ class IdentityForm(Form):
 
 
 class IdentityView(BaseView):
-    title = _("Profile setup")
+    title = _("Profile configuration")
     excerpt = _(
         "Enter the username and password you will use to log in to "
-        "the system. You can configure SSH access on a later screen "
+        "the system. You can configure SSH access on a later screen, "
         "but a password is still needed for sudo."
     )
 

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -41,7 +41,7 @@ class MyLineBox(LineBox):
 
 
 class ProgressView(BaseView):
-    title = _("Install progress")
+    title = _("Installation progress")
 
     def __init__(self, controller):
         self.controller = controller
@@ -149,14 +149,14 @@ class ProgressView(BaseView):
             self.title = _("Installing system")
             btns = [self.view_log_btn]
         elif state == ApplicationState.UU_RUNNING:
-            self.title = _("Install complete!")
+            self.title = _("Installation complete!")
             self.reboot_btn.base_widget.set_label(_("Cancel update and reboot"))
             btns = [
                 self.view_log_btn,
                 self.reboot_btn,
             ]
         elif state == ApplicationState.UU_CANCELLING:
-            self.title = _("Install complete!")
+            self.title = _("Installation complete!")
             self.reboot_btn.base_widget.set_label(_("Rebooting..."))
             self.reboot_btn.enabled = False
             btns = [
@@ -164,7 +164,7 @@ class ProgressView(BaseView):
                 self.reboot_btn,
             ]
         elif state == ApplicationState.DONE:
-            self.title = _("Install complete!")
+            self.title = _("Installation complete!")
             self.reboot_btn.base_widget.set_label(_("Reboot Now"))
             btns = [
                 self.view_log_btn,

--- a/subiquity/ui/views/mirror.py
+++ b/subiquity/ui/views/mirror.py
@@ -34,29 +34,27 @@ from subiquitycore.view import BaseView
 
 log = logging.getLogger("subiquity.ui.views.mirror")
 
-mirror_help = _(
-    "You may provide an archive mirror that will be used instead of the default."
-)
+mirror_help = _("You may provide an archive mirror to be used instead of the default.")
 
 MIRROR_CHECK_CONFIRMATION_TEXTS = {
     MirrorCheckStatus.RUNNING: (
         _("Mirror check still running"),
         _(
-            "The check of the mirror URL is still running. You can continue but"
+            "The check of the mirror URL is still running. You can continue, but"
             " there is a chance that the installation will fail."
         ),
     ),
     MirrorCheckStatus.FAILED: (
         _("Mirror check failed"),
         _(
-            "The check of the mirror URL failed. You can continue but it is very"
+            "The check of the mirror URL failed. You can continue, but it is very"
             " likely that the installation will fail."
         ),
     ),
     None: (
         _("Mirror check has not run"),
         _(
-            "The check of the mirror has not yet started. You can continue but"
+            "The check of the mirror has not yet started. You can continue, but"
             " there is a chance that the installation will fail."
         ),
     ),
@@ -96,7 +94,7 @@ explain the problem. You can try again once the issue has been fixed
 
 
 class MirrorView(BaseView):
-    title = _("Configure Ubuntu archive mirror")
+    title = _("Ubuntu archive mirror configuration")
     excerpt = _("If you use an alternative mirror for Ubuntu, enter its details here.")
 
     def __init__(

--- a/subiquity/ui/views/proxy.py
+++ b/subiquity/ui/views/proxy.py
@@ -42,7 +42,7 @@ class ProxyForm(Form):
 
 
 class ProxyView(BaseView):
-    title = _("Configure proxy")
+    title = _("Proxy configuration")
     excerpt = _(
         "If this system requires a proxy to connect to the internet, "
         "enter its details here."

--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -368,7 +368,7 @@ class SnapCheckBox(CheckBox):
 
 
 class SnapListView(BaseView):
-    title = _("Featured Server Snaps")
+    title = _("Featured server snaps")
 
     def __init__(self, controller, data):
         self.selections_by_name = {}

--- a/subiquity/ui/views/source.py
+++ b/subiquity/ui/views/source.py
@@ -27,7 +27,7 @@ log = logging.getLogger("subiquity.ui.views.source")
 
 
 class SourceView(BaseView):
-    title = _("Choose type of install")
+    title = _("Choose the type of installation")
 
     def __init__(self, controller, sources, current_id, search_drivers: bool):
         self.controller = controller

--- a/subiquity/ui/views/ssh.py
+++ b/subiquity/ui/views/ssh.py
@@ -207,7 +207,7 @@ class ConfirmSSHKeys(Stretchy):
 
 
 class SSHView(BaseView):
-    title = _("SSH Setup")
+    title = _("SSH configuration")
     excerpt = _(
         "You can choose to install the OpenSSH server package to "
         "enable secure remote access to your server."

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -176,7 +176,7 @@ class UpgradeYesNoForm(Form):
     |                                                         |
     | ( )  Skip for now                                       |
     |                                                         |
-    |      You can always enable Ubuntu Pro later via the     |
+    |      You can always enable Ubuntu Pro later using the   |
     |      'pro attach' command.                              |
     |                                                         |
     |                       [ Continue ]                      |
@@ -193,7 +193,7 @@ class UpgradeYesNoForm(Form):
         group,
         _("Skip for now"),
         help="\n"
-        + _("You can always enable Ubuntu Pro later via the 'pro attach' command."),
+        + _("You can always enable Ubuntu Pro later using the 'pro attach' command."),
     )
 
 
@@ -205,8 +205,8 @@ class UpgradeYesNoFormNoNetwork(UpgradeYesNoForm):
     |                                                         |
     | (X)  Skip Ubuntu Pro setup for now                      |
     |                                                         |
-    |      Once you are connected to the Internet, you can    |
-    |      enable Ubuntu Pro via the 'pro attach' command.    |
+    |      Once you are connected to the internet, you can    |
+    |      enable Ubuntu Pro using the 'pro attach' command.  |
     |                                                         |
     |                       [ Continue ]                      |
     |                       [ Back     ]                      |
@@ -221,7 +221,7 @@ class UpgradeYesNoFormNoNetwork(UpgradeYesNoForm):
         _("Skip Ubuntu Pro setup for now"),
         help="\n"
         + _(
-            "Once you are connected to the Internet, you can"
+            "Once you are connected to the internet, you can"
             " enable Ubuntu Po via the 'pro attach' command."
         ),
     )
@@ -372,7 +372,7 @@ class UbuntuProView(BaseView):
         | ( )  Enable Ubuntu Pro                                  |
         |                                                         |
         | (X)  Skip for now                                       |
-        |      You can always enable Ubuntu Pro later via the     |
+        |      You can always enable Ubuntu Pro later using the   |
         |      'pro attach' command.                              |
         |                                                         |
         |                        [ Continue ]                     |
@@ -388,7 +388,7 @@ class UbuntuProView(BaseView):
             " STIG, HIPAA and other compliance or hardening"
             " requirements."
         )
-        excerpt_no_net = _("An Internet connection is required to enable Ubuntu Pro.")
+        excerpt_no_net = _("An internet connection is required to enable Ubuntu Pro.")
 
         about_pro_btn = menu_btn(
             _("About Ubuntu Pro"), on_press=lambda unused: self.show_about_ubuntu_pro()
@@ -423,7 +423,7 @@ class UbuntuProView(BaseView):
         |   * ...                                                 |
         |                                                         |
         | If you want to change the default enablements for your  |
-        | token, you can do so via the ubuntu.com/pro web         |
+        | token, you can do so using the ubuntu.com/pro web       |
         | interface. Alternatively, you can change enabled        |
         | services using the `pro' command-line tool once the     |
         | installation is finished.                               |
@@ -479,8 +479,8 @@ class UbuntuProView(BaseView):
             Text(
                 _(
                     "If you want to change the default enablements for your"
-                    " token, you can do so via the ubuntu.com/pro web"
-                    " interface. Alternatively you can change enabled services"
+                    " token, you can do so using the ubuntu.com/pro web"
+                    " interface. Alternatively, you can change enabled services"
                     " using the `pro` command-line tool once the installation"
                     " is finished."
                 )
@@ -566,11 +566,11 @@ class UbuntuProView(BaseView):
 
         def on_failure(status: UbuntuProCheckTokenStatus) -> None:
             """Open a message box stating that the contract-token
-            obtained via contract-selection is not valid ; and then go
+            obtained using contract-selection is not valid and then go
             back to the previous screen."""
 
             log.error(
-                "contract-token obtained via contract-selection"
+                "contract-token obtained using contract-selection"
                 " counld not be validated: %r",
                 status,
             )
@@ -584,7 +584,7 @@ class UbuntuProView(BaseView):
             )
 
         # It would be uncommon to have this call fail in production
-        # because the contract token obtained via contract-selection is
+        # because the contract token obtained using contract-selection is
         # expected to be valid. During testing, a mismatch in the
         # environment used (e.g., staging in subiquity and production
         # in u-a-c) can lead to this error though.
@@ -767,23 +767,23 @@ class TokenAddedWidget(Stretchy):
 
 class AboutProWidget(Stretchy):
     """Widget showing some information about what Ubuntu Pro offers.
-    +------------------- About Ubuntu Pro --------------------+
-    |                                                         |
-    | Ubuntu Pro is the same base Ubuntu, with an additional  |
-    | layer of security and compliance services and security  |
-    | patches covering a wider range of packages.             |
-    |   • Security patch coverage for CVSS critical, high and |
-    |     selected medium vulnerabilities in all 23,000       |
-    |     packages in "universe" (extended from the normal    |
-    |     2,300 "main" packages).                             |
-    |   • ...                                                 |
-    |   • ...                                                 |
-    |                                                         |
-    | Ubuntu Pro is free for personal use on up to 3 machines.|
-    | More information is at ubuntu.com/pro                   |
-    |                                                         |
-    |                       [ Continue ]                      |
-    +---------------------------------------------------------+
+    +------------------- About Ubuntu Pro ---------------------+
+    |                                                          |
+    | Ubuntu Pro is the same base as Ubuntu but adds an        |
+    | additional layer of security and compliance services     |
+    | and security patches covering a wider range of packages. |
+    |   • Security patch coverage for CVSS critical, high and  |
+    |     selected medium vulnerabilities in all 23,000        |
+    |     packages in "universe" (extended from the normal     |
+    |     2,300 "main" packages).                              |
+    |   • ...                                                  |
+    |   • ...                                                  |
+    |                                                          |
+    | Ubuntu Pro is free for personal use on up to five        |
+    | machines. More information is at ubuntu.com/pro          |
+    |                                                          |
+    |                       [ Continue ]                       |
+    +----------------------------------------------------------+
     """
 
     def __init__(self, parent: UbuntuProView) -> None:
@@ -794,7 +794,7 @@ class AboutProWidget(Stretchy):
 
         title = _("About Ubuntu Pro")
         header = _(
-            "Ubuntu Pro is the same base Ubuntu, with an additional"
+            "Ubuntu Pro is the same base as Ubuntu but adds an additional"
             " layer of security and compliance services and security"
             " patches covering a wider range of packages."
         )
@@ -832,7 +832,7 @@ class AboutProWidget(Stretchy):
             Text(""),
             Pile([itemize(svc, marker="  •") for svc in services]),
             Text(""),
-            Text(_("Ubuntu Pro is free for personal use on up to 3 machines.")),
+            Text(_("Ubuntu Pro is free for personal use on up to five machines.")),
             Text(_("More information is at ubuntu.com/pro")),
             Text(""),
             button_pile([ok]),
@@ -851,7 +851,7 @@ class HowToRegisterWidget(Stretchy):
     |                                                         |
     |_Create your Ubuntu One account with your email. Each    |
     | Ubuntu One account gets a free personal Ubuntu Pro      |
-    | subscription for up to three machines, including        |
+    | subscription for up to five machines, including         |
     | laptops, servers or cloud virtual machines.             |
     |                                                         |
     | Visit ubuntu.com/pro to get started.                    |
@@ -870,7 +870,7 @@ class HowToRegisterWidget(Stretchy):
         header = _(
             "Create your Ubuntu One account with your email. Each"
             " Ubuntu One account gets a free personal Ubuntu Pro"
-            " subscription for up to three machines, including"
+            " subscription for up to five machines, including"
             " laptops, servers or cloud virtual machines."
         )
 

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -222,7 +222,7 @@ class UpgradeYesNoFormNoNetwork(UpgradeYesNoForm):
         help="\n"
         + _(
             "Once you are connected to the internet, you can"
-            " enable Ubuntu Po via the 'pro attach' command."
+            " enable Ubuntu Pro using the 'pro attach' command."
         ),
     )
 

--- a/subiquity/ui/views/zdev.py
+++ b/subiquity/ui/views/zdev.py
@@ -143,7 +143,7 @@ class ZdevList(WidgetWrap):
 
 
 class ZdevView(BaseView):
-    title = _("Zdev setup")
+    title = _("Zdev configuration")
 
     def __init__(self, controller, zdevinfos):
         log.debug("FileSystemView init start()")

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -232,7 +232,7 @@ Wifi support packages will be installed in the target system.
 
 
 class NetworkView(BaseView):
-    title = _("Network connections")
+    title = _("Network configuration")
     excerpt = _(
         "Configure at least one interface this server can use to talk "
         "to other machines, and which preferably provides sufficient "


### PR DESCRIPTION
* Unifies installer screen titles to use '&lt;Topic&gt; configuration' (where approapriate).
* Fixes minor lang. problems and typos (commas, Ubuntu Po -> Pro, Internet -> internet, ...).

(Fixes [FR-5900](https://warthogs.atlassian.net/browse/FR-5900))

[FR-5900]: https://warthogs.atlassian.net/browse/FR-5900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ