### PR TITLE
filesystem: datasets for /root and /home

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -616,6 +616,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         rpool.create_zfs(f"ROOT/ubuntu_{uuid}/var/spool")
         rpool.create_zfs(f"ROOT/ubuntu_{uuid}/var/www")
 
+        userdata_uuid = gen_zsys_uuid()
+        rpool.create_zfs("USERDATA", canmount="off", mountpoint="none")
+        rpool.create_zfs(f"USERDATA/root_{userdata_uuid}", mountpoint="/root")
+        rpool.create_zfs(f"USERDATA/home_{userdata_uuid}", mountpoint="/home")
+
     @functools.singledispatchmethod
     def start_guided(self, target: GuidedStorageTarget, disk: ModelDisk) -> gaps.Gap:
         """Setup changes to the disk to prepare the gap that we will be

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -593,6 +593,11 @@ class TestGuided(IsolatedAsyncioTestCase):
         zfs_boot = self.model._mount_for_path("/boot")
         self.assertEqual("zfs", zfs_boot.type)
 
+        # checking that these were created
+        [userdata] = self.model._all(type="zfs", volume="USERDATA")
+        [userdata_home] = self.model._all(type="zfs", path="/home")
+        [userdata_root] = self.model._all(type="zfs", path="/root")
+
     @parameterized.expand(boot_expectations)
     async def test_guided_zfs_luks_keystore(self, bootloader, ptable, p1mnt):
         await self._guided_setup(bootloader, ptable)


### PR DESCRIPTION
Partial implementation of LP:#2057837.  To create a specific dataset for /home/$user, this requires moving where and when users are created, which is not in plan for 24.04.

FR-7081