### PR TITLE
snapcraft: bump curtin revision for apt-config warning fix

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 54cc7d980b9300339e773dc579daa5f11fd12fd0
+    source-commit: a02daee21e8508622ea9755fa667dd2c70335f53
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Full changelog:

* canonical/curtin@4d9513d60ae2e74fd88918c821b93ff17c8ababa
* canonical/curtin@a02daee21e8508622ea9755fa667dd2c70335f53

LP:#2058741