### PR TITLE
Move metadata collection to Curtin

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: a5b815bc688fcc18877ef2cd05ea56bc58d7fe00
+    source-commit: 7db312f27463e7f56ede4778e5cfac91a0db14a2
 
     override-pull: |
       craftctl default

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -486,13 +486,6 @@ class SubiquityModel:
             os.makedirs(os.path.dirname(path), exist_ok=True)
             write_file(path, content, mode=mode)
 
-    def _media_info(self):
-        if os.path.exists("/cdrom/.disk/info"):
-            with open("/cdrom/.disk/info") as fp:
-                return fp.read()
-        else:
-            return "media-info"
-
     def _machine_id(self):
         with open("/etc/machine-id") as fp:
             return fp.read()
@@ -524,11 +517,6 @@ class SubiquityModel:
                     "path": "etc/machine-id",
                     "content": self._machine_id(),
                     "permissions": 0o444,
-                },
-                "media_info": {
-                    "path": "var/log/installer/media-info",
-                    "content": self._media_info(),
-                    "permissions": 0o644,
                 },
             },
         }

--- a/subiquity/models/tests/test_subiquity.py
+++ b/subiquity/models/tests/test_subiquity.py
@@ -180,7 +180,6 @@ class TestSubiquityModel(unittest.IsolatedAsyncioTestCase):
         for model in model_no_proxy, model_proxy:
             config = model.render()
             self.assertConfigWritesFile(config, "etc/machine-id")
-            self.assertConfigWritesFile(config, "var/log/installer/media-info")
 
     def test_storage_version(self):
         model = self.make_model()


### PR DESCRIPTION
Move copying of installation media metadata (i.e., things in `/cdrom/.disk/`) to Curtin. Includes fix for [LP: #2037038](https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2037038). 

Curtin [MP 462092](https://code.launchpad.net/~cpete/curtin/+git/curtin/+merge/462092)
