### PR TITLE
Update autoinstall-reference.rst

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -270,9 +270,9 @@ The default is:
         primary:
           - country-mirror
           - arches: [i386, amd64]
-            uri: "http://archive.ubuntu.com/ubuntu"
+          - uri: "http://archive.ubuntu.com/ubuntu"
           - arches: [s390x, arm64, armhf, powerpc, ppc64el, riscv64]
-            uri: "http://ports.ubuntu.com/ubuntu-ports"
+          - uri: "http://ports.ubuntu.com/ubuntu-ports"
       fallback: abort
       geoip: true
 


### PR DESCRIPTION
Missing hypen for uri will result in an error, if it is the only value in list.

error: { 'uri': 'http://archive.ubuntu.com/ubuntu/' } is not of type 'array'