### PR TITLE
workflow: +noble

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
           - ubuntu-daily:jammy
           - ubuntu-daily:lunar
           - ubuntu-daily:mantic
+          - ubuntu-daily:noble
     steps:
     - uses: actions/checkout@v4
     - name: run
@@ -29,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - ubuntu-daily:jammy    # match the core snap we're running against
-          - ubuntu-daily:mantic   # latest
+          - ubuntu-daily:jammy   # match the core snap we're running against
+          - ubuntu-daily:noble   # latest
     steps:
     - uses: actions/checkout@v4
     - name: lint

--- a/scripts/test-in-lxd.sh
+++ b/scripts/test-in-lxd.sh
@@ -45,7 +45,18 @@ then
     done
 fi
 
-lxc exec $TESTER -- cloud-init status --wait
+if ! lxc exec $TESTER -- cloud-init status --wait; then
+    ec=$?
+    case $ec in
+        0|2)
+            # 2 is warnings
+            ;;
+        *)
+            echo "cloud-init status failed with $ec"
+            exit $ec
+            ;;
+    esac
+fi
 
 lxc exec $TESTER -- sh -ec "
     cd ~/subiquity

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -53,15 +53,19 @@ class RealnameEditor(StringEditor, WantsToKnowFormField):
             return super().valid_char(ch)
 
 
-class _AsyncValidatedMixin:
-    """Provides Editor widgets with async validation capabilities"""
-
+class UsernameEditor(StringEditor, WantsToKnowFormField):
     def __init__(self):
         self.validation_task = None
         self.initial = None
         self.validation_result = None
         self._validate_async_inner = None
         connect_signal(self, "change", self._reset_validation)
+
+        self.valid_char_pat = r"[-a-z0-9_]"
+        self.error_invalid_char = _(
+            "The only characters permitted in this field are a-z, 0-9, _ and -"
+        )
+        super().__init__()
 
     def set_initial_state(self, initial):
         self.initial = initial
@@ -85,15 +89,6 @@ class _AsyncValidatedMixin:
         if self._validate_async_inner is not None:
             self.validation_result = await self._validate_async_inner(value)
             self.bff.validate()
-
-
-class UsernameEditor(StringEditor, _AsyncValidatedMixin, WantsToKnowFormField):
-    def __init__(self):
-        self.valid_char_pat = r"[-a-z0-9_]"
-        self.error_invalid_char = _(
-            "The only characters permitted in this field are a-z, 0-9, _ and -"
-        )
-        super().__init__()
 
     def valid_char(self, ch):
         if len(ch) == 1 and not re.match(self.valid_char_pat, ch):


### PR DESCRIPTION
Enable the noble series in the workflows, along with some prerequisite fixes:
* `cloud-init status` == 2 is not fatal
* Address a multiple inheritance problem where a change to urwid is having the side effect that an initializer isn't running.