### PR TITLE
filesystem: reset-partition size bug

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1457,7 +1457,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         rp_input = layout.get("reset-partition", None)
         if rp_input:
             reset_partition = True
-            if isinstance(rp_input, (str, int)):
+            # bool is a subclass of int -- check for int explicitly
+            if isinstance(rp_input, str) or type(rp_input) is int:
                 reset_partition_size = int(human2bytes(rp_input))
                 log.info(
                     "autoinstall: will install reset partition "


### PR DESCRIPTION
In python, bool is a subclass of int so we can't use isinstance to check if the user specified a size for the reset partition. This causes autoinstall with "reset-partition: True" and "reset-partition-only: true" to crash the installer. (LP: #2061042).

I'm not too sure how useful the following autoinstall config is:
```yaml
autoinstall:
  version: 1
  storage:
    layout:
      name: direct
      reset-partition: true
      reset-partition-only: true
```
but this will cause subiquity to report the following:

`2024-04-12 22:16:10,913 INFO subiquity.server.controllers.filesystem:1463 autoinstall: will install reset partition of size 1`

and then crash during rsync. 