### PR TITLE
ubuntu-pro: enable on noble, although it's not yet marked LTS

### DIFF
--- a/subiquity/client/controllers/tests/test_ubuntu_pro.py
+++ b/subiquity/client/controllers/tests/test_ubuntu_pro.py
@@ -78,3 +78,25 @@ class TestUbuntuProController(unittest.IsolatedAsyncioTestCase):
         view.assert_called_once_with(
             ctrler, token="", has_network=False, pre_release=True
         )
+
+    @patch("subiquity.client.controllers.ubuntu_pro.UbuntuProView")
+    @patch(
+        "subiquity.client.controllers.ubuntu_pro.lsb_release",
+        return_value={
+            "description": "Ubuntu R R (development branch)",
+            "release": "26.04",
+        },
+    )
+    async def test_make_ui__26_04_future(self, release, view):
+        ctrler = self.ctrler
+
+        rv = UbuntuProResponse(token="", has_network=False)
+
+        with patch.object(ctrler.endpoint, "GET", return_value=rv):
+            await ctrler.make_ui()
+
+        view.assert_called_once()
+
+        view.assert_called_once_with(
+            ctrler, token="", has_network=False, pre_release=True
+        )

--- a/subiquity/client/controllers/tests/test_ubuntu_pro.py
+++ b/subiquity/client/controllers/tests/test_ubuntu_pro.py
@@ -42,7 +42,9 @@ class TestUbuntuProController(unittest.IsolatedAsyncioTestCase):
         with patch.object(ctrler.endpoint, "GET", return_value=rv):
             await ctrler.make_ui()
 
