### PR TITLE
logging: capture warnings emitted using warnings.warn()

### DIFF
--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -193,6 +193,7 @@ def main():
 
     logfiles = setup_logger(dir=logdir, base="subiquity-server")
 
+    logging.captureWarnings(True)
     logger = logging.getLogger("subiquity")
     revision = os.environ.get("SNAP_REVISION", "unknown")
     version = os.environ.get("SNAP_VERSION", "unknown")

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -124,6 +124,7 @@ def main():
         logdir = opts.output_base
     logfiles = setup_logger(dir=logdir, base="subiquity-client")
 
+    logging.captureWarnings(True)
     logger = logging.getLogger("subiquity")
     version = os.environ.get("SNAP_REVISION", "unknown")
     snap = os.environ.get("SNAP", "unknown")


### PR DESCRIPTION
By default, warnings emitted by warnings.warn() will show on stderr. For a TUI application, this is a problem because they will be displayed over the UI and create visual glitches.

For parts of the UI that are regularly redrawn, the text of the warning will eventually go away (sometimes instantly, making the warning impossible to read).

For parts of the screen that are *not* regularly redrawn, the text of the warning will stay until the user sends a Ctrl-L sequence.

We now make use of logging.captureWarnings() to redirect the warnings to the log files. This prevents the UI glitches and if any warning is emitted, we can actually find it in the logs.



NOTE I witnessed this issue after upgrading to noble. urwid started throwing warnings and they weren't readable.