### PR TITLE
AutoinstallError exception  

### DIFF
--- a/autoinstall-schema.json
+++ b/autoinstall-schema.json
@@ -6,6 +6,12 @@
             "minimum": 1,
             "maximum": 1
         },
+        "interactive-sections": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "early-commands": {
             "type": "array",
             "items": {

--- a/autoinstall-system-setup-schema.json
+++ b/autoinstall-system-setup-schema.json
@@ -6,6 +6,12 @@
             "minimum": 1,
             "maximum": 1
         },
+        "interactive-sections": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "early-commands": {
             "type": "array",
             "items": {

--- a/subiquity/server/autoinstall.py
+++ b/subiquity/server/autoinstall.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import logging
+
+log = logging.getLogger("subiquity.server.autoinstall")
+
+
+class AutoinstallError(Exception):
+    pass
+
+
+class AutoinstallValidationError(AutoinstallError):
+    def __init__(
+        self,
+        owner: str,
+    ):
+        self.message = f"Malformed autoinstall in {owner!r} section"
+        self.owner = owner
+        super().__init__(self.message)

--- a/subiquity/server/controllers/tests/test_cmdlist.py
+++ b/subiquity/server/controllers/tests/test_cmdlist.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.cmdlist import CmdListController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestCmdListController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            CmdListController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(CmdListController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_codecs.py
+++ b/subiquity/server/controllers/tests/test_codecs.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.codecs import CodecsController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestCodecsController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            CodecsController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(CodecsController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_debconf.py
+++ b/subiquity/server/controllers/tests/test_debconf.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.debconf import DebconfController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestDebconfController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            DebconfController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(DebconfController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_drivers.py
+++ b/subiquity/server/controllers/tests/test_drivers.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.drivers import DriversController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestDriversController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            DriversController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(DriversController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -18,7 +18,9 @@ import subprocess
 import uuid
 from unittest import IsolatedAsyncioTestCase, mock
 
+import jsonschema
 from curtin.commands.extract import TrivialSourceHandler
+from jsonschema.validators import validator_for
 
 from subiquity.common.filesystem import gaps, labels
 from subiquity.common.filesystem.actions import DeviceAction
@@ -398,6 +400,15 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
         self.assertEqual(len(self.fsc._variation_info), 1)
         self.assertEqual(self.fsc._variation_info["default"].name, "default")
+
+    def test_valid_schema(self):
+        """Test that the expected autoinstall JSON schema is valid"""
+
+        JsonValidator: jsonschema.protocols.Validator = validator_for(
+            FilesystemController.autoinstall_schema
+        )
+
+        JsonValidator.check_schema(FilesystemController.autoinstall_schema)
 
 
 class TestGuided(IsolatedAsyncioTestCase):

--- a/subiquity/server/controllers/tests/test_identity.py
+++ b/subiquity/server/controllers/tests/test_identity.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.identity import IdentityController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestIdentityController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            IdentityController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(IdentityController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_keyboard.py
+++ b/subiquity/server/controllers/tests/test_keyboard.py
@@ -17,6 +17,9 @@ import os
 import unittest
 from unittest.mock import Mock, patch
 
+import jsonschema
+from jsonschema.validators import validator_for
+
 from subiquity.common.types import KeyboardSetting
 from subiquity.models.keyboard import KeyboardModel
 from subiquity.server.controllers.keyboard import KeyboardController
@@ -27,6 +30,16 @@ from subiquitycore.tests.parameterized import parameterized
 
 class opts:
     dry_run = True
+
+
+class TestKeyboardController(SubiTestCase):
+    def test_valid_schema(self):
+        """Test that the expected autoinstall JSON schema is valid"""
+
+        JsonValidator: jsonschema.protocols.Validator = validator_for(
+            KeyboardController.autoinstall_schema
+        )
+        JsonValidator.check_schema(KeyboardController.autoinstall_schema)
 
 
 class TestSubiquityModel(SubiTestCase):

--- a/subiquity/server/controllers/tests/test_locale.py
+++ b/subiquity/server/controllers/tests/test_locale.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.locale import LocaleController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestLocaleController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            LocaleController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(LocaleController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_mirror.py
+++ b/subiquity/server/controllers/tests/test_mirror.py
@@ -19,6 +19,7 @@ import unittest
 from unittest import mock
 
 import jsonschema
+from jsonschema.validators import validator_for
 
 from subiquity.common.types import MirrorSelectionFallback
 from subiquity.models.mirror import MirrorModel
@@ -264,3 +265,12 @@ class TestMirrorController(unittest.IsolatedAsyncioTestCase):
                 mock_fallback.assert_not_called()
                 await controller.run_mirror_selection_or_fallback(context=None)
                 mock_fallback.assert_called_once()
+
+    def test_valid_schema(self):
+        """Test that the expected autoinstall JSON schema is valid"""
+
+        JsonValidator: jsonschema.protocols.Validator = validator_for(
+            MirrorController.autoinstall_schema
+        )
+
+        JsonValidator.check_schema(MirrorController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_network.py
+++ b/subiquity/server/controllers/tests/test_network.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.network import NetworkController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestNetworkController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            NetworkController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(NetworkController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_oem.py
+++ b/subiquity/server/controllers/tests/test_oem.py
@@ -16,6 +16,9 @@
 import subprocess
 from unittest.mock import Mock, patch
 
+import jsonschema
+from jsonschema.validators import validator_for
+
 from subiquity.server.controllers.oem import OEMController
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
@@ -110,3 +113,12 @@ Ubuntu-Oem-Kernel-Flavour: oem
                     "oem-sutton-balint-meta", context=None, overlay=Mock()
                 )
             )
+
+    def test_valid_schema(self):
+        """Test that the expected autoinstall JSON schema is valid"""
+
+        JsonValidator: jsonschema.protocols.Validator = validator_for(
+            OEMController.autoinstall_schema
+        )
+
+        JsonValidator.check_schema(OEMController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_package.py
+++ b/subiquity/server/controllers/tests/test_package.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.package import PackageController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestPackageController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            PackageController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(PackageController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_proxy.py
+++ b/subiquity/server/controllers/tests/test_proxy.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.proxy import ProxyController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestProxyController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            ProxyController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(ProxyController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_refresh.py
+++ b/subiquity/server/controllers/tests/test_refresh.py
@@ -15,6 +15,9 @@
 
 from unittest import mock
 
+import jsonschema
+from jsonschema.validators import validator_for
+
 from subiquity.server import snapdapi
 from subiquity.server.controllers import refresh as refresh_mod
 from subiquity.server.controllers.refresh import RefreshController, SnapChannelSource
@@ -99,3 +102,12 @@ class TestRefreshController(SubiTestCase):
                     await self.rc.configure_snapd(context=self.rc.context)
 
         paw.assert_not_called()
+
+    def test_valid_schema(self):
+        """Test that the expected autoinstall JSON schema is valid"""
+
+        JsonValidator: jsonschema.protocols.Validator = validator_for(
+            RefreshController.autoinstall_schema
+        )
+
+        JsonValidator.check_schema(RefreshController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_reporting.py
+++ b/subiquity/server/controllers/tests/test_reporting.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.reporting import ReportingController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestReportingController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            ReportingController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(ReportingController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_shutdown.py
+++ b/subiquity/server/controllers/tests/test_shutdown.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.shutdown import ShutdownController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestShutdownController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            ShutdownController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(ShutdownController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_snaplist.py
+++ b/subiquity/server/controllers/tests/test_snaplist.py
@@ -16,13 +16,17 @@
 import unittest
 from unittest.mock import AsyncMock
 
+import jsonschema
 import requests
+from jsonschema.validators import validator_for
 
 from subiquity.models.snaplist import SnapListModel
 from subiquity.server.controllers.snaplist import (
     SnapdSnapInfoLoader,
+    SnapListController,
     SnapListFetchError,
 )
+from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
 
 
@@ -56,3 +60,14 @@ class TestSnapdSnapInfoLoader(unittest.IsolatedAsyncioTestCase):
         await self.loader.get_snap_list_task()
         self.assertTrue(self.loader.fetch_list_completed())
         self.assertFalse(self.loader.fetch_list_failed())
+
+
+class TestSnapListController(SubiTestCase):
+    def test_valid_schema(self):
+        """Test that the expected autoinstall JSON schema is valid"""
+
+        JsonValidator: jsonschema.protocols.Validator = validator_for(
+            SnapListController.autoinstall_schema
+        )
+
+        JsonValidator.check_schema(SnapListController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_ssh.py
+++ b/subiquity/server/controllers/tests/test_ssh.py
@@ -16,6 +16,9 @@
 import unittest
 from unittest import mock
 
+import jsonschema
+from jsonschema.validators import validator_for
+
 from subiquity.common.types import SSHFetchIdStatus, SSHIdentity
 from subiquity.server.controllers.ssh import (
     SSHController,
@@ -98,3 +101,12 @@ class TestSSHController(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(response.status, SSHFetchIdStatus.FINGERPRINT_ERROR)
             self.assertEqual(response.error, stderr)
             self.assertIsNone(response.identities)
+
+    def test_valid_schema(self):
+        """Test that the expected autoinstall JSON schema is valid"""
+
+        JsonValidator: jsonschema.protocols.Validator = validator_for(
+            SSHController.autoinstall_schema
+        )
+
+        JsonValidator.check_schema(SSHController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_timezone.py
+++ b/subiquity/server/controllers/tests/test_timezone.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.timezone import TimeZoneController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestTimeZoneController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            TimeZoneController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(TimeZoneController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_updates.py
+++ b/subiquity/server/controllers/tests/test_updates.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,35 +13,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import jsonschema
 from jsonschema.validators import validator_for
 
-from subiquity.server.controllers.ubuntu_pro import UbuntuProController
-from subiquity.server.dryrun import DRConfig
-from subiquitycore.tests.mocks import make_app
+from subiquity.server.controllers.updates import UpdatesController
+from subiquitycore.tests import SubiTestCase
 
 
-class TestUbuntuProController(unittest.TestCase):
-    def setUp(self):
-        app = make_app()
-        app.dr_cfg = DRConfig()
-        self.controller = UbuntuProController(app)
-
-    def test_serialize(self):
-        self.controller.model.token = "1a2b3C"
-        self.assertEqual(self.controller.serialize(), "1a2b3C")
-
-    def test_deserialize(self):
-        self.controller.deserialize("1A2B3C4D")
-        self.assertEqual(self.controller.model.token, "1A2B3C4D")
-
+class TestUpdatesController(SubiTestCase):
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 
         JsonValidator: jsonschema.protocols.Validator = validator_for(
-            UbuntuProController.autoinstall_schema
+            UpdatesController.autoinstall_schema
         )
 
-        JsonValidator.check_schema(UbuntuProController.autoinstall_schema)
+        JsonValidator.check_schema(UpdatesController.autoinstall_schema)

--- a/subiquity/server/controllers/tests/test_userdata.py
+++ b/subiquity/server/controllers/tests/test_userdata.py
@@ -15,7 +15,9 @@
 
 import unittest
 
+import jsonschema
 from cloudinit.config.schema import SchemaValidationError
+from jsonschema.validators import validator_for
 
 from subiquity.server.controllers.userdata import UserdataController
 from subiquitycore.tests.mocks import make_app
@@ -58,3 +60,12 @@ class TestUserdataController(unittest.TestCase):
             validate.assert_called_with(
                 data=invalid_schema, data_source="autoinstall.user-data"
             )
+
+    def test_valid_schema(self):
+        """Test that the expected autoinstall JSON schema is valid"""
+
+        JsonValidator: jsonschema.protocols.Validator = validator_for(
+            UserdataController.autoinstall_schema
+        )
+
+        JsonValidator.check_schema(UserdataController.autoinstall_schema)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -222,6 +222,12 @@ class SubiquityServer(Application):
                 "minimum": 1,
                 "maximum": 1,
             },
+            "interactive-sections": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                },
+            },
         },
         "required": ["version"],
         "additionalProperties": True,

--- a/subiquity/server/tests/test_controller.py
+++ b/subiquity/server/tests/test_controller.py
@@ -61,7 +61,7 @@ class TestController(SubiTestCase):
         mock_load.assert_called_once_with("default-data")
 
     def test_autoinstall_validation(self):
-        """Test validation error type"""
+        """Test validation error type and no apport reporting"""
 
         self.controller.autoinstall_schema = {
             "type": "object",
@@ -84,3 +84,8 @@ class TestController(SubiTestCase):
 
         # Assert error section is based on autoinstall_key
         self.assertEquals(exception.owner, "some-key")
+
+        # Assert apport report is not created
+        # This only checks that controllers do not manually create an apport
+        # report on validation. Should also be tested in Server
+        self.controller.app.make_apport_report.assert_not_called()

--- a/subiquity/server/tests/test_controller.py
+++ b/subiquity/server/tests/test_controller.py
@@ -41,7 +41,6 @@ class TestController(SubiTestCase):
         }
         self.controller.autoinstall_key = "sample"
         self.controller.autoinstall_key_alias = "sample-alias"
-        self.controller.autoinstall_default = "default-data"
         self.controller.setup_autoinstall()
         mock_load.assert_called_once_with("some-sample-data")
 
@@ -56,5 +55,6 @@ class TestController(SubiTestCase):
         mock_load.reset_mock()
         self.controller.autoinstall_key = "inexistent"
         self.controller.autoinstall_key_alias = "inexistent"
+        self.controller.autoinstall_default = "default-data"
         self.controller.setup_autoinstall()
         mock_load.assert_called_once_with("default-data")

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -160,6 +160,7 @@ class TestAutoinstallValidation(SubiTestCase):
                 },
             },
         }
+        self.server.make_apport_report = Mock()
 
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
@@ -178,6 +179,20 @@ class TestAutoinstallValidation(SubiTestCase):
 
         with self.assertRaises(AutoinstallValidationError):
             self.server.validate_autoinstall()
+
+    async def test_autoinstall_validation__no_error_report(self):
+        """Test no apport reporting"""
+
+        exception = AutoinstallValidationError("Mock")
+
+        loop = Mock()
+        context = {"exception": exception}
+
+        with patch("subiquity.server.server.log"):
+            with patch.object(self.server, "_run_error_cmds"):
+                self.server._exception_handler(loop, context)
+
+        self.server.make_apport_report.assert_not_called()
 
 
 class TestMetaController(SubiTestCase):

--- a/subiquitycore/tests/mocks.py
+++ b/subiquitycore/tests/mocks.py
@@ -50,5 +50,6 @@ def make_app(model=None):
     app.log_syslog_id = None
     app.report_start_event = mock.Mock()
     app.report_finish_event = mock.Mock()
+    app.make_apport_report = mock.Mock()
 
     return app


### PR DESCRIPTION
Adds a special exception for Autoinstall related failures and a
specific implementation for autoinstall validation failures.

When a user passes incorrect autoinstall data, the generated
bug report will be titled:

    "Autoinstall crashed with AutoinstallValidationError"

Where the traceback will start with a hint on the offending
section. For example:

    "Malformed autoinstall in 'apt' section"

Information from the original jsonschema ValidationError is
also available in the traceback to point to specific issues
with the provided data.

The section reporting is a little crude in the validation
of the base schema done by SubiquityServer, which can't discern
between the 'interative-sessions' and 'version' keys, but for now
the scope is pretty limited and can be fixed up at a later time.
