### PR TITLE
network: fix detection of netplan on recent Ubuntu releases

### DIFF
--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -18,6 +18,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import pathlib
 import subprocess
 from typing import Optional
 
@@ -315,7 +316,14 @@ class BaseNetworkController(BaseController):
             if self.opts.dry_run:
                 delay = 1 / self.app.scale_factor
                 await arun_command(["sleep", str(delay)])
-                if os.path.exists("/lib/netplan/generate"):
+
+                # /usr/libexec/netplan/generate exists starting with 22.04.
+                # When we stop supporting 20.04, we should drop the
+                # reference to /lib/netplan/generate.
+                netplan_generator_legacy = pathlib.Path("/lib/netplan/generate")
+                netplan_generator = pathlib.Path("/usr/libexec/netplan/generate")
+
+                if netplan_generator.exists() or netplan_generator_legacy.exists():
                     # If netplan appears to be installed, run generate to
                     # at least test that what we wrote is acceptable to
                     # netplan but clear the SNAP environment variable to


### PR DESCRIPTION
Subiquity has a mechanism to detect the presence of netplan. It does so by checking the existence of the file `/lib/netplan/generate`. This mechanism is used in the network screen to validate the YAML configuration.

However, since netplan 0.107 (present in mantic and noble), the file `/lib/netplan/generate` is no longer present. It used to be provided as an alias for `/usr/libexec/netplan/generate` ; starting in jammy.

This made Subiquity unable to detect that netplan is running ; and therefore skip the YAML validation against netplan.

Since we support focal in Subiquity, let's change the detection code so that we look for both locations. When we stop supporting Focal in the future, we can drop the reference to `/lib/netplan/generate`.