### PR TITLE
Cloud init schema failures

### DIFF
--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -426,6 +426,7 @@ class ErrorReportListStretchy(Stretchy):
 nonreportable_titles: dict[str, str] = {
     "AutoinstallError": _("an Autoinstall error"),
     "AutoinstallValidationError": _("an Autoinstall validation error"),
+    "CloudInitSchemaValidationError": _("a cloud-init schema validation error"),
 }
 
 nonreportable_footers: dict[str, str] = {
@@ -436,6 +437,11 @@ nonreportable_footers: dict[str, str] = {
     "AutoinstallValidationError": _(
         "The installer has detected an issue with the provided Autoinstall "
         "file. Please modify it and try again."
+    ),
+    "CloudInitSchemaValidationError": _(
+        "The installer has detected a cloud-init schema validation error "
+        "that will likely cause the installation to not proceed as intended. "
+        "Please address the validation errors and try again."
     ),
 }
 

--- a/subiquitycore/context.py
+++ b/subiquitycore/context.py
@@ -17,6 +17,8 @@ import asyncio
 import enum
 import functools
 import inspect
+from logging import Logger
+from typing import Optional
 
 
 class Status(enum.Enum):
@@ -118,13 +120,19 @@ class Context:
             c = c.parent
         return default
 
-    def info(self, message: str) -> None:
+    def info(self, message: str, log: Optional[Logger] = None) -> None:
+        if log is not None:
+            log.info(message)
         self.app.report_info_event(self, message)
 
-    def warning(self, message: str) -> None:
+    def warning(self, message: str, log: Optional[Logger] = None) -> None:
+        if log is not None:
+            log.warning(message)
         self.app.report_warning_event(self, message)
 
-    def error(self, message: str) -> None:
+    def error(self, message: str, log: Optional[Logger] = None) -> None:
+        if log is not None:
+            log.error(message)
         self.app.report_error_event(self, message)
 
 


### PR DESCRIPTION
Users attempting to do autoinstall may incorrectly send autoinstall directives as cloud-config, which will result in cloud-init schema validation errors. When loading autoinstall from cloud-config, we now check to see if there are any cloud-init schema validation errors and warn the user. Additionally, if the source of the error is from a known autoinstall error, we inform the user and halt the installation with a nonreportable AutoinstallError.

Requires #1945 and #1947. 