### PR TITLE
storage: fix UI crash when partition size gets capped

### DIFF
--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -117,8 +117,8 @@ class SizeWidget(StringEditor):
                 )
             )
             # This will invoke self.form.clean_size() and it is expected that
-            # size_str (and therefore self.value) are propertly aligned.
-            self.accurate_value = self.form.size
+            # size_str (and therefore self.value) are properly aligned.
+            self.accurate_value = self.form.size.value
         else:
             aligned_sz = align_up(sz, self.form.alignment)
             aligned_sz_str = humanize_size(aligned_sz)


### PR DESCRIPTION
In cda6c54b87b81edaf6b2623902eb16b6d86e5a75, we introduced the accurate size vs human readable size for the size form fields. Unfortunately, we also introduced a regression when the size gets capped (when it exceeds the maximum size defined on the form). Currently, specifying a size that is beyond the maximum value fails when submitting the form with:
```python
  [...]
  File "urwid/wimp.py", line 543, in keypress
    self._emit('click')
  File "urwid/widget.py", line 461, in _emit
    signals.emit_signal(self, name, self, *args)
  File "urwid/signals.py", line 265, in emit
    result |= self._call_callback(callback, user_arg, user_args, args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "urwid/signals.py", line 295, in _call_callback
    return bool(callback(*args_to_pass))
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "subiquitycore/ui/form.py", line 486, in _click_done
    emit_signal(self, "submit", self)
  File "urwid/signals.py", line 265, in emit
    result |= self._call_callback(callback, user_arg, user_args, args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "urwid/signals.py", line 295, in _call_callback
    return bool(callback(*args_to_pass))
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "subiquity/ui/views/filesystem/partition.py", line 636, in done
    handler(self.disk, spec, partition=self.partition, gap=self.gap)
  File "subiquity/common/filesystem/manipulator.py", line 334, in logical_volume_handler
    lv.size = align_up(spec["size"])
              ^^^^^^^^^^^^^^^^^^^^^^
  File "subiquity/models/filesystem.py", line 1382, in align_up
    return (size + block_size - 1) & ~(block_size - 1)
            ~~~~~^~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'BoundFormField' and 'int'
```

Based on my own comment [1] and type hint [2], it looks obvious that I intended to write `size.value` and not just `size`. The `clean_size` method is called by the `value` property [3], so I'm not sure what I did there :man_shrugging: 

[1] https://github.com/canonical/subiquity/blob/16bcfcf7ae5ce074f182e46a7ee78aaa01b79a61/subiquity/ui/views/filesystem/partition.py#L119-L120
[2] https://github.com/canonical/subiquity/blob/16bcfcf7ae5ce074f182e46a7ee78aaa01b79a61/subiquity/ui/views/filesystem/partition.py#L93
[2] https://github.com/canonical/subiquity/blob/16bcfcf7ae5ce074f182e46a7ee78aaa01b79a61/subiquitycore/ui/form.py#L219-L220

LP:#2045280