### PR TITLE
curtin: desktop grub.replace_linux_default False

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -517,6 +517,9 @@ class SubiquityModel:
             },
         }
 
+        if self.source.current.variant == "desktop":
+            config["grub"]["replace_linux_default"] = False
+
         if os.path.exists("/run/casper-md5check.json"):
             with open("/run/casper-md5check.json") as fp:
                 config["write_files"]["md5check"] = {


### PR DESCRIPTION
Grub provides "quiet splash" for GRUB_CMDLINE_LINUX_DEFAULT out of the box, but curtin rewrites that value and drops both "quiet" and "splash". On desktop, retain "quiet splash".

This should be configurable via autoinstall if this change is undesired.