### PR TITLE
mirror: switch default policy to OFFLINE_INSTALL by default

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -327,7 +327,7 @@ fallback
 ^^^^^^^^
 
 * **type:** string (enumeration)
-* **default:** abort
+* **default:** offline-install
 
 Controls what Subiquity does when no primary mirror is usable. Supported values are:
 

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -269,7 +269,7 @@ class MirrorModel(object):
         self.default_mirror = LegacyPrimaryEntry.new_from_default(parent=self).uri
 
         # What to do if automatic mirror-selection fails.
-        self.fallback = MirrorSelectionFallback.ABORT
+        self.fallback = MirrorSelectionFallback.OFFLINE_INSTALL
 
     def _default_primary_entries(self) -> List[PrimaryEntry]:
         return [


### PR DESCRIPTION
Automated installations and desktop installations will now switch to an offline installation by default. In this mode, only packages from the pool will be fetched.

This should allow the installation to proceed when installing from a private network without external access to the internet.

This is similar in essence to #1816 but applies the policy to automated server installs as well.

If you are doing a desktop installation (or an automated server installation) in a private network with no Internet access, the mirror connectivity test will eventually timeout and the installer will switch to an "offline" installation. (let's call it semi-offline). 

Going forward, I think we should have a new directive in autoinstall configuration mimicking `use_during_installation` from #1968, so that users can do a semi-offline installation without going through the mirror connectivity test at all.