### PR TITLE
ssh: invoke sshd -T with a clean environment

### DIFF
--- a/subiquitycore/ssh.py
+++ b/subiquitycore/ssh.py
@@ -17,7 +17,7 @@ import logging
 import os
 import pwd
 
-from subiquitycore.utils import run_command
+from subiquitycore.utils import orig_environ, run_command
 
 log = logging.getLogger("subiquitycore.ssh")
 
@@ -28,7 +28,7 @@ def host_key_fingerprints():
     Returns a sequence of (key-type, fingerprint) pairs.
     """
     try:
-        config = run_command(["sshd", "-T"])
+        config = run_command(["sshd", "-T"], env=orig_environ(None))
     except FileNotFoundError:
         log.debug("sshd not found")
         return []


### PR DESCRIPTION
When calling `sshd -T`, we used to inherit the LD_LIBRARY_PATH variable, resulting in the following errors on focal:

```
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /snap/subiquity/5270/usr/lib/x86_64-linux-gnu/libsystemd.so.0)
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /snap/subiquity/5270/usr/lib/x86_64-linux-gnu/libsystemd.so.0)
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /snap/subiquity/5270/usr/lib/x86_64-linux-gnu/libsystemd.so.0)
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /snap/core22/current/lib/x86_64-linux-gnu/liblzma.so.5)
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /snap/core22/current/lib/x86_64-linux-gnu/liblzma.so.5)
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /snap/core22/current/lib/x86_64-linux-gnu/libcap.so.2)
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /snap/core22/current/lib/x86_64-linux-gnu/libgcrypt.so.20)
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /snap/core22/current/lib/x86_64-linux-gnu/libgpg-error.so.0)
sshd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /snap/core22/current/lib/x86_64-linux-gnu/libgpg-error.so.0)
```

Fixed by sanitizing the environment first. We don't expect sshd to be present in the snap anyway.

I encountered this while trying to reproduce the bug described at LP:#2050030