### PR TITLE
ssh: fix UI crash when importing key on non UTF-8 and/or serial terminal

### DIFF
--- a/subiquity/ui/views/ssh.py
+++ b/subiquity/ui/views/ssh.py
@@ -394,7 +394,12 @@ class SSHView(BaseView):
                 make_action_menu_row(
                     [
                         Text("["),
-                        Text(key, wrap="ellipsis"),
+                        # LP: #2055702 wrap="ellipsis" looks better but it
+                        # produces crashes on non UTF-8 and/or serial
+                        # terminals,
+                        # We can move back to wrap="ellipsis" when we switch to
+                        # core24 or if the fix gets SRUd to jammy.
+                        Text(key, wrap="clip"),
                         menu,
                         Text("]"),
                     ],


### PR DESCRIPTION
When importing a key on a terminal with limited capabilities, the UI can crash with:

```python
 File "urwid/canvas.py", line 1315, in apply_text_layout
     return TextCanvas(t, a, c, maxcol=maxcol)
   File "urwid/canvas.py", line 358, in __init__
     raise CanvasError("Canvas text is wider than the maxcol [...]
 urwid.canvas.CanvasError: Canvas text is wider than the maxcol specified
```

When a SSH key is too long to be displayed on the terminal, we clip the end and show the ellipsis `…` character instead. It is supposedly 1 column wide but it reverts to `...` (3 columns wide) on terminals with limited capabilities.

The bug seems fixed in urwid in noble but we're using core22 for now. Let's not try to show the character until we switch to core24 (or until the bug is fixed in jammy).

LP:#2055702