### PR TITLE
drivers: ensure DEBIAN_FRONTEND=noninteractive on install

### DIFF
--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -51,6 +51,8 @@ class UbuntuDriversInterface(ABC):
         # This is not ideal but should be acceptable because we want OEM
         # meta-packages installed unconditionally (except in autoinstall).
         self.install_drivers_cmd = [
+            "env",
+            "DEBIAN_FRONTEND=noninteractive",
             "ubuntu-drivers",
             "install",
             "--no-oem",


### PR DESCRIPTION
If ubuntu-drivers picks a dkms package to install, the ubuntu-drivers process will hang on an unsupressed debconf prompt to enter a MOK enrollment key (LP: #2060353).

Somehow, I didn't encounter this bug with broadcom-sta-dkms. Although after looking at the logs/doing some tests with that package, there appears to be some dpkg failures with that package that were stopping the prompt from coming up at all.

Testing this with the LP: #2060353 conditions will take some time to set up since I have to do an offline install now the archive is fixed, and I'm deferring this to later as it's not urgent, but it should just DTRT.  You can simulate the good vs bad condition this with autoinstall today with the following late-commands snippets:

hangs:
```yaml
late-commands:
    - curtin in-target -- sh -c "apt install -y nvidia-dkms-535"
```

completes:
```yaml
late-commands:
    - curtin in-target -- sh -c "DEBIAN_FRONTEND=noninteractive apt install -y nvidia-dkms-535"
```

