### PR TITLE
console_conf: do not attempt to obtain user's public key fingerprints

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -156,9 +156,6 @@ class IdentityController(TuiController):
             device_owner = get_device_owner()
             if device_owner:
                 self.model.add_user(device_owner)
-                key_file = os.path.join(device_owner["homedir"], ".ssh/authorized_keys")
-                cp = run_command(["ssh-keygen", "-lf", key_file])
-                self.model.user.fingerprints = cp.stdout.replace("\r", "").splitlines()
             return self.make_login_view()
         else:
             return IdentityView(self.model, self)

--- a/console_conf/models/identity.py
+++ b/console_conf/models/identity.py
@@ -25,7 +25,6 @@ class User(object):
     realname = attr.ib()
     username = attr.ib()
     homedir = attr.ib(default=None)
-    fingerprints = attr.ib(init=False, default=[])
 
 
 class IdentityModel(object):


### PR DESCRIPTION
In preparation for running console-conf as a strictly confined snaps, review of
the existing code has shown that user's key fingerprints are not being used or
displayed anywhere. Since we would not be able to read those public keys anyway,
we may as well drop the code which attempts to device the key fingerprints.

See #1873 for context