-        view.assert_called_once_with(ctrler, token="", has_network=False)
+        view.assert_called_once_with(
+            ctrler, token="", has_network=False, pre_release=False
+        )
 
     @patch("subiquity.client.controllers.ubuntu_pro.UbuntuProView")
     @patch(
@@ -72,3 +74,7 @@ class TestUbuntuProController(unittest.IsolatedAsyncioTestCase):
             await ctrler.make_ui()
 
         view.assert_called_once()
+
+        view.assert_called_once_with(
+            ctrler, token="", has_network=False, pre_release=True
+        )

--- a/subiquity/client/controllers/tests/test_ubuntu_pro.py
+++ b/subiquity/client/controllers/tests/test_ubuntu_pro.py
@@ -1,0 +1,74 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from subiquity.client.controllers.ubuntu_pro import UbuntuProController
+from subiquity.common.types import UbuntuProResponse
+from subiquitycore.tests.mocks import make_app
+from subiquitycore.tuicontroller import Skip
+
+
+class TestUbuntuProController(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        app = make_app()
+        app.client = AsyncMock()
+
+        self.ctrler = UbuntuProController(app)
+
+    @patch("subiquity.client.controllers.ubuntu_pro.UbuntuProView")
+    @patch(
+        "subiquity.client.controllers.ubuntu_pro.lsb_release",
+        return_value={"description": "Ubuntu 22.04 LTS", "release": "22.04"},
+    )
+    async def test_make_ui__lts(self, release, view):
+        ctrler = self.ctrler
+
+        rv = UbuntuProResponse(token="", has_network=False)
+
+        with patch.object(ctrler.endpoint, "GET", return_value=rv):
+            await ctrler.make_ui()
+
+        view.assert_called_once_with(ctrler, token="", has_network=False)
+
+    @patch("subiquity.client.controllers.ubuntu_pro.UbuntuProView")
+    @patch(
+        "subiquity.client.controllers.ubuntu_pro.lsb_release",
+        return_value={"description": "Ubuntu 23.10", "release": "23.10"},
+    )
+    async def test_make_ui__not_lts(self, release, view):
+        with self.assertRaises(Skip):
+            await self.ctrler.make_ui()
+
+        view.assert_not_called()
+
+    @patch("subiquity.client.controllers.ubuntu_pro.UbuntuProView")
+    @patch(
+        "subiquity.client.controllers.ubuntu_pro.lsb_release",
+        return_value={
+            "description": "Ubuntu Noble Numbat (development branch)",
+            "release": "24.04",
+        },
+    )
+    async def test_make_ui__noble_devel(self, release, view):
+        ctrler = self.ctrler
+
+        rv = UbuntuProResponse(token="", has_network=False)
+
+        with patch.object(ctrler.endpoint, "GET", return_value=rv):
+            await ctrler.make_ui()
+
+        view.assert_called_once()

--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -66,8 +66,11 @@ class UbuntuProController(SubiquityTuiController):
         lsb = lsb_release(dry_run=dry_run)
 
         if "LTS" not in lsb["description"]:
-            # TODO remove special handling of 24.04 when it is marked LTS
-            if lsb["release"] == "24.04":
+            major, minor = lsb["release"].split(".")
+
+            # If running a pre-LTS (e.g., 24.04, 26.04, ...), show the SSH UI
+            # for testing, but with a warning.
+            if int(major) >= 20 and int(major) % 2 == 0 and minor == "04":
                 pre_release = True
             else:
                 await self.endpoint.skip.POST()

--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -63,7 +63,8 @@ class UbuntuProController(SubiquityTuiController):
         dry_run: bool = self.app.opts.dry_run
 
         lsb = lsb_release(dry_run=dry_run)
-        if "LTS" not in lsb["description"]:
+        # TODO remove special handling of 24.04 when it is marked LTS
+        if "LTS" not in lsb["description"] and lsb["release"] != "24.04":
             await self.endpoint.skip.POST()
             raise Skip("Not running LTS version")
 

--- a/subiquity/client/controllers/ubuntu_pro.py
+++ b/subiquity/client/controllers/ubuntu_pro.py
@@ -61,16 +61,24 @@ class UbuntuProController(SubiquityTuiController):
         """Generate the UI, based on the data provided by the model."""
 
         dry_run: bool = self.app.opts.dry_run
+        pre_release = False
 
         lsb = lsb_release(dry_run=dry_run)
-        # TODO remove special handling of 24.04 when it is marked LTS
-        if "LTS" not in lsb["description"] and lsb["release"] != "24.04":
-            await self.endpoint.skip.POST()
-            raise Skip("Not running LTS version")
+
+        if "LTS" not in lsb["description"]:
+            # TODO remove special handling of 24.04 when it is marked LTS
+            if lsb["release"] == "24.04":
+                pre_release = True
+            else:
+                await self.endpoint.skip.POST()
+                raise Skip("Not running LTS version")
 
         ubuntu_pro_info: UbuntuProResponse = await self.endpoint.GET()
         return UbuntuProView(
-            self, token=ubuntu_pro_info.token, has_network=ubuntu_pro_info.has_network
+            self,
+            token=ubuntu_pro_info.token,
+            has_network=ubuntu_pro_info.has_network,
+            pre_release=pre_release,
         )
 
     async def run_answers(self) -> None:

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -37,7 +37,7 @@ from subiquitycore.ui.form import (
 from subiquitycore.ui.interactive import StringEditor
 from subiquitycore.ui.spinner import Spinner
 from subiquitycore.ui.stretchy import Stretchy
-from subiquitycore.ui.utils import SomethingFailed, button_pile, screen
+from subiquitycore.ui.utils import Color, SomethingFailed, button_pile, screen
 from subiquitycore.view import BaseView
 
 log = logging.getLogger("subiquity.ui.views.ubuntu_pro")
@@ -270,11 +270,12 @@ class UbuntuProView(BaseView):
     title = _("Upgrade to Ubuntu Pro")
     subscription_done_label = _("Continue")
 
-    def __init__(self, controller, token: str, has_network: bool):
+    def __init__(self, controller, token: str, has_network: bool, *, pre_release=False):
         """Initialize the view with the default value for the token."""
         self.controller = controller
 
         self.has_network = has_network
+        self.pre_release = pre_release
 
         if self.has_network:
             self.upgrade_yes_no_form = UpgradeYesNoForm(
@@ -399,7 +400,22 @@ class UbuntuProView(BaseView):
         rows = [
             bp,
             Text(""),
-        ] + self.upgrade_yes_no_form.as_rows()
+        ]
+        if self.pre_release:
+            rows.extend(
+                [
+                    Color.info_error(
+                        Text(
+                            _(
+                                "Please note that this is not an official LTS build."
+                                " This screen is only provided for testing."
+                            )
+                        )
+                    ),
+                    Text(""),
+                ]
+            )
+        rows.extend(self.upgrade_yes_no_form.as_rows())
         return screen(
             ListBox(rows),
             self.upgrade_yes_no_form.buttons,


### PR DESCRIPTION
The /etc/lsb-release file currently on noble shows:

```
  DISTRIB_ID=Ubuntu
  DISTRIB_RELEASE=24.04
  DISTRIB_CODENAME=noble
  DISTRIB_DESCRIPTION="Ubuntu Noble Numbat (development branch)"
```

Therefore, the Ubuntu Pro pages get skipped. This makes testing on noble difficult, so make an exception for noble now and we'll drop it once it's marked LTS.