### PR TITLE
Support for Non Reportable Errors

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -333,14 +333,17 @@ class SubiquityClient(TuiApplication):
                     print(line)
                 return
 
-            # Get the variant from the server and reload desired
-            # controllers if an override exists
-            variant = await self.client.meta.client_variant.GET()
-            if variant != self.variant:
-                self.variant = variant
-                controllers = self.variant_to_controllers.get(variant)
-                if controllers:
-                    self.load_controllers(controllers)
+            # The server could end up in an error state before we get here
+            # so skip to allow urwid to come up and show an error screen
+            if status.state != ApplicationState.ERROR:
+                # Get the variant from the server and reload desired
+                # controllers if an override exists
+                variant = await self.client.meta.client_variant.GET()
+                if variant != self.variant:
+                    self.variant = variant
+                    controllers = self.variant_to_controllers.get(variant)
+                    if controllers:
+                        self.load_controllers(controllers)
 
             await super().start()
             # Progress uses systemd to collect and display the installation

--- a/subiquity/client/controllers/tests/test_progress.py
+++ b/subiquity/client/controllers/tests/test_progress.py
@@ -1,0 +1,95 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import AsyncMock, Mock
+
+from subiquity.client.controllers.progress import ProgressController
+from subiquity.common.types import ApplicationState, ApplicationStatus
+from subiquitycore.tests.mocks import make_app
+
+
+class TestProgressController(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        app = make_app()
+        app.client = AsyncMock()
+        app.show_error_report = Mock()
+        app.show_nonreportable_error = Mock()
+
+        self.controller = ProgressController(app)
+
+    async def test_handle_error_state(self):
+        # Reportable error case
+
+        status: ApplicationStatus = ApplicationStatus(
+            state=ApplicationState.ERROR,
+            confirming_tty="",
+            error=Mock(),
+            nonreportable_error=None,
+            cloud_init_ok=Mock(),
+            interactive=Mock(),
+            echo_syslog_id=Mock(),
+            log_syslog_id=Mock(),
+            event_syslog_id=Mock(),
+        )
+
+        self.controller._handle_error_state(status)
+        self.controller.app.show_error_report.assert_called_once()
+        self.controller.app.show_nonreportable_error.assert_not_called()
+
+        # Reset mocks between cases
+        self.controller.app.show_error_report.reset_mock()
+        self.controller.app.show_nonreportable_error.reset_mock()
+
+        # Non Reportable error case
+
+        status: ApplicationStatus = ApplicationStatus(
+            state=ApplicationState.ERROR,
+            confirming_tty="",
+            error=None,
+            nonreportable_error=Mock(),
+            cloud_init_ok=Mock(),
+            interactive=Mock(),
+            echo_syslog_id=Mock(),
+            log_syslog_id=Mock(),
+            event_syslog_id=Mock(),
+        )
+
+        self.controller._handle_error_state(status)
+        self.controller.app.show_error_report.assert_not_called()
+        self.controller.app.show_nonreportable_error.assert_called_once()
+
+        # Reset mocks between cases
+        self.controller.app.show_error_report.reset_mock()
+        self.controller.app.show_nonreportable_error.reset_mock()
+
+        # Bug case
+
+        status: ApplicationStatus = ApplicationStatus(
+            state=ApplicationState.ERROR,
+            confirming_tty="",
+            error=None,
+            nonreportable_error=None,
+            cloud_init_ok=Mock(),
+            interactive=Mock(),
+            echo_syslog_id=Mock(),
+            log_syslog_id=Mock(),
+            event_syslog_id=Mock(),
+        )
+
+        with self.assertRaises(Exception):
+            self.controller._handle_error_state(status)
+        self.controller.app.show_error_report.assert_not_called()
+        self.controller.app.show_nonreportable_error.assert_not_called()

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -121,11 +121,11 @@ class API:
                 """Confirm that the installation should proceed."""
 
         class restart:
+            @allowed_before_start
             def POST() -> None:
                 """Restart the server process."""
 
         class ssh_info:
-            @allowed_before_start
             def GET() -> Optional[LiveSessionSSHInfo]:
                 ...
 

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -125,6 +125,7 @@ class API:
                 """Restart the server process."""
 
         class ssh_info:
+            @allowed_before_start
             def GET() -> Optional[LiveSessionSSHInfo]:
                 ...
 

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import attr
 
+from subiquity.server.nonreportable import NonReportableException
 from subiquitycore.models.network import NetDevInfo
 
 
@@ -53,6 +54,21 @@ class ErrorReportRef:
     kind: ErrorReportKind
     seen: bool
     oops_id: Optional[str]
+
+
+@attr.s(auto_attribs=True)
+class NonReportableError:
+    cause: str
+    message: str
+    details: Optional[str]
+
+    @classmethod
+    def from_exception(cls, exc: NonReportableException):
+        return cls(
+            cause=type(exc).__name__,
+            message=str(exc),
+            details=exc.details,
+        )
 
 
 class ApplicationState(enum.Enum):
@@ -87,6 +103,7 @@ class ApplicationStatus:
     state: ApplicationState
     confirming_tty: str
     error: Optional[ErrorReportRef]
+    nonreportable_error: Optional[NonReportableError]
     cloud_init_ok: Optional[bool]
     interactive: Optional[bool]
     echo_syslog_id: str

--- a/subiquity/server/nonreportable.py
+++ b/subiquity/server/nonreportable.py
@@ -15,21 +15,11 @@
 import logging
 from typing import Optional
 
-from subiquity.server.nonreportable import NonReportableException
-
-log = logging.getLogger("subiquity.server.autoinstall")
+log = logging.getLogger("subiquity.server.nonreportable")
 
 
-class AutoinstallError(NonReportableException):
-    pass
-
-
-class AutoinstallValidationError(AutoinstallError):
-    def __init__(
-        self,
-        owner: str,
-        details: Optional[str] = None,
-    ):
-        self.message = f"Malformed autoinstall in {owner!r} section"
-        self.owner = owner
-        super().__init__(self.message, details=details)
+class NonReportableException(Exception):
+    def __init__(self, message: str, details: Optional[str] = None):
+        self.message: str = message
+        self.details: Optional[str] = None
+        super().__init__(message)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -41,11 +41,12 @@ from subiquity.common.types import (
     PasswordKind,
 )
 from subiquity.models.subiquity import ModelNames, SubiquityModel
-from subiquity.server.autoinstall import AutoinstallError, AutoinstallValidationError
+from subiquity.server.autoinstall import AutoinstallValidationError
 from subiquity.server.controller import SubiquityController
 from subiquity.server.dryrun import DRConfig
 from subiquity.server.errors import ErrorController
 from subiquity.server.geoip import DryRunGeoIPStrategy, GeoIP, HTTPGeoIPStrategy
+from subiquity.server.nonreportable import NonReportableException
 from subiquity.server.pkghelper import get_package_installer
 from subiquity.server.runner import get_command_runner
 from subiquity.server.snapdapi import make_api_client
@@ -290,7 +291,7 @@ class SubiquityServer(Application):
         self.update_state(ApplicationState.STARTING_UP)
         self.interactive = None
         self.confirming_tty = ""
-        self.fatal_error = None
+        self.fatal_error: Optional[ErrorReport] = None
         self.running_error_commands = False
         self.installer_user_name = None
         self.installer_user_passwd_kind = PasswordKind.NONE
@@ -415,16 +416,29 @@ class SubiquityServer(Application):
             self.update_state(ApplicationState.ERROR)
 
     def _exception_handler(self, loop, context):
-        exc = context.get("exception")
+        exc: Optional[Exception] = context.get("exception")
         if exc is None:
             super()._exception_handler(loop, context)
             return
-        report = self.error_reporter.report_for_exc(exc)
         log.error("top level error", exc_info=exc)
-        if not isinstance(exc, AutoinstallError) and not report:
-            report = self.make_apport_report(
-                ErrorReportKind.UNKNOWN, "unknown error", exc=exc
-            )
+
+        # Some common errors have apport reports written closer to where the
+        # exception was originally thrown. We write a generic "unknown error"
+        # report for cases where it wasn't written already, except in cases
+        # where we want to explicitly supress report generation (e.g., bad
+        # autoinstall cases).
+
+        report: Optional[ErrorReport] = None
+
+        if isinstance(exc, NonReportableException):
+            pass
+        else:
+            report = self.error_reporter.report_for_exc(exc)
+            if report is None:
+                report = self.make_apport_report(
+                    ErrorReportKind.UNKNOWN, "unknown error", exc=exc
+                )
+
         self.fatal_error = report
         if self.interactive:
             self.update_state(ApplicationState.ERROR)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -38,6 +38,7 @@ from subiquity.common.types import (
     ErrorReportRef,
     KeyFingerprint,
     LiveSessionSSHInfo,
+    NonReportableError,
     PasswordKind,
 )
 from subiquity.models.subiquity import ModelNames, SubiquityModel
@@ -84,6 +85,7 @@ class MetaController:
             state=self.app.state,
             confirming_tty=self.app.confirming_tty,
             error=self.app.fatal_error,
+            nonreportable_error=self.app.nonreportable_error,
             cloud_init_ok=self.app.cloud_init_ok,
             interactive=self.app.interactive,
             echo_syslog_id=self.app.echo_syslog_id,
@@ -292,6 +294,7 @@ class SubiquityServer(Application):
         self.interactive = None
         self.confirming_tty = ""
         self.fatal_error: Optional[ErrorReport] = None
+        self.nonreportable_error: Optional[NonReportableError] = None
         self.running_error_commands = False
         self.installer_user_name = None
         self.installer_user_passwd_kind = PasswordKind.NONE
@@ -431,7 +434,7 @@ class SubiquityServer(Application):
         report: Optional[ErrorReport] = None
 
         if isinstance(exc, NonReportableException):
-            pass
+            self.nonreportable_error = NonReportableError.from_exception(exc)
         else:
             report = self.error_reporter.report_for_exc(exc)
             if report is None:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -498,7 +498,7 @@ class SubiquityServer(Application):
             except ValidationError as original_exception:
                 # SubiquityServer currently only checks for these sections
                 # of autoinstall. Hardcode until we have better validation.
-                section = "version or interative-sessions"
+                section = "version or interactive-sections"
                 new_exception: AutoinstallValidationError = AutoinstallValidationError(
                     section,
                 )

--- a/subiquity/ui/views/tests/test_installprogress.py
+++ b/subiquity/ui/views/tests/test_installprogress.py
@@ -30,3 +30,26 @@ class IdentityViewTests(unittest.TestCase):
         self.assertIsNot(btn, None)
         view_helpers.click(btn)
         view.controller.click_reboot.assert_called_once_with()
+
+    def test_error_disambiguation(self):
+        view = self.make_view()
+
+        # Reportable errors
+        view.controller.has_nonreportable_error = False
+        view.update_for_state(ApplicationState.ERROR)
+        btn = view_helpers.find_button_matching(view, "^View error report$")
+        self.assertIsNotNone(btn)
+        btn = view_helpers.find_button_matching(view, "^Reboot Now$")
+        self.assertIsNotNone(btn)
+        btn = view_helpers.find_button_matching(view, "^Restart Installer$")
+        self.assertIsNone(btn)
+
+        # Non-Reportable errors
+        view.controller.has_nonreportable_error = True
+        view.update_for_state(ApplicationState.ERROR)
+        btn = view_helpers.find_button_matching(view, "^View error report$")
+        self.assertIsNone(btn)
+        btn = view_helpers.find_button_matching(view, "^Reboot Now$")
+        self.assertIsNone(btn)
+        btn = view_helpers.find_button_matching(view, "^Restart Installer$")
+        self.assertIsNotNone(btn)

--- a/test_data/autoinstall/bad-early-command.yaml
+++ b/test_data/autoinstall/bad-early-command.yaml
@@ -1,0 +1,12 @@
+version: 1
+
+identity:
+  realname: ''
+  hostname: ubuntu
+  username: ubuntu
+  password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+
+
+early-commands:
+  - $((1/0))
+

--- a/test_data/autoinstall/invalid-early.yaml
+++ b/test_data/autoinstall/invalid-early.yaml
@@ -1,0 +1,6 @@
+version: 0
+identity:
+        realname: ''
+        username: ubuntu
+        password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+        hostname: ubuntu


### PR DESCRIPTION
The original attempt to make a new class of non apport reportable errors in #1897 didn't quite cover everything needed, especially in regards to the changes needed in the API to inform the client of the nuance of the error state. These changes include:

- A refactor to make the apport generation suppression generic and tested
- Changes to the /meta/status API response object (`ApplicationStatus`) to include a new field `nonreportable_error`
  - Reportable errors are still available under the `error` field, so disambiguating the error difference requires checking which of `error` and `nonreportable_error` isn't `None`
- The endpoints `/meta/restart` (POST) and `/meta/ssh_info` (GET) are now available before the server has finished loading all of its controllers. 
- The server now sets the `interactive` state as the first step in loading the autoinstall data, not the last
- The subiquity TUI can discern between reportable and non-reportable errors and will show a different overlay accordingly 