### PR TITLE
server: fix desktop INSTALL_MODEL_NAMES

### DIFF
--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -190,11 +190,10 @@ INSTALL_MODEL_NAMES = ModelNames(
         "filesystem",
         "kernel",
         "keyboard",
-        "proxy",
         "source",
     },
-    desktop={"mirror", "network"},
-    server={"mirror", "network"},
+    desktop={"network"},
+    server={"mirror", "network", "proxy"},
 )
 
 POSTINSTALL_MODEL_NAMES = ModelNames(


### PR DESCRIPTION
Mirror and proxy are not in plan to be shown in the UI, so stop requiring them.