### PR TITLE
network: ensure we pass tasks to asyncio.wait

### DIFF
--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -169,7 +169,8 @@ class NetworkController(BaseNetworkController, SubiquityController):
         with context.child("wait_dhcp"):
             try:
                 await asyncio.wait_for(
-                    asyncio.wait({e.wait() for e in dhcp_events}), 10
+                    asyncio.wait({asyncio.create_task(e.wait()) for e in dhcp_events}),
+                    10,
                 )
             except asyncio.TimeoutError:
                 pass

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -391,7 +391,9 @@ class BaseNetworkController(BaseController):
             return
 
         try:
-            await asyncio.wait_for(asyncio.wait({e.wait() for e in dhcp_events}), 10)
+            await asyncio.wait_for(
+                asyncio.wait({asyncio.create_task(e.wait()) for e in dhcp_events}), 10
+            )
         except asyncio.TimeoutError:
             pass
 


### PR DESCRIPTION
In Python < 3.11, when passing a coroutine to `asyncio.wait`, it would automatically be scheduled as a task. This isn't the case anymore with Python 3.11. Now passing coroutines to `asyncio.wait` fails with:

```
 TypeError: Passing coroutines is forbidden, use tasks explicitly.
```

Let's ensure we schedule the coroutines as tasks before passing them on to `asyncio.wait`.

LP:#2045663