### PR TITLE
pre-commit: add spelling check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,20 @@
-files: "(console_conf|subiquity|subiquitycore|system_setup)"
+files: "(console_conf|subiquity|subiquitycore|system_setup|doc)"
 repos:
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:
       - id: black
+        files: "(console_conf|subiquity|subiquitycore|system_setup)"
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         name: isort
+        files: "(console_conf|subiquity|subiquitycore|system_setup)"
+  - repo: local
+    hooks:
+      - id: doc-spelling
+        name: doc-spelling
+        language: system
+        entry: bash -c "cd doc/ && ./pre-commit-spell-check"
+        files: "doc/.*rst"

--- a/doc/pre-commit-spell-check
+++ b/doc/pre-commit-spell-check
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Setup sphinx virtual env if it's not already
+if [ ! -d .sphinx/venv ]; then
+    make install
+fi
+
+make spelling


### PR DESCRIPTION
Tired of forgetting to run `make spelling` before committing changes to the documentation? This is why we have pre-commit!

The downside is that the spell check can take a little while, but I think it's better than waiting for CI to yell at you. I recently had a PR that was unnecessarily noisy due to fixing spelling errors.
