### PR TITLE
filesystem: autoinstall reformat_disk match raids

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1641,6 +1641,7 @@ class FilesystemModel:
         return matchers
 
     def disk_for_match(self, disks, match):
+        log.info(f"considering {disks} for {match}")
         matchers = self._make_matchers(match)
         candidates = []
         for candidate in disks:
@@ -1658,7 +1659,9 @@ class FilesystemModel:
         if match.get("size") == "largest":
             candidates.sort(key=lambda d: d.size, reverse=True)
         if candidates:
+            log.info(f"For match {match}, using the first candidate from {candidates}")
             return candidates[0]
+        log.info(f"For match {match}, no devices match")
         return None
 
     def assign_omitted_offsets(self):

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -36,6 +36,7 @@ from curtin.util import human2bytes
 from probert.storage import StorageInfo
 
 from subiquity.common.types import Bootloader, OsProber, RecoveryKey
+from subiquity.server.autoinstall import AutoinstallError
 from subiquitycore.utils import write_named_tempfile
 
 log = logging.getLogger("subiquity.models.filesystem")
@@ -1722,9 +1723,9 @@ class FilesystemModel:
                     if disk is None:
                         action["match"] = match
                 if disk is None:
-                    raise Exception("{} matched no disk".format(action))
+                    raise AutoinstallError("{} matched no disk".format(action))
                 if disk not in disks:
-                    raise Exception(
+                    raise AutoinstallError(
                         "{} matched {} which was already used".format(action, disk)
                     )
                 disks.remove(disk)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -986,7 +986,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def has_bitlocker_GET(self) -> List[Disk]:
         """list of Disks that contain a partition that is BitLockered"""
         bitlockered_disks = []
-        for disk in self.model.all_disks():
+        for disk in self.model.all_disks() + self.model.all_raids():
             for part in disk.partitions():
                 fs = part.fs()
                 if not fs:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1428,11 +1428,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             disk = self.get_bootable_matching_disk(match)
             target = GuidedStorageTargetReformat(disk_id=disk.id, allowed=[])
         elif mode == "use_gap":
-            bootable = [
-                d
-                for d in self.model.all_disks()
-                if boot.can_be_boot_device(d, with_reformatting=False)
-            ]
+            bootable = self.potential_boot_disks(with_reformatting=False)
             gap = gaps.largest_gap(bootable)
             if not gap:
                 raise Exception(


### PR DESCRIPTION
Fix matching raids as part of layout-style storage autoinstall, along with some related issues
* add logging to match handling, it's a bit inscrutable
* raise AutoinstallError on a failed match.  Today layout style match just fails with a `None` deref, and config style raises a generic `Exception`