### PR TITLE
snapcraft: bump curtin revision for the SYSTEMD_OFFLINE handling and deb822 sources

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 5094d95fa5b8506412979e21548069bc12681dc7
+    source-commit: a5b815bc688fcc18877ef2cd05ea56bc58d7fe00
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Full changelog:

* canonical/curtin@3d0994a3bfb47318bd8b4c0aa5e345e198eabe77
* canonical/curtin@a5b815bc688fcc18877ef2cd05ea56bc58d7fe00

This should address LP:#2056570 and LP:#2056308