### PR TITLE
Revert grub2 workaround for cloud_style_installation

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -161,12 +161,6 @@ class DebconfSelectionsModel:
         return {}
 
     def get_apt_config(self, final: bool, has_network: bool) -> Dict[str, Any]:
-        # Workaround for LP: #2055294
-        # TODO remove when the bug is fixed
-        if not self.selections:
-            grub2_selection = "grub-pc grub-efi/cloud_style_installation boolean false"
-            return {"debconf_selections": {"subiquity": grub2_selection}}
-
         return {"debconf_selections": {"subiquity": self.selections}}
 
 


### PR DESCRIPTION
To workaround a grub2 bug (LP: #2055294) causing 24.04 installations to fail, we added a default debconf-selection in Subiquity.

grub2 2.12-1ubuntu4 fixes the issue and migrated to the noble release pocket on 2024-03-06.

We can now drop the workaround.

https://launchpad.net/ubuntu/+source/grub2/2.12-1ubuntu4

This reverts commit cffce3230500526af8a1100ac149b0883a17b092.

NOTE: if the three conditions are true for you, you will need to download a new installer ISO:

1. you are using an old ISO that does not have grub2 2.12-1ubuntu4 (or more recent) in the pool
2. you update the installer using the self-refresh mechanism
3. you perform an offline install

LP:#2055294