### PR TITLE
Update README with hosted documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The first three steps are bundled into the script ./scripts/test-this-branch.sh.
 
 # Contributing
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md)
+Please see our [contributing guidelines](CONTRIBUTING.md).
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -129,3 +129,11 @@ The first three steps are bundled into the script ./scripts/test-this-branch.sh.
 # Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+# Documentation
+
+Subiquity's documentation is hosted at
+[https://canonical-subiquity.readthedocs-hosted.com/en/latest/](https://canonical-subiquity.readthedocs-hosted.com/en/latest/).
+
+The documentation source can be found in the [doc/](doc/) folder, which
+contains instructions for building a local preview.


### PR DESCRIPTION
We currently have a hosted version of our documentation ( https://canonical-subiquity.readthedocs-hosted.com/en/latest/ ) but it's not listed anywhere. Let's put it in the README so it can be found.  