### PR TITLE
Accept a fixed partition size for reset partition in autoinstall.yaml

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -423,6 +423,41 @@ Example with no size scaling and a passphrase:
         sizing-policy: all
         password: LUKS_PASSPHRASE
 
+Reset Partition
+^^^^^^^^^^^^^^^
+
+``reset-partition`` is used for creating a Reset Partition, which is a FAT32 file system containing the entire content of the installer image, so that the user can start the installer from GRUB or EFI without using the installation media. This option is useful for OEM system provisioning.
+
+By default, the size of a Reset Partition is roughly 1.1x the used file system size of the installation media.
+
+An example to enable Reset Partition:
+
+.. code-block:: yaml
+
+    storage:
+      layout:
+        name: direct
+        reset-partition: true
+
+The size of the reset partition can also be fixed to a specified size.  This is an example to fix Reset Partition to 12 GiB:
+
+.. code-block:: yaml
+
+    storage:
+      layout:
+        name: direct
+        reset-partition: 12G
+
+The installer can also install Reset Partition without installing the system.  To do this, set ``reset-partition-only`` to ``true``:
+
+.. code-block:: yaml
+
+    storage:
+      layout:
+        name: direct
+        reset-partition: true
+        reset-partition-only: true
+
 Action-based configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -531,6 +531,7 @@ class GuidedChoiceV2:
 
     sizing_policy: Optional[SizingPolicy] = SizingPolicy.SCALED
     reset_partition: bool = False
+    reset_partition_size: Optional[int] = None
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -459,6 +459,26 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertEqual(DRY_RUN_RESET_SIZE, d1p2.size)
         self.assertEqual("/", d1p3.mount)
 
+    async def test_fixed_reset_partition(self):
+        await self._guided_setup(Bootloader.UEFI, "gpt")
+        target = GuidedStorageTargetReformat(
+            disk_id=self.d1.id, allowed=default_capabilities
+        )
+        fixed_reset_size = 12 << 30
+        await self.controller.guided(
+            GuidedChoiceV2(
+                target=target,
+                capability=GuidedCapability.DIRECT,
+                reset_partition=True,
+                reset_partition_size=fixed_reset_size,
+            )
+        )
+        [d1p1, d1p2, d1p3] = self.d1.partitions()
+        self.assertEqual("/boot/efi", d1p1.mount)
+        self.assertIsNone(d1p2.mount)
+        self.assertEqual(fixed_reset_size, d1p2.size)
+        self.assertEqual("/", d1p3.mount)
+
     async def test_guided_reset_partition_only(self):
         await self._guided_setup(Bootloader.UEFI, "gpt")
         target = GuidedStorageTargetReformat(


### PR DESCRIPTION
This changeset will allow reset_partition to accept int or human-readable disk size (e.g. "12G"), so that the size of reset partition can be fixed.  This will be used for some OEM deployments and automated testing where overwriting or updating reset partition is necessary.