### PR TITLE
update rationale for netplan config permissions

### DIFF
--- a/subiquity/models/network.py
+++ b/subiquity/models/network.py
@@ -38,11 +38,12 @@ class NetworkModel(CoreNetworkModel):
 
     def render(self):
         netplan = self.render_config()
-        # We write wifi config -- which almost certainly contains secrets -- to
-        # a separate file with more restrictive permissions. This isn't a
-        # perfect solution because in principle there could be wired 802.1x
-        # stuff that has secrets too but the subiquity UI does not support any
-        # of that yet so this will do for now.
+        # We write the wifi config -- which almost certainly contains secrets --
+        # to a separate file since it's possible the default file may
+        # be shared (e.g., via apport for a bug report) and we don't want to
+        # leak them. This isn't a perfect solution because in principle there
+        # could be wired 802.1x stuff that has secrets too, but the subiquity
+        # UI does not support any of that yet so this will do for now.
 
         # If host cloud-init version has no readable combined-cloud-config,
         # default to False.
@@ -63,7 +64,6 @@ class NetworkModel(CoreNetworkModel):
             }
         else:
             # Separate sensitive wifi config from potentially shared config
-            # e.g. via apport
             wifis = netplan["network"].pop("wifis", None)
             r = {
                 "write_files": {


### PR DESCRIPTION
Previously we had stripped the wifi config and wrote it separately with stricter permissions than normal to avoid leaking sensitive data, but now at first glance this seems redundant with all the netplan config file permissions being the same. The reason we didn't collapse everything back to one file with the permissions change is that there are scenarios in which the 00-installer-config.yaml file could purposefully be shared, so we should continue to strip known private information from that file.