### PR TITLE
identity: fail on missing section sooner

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -294,6 +294,16 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         # log.debug("self.ai_data = %s", data)
         self.ai_data = data
 
+    # The identity and user-data section are optional if we are only installing
+    # the reset partition, however the identity controller needs to know this
+    # before the filesystem controller naturally sets this. So this is a
+    # function to inspect the outcome early.
+    # See: https://github.com/canonical/subiquity/pull/1965
+    def is_reset_partition_only(self):
+        storage_config = self.app.autoinstall_config.get(self.autoinstall_key, {})
+        layout = storage_config.get("layout", {})
+        return layout.get("reset-partition-only", False)
+
     async def configured(self):
         self._configured = True
         if self._info is None:

--- a/subiquity/server/controllers/identity.py
+++ b/subiquity/server/controllers/identity.py
@@ -89,14 +89,7 @@ class IdentityController(SubiquityController):
         if self.app.base_model.source.current.variant != "server":
             return
         # 3. we are only refreshing the reset partition
-        # (The identity controller doesn't figure this out until the apply
-        # step, so we are going to cheat and inspect the situation here)
-        storage_config = self.app.autoinstall_config.get("storage")
-        if (
-            storage_config is not None
-            and storage_config.get("layout") is not None
-            and storage_config["layout"].get("reset-partition-only")
-        ):
+        if self.app.controllers.Filesystem.is_reset_partition_only():
             return
         # 4. identity section is interactive
         if self.interactive():

--- a/subiquity/server/controllers/identity.py
+++ b/subiquity/server/controllers/identity.py
@@ -22,8 +22,8 @@ import attr
 from subiquity.common.apidef import API
 from subiquity.common.resources import resource_path
 from subiquity.common.types import IdentityData, UsernameValidation
+from subiquity.server.autoinstall import AutoinstallError
 from subiquity.server.controller import SubiquityController
-from subiquitycore.context import with_context
 
 log = logging.getLogger("subiquity.server.controllers.identity")
 
@@ -79,18 +79,29 @@ class IdentityController(SubiquityController):
                 crypted_password=data["password"],
             )
             self.model.add_user(identity_data)
-
-    @with_context()
-    async def apply_autoinstall_config(self, context=None):
-        if self.model.user:
             return
+
+        # The identity section is required except if (any):
+        # 1. a user-data section is provided
         if "user-data" in self.app.autoinstall_config:
             return
-        if self.app.base_model.target is None:
-            return
+        # 2. we are installing not-Server (Desktop)
         if self.app.base_model.source.current.variant != "server":
             return
-        raise Exception("neither identity nor user-data provided")
+        # 3. we are only refreshing the reset partition
+        # (The identity controller doesn't figure this out until the apply
+        # step, so we are going to cheat and inspect the situation here)
+        storage_config = self.app.autoinstall_config.get("storage")
+        if (
+            storage_config is not None
+            and storage_config.get("layout") is not None
+            and storage_config["layout"].get("reset-partition-only")
+        ):
+            return
+        # 4. identity section is interactive
+        if self.interactive():
+            return
+        raise AutoinstallError("neither identity nor user-data provided")
 
     def make_autoinstall(self):
         if self.model.user is None:

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -1660,3 +1660,50 @@ class TestMatchingDisks(IsolatedAsyncioTestCase):
         # overhead
         actual = self.fsc.get_bootable_matching_disk({"path": "/dev/md/*"})
         self.assertEqual(r1, actual)
+
+
+class TestResetPartitionLookAhead(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.app = make_app()
+        self.app.opts.bootloader = None
+        self.fsc = FilesystemController(app=self.app)
+
+    @parameterized.expand(
+        # (config, is reset only)
+        (
+            ({}, False),
+            (
+                {
+                    "storage": {},
+                },
+                False,
+            ),
+            (
+                {
+                    "storage": {
+                        "layout": {
+                            "name": "direct",
+                            "reset-partition": True,
+                        },
+                    },
+                },
+                False,
+            ),
+            (
+                {
+                    "storage": {
+                        "layout": {
+                            "reset-partition-only": True,
+                        },
+                    },
+                },
+                True,
+            ),
+        )
+    )
+    def test_is_reset_partition_only_utility(self, config, expected):
+        """Test is_reset_partition_only utility"""
+
+        self.app.autoinstall_config = config
+
+        self.assertEqual(self.fsc.is_reset_partition_only(), expected)

--- a/subiquity/server/controllers/tests/test_identity.py
+++ b/subiquity/server/controllers/tests/test_identity.py
@@ -17,6 +17,7 @@ import jsonschema
 from jsonschema.validators import validator_for
 
 from subiquity.server.autoinstall import AutoinstallError
+from subiquity.server.controllers.filesystem import FilesystemController
 from subiquity.server.controllers.identity import IdentityController
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
@@ -39,6 +40,8 @@ class TestControllerUserCreationFlows(SubiTestCase):
     # See subiquity/models/tests/test_subiquity.py for details.
     def setUp(self):
         self.app = make_app()
+        self.app.opts.bootloader = False
+        self.app.controllers.Filesystem = FilesystemController(self.app)
         self.ic = IdentityController(self.app)
         self.ic.model.user = None
 
@@ -54,9 +57,9 @@ class TestControllerUserCreationFlows(SubiTestCase):
         ({"interactive-sections": ["*"]}, True),
         # No Autoinstall => interactive
         ({}, True),
-        # Can be missing if reset-parition-only specified
+        # Can be missing if reset-partition-only specified
         ({"storage": {"layout": {"reset-partition-only": True}}}, True),
-        # Can't be missing if reset-parition-only is not specified
+        # Can't be missing if reset-partition-only is not specified
         ({"storage": {"layout": {}}}, False),
         # user-data passed instead
         ({"user-data": "..."}, True),

--- a/subiquity/server/controllers/tests/test_identity.py
+++ b/subiquity/server/controllers/tests/test_identity.py
@@ -19,6 +19,7 @@ from jsonschema.validators import validator_for
 from subiquity.server.autoinstall import AutoinstallError
 from subiquity.server.controllers.filesystem import FilesystemController
 from subiquity.server.controllers.identity import IdentityController
+from subiquity.server.controllers.source import SourceController
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
 from subiquitycore.tests.parameterized import parameterized
@@ -43,6 +44,8 @@ class TestControllerUserCreationFlows(SubiTestCase):
         self.app.opts.bootloader = False
         self.app.controllers.Filesystem = FilesystemController(self.app)
         self.ic = IdentityController(self.app)
+        self.app.opts.source_catalog = "examples/sources/install.yaml"
+        self.app.controllers.Source = SourceController(self.app)
         self.ic.model.user = None
 
     # Test cases for 4a1. Copied for 4a2 but all cases should be valid for desktop.


### PR DESCRIPTION
Moves the logic for checking if user-data or identity section is provided (on server) in the autoinstall config to the load_autoinstall_data function. Without this change, the exception thrown in apply_autoinstall_config won't halt the installer until
the postinstall steps (LP: 2060547).


The change is ready but I am keeping this as a draft PR until I can test this on Desktop.