### PR TITLE
Bump curtin rev for conditional nvme-stas installation

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 7db312f27463e7f56ede4778e5cfac91a0db14a2
+    source-commit: 54cc7d980b9300339e773dc579daa5f11fd12fd0
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Full changelog:

* canonical/curtin@54cc7d980b9300339e773dc579daa5f11fd12fd0
* canonical/curtin@4b3395bd71960406498cb8ee09db2f26fea9680c
* canonical/curtin@cf8f7a48905109dbc28808db90fd63c3d6ec37f6
* canonical/curtin@69e315408e3b33010e00387e624680cd66056c61 (unrelated but should be harmless)

LP:#2056730