### PR TITLE
console-conf: set project name, consistently use as state directory

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -183,8 +183,7 @@ class IdentityController(TuiController):
                     "realname": email,
                     "username": data["username"],
                 }
-                os.makedirs("/run/console-conf", exist_ok=True)
-                login_details_path = "/run/console-conf/login-details.txt"
+                login_details_path = self.app.state_path("login-details.txt")
                 self.model.add_user(result)
         ips = []
         net_model = self.app.base_model.network

--- a/console_conf/controllers/tests/test_identity.py
+++ b/console_conf/controllers/tests/test_identity.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os.path
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from console_conf.controllers.identity import IdentityController
+from subiquitycore.models.network import NetworkDev
+from subiquitycore.tests.mocks import make_app
+
+
+class TestIdentityController(unittest.TestCase):
+    @patch("os.ttyname", return_value="/dev/tty1")
+    @patch("console_conf.controllers.identity.get_core_version", return_value="24")
+    @patch("console_conf.controllers.identity.run_command")
+    def test_snap_integration(self, run_command, core_version, ttyname):
+        with tempfile.TemporaryDirectory(suffix="console-conf-test") as statedir:
+            proc_mock = MagicMock()
+            run_command.return_value = proc_mock
+            proc_mock.returncode = 0
+            proc_mock.stdout = '{"username":"foo"}'
+
+            app = make_app()
+            app.opts.dry_run = False
+            network_model = MagicMock()
+            mock_devs = [MagicMock(spec=NetworkDev)]
+            network_model.get_all_netdevs.return_value = mock_devs
+            mock_devs[0].actual_global_ip_addresses = ["1.2.3.4"]
+            app.base_model.network = network_model
+            app.urwid_loop = MagicMock()
+
+            def state_path(*parts):
+                return os.path.join(statedir, *parts)
+
+            app.state_path = MagicMock(side_effect=state_path)
+
+            c = IdentityController(app)
+            c.identity_done("foo@bar.com")
+            run_command.assert_called_with(
+                ["snap", "create-user", "--sudoer", "--json", "foo@bar.com"]
+            )
+
+            with open(os.path.join(statedir, "login-details.txt")) as inf:
+                data = inf.read()
+            self.assertIn("Ubuntu Core 24 on 1.2.3.4 (tty1)\n", data)

--- a/console_conf/core.py
+++ b/console_conf/core.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 
 from console_conf.models.console_conf import ConsoleConfModel
 from console_conf.models.systems import RecoverySystemsModel
@@ -22,11 +23,17 @@ from subiquitycore.tui import TuiApplication
 
 log = logging.getLogger("console_conf.core")
 
+# project is used to build the state directory path under /run/, which usually
+# ends up as /run/console-conf. Note this should only be changed in
+# coordination with console-conf-wrapper and any other glue shipped with Ubuntu
+# Core boot base
+CONSOLE_CONF_PROJECT = os.getenv("SNAP_INSTANCE_NAME", "console-conf")
+
 
 class ConsoleConf(TuiApplication):
     from console_conf import controllers as controllers_mod
 
-    project = "console-conf"
+    project = CONSOLE_CONF_PROJECT
 
     make_model = ConsoleConfModel
 
@@ -44,7 +51,7 @@ class ConsoleConf(TuiApplication):
 class RecoveryChooser(TuiApplication):
     from console_conf import controllers as controllers_mod
 
-    project = "console-conf"
+    project = CONSOLE_CONF_PROJECT
 
     controllers = [
         "RecoveryChooserWelcome",

--- a/console_conf/core.py
+++ b/console_conf/core.py
@@ -14,11 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 
 from console_conf.models.console_conf import ConsoleConfModel
 from console_conf.models.systems import RecoverySystemsModel
 from subiquitycore.prober import Prober
+from subiquitycore.snap import snap_name
 from subiquitycore.tui import TuiApplication
 
 log = logging.getLogger("console_conf.core")
@@ -27,7 +27,7 @@ log = logging.getLogger("console_conf.core")
 # ends up as /run/console-conf. Note this should only be changed in
 # coordination with console-conf-wrapper and any other glue shipped with Ubuntu
 # Core boot base
-CONSOLE_CONF_PROJECT = os.getenv("SNAP_INSTANCE_NAME", "console-conf")
+CONSOLE_CONF_PROJECT = snap_name() or "console-conf"
 
 
 class ConsoleConf(TuiApplication):

--- a/console_conf/core.py
+++ b/console_conf/core.py
@@ -26,7 +26,7 @@ log = logging.getLogger("console_conf.core")
 class ConsoleConf(TuiApplication):
     from console_conf import controllers as controllers_mod
 
-    project = "console_conf"
+    project = "console-conf"
 
     make_model = ConsoleConfModel
 
@@ -44,7 +44,7 @@ class ConsoleConf(TuiApplication):
 class RecoveryChooser(TuiApplication):
     from console_conf import controllers as controllers_mod
 
-    project = "console_conf"
+    project = "console-conf"
 
     controllers = [
         "RecoveryChooserWelcome",


### PR DESCRIPTION
Set a console-conf as project name, which ensures that the early app setup creates a relevant state directory under /run. Update code where /run/console-conf was hardcoded to use the app level helpers to derive the correct state directory location.

The intention is to supersede #1869 