### PR TITLE
Fake ubuntu drivers

### DIFF
--- a/examples/dry-run-configs/broadcom.yaml
+++ b/examples/dry-run-configs/broadcom.yaml
@@ -1,0 +1,1 @@
+ubuntu_drivers_run_on_host_umockdev: "examples/umockdev/broadcom.yaml"

--- a/examples/umockdev/broadcom.yaml
+++ b/examples/umockdev/broadcom.yaml
@@ -1,0 +1,7 @@
+devices:
+  # This is a fake broadcom wireless chip
+  - modalias: 'pci:v000014E4d00004353sv00sd01bc02sc80i00'
+    vendor: '0x14E4'
+    device: '0x4353'
+
+

--- a/scripts/kvm-test.py
+++ b/scripts/kvm-test.py
@@ -238,6 +238,12 @@ parser.add_argument('--with-tpm2', action='store_true',
                     package)''')
 parser.add_argument('--profile', default="server",
                     help='load predefined memory, disk size and qemu options')
+parser.add_argument('--fake-pci-devices', action='store_true', default=False,
+                    help='trick ubuntu-drivers into installing drivers')
+parser.add_argument('--server-force-no-gpgpu', action='store_true', default=False,
+                    help=('Allows for broadcom driver install on Server but only'
+                          ' during online install'),
+                    )
 
 
 cc_group = parser.add_mutually_exclusive_group()
@@ -587,6 +593,12 @@ def install(ctx):
 
             if ctx.args.update:
                 appends.append('subiquity-channel=' + ctx.args.update)
+
+            if ctx.args.fake_pci_devices:
+                appends.append('fake-pci-devices')
+
+            if ctx.args.server_force_no_gpgpu:
+                appends.append('server-force-no-gpgpu')
 
             match ctx.args.disk_interface:
                 case 'virtio':

--- a/subiquity/cmd/schema.py
+++ b/subiquity/cmd/schema.py
@@ -54,6 +54,7 @@ def make_schema(app):
 def make_app():
     parser = make_server_args_parser()
     opts, unknown = parser.parse_known_args(["--dry-run"])
+    opts.kernel_cmdline = {}
     app = SubiquityServer(opts, "")
     # This is needed because the ubuntu-pro server controller accesses dr_cfg
     # in the initializer.

--- a/subiquity/models/drivers.py
+++ b/subiquity/models/drivers.py
@@ -15,8 +15,28 @@
 
 import logging
 
+from subiquity.common.pkg import TargetPkg
+
 log = logging.getLogger("subiquity.models.drivers")
 
 
 class DriversModel:
     do_install = False
+    fake_pci_devices: bool = False
+
+    async def target_packages(self) -> list[TargetPkg]:
+        if self.fake_pci_devices:
+            return [
+                TargetPkg(name="umockdev", skip_when_offline=False),
+                TargetPkg(name="gir1.2-umockdev-1.0", skip_when_offline=False),
+            ]
+        else:
+            return []
+
+    async def live_packages(self) -> tuple[set, set]:
+        before = set()
+        during = set()
+        if self.fake_pci_devices:
+            before.add("umockdev")
+            before.add("gir1.2-umockdev-1.0")
+        return (before, during)

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -411,7 +411,10 @@ class SubiquityModel:
         """
         before = set()
         during = set()
-        for model_name in self._install_model_names.all():
+        models: set[str] = (
+            self._install_model_names.all() | self._postinstall_model_names.all()
+        )
+        for model_name in models:
             meth = getattr(getattr(self, model_name), "live_packages", None)
             if meth is not None:
                 packages = await meth()

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -598,6 +598,8 @@ class InstallController(SubiquityController):
 
             self.app.update_state(ApplicationState.RUNNING)
 
+            await self.install_live_packages(context=context)
+
             if self.model.target is None:
                 for_install_path = None
             elif self.supports_apt():
@@ -607,8 +609,6 @@ class InstallController(SubiquityController):
             else:
                 fsc = self.app.controllers.Filesystem
                 for_install_path = self.model.source.get_source(fsc._info.name)
-
-            await self.install_live_packages(context=context)
 
             if self.model.target is not None:
                 if os.path.exists(self.model.target):

--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -301,4 +301,10 @@ def get_ubuntu_drivers_interface(app) -> UbuntuDriversInterface:
         cls = UbuntuDriversFakePCIDevicesInterface
         log.debug("Using fake-devices-wrapper")
 
+    # For quickly testing MOK enrollment we install on server and force no gpgpu
+    # The caveat to this is that it also has to be an online install
+    if "server-force-no-gpgpu" in app.opts.kernel_cmdline:
+        log.debug("Forcing no gpgpu drivers. Requires online install on server.")
+        is_server = False
+
     return cls(app, gpgpu=is_server)

--- a/subiquitycore/tests/mocks.py
+++ b/subiquitycore/tests/mocks.py
@@ -45,6 +45,7 @@ def make_app(model=None):
     app.prev_screen = mock.Mock()
     app.hub = MessageHub()
     app.opts = mock.Mock()
+    app.opts.kernel_cmdline = {}
     app.opts.dry_run = True
     app.scale_factor = 1000
     app.echo_syslog_id = None


### PR DESCRIPTION
This wraps the `ubuntu-drivers` calls with the `fake-devices-wrapper` script from `ubuntu-drivers-common`. In the future it would probably be nice to copy/transplant some of the code we have in [scripts/umockdev-wrapper.py](https://github.com/canonical/subiquity/blob/72bac060057bd9b5c8e9a6e942c728ca30a73c9f/scripts/umockdev-wrapper.py) to facilitate this instead of calling `fake-devices-wrapper`, but I think this keeps it pretty simple for now. (We could probably provide the config via autoinstall somehow but getting it to the target would be slightly more difficult I think?).

Two related questionable things here:

1. Currently, only install models are able to specify packages to be installed into the live system. I've changed this to allow post install models to specify these as well.  I suppose post install models aren't really given a chance to be configured and change this before packages are set to be installed, but in the ubuntu-drivers case we need to have `gir1.2-umockdev-1.0` and `umockdev` installed before the list drivers command is called and we know early on if it's needed or not. 

2. I moved installation of live packages up a step. Particularly we were waiting to do the steps to configure apt before installing live packages, but I don't see any reason live packages have to wait for apt configuration (I'm assuming on the target system). The problem I was running into is that ubuntu drivers waits on apt to be configured and then calls the ubuntu-drivers list command as soon as it's ready. This makes sense normally (ubuntu-drivers list is normally called in the target system) but when doing MOK enrollment testing we need the packages in the live environment before this. 


If these changes are more dangerous than I suspect, we could remove all of the live_packages logic and get away with using autoinstall and specifying that these packages are installed in early commands. Although I think remembering a few debug flags is better than having to keep around an autoinstall file, it might be good motivation to start a "how-to-test X" doc somewhere to keep this type of information which would be good. Opinions please.

If you want to test out these changes: Build the snap as normal, but when injecting it into an ISO, make sure to add `umockdev` and `gir1.2-umockdev-1.0` to the pool on the ISO as well:

```bash
  sudo python3 -m livefs_edit <bash-iso-path> <new-iso-dest> --inject-snap <snap-path> --add-packages-to-pool umockdev gir1.2-umockdev-1.0
```

Then you can launch the VM with:

```bash
./scripts/kvm-test.py --install -o --iso <iso-path> --secure-boot --fake-pci-devices --server-force-no-gpgpu
```

The quickest way to check if drivers were installed on the secure boot system is check for `MOK.der` in `/target/var/lib/shim-signed/mok/` (created by dmks on install)

If you want to do it with autoinstall you can do that too. Just use
```yaml
drivers:
  install: true
```
