### PR TITLE
apt: Only backup/restore sources.list if it exists

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -327,8 +327,10 @@ class AptConfigurer:
         # The file only exists if we are online
         with contextlib.suppress(FileNotFoundError):
             os.unlink(target_mnt.p("etc/apt/sources.list.d/original.list"))
-        with contextlib.suppress(FileNotFoundError):
+        try:
             _restore_file("etc/apt/sources.list")
+        except FileNotFoundError:
+            os.unlink(target_mnt.p("etc/apt/sources.list"))
 
         with contextlib.suppress(FileNotFoundError):
             _restore_file("etc/apt/apt.conf.d/90curtin-aptproxy")

--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -243,10 +243,11 @@ class AptConfigurer:
         await self.mounter.mount("/cdrom", self.install_tree.p("cdrom"), options="bind")
 
         if self.app.base_model.network.has_network:
-            os.rename(
-                self.install_tree.p("etc/apt/sources.list"),
-                self.install_tree.p("etc/apt/sources.list.d/original.list"),
-            )
+            with contextlib.suppress(FileNotFoundError):
+                os.rename(
+                    self.install_tree.p("etc/apt/sources.list"),
+                    self.install_tree.p("etc/apt/sources.list.d/original.list"),
+                )
         else:
             proxy_path = self.install_tree.p("etc/apt/apt.conf.d/90curtin-aptproxy")
             if os.path.exists(proxy_path):
@@ -326,7 +327,8 @@ class AptConfigurer:
         # The file only exists if we are online
         with contextlib.suppress(FileNotFoundError):
             os.unlink(target_mnt.p("etc/apt/sources.list.d/original.list"))
-        _restore_file("etc/apt/sources.list")
+        with contextlib.suppress(FileNotFoundError):
+            _restore_file("etc/apt/sources.list")
 
         with contextlib.suppress(FileNotFoundError):
             _restore_file("etc/apt/apt.conf.d/90curtin-aptproxy")


### PR DESCRIPTION
We backup the sources.list to a file in sources.list.d to be able to insert our source first; if we do not have a sources.list this is not necessary.

If an image uses ubuntu.sources, this logic also works fine as sources.list that we write will be sourced before the ubuntu.sources.