### PR TITLE
models/subiquity: disable cc_dpkg_grub

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -437,7 +437,9 @@ class SubiquityModel:
                 },
             }
         )
+        grub_dpkg = yaml.dump({"grub_dpkg": {"enabled": False}})
         files = [
+            ("etc/cloud/cloud.cfg.d/20-disable-cc-dpkg-grub.cfg", grub_dpkg, 0o644),
             ("etc/cloud/cloud.cfg.d/99-installer.cfg", config, 0o600),
             ("etc/cloud/ds-identify.cfg", "policy: enabled\n", 0o644),
         ]

--- a/subiquity/models/tests/test_subiquity.py
+++ b/subiquity/models/tests/test_subiquity.py
@@ -277,6 +277,10 @@ class TestSubiquityModel(unittest.IsolatedAsyncioTestCase):
         model.identity.add_user(main_user)
         model.userdata = {}
         expected_files = {
+            "etc/cloud/cloud.cfg.d/20-disable-cc-dpkg-grub.cfg": """\
+grub_dpkg:
+  enabled: false
+""",
             "etc/cloud/cloud.cfg.d/99-installer.cfg": re.compile(
                 "datasource:\n  None:\n    metadata:\n      instance-id: .*\n    userdata_raw: \"#cloud-config\\\\ngrowpart:\\\\n  mode: \\'off\\'\\\\npreserve_hostname: true\\\\n\\\\\n"  # noqa
             ),


### PR DESCRIPTION
On first boot, there appear to be cases where the cc_dpkg_grub module in cloud-init is not doing the right thing, which are to be sorted out. But for first boot to happen we have a working boot config, so let's not perturb that.

LP:#2060695 / FR-7389