### PR TITLE
Allow skip identity

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -380,6 +380,11 @@ class SubiquityModel:
         else:
             if self.userdata is None:
                 config["users"] = []
+                if self.ssh.authorized_keys:
+                    log.warning(
+                        "likely configuration error: "
+                        "authorized_keys supplied but no known user login"
+                    )
             if self.ssh.authorized_keys:
                 config["ssh_authorized_keys"] = self.ssh.authorized_keys
         if self.ssh.install_server:

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -207,7 +207,7 @@ class SubiquityModel:
         self.timezone = TimeZoneModel()
         self.ubuntu_pro = UbuntuProModel()
         self.updates = UpdatesModel()
-        self.userdata = {}
+        self.userdata = None
 
         self._confirmation = asyncio.Event()
         self._confirmation_task = None
@@ -378,6 +378,8 @@ class SubiquityModel:
                 user_info["ssh_authorized_keys"] = self.ssh.authorized_keys
             config["users"] = [user_info]
         else:
+            if self.userdata is None:
+                config["users"] = []
             if self.ssh.authorized_keys:
                 config["ssh_authorized_keys"] = self.ssh.authorized_keys
         if self.ssh.install_server:
@@ -388,7 +390,8 @@ class SubiquityModel:
                 merge_config(config, model.make_cloudconfig())
         for package in self.cloud_init_packages:
             merge_config(config, {"packages": list(self.cloud_init_packages)})
-        merge_cloud_init_config(config, self.userdata)
+        if self.userdata is not None:
+            merge_cloud_init_config(config, self.userdata)
         if lsb_release()["release"] not in ("20.04", "22.04"):
             config.setdefault("write_files", []).append(CLOUDINIT_DISABLE_AFTER_INSTALL)
         self.validate_cloudconfig_schema(data=config, data_source="system install")

--- a/subiquity/models/tests/test_subiquity.py
+++ b/subiquity/models/tests/test_subiquity.py
@@ -498,7 +498,8 @@ class TestUserCreationFlows(unittest.IsolatedAsyncioTestCase):
         [actual] = cloud_cfg["users"]
         self.assertDictSubset(self.user, actual)
 
-    # 4a1 fails before we get here, so needs to be tested elsewhere
+    # 4a1 fails before we get here, see TestControllerUserCreationFlows in
+    # subiquity/server/controllers/tests/test_identity.py for details.
 
     def test_create_nothing_case_4b(self):
         self.model.userdata = {}

--- a/subiquity/server/controllers/identity.py
+++ b/subiquity/server/controllers/identity.py
@@ -88,7 +88,9 @@ class IdentityController(SubiquityController):
             return
         if self.app.base_model.target is None:
             return
-        raise Exception("no identity data provided")
+        if self.app.base_model.source.current.variant != "server":
+            return
+        raise Exception("neither identity nor user-data provided")
 
     def make_autoinstall(self):
         if self.model.user is None:

--- a/subiquity/server/controllers/tests/test_identity.py
+++ b/subiquity/server/controllers/tests/test_identity.py
@@ -18,6 +18,7 @@ from jsonschema.validators import validator_for
 
 from subiquity.server.controllers.identity import IdentityController
 from subiquitycore.tests import SubiTestCase
+from subiquitycore.tests.mocks import make_app
 
 
 class TestIdentityController(SubiTestCase):
@@ -29,3 +30,22 @@ class TestIdentityController(SubiTestCase):
         )
 
         JsonValidator.check_schema(IdentityController.autoinstall_schema)
+
+
+class TestControllerUserCreationFlows(SubiTestCase):
+    # TestUserCreationFlows has more information about user flow use cases.
+    # See subiquity/models/tests/test_subiquity.py for details.
+    def setUp(self):
+        self.app = make_app()
+        self.ic = IdentityController(self.app)
+        self.ic.model.user = None
+
+    async def test_server_requires_identity_case_4a1(self):
+        self.app.base_model.source.current.variant = "server"
+        with self.assertRaises(Exception):
+            await self.ic.apply_autoinstall_config()
+
+    async def test_desktop_does_not_require_identity_case_4a2(self):
+        self.app.base_model.source.current.variant = "desktop"
+        await self.ic.apply_autoinstall_config()
+        # should not raise

--- a/subiquity/server/controllers/tests/test_userdata.py
+++ b/subiquity/server/controllers/tests/test_userdata.py
@@ -33,6 +33,7 @@ except ImportError:
 class TestUserdataController(unittest.TestCase):
     def setUp(self):
         self.controller = UserdataController(make_app())
+        self.controller.model = None
 
     def test_load_autoinstall_data(self):
         with self.subTest("Valid user-data resets userdata model"):
@@ -69,3 +70,15 @@ class TestUserdataController(unittest.TestCase):
         )
 
         JsonValidator.check_schema(UserdataController.autoinstall_schema)
+
+    def test_load_none(self):
+        self.controller.load_autoinstall_data(None)
+        self.assertIsNone(self.controller.model)
+
+    def test_load_empty(self):
+        self.controller.load_autoinstall_data({})
+        self.assertEqual({}, self.controller.model)
+
+    def test_load_some(self):
+        self.controller.load_autoinstall_data({"stuff": "things"})
+        self.assertEqual({"stuff": "things"}, self.controller.model)

--- a/subiquity/server/controllers/userdata.py
+++ b/subiquity/server/controllers/userdata.py
@@ -23,19 +23,20 @@ log = logging.getLogger("subiquity.server.controllers.userdata")
 class UserdataController(NonInteractiveController):
     model_name = "userdata"
     autoinstall_key = "user-data"
-    autoinstall_default = {}
+    autoinstall_default = None
     autoinstall_schema = {
         "type": "object",
     }
 
     def load_autoinstall_data(self, data):
-        self.model.clear()
+        if data is None:
+            return
         if data:
             self.app.base_model.validate_cloudconfig_schema(
                 data=data,
                 data_source="autoinstall.user-data",
             )
-        self.model.update(data)
+        self.app.base_model.userdata = self.model = data.copy()
 
     def make_autoinstall(self):
-        return self.app.base_model.userdata
+        return self.app.base_model.userdata or {}


### PR DESCRIPTION
For Desktop we want to be able to not require creating a user.  To this end the existing use cases were enumerated, existing behavior confirmed, and the new scenario added. 