### PR TITLE
Fix emtpy list of authorized_keys in /ssh endpoint

### DIFF
--- a/subiquity/models/ssh.py
+++ b/subiquity/models/ssh.py
@@ -26,10 +26,6 @@ class SSHModel:
         self.install_server = False
         self.authorized_keys: List[str] = []
         self.pwauth = True
-        # Although the generated config just contains the key above,
-        # we store the imported id so that we can re-fill the form if
-        # we go back to it.
-        self.ssh_import_id = ""
 
     async def target_packages(self) -> List[TargetPkg]:
         if not self.install_server:

--- a/subiquity/server/controllers/ssh.py
+++ b/subiquity/server/controllers/ssh.py
@@ -70,7 +70,9 @@ class SSHController(SubiquityController):
 
     async def GET(self) -> SSHData:
         return SSHData(
-            install_server=self.model.install_server, allow_pw=self.model.pwauth
+            install_server=self.model.install_server,
+            allow_pw=self.model.pwauth,
+            authorized_keys=self.model.authorized_keys,
         )
 
     async def POST(self, data: SSHData) -> None:

--- a/subiquity/server/controllers/tests/test_ssh.py
+++ b/subiquity/server/controllers/tests/test_ssh.py
@@ -29,6 +29,24 @@ class TestSSHController(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.controller = SSHController(make_app())
 
+    async def test_GET(self):
+        model = self.controller.model
+
+        model.pwauth = False
+        model.authorized_keys = [
+            "ssh-rsa AAAAAAAAAAAAAAAAAAAAAAAAA # ssh-import-id lp:subiquity",
+        ]
+        model.install_server = True
+
+        data = await self.controller.GET()
+
+        self.assertFalse(data.allow_pw)
+        self.assertTrue(data.install_server)
+        self.assertIn(
+            "ssh-rsa AAAAAAAAAAAAAAAAAAAAAAAAA # ssh-import-id lp:subiquity",
+            data.authorized_keys,
+        )
+
     async def test_fetch_id_GET_ok(self):
         key = "ssh-rsa AAAAA[..] user@host # ssh-import-id lp:user"
         mock_fetch_keys = mock.patch.object(


### PR DESCRIPTION
The /ssh endpoint was, I think, meant to return a list of authorized_keys but it didn't. 

Fixed the issue and also removed a variable that probably has been unused for years now.