### PR TITLE
types: rename ZFS_LUKS -> ZFS_LUKS_KEYSTORE

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -347,7 +347,7 @@ class GuidedCapability(enum.Enum):
     LVM = enum.auto()
     LVM_LUKS = enum.auto()
     ZFS = enum.auto()
-    ZFS_LUKS = enum.auto()
+    ZFS_LUKS_KEYSTORE = enum.auto()
 
     CORE_BOOT_ENCRYPTED = enum.auto()
     CORE_BOOT_UNENCRYPTED = enum.auto()
@@ -384,7 +384,7 @@ class GuidedCapability(enum.Enum):
     def is_zfs(self) -> bool:
         return self in [
             GuidedCapability.ZFS,
-            GuidedCapability.ZFS_LUKS,
+            GuidedCapability.ZFS_LUKS_KEYSTORE,
         ]
 
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -217,7 +217,7 @@ class VariationInfo:
                     GuidedCapability.LVM,
                     GuidedCapability.LVM_LUKS,
                     GuidedCapability.ZFS,
-                    GuidedCapability.ZFS_LUKS,
+                    GuidedCapability.ZFS_LUKS_KEYSTORE,
                 ]
             ),
         )

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -76,7 +76,7 @@ default_capabilities = [
     GuidedCapability.LVM,
     GuidedCapability.LVM_LUKS,
     GuidedCapability.ZFS,
-    GuidedCapability.ZFS_LUKS,
+    GuidedCapability.ZFS_LUKS_KEYSTORE,
 ]
 
 
@@ -590,7 +590,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertEqual("zfs", zfs_boot.type)
 
     @parameterized.expand(boot_expectations)
-    async def test_guided_zfs_luks(self, bootloader, ptable, p1mnt):
+    async def test_guided_zfs_luks_keystore(self, bootloader, ptable, p1mnt):
         await self._guided_setup(bootloader, ptable)
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
@@ -598,7 +598,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         await self.controller.guided(
             GuidedChoiceV2(
                 target=target,
-                capability=GuidedCapability.ZFS_LUKS,
+                capability=GuidedCapability.ZFS_LUKS_KEYSTORE,
                 password="passw0rd",
             )
         )


### PR DESCRIPTION
Clarify that the implemented mechanism is the keystore setup.  An implementation that doesn't use native ZFS encryption is plausibly interesting, which is a better use of the term ZFS_LUKS.