### PR TITLE
Upgrade to noble, systemd files are now in /usr/lib

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+subiquity (24.04.1+git45g5f9fae19) noble; urgency=medium
+
+  * Upgrade to noble, systemd files are now in /usr/lib
+
+ -- Dimitri John Ledkov <dimitri.ledkov@canonical.com>  Fri, 24 Nov 2023 23:10:15 +0000
+
 subiquity (20.04.1+git45g5f9fae19) focal; urgency=medium
 
   * Upload subquity snapshot with reverted consoleconf patch.

--- a/debian/rules
+++ b/debian/rules
@@ -26,10 +26,10 @@ override_dh_python3:
 override_dh_installinit:
 	dh_installsystemd --no-start --name=console-conf@
 	dh_installsystemd --no-start --name=serial-console-conf@
-	mkdir $(CURDIR)/debian/console-conf/lib/systemd/system/getty@.service.d/
-	install -m 0644 $(CURDIR)/debian/console-conf.conf $(CURDIR)/debian/console-conf/lib/systemd/system/getty@.service.d/
-	mkdir $(CURDIR)/debian/console-conf/lib/systemd/system/serial-getty@.service.d/
-	install -m 0644 $(CURDIR)/debian/console-conf-serial.conf $(CURDIR)/debian/console-conf/lib/systemd/system/serial-getty@.service.d/
+	mkdir $(CURDIR)/debian/console-conf/usr/lib/systemd/system/getty@.service.d/
+	install -m 0644 $(CURDIR)/debian/console-conf.conf $(CURDIR)/debian/console-conf/usr/lib/systemd/system/getty@.service.d/
+	mkdir $(CURDIR)/debian/console-conf/usr/lib/systemd/system/serial-getty@.service.d/
+	install -m 0644 $(CURDIR)/debian/console-conf-serial.conf $(CURDIR)/debian/console-conf/usr/lib/systemd/system/serial-getty@.service.d/
 
 override_dh_auto_test:
 	@echo "No tests."


### PR DESCRIPTION
core24 started to ftbfs as it build the consoleconf deb and that is now failing with noble's debhelper, as it installs systemd units into usr/lib now.