### PR TITLE
tests: terminate curl processes on timeout

### DIFF
--- a/scripts/test-system-setup-loopback-only.py
+++ b/scripts/test-system-setup-loopback-only.py
@@ -39,6 +39,8 @@ async def test_connect(cmd: List[str]) -> bool:
     try:
         await asyncio.wait_for(proc.wait(), 10)
     except asyncio.TimeoutError:
+        proc.terminate()
+        await proc.wait()
         return False
     return proc.returncode == 0
 


### PR DESCRIPTION
When ensuring that the system-setup process can only be connected to on the loopback interface, we spawn a bunch of `curl --interface ...` processes. If the connection times out (which is the expectation in most scenarios), the curl processes ended up not being terminated. Not only this is small waste of resources, this is also causing errors on noble:
```python
Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x745692661300>
Traceback (most recent call last):
  File "/usr/lib/python3.12/asyncio/base_subprocess.py", line 126, in __del__
    self.close()
  File "/usr/lib/python3.12/asyncio/base_subprocess.py", line 104, in close
    proto.pipe.close()
  File "/usr/lib/python3.12/asyncio/unix_events.py", line 568, in close
    self._close(None)
  File "/usr/lib/python3.12/asyncio/unix_events.py", line 592, in _close
    self._loop.call_soon(self._call_connection_lost, exc)
  File "/usr/lib/python3.12/asyncio/base_events.py", line 793, in call_soon
    self._check_closed()
  File "/usr/lib/python3.12/asyncio/base_events.py", line 540, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

Fixed by terminating the curl processes (and waiting for them to terminate) before exiting the script.