### PR TITLE
mirror: if the mirror test fails, suggest an offline install

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -879,6 +879,7 @@ class MirrorPost:
     elected: Optional[str] = None
     candidates: Optional[List[str]] = None
     staged: Optional[str] = None
+    use_during_installation: Optional[bool] = None
 
 
 class MirrorPostResponse(enum.Enum):
@@ -892,6 +893,9 @@ class MirrorGet:
     elected: Optional[str]
     candidates: List[str]
     staged: Optional[str]
+    # Tells whether the mirror will be used during the installation.
+    # When it is False, we will only fetch packages from the pool.
+    use_during_installation: bool
 
 
 class MirrorSelectionFallback(enum.Enum):

--- a/subiquity/server/controllers/mirror.py
+++ b/subiquity/server/controllers/mirror.py
@@ -368,7 +368,11 @@ class MirrorController(SubiquityController):
             # Skip the country-mirrors if they have not been resolved yet.
             candidates = [c.uri for c in compatibles if c.uri is not None]
         return MirrorGet(
-            relevant=relevant, elected=elected, candidates=candidates, staged=staged
+            relevant=relevant,
+            elected=elected,
+            candidates=candidates,
+            staged=staged,
+            use_during_installation=not self.app.base_model.network.force_offline,
         )
 
     async def POST(self, data: Optional[MirrorPost]) -> MirrorPostResponse:
@@ -420,6 +424,10 @@ class MirrorController(SubiquityController):
                 ensure_elected_in_candidates()
 
             await self.configured()
+
+        if data.use_during_installation is not None:
+            self.app.base_model.network.force_offline = not data.use_during_installation
+
         return MirrorPostResponse.OK
 
     async def disable_components_GET(self) -> List[str]:


### PR DESCRIPTION
Client / TUI change
-----------
In the mirror screen, if the test fails and the user decides to ignore the failure, we used to continue the installation normally ; which in most scenarios resulted in an error at a later stage of the installation.

Instead, we now revert to an installation without network (i.e., only packages from the pool are considered for installation) if the user decides to ignore the failure.

Current design:
![2024-04-11T11:07:57,433958092+02:00](https://github.com/canonical/subiquity/assets/4038023/c50e724e-0d95-4e43-8cbb-7d4eba3843bd)

Proposed design:
<details>
<summary>Previously proposed design</summary>

![2024-04-11T11:07:27,317845628+02:00](https://github.com/canonical/subiquity/assets/4038023/ba5f1ed4-2cf2-448a-9aab-9f3f67365ad8)
</details>

![2024-04-17T09:58:43,258322845+02:00](https://github.com/canonical/subiquity/assets/4038023/3865b5fc-401e-44da-9945-14d4e9fb42be)


Note that the behavior hasn't changed if the user decides to skip the test _while it is running,_ 

Backend change
------------------

The /mirror GET and POST endpoints now include a boolean field named `use_during_installation`.

* if set to `True`, the mirror information will be used during installation to fetch packages online.
* if set to `False`, we will only fetch packages from the pool.

In either case, the mirror information will still be used to build the `etc/apt/` directory in the target system.

Currently, the way use_during_installation is implemented is coupled with the force_offline property of the network model. This means that Ubuntu Pro and other stuff will be disabled too if we're skipping the use of the archive.

NOTE: the default value for "use_during_installation" in the POST endpoint is `null` ; which means that we should not change the current value of force_offline.

LP:#2059898 and similar reports