### PR TITLE
bug(cloudinit): do not call cloudinit stages.Init when disabled

### DIFF
--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -583,7 +583,10 @@ class SubiquityServer(Application):
         log.debug("waited %ss for cloud-init", time.time() - ci_start)
         log.debug("cloud-init status: %r", status)
         if self.cloud_init_ok:
-            self.load_cloud_config()
+            if "disabled" in status:
+                log.debug("Skip cloud-init autoinstall, cloud-init is disabled")
+            else:
+                self.load_cloud_config()
 
     def select_autoinstall(self):
         # precedence


### PR DESCRIPTION
Inspect cloud-init status for disabled. When disabled do not call stages.Init due to a side-effect that cloud-init tries to rediscover any viable datasource when none are previously discovered.

LP: #2055077