### PR TITLE
Enforce top level keys in autoinstall user data

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -3,7 +3,9 @@
 Autoinstall configuration reference manual
 ==========================================
 
-The autoinstall file uses the YAML format. At the top level, it must be a mapping containing the keys described in this document. Unrecognised keys are ignored.
+The autoinstall file uses the YAML format. At the top level, it must be a
+mapping containing the keys described in this document. Unrecognised keys are
+currently ignored, but may cause a run-time failure in future versions.
 
 .. _ai-schema:
 

--- a/subiquity/server/autoinstall.py
+++ b/subiquity/server/autoinstall.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
+from typing import Optional
 
 log = logging.getLogger("subiquity.server.autoinstall")
 
@@ -24,8 +25,13 @@ class AutoinstallError(Exception):
 class AutoinstallValidationError(AutoinstallError):
     def __init__(
         self,
-        owner: str,
+        section: str,
+        message: Optional[str] = None,
     ):
-        self.message = f"Malformed autoinstall in {owner!r} section"
-        self.owner = owner
+        if not message:
+            self.message: str = f"Malformed autoinstall in {section!r} section"
+        else:
+            self.message: str = message
+
+        self.section: str = section
         super().__init__(self.message)

--- a/subiquity/server/tests/test_controller.py
+++ b/subiquity/server/tests/test_controller.py
@@ -83,7 +83,7 @@ class TestController(SubiTestCase):
         exception = ctx.exception
 
         # Assert error section is based on autoinstall_key
-        self.assertEquals(exception.owner, "some-key")
+        self.assertEquals(exception.section, "some-key")
 
         # Assert apport report is not created
         # This only checks that controllers do not manually create an apport


### PR DESCRIPTION
Subiquity has, until now, silently ignored invalid top-level keys.
This has likely been a major source of confusion of autoinstall
capabilities.

The following autoinstall config:

    version: 1
    interative-sections:
        - identity
    literally-anything: lmao

will now throw an AutoinstallValidationError.