### PR TITLE
filesystem: don't suggest target resize if part is mounted

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1141,6 +1141,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         for disk in self.potential_boot_disks(check_boot=False):
             part_align = disk.alignment_data().part_align
             for partition in disk.partitions():
+                if partition._is_in_use:
+                    continue
                 vals = sizes.calculate_guided_resize(
                     partition.estimated_min_size,
                     partition.size,


### PR DESCRIPTION
When a partition is mounted in the live environment (either by casper or another process) and is selected for resize, curtin will fail when running e2fsck (or equivalent) with an error such as:

```
Resize requested for format ext4
Resizing /dev/sdb4 of type ext4 down to 12546211840
Running command ['e2fsck', '-p', '-f', '/dev/sdb4'] with allowed return codes [0] (capture=False)
/dev/sdb4 is mounted.
e2fsck: Cannot continue, aborting.

An error occured handling 'disk-sdb': ProcessExecutionError - Unexpected error while running command.
Command: ['e2fsck', '-p', '-f', '/dev/sdb4']
Exit code: 8
```
This is what happens when casper creates a partition on the installer media to store /var/log and /var/crash. Usually the partition is large enough to install Ubuntu so a GuidedStorageTargetResize scenario gets emitted.

This patch prevents the emission of a GuidedStorageTargetResize scenario if the partition is marked as mounted already.

LP:#2059389