### PR TITLE
debconf-selections: work around grub2 bug until it is fixed

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -161,6 +161,12 @@ class DebconfSelectionsModel:
         return {}
 
     def get_apt_config(self, final: bool, has_network: bool) -> Dict[str, Any]:
+        # Workaround for LP: #2055294
+        # TODO remove when the bug is fixed
+        if not self.selections:
+            grub2_selection = "grub-pc grub-efi/cloud_style_installation boolean false"
+            return {"debconf_selections": {"subiquity": grub2_selection}}
+
         return {"debconf_selections": {"subiquity": self.selections}}
 
 


### PR DESCRIPTION
Currently, installations of Ubuntu Server and Ubuntu Desktop 24.04 both fail on UEFI-based systems because of a grub2 bug. This is a workaround to avoid failing installs until grub2 migrates to the release pocket.