### PR TITLE
Enforce top-level keys

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -3,7 +3,11 @@
 Autoinstall configuration reference manual
 ==========================================
 
-The autoinstall file uses the YAML format. At the top level, it must be a mapping containing the keys described in this document. Unrecognised keys are ignored.
+The autoinstall file uses the YAML format. At the top level, it must be a
+mapping containing the keys described in this document. Unrecognised keys
+are ignored in version 1, but will cause a fatal validation error in future
+versions.
+
 
 .. _ai-schema:
 
@@ -24,6 +28,12 @@ Several configuration keys are lists of commands to be executed. Each command ca
 
 Top-level keys
 --------------
+
+
+.. warning::
+  In version 1, Subiquity will emit warnings when encountering unrecognised
+  keys. In later versions, a fatal validation error is thrown and the
+  installation will halt.
 
 .. _ai-version:
 


### PR DESCRIPTION
Subiquity currently ignores invalid top-level keys, but this has likely been a major source of confusion of autoinstall capabilities.

In future versions, the following autoinstall config will throw an AutoinstallValidationError:
```yaml
version: 2
interactive-sections:
  - identity
 literally-anything: lmao
```
 This patch adds warnings for version 1 and will begin to throw an AutoinstallValidationError on these instances in version 2 once it has been enabled.
