### PR TITLE
factory-reset: remove EFI boot entry, retarget GRUB entry to chainload Reset Partition GRUB

### DIFF
--- a/subiquity/server/controllers/tests/test_install.py
+++ b/subiquity/server/controllers/tests/test_install.py
@@ -19,7 +19,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import ANY, AsyncMock, Mock, call, mock_open, patch
+from unittest.mock import ANY, AsyncMock, Mock, mock_open, patch
 
 from curtin.util import EFIBootEntry, EFIBootState
 
@@ -261,105 +261,6 @@ class TestInstallController(unittest.IsolatedAsyncioTestCase):
         app.package_installer.install_pkg = AsyncMock()
         app.package_installer.install_pkg.return_value = PackageInstallState.DONE
         fsm, self.part = make_model_and_partition()
-
-    @patch("subiquity.server.controllers.install.get_efibootmgr")
-    async def test_configure_rp_boot_uefi_add(self, m_get_efibootmgr):
-        m_get_efibootmgr.side_effect = iter([efi_state_no_rp, efi_state_with_rp])
-        self.setup_rp_test()
-        await self.controller.configure_rp_boot_uefi(rp=self.part)
-        calls = [
-            call(
-                [
-                    "efibootmgr",
-                    "--create",
-                    "--loader",
-                    "\\EFI\\boot\\bootx64.efi",
-                    "--disk",
-                    self.part.device.path,
-                    "--part",
-                    str(self.part.number),
-                    "--label",
-                    "Restore Ubuntu to factory state",
-                ]
-            ),
-            call(
-                [
-                    "efibootmgr",
-                    "--bootorder",
-                    "0000,0002,0003",
-                ]
-            ),
-        ]
-        self.run.assert_has_awaits(calls)
-
-    @patch("subiquity.server.controllers.install.get_efibootmgr")
-    async def test_configure_rp_boot_uefi_bootnext(self, m_get_efibootmgr):
-        m_get_efibootmgr.side_effect = iter([efi_state_no_rp, efi_state_with_rp])
-        self.setup_rp_test()
-        self.controller.app.base_model.target = None
-        await self.controller.configure_rp_boot_uefi(rp=self.part)
-        calls = [
-            call(
-                [
-                    "efibootmgr",
-                    "--create",
-                    "--loader",
-                    "\\EFI\\boot\\bootx64.efi",
-                    "--disk",
-                    self.part.device.path,
-                    "--part",
-                    str(self.part.number),
-                    "--label",
-                    "Restore Ubuntu to factory state",
-                ]
-            ),
-            call(
-                [
-                    "efibootmgr",
-                    "--bootorder",
-                    "0000,0002,0003",
-                ]
-            ),
-            call(
-                [
-                    "efibootmgr",
-                    "--bootnext",
-                    "0003",
-                ]
-            ),
-        ]
-        self.run.assert_has_awaits(calls)
-
-    @patch("subiquity.server.controllers.install.get_efibootmgr")
-    async def test_configure_rp_boot_uefi_dup(self, m_get_efibootmgr):
-        m_get_efibootmgr.side_effect = iter([efi_state_with_rp, efi_state_with_dup_rp])
-        self.setup_rp_test()
-        await self.controller.configure_rp_boot_uefi(rp=self.part)
-        calls = [
-            call(
-                [
-                    "efibootmgr",
-                    "--create",
-                    "--loader",
-                    "\\EFI\\boot\\bootx64.efi",
-                    "--disk",
-                    self.part.device.path,
-                    "--part",
-                    str(self.part.number),
-                    "--label",
-                    "Restore Ubuntu to factory state",
-                ]
-            ),
-            call(
-                [
-                    "efibootmgr",
-                    "--delete-bootnum",
-                    "--bootnum",
-                    "0004",
-                ]
-            ),
-        ]
-        self.run.assert_has_awaits(calls)
 
     async def test_configure_rp_boot_grub(self):
         fsuuid, partuuid = "fsuuid", "partuuid"

--- a/subiquity/server/controllers/tests/test_install.py
+++ b/subiquity/server/controllers/tests/test_install.py
@@ -364,14 +364,10 @@ class TestInstallController(unittest.IsolatedAsyncioTestCase):
     async def test_configure_rp_boot_grub(self):
         fsuuid, partuuid = "fsuuid", "partuuid"
         self.setup_rp_test(f"{fsuuid}\t{partuuid}".encode("ascii"))
-        await self.controller.configure_rp_boot_grub(
-            rp=self.part, casper_uuid="casper-uuid"
-        )
+        await self.controller.configure_rp_boot_grub(rp=self.part)
         with open(self.controller.tpath("etc/grub.d/99_reset")) as fp:
             cfg = fp.read()
         self.assertIn("--fs-uuid fsuuid", cfg)
-        self.assertIn("rp-partuuid=partuuid", cfg)
-        self.assertIn("uuid=casper-uuid", cfg)
 
     @patch("platform.machine", return_value="s390x")
     @patch("subiquity.server.controllers.install.arun_command")


### PR DESCRIPTION
This resolves https://pad.lv/2051099

The reason removing EFI boot entry is because any of our known factory workflow is not able to create EFI boot entry on the target machine.

GRUB boot entry is that we would like to adjust kernel boot commands in the reset partition.  Do we have any concern using chainloading?