### PR TITLE
debian: use 'install -D' instead 'mkdir + install'

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,10 +26,8 @@ override_dh_python3:
 override_dh_installinit:
 	dh_installsystemd --no-start --name=console-conf@
 	dh_installsystemd --no-start --name=serial-console-conf@
-	mkdir $(CURDIR)/debian/console-conf/usr/lib/systemd/system/getty@.service.d/
-	install -m 0644 $(CURDIR)/debian/console-conf.conf $(CURDIR)/debian/console-conf/usr/lib/systemd/system/getty@.service.d/
-	mkdir $(CURDIR)/debian/console-conf/usr/lib/systemd/system/serial-getty@.service.d/
-	install -m 0644 $(CURDIR)/debian/console-conf-serial.conf $(CURDIR)/debian/console-conf/usr/lib/systemd/system/serial-getty@.service.d/
+	install -D -m 0644 $(CURDIR)/debian/console-conf.conf $(CURDIR)/debian/console-conf/usr/lib/systemd/system/getty@.service.d/console-conf.conf
+	install -D -m 0644 $(CURDIR)/debian/console-conf-serial.conf $(CURDIR)/debian/console-conf/usr/lib/systemd/system/serial-getty@.service.d/console-conf-serial.conf
 
 override_dh_auto_test:
 	@echo "No tests."


### PR DESCRIPTION
In some situations build might fail on  `mkdir $(CURDIR)/debian/console-conf/usr/lib/systemd/system/getty@.service.d` as the leading directory does not exist.
Combine `mkdir` and `install` into `install -D`