### PR TITLE
bin/console-conf-wrapper: use /run/console-conf, fix mode extraction

### DIFF
--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -26,7 +26,7 @@ fi
 if [ -e "/var/lib/snapd/modeenv" ]; then
     mode="$(sed -n 's/mode=\([^[:space:]]*\)/\1/p' /var/lib/snapd/modeenv)"
 else
-    mode="$(sed 's/.*snapd_recovery_mode=\([^[:space:]]*\)[[:space:]].*/\1/' /proc/cmdline))"
+    mode="$(sed 's/.*snapd_recovery_mode=\([^[:space:]]*\)[[:space:]].*/\1/' /proc/cmdline)"
 fi
 
 if [ "${mode}" = "install" ]; then

--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -99,8 +99,8 @@ if snap routine console-conf-start --help >/dev/null 2>/dev/null; then
     snap routine console-conf-start
 fi
 # preapre host finger prints for console-conf as it cannot access sshd or host keys
-mkdir -p /run/console_conf
-/usr/share/subiquity/console-conf-write-login-details --host-fingerprints > /run/console_conf/host-fingerprints.txt
+mkdir -p /run/console-conf
+/usr/share/subiquity/console-conf-write-login-details --host-fingerprints > /run/console-conf/host-fingerprints.txt
 snap run console-conf "$@"
 rval=$?
 if [ ! ${rval} -eq 0 ]; then


### PR DESCRIPTION
The changes in https://github.com/canonical/subiquity/commit/66e8222a09da0fbc27ada889acab28ba8374cf42 and https://github.com/canonical/subiquity/commit/f3043cde88d04bc4c33d2c0f50e27b5e69262910 introduced established /run/console-conf as the project runtime directory. Make sure that the wrapper uses the same location.

Also a small fix for a bug that was fixed in master once and then reintroduced accidentally in https://github.com/canonical/subiquity/pull/1656.  We generally expect /var/lib/snapd/modeenv to exist, but in case it does not, fall back to picking up the mode from kernel command line (just like snapd does it).
