### PR TITLE
Update intro-to-autoinstall.rst

### DIFF
--- a/doc/intro-to-autoinstall.rst
+++ b/doc/intro-to-autoinstall.rst
@@ -61,8 +61,8 @@ placed under a top level :code:`autoinstall:` key, like so:
 .. code-block:: yaml
 
     #cloud-config
+    version: 1
     autoinstall:
-        version: 1
         ....
 
 .. note::
@@ -192,8 +192,8 @@ A minimal autoinstall configuration in
 .. code-block:: yaml
 
     #cloud-config
+    version: 1
     autoinstall:
-        version: 1
         identity:
             hostname: hostname
             username: username


### PR DESCRIPTION
The installer will throw an error if the `version` key is not on the top level. This patch addresses this in our documentation.