### PR TITLE
Improve context logging

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -265,10 +265,9 @@ class SubiquityClient(TuiApplication):
             app_status = await self._status_get(app_state)
 
     def subiquity_event_noninteractive(self, event):
-        if event["SUBIQUITY_EVENT_TYPE"] == "start":
-            print("start: " + event["MESSAGE"])
-        elif event["SUBIQUITY_EVENT_TYPE"] == "finish":
-            print("finish: " + event["MESSAGE"])
+        event_type = event["SUBIQUITY_EVENT_TYPE"]
+        message = event["MESSAGE"]
+        print(f"{event_type}: {message}")
 
     async def connect(self):
         def p(s):
@@ -379,7 +378,9 @@ class SubiquityClient(TuiApplication):
                 # prompting for confirmation will be confusing.
                 os.system("stty sane")
             journald_listen(
-                [status.event_syslog_id], self.subiquity_event_noninteractive, seek=True
+                [status.event_syslog_id],
+                self.subiquity_event_noninteractive,
+                seek=False,
             )
             run_bg_task(self.noninteractive_watch_app_state(status))
 

--- a/subiquity/server/controllers/reporting.py
+++ b/subiquity/server/controllers/reporting.py
@@ -27,6 +27,7 @@ from curtin.reporter.events import (
 from curtin.reporter.handlers import LogHandler as CurtinLogHandler
 
 from subiquity.server.controller import NonInteractiveController
+from subiquity.server.event_listener import EventListener
 from subiquitycore.context import Context
 
 
@@ -46,7 +47,7 @@ INITIAL_CONFIG = {
 NON_INTERACTIVE_CONFIG = {"builtin": {"type": "print"}}
 
 
-class ReportingController(NonInteractiveController):
+class ReportingController(EventListener, NonInteractiveController):
     autoinstall_key = "reporting"
     autoinstall_schema = {
         "type": "object",

--- a/subiquity/server/controllers/reporting.py
+++ b/subiquity/server/controllers/reporting.py
@@ -17,10 +17,17 @@ import copy
 import logging
 
 from curtin.reporter import available_handlers, update_configuration
-from curtin.reporter.events import report_finish_event, report_start_event, status
+from curtin.reporter.events import (
+    ReportingEvent,
+    report_event,
+    report_finish_event,
+    report_start_event,
+    status,
+)
 from curtin.reporter.handlers import LogHandler as CurtinLogHandler
 
 from subiquity.server.controller import NonInteractiveController
+from subiquitycore.context import Context
 
 
 class LogHandler(CurtinLogHandler):
@@ -76,3 +83,18 @@ class ReportingController(NonInteractiveController):
         report_finish_event(
             context.full_name(), description, result, level=context.level
         )
+
+    def report_info_event(self, context: Context, message: str):
+        """Report an "info" event."""
+        event = ReportingEvent("info", context.full_name(), message, level="INFO")
+        report_event(event)
+
+    def report_warning_event(self, context: Context, message: str):
+        """Report a "warning" event."""
+        event = ReportingEvent("warning", context.full_name(), message, level="WARNING")
+        report_event(event)
+
+    def report_error_event(self, context: Context, message: str):
+        """Report an "error" event."""
+        event = ReportingEvent("error", context.full_name(), message, level="ERROR")
+        report_event(event)

--- a/subiquity/server/controllers/tests/test_reporting.py
+++ b/subiquity/server/controllers/tests/test_reporting.py
@@ -13,11 +13,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest.mock import Mock, patch
+
 import jsonschema
+from curtin.reporter.events import status as CurtinStatus
 from jsonschema.validators import validator_for
 
 from subiquity.server.controllers.reporting import ReportingController
+from subiquitycore.context import Context
+from subiquitycore.context import Status as ContextStatus
 from subiquitycore.tests import SubiTestCase
+from subiquitycore.tests.mocks import MockedApplication, make_app
 
 
 class TestReportingController(SubiTestCase):
@@ -29,3 +35,85 @@ class TestReportingController(SubiTestCase):
         )
 
         JsonValidator.check_schema(ReportingController.autoinstall_schema)
+
+
+@patch("subiquity.server.controllers.reporting.report_event")
+class TestReportingCurtinCalls(SubiTestCase):
+    def setUp(self):
+        app: MockedApplication = make_app()
+        self.controller: ReportingController = ReportingController(app)
+        self.context: Context = app.context
+
+    @patch("subiquity.server.controllers.reporting.report_start_event")
+    def test_start_event(self, report_start_event, report_event):
+        self.controller.report_start_event(self.context, "description")
+
+        # Calls specific start event method
+        report_start_event.assert_called_with(
+            self.context.full_name(), "description", level=self.context.level
+        )
+
+        # Not the generic one
+        report_event.assert_not_called()
+
+    @patch("subiquity.server.controllers.reporting.report_finish_event")
+    def test_finish_event(self, report_finish_event, report_event):
+        self.controller.report_finish_event(
+            self.context, "description", ContextStatus.FAIL
+        )
+
+        # Calls specific finish event method
+        report_finish_event.assert_called_with(
+            self.context.full_name(),
+            "description",
+            CurtinStatus.FAIL,
+            level=self.context.level,
+        )
+
+        # Not the generic one
+        report_event.assert_not_called()
+
+        # Test default WARN
+        status = Mock()
+        status.name = "NEW LEVEL"
+        self.controller.report_finish_event(self.context, "description", status)
+
+        report_finish_event.assert_called_with(
+            self.context.full_name(),
+            "description",
+            CurtinStatus.WARN,
+            level=self.context.level,
+        )
+
+    @patch("subiquity.server.controllers.reporting.ReportingEvent")
+    def test_info_event(self, mock_class, report_event):
+        self.controller.report_info_event(self.context, "description")
+
+        mock_class.assert_called_with(
+            "info",
+            self.context.full_name(),
+            "description",
+            level="INFO",
+        )
+
+    @patch("subiquity.server.controllers.reporting.ReportingEvent")
+    def test_warning_event(self, mock_class, report_event):
+        self.controller.report_warning_event(self.context, "description")
+
+        mock_class.assert_called_with(
+            "warning",
+            self.context.full_name(),
+            "description",
+            level="WARNING",
+        )
+
+    @patch("subiquity.server.controllers.reporting.ReportingEvent")
+    def test_error_event(self, mock_class, report_event):
+        self.controller.report_error_event(self.context, "description")
+
+        mock_class.assert_called_with(
+            "error",
+            self.context.full_name(),
+            "description",
+            level="ERROR",
+        )

--- a/subiquity/server/event_listener.py
+++ b/subiquity/server/event_listener.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from abc import ABC, abstractmethod
+from typing import Any
+
+from subiquitycore.context import Context
+
+
+class EventListener(ABC):
+    """Interface for SubiquitySever event listeners"""
+
+    @abstractmethod
+    def report_start_event(self, context: Context, description: str) -> None:
+        """Report a "start" event."""
+
+    @abstractmethod
+    def report_finish_event(
+        self, context: Context, description: str, result: Any
+    ) -> None:
+        """Report a "finish" event."""
+
+    @abstractmethod
+    def report_info_event(self, context: Context, message: str) -> None:
+        """Report an "info" event."""
+
+    @abstractmethod
+    def report_warning_event(self, context: Context, message: str) -> None:
+        """Report a "warning" event."""
+
+    @abstractmethod
+    def report_error_event(self, context: Context, message: str) -> None:
+        """Report an "error" event."""

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -46,6 +46,7 @@ from subiquity.server.autoinstall import AutoinstallValidationError
 from subiquity.server.controller import SubiquityController
 from subiquity.server.dryrun import DRConfig
 from subiquity.server.errors import ErrorController
+from subiquity.server.event_listener import EventListener
 from subiquity.server.geoip import DryRunGeoIPStrategy, GeoIP, HTTPGeoIPStrategy
 from subiquity.server.nonreportable import NonReportableException
 from subiquity.server.pkghelper import get_package_installer
@@ -326,7 +327,7 @@ class SubiquityServer(Application):
             log.info("no snapd socket found. Snap support is disabled")
             self.snapd = None
         self.note_data_for_apport("SnapUpdated", str(self.updated))
-        self.event_listeners = []
+        self.event_listeners: list[EventListener] = []
         self.autoinstall_config = None
         self.hub.subscribe(InstallerChannels.NETWORK_UP, self._network_change)
         self.hub.subscribe(InstallerChannels.NETWORK_PROXY_SET, self._proxy_set)
@@ -344,7 +345,7 @@ class SubiquityServer(Application):
         for controller in self.controllers.instances:
             controller.load_state()
 
-    def add_event_listener(self, listener):
+    def add_event_listener(self, listener: EventListener):
         self.event_listeners.append(listener)
 
     def _maybe_push_to_journal(

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -328,8 +328,20 @@ class TestEventReporting(SubiTestCase):
 
     @parameterized.expand(
         (
-            # A very incomprehensible truth table for testing code behavior
-            # This is probably collapsable, but I need a baseline
+            # A very tedious to read truth table for testing
+            # behavior. A value of None should mean another
+            # option is shadowing the importance of that value
+            # ex: in the is-install-context it doesn't matter
+            # if it came from a controller. Except interactive=None
+            # is a valid value.
+            #
+            #
+            #  -> Special "is-install-context" to force logging
+            # |     -> Install is interactive
+            # |    |      -> Comes from a controller
+            # |    |     |      -> That controller is interactive
+            # |    |     |     |      -> Expected to send
+            # |    |     |     |     |
             (True, True, None, None, True),
             (True, False, None, None, True),
             (True, None, None, None, True),

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -378,3 +378,81 @@ class TestEventReporting(SubiTestCase):
             journal_send_mock.assert_called_once()
         else:
             journal_send_mock.assert_not_called()
+
+    @parameterized.expand(
+        (
+            # interactive, pushed to journal
+            (True, False),
+            (None, False),
+            (False, True),
+        )
+    )
+    def test_push_info_events(self, interactive, expect_pushed):
+        """Test info event publication"""
+
+        context: Context = Context(
+            self.server, "MockContext", "description", None, "INFO"
+        )
+        self.server.interactive = interactive
+
+        with patch("subiquity.server.server.journal.send") as journal_send_mock:
+            self.server.report_info_event(context, "message")
+
+        if not expect_pushed:
+            journal_send_mock.assert_not_called()
+        else:
+            journal_send_mock.assert_called_once()
+            # message is the only positional argument
+            (message,) = journal_send_mock.call_args.args
+            self.assertIn("message", message)
+            self.assertNotIn("description", message)
+
+    @parameterized.expand(
+        (
+            # interactive
+            (True,),
+            (None,),
+            (False,),
+        )
+    )
+    def test_push_warning_events(self, interactive):
+        """Test warning event publication"""
+
+        context: Context = Context(
+            self.server, "MockContext", "description", None, "INFO"
+        )
+        self.server.interactive = interactive
+
+        with patch("subiquity.server.server.journal.send") as journal_send_mock:
+            self.server.report_warning_event(context, "message")
+
+        journal_send_mock.assert_called_once()
+        # message is the only positional argument
+        (message,) = journal_send_mock.call_args.args
+        self.assertIn("message", message)
+        self.assertNotIn("description", message)
+
+    @parameterized.expand(
+        (
+            # interactive
+            (True,),
+            (None,),
+            (False,),
+        )
+    )
+    def test_push_error_events(self, interactive):
+        """Test error event publication"""
+
+        context: Context = Context(
+            self.server, "MockContext", "description", None, "INFO"
+        )
+        self.server.interactive = interactive
+
+        with patch("subiquity.server.server.journal.send") as journal_send_mock:
+            self.server.report_error_event(context, "message")
+
+        journal_send_mock.assert_called_once()
+        # message is the only positional argument
+        (message,) = journal_send_mock.call_args.args
+        self.assertIn("message", message)
+        self.assertNotIn("description", message)

--- a/subiquitycore/context.py
+++ b/subiquitycore/context.py
@@ -118,6 +118,15 @@ class Context:
             c = c.parent
         return default
 
+    def info(self, message: str) -> None:
+        self.app.report_info_event(self, message)
+
+    def warning(self, message: str) -> None:
+        self.app.report_warning_event(self, message)
+
+    def error(self, message: str) -> None:
+        self.app.report_error_event(self, message)
+
 
 def with_context(name=None, description="", **context_kw):
     def decorate(meth):

--- a/subiquitycore/tests/mocks.py
+++ b/subiquitycore/tests/mocks.py
@@ -36,6 +36,7 @@ def make_app(model=None):
         app.base_model = model
     else:
         app.base_model = mock.Mock()
+    app.add_event_listener = mock.Mock()
     app.controllers = mock.Mock()
     app.context = Context.new(app)
     app.exit = mock.Mock()


### PR DESCRIPTION
Adds new reporting type events "INFO", "WARNING", and "ERROR" to be used for context logging. These can be invoked with the new `.info`, `.warning`, and `.error` methods on the context object accordingly. Useful for warning/errors on autoinstall configurations.

The first two commits can probably be squashed, but I left them there for reviewability. It took me some time to fully understand what's going on with the code, so I wrote some tests to make sure I didn't change the reporting behavior during the refactor.