### PR TITLE
storage: log snapd response text when v2/systems/{system} or v2/snaps/{snap} fails

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -43,6 +43,7 @@ python3-pytest
 python3-pytest-xdist
 python3-pyudev
 python3-requests
+python3-requests-mock
 python3-requests-unixsocket
 python3-setuptools
 python3-systemd

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import attr
 import pyudev
+import requests
 from curtin import swap
 from curtin.commands.extract import AbstractSourceHandler
 from curtin.storage_config import ptable_part_type_to_flag
@@ -342,6 +343,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             return None
         try:
             system = await self.app.snapdapi.v2.systems[label].GET()
+        except requests.exceptions.HTTPError as http_err:
+            log.warning("v2/systems/%s returned %s", label, http_err.response.text)
+            raise
         finally:
             await self._unmount_systems_dir()
         log.debug("got system %s", system)

--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -214,9 +214,15 @@ class RefreshController(SubiquityController):
 
     @with_context()
     async def start_update(self, context):
-        change_id = await self.app.snapdapi.v2.snaps[self.snap_name].POST(
-            SnapActionRequest(action=SnapAction.REFRESH, ignore_running=True)
-        )
+        try:
+            change_id = await self.app.snapdapi.v2.snaps[self.snap_name].POST(
+                SnapActionRequest(action=SnapAction.REFRESH, ignore_running=True)
+            )
+        except requests.exceptions.HTTPError as http_err:
+            log.warning(
+                "v2/snaps/%s returned %s", self.snap_name, http_err.response.text
+            )
+            raise
         context.description = "change id: {}".format(change_id)
         return change_id
 


### PR DESCRIPTION
When the request to `v2/systems/enhanced-secureboot-desktop` (or equivalent) fails, Subiquity did not capture the reason. This makes it difficult to understand why this call sometimes fails. We now log the response text to understand better what's going on.

LP:#2061757

Also did the same change for the call to `v2/snaps/ubuntu-desktop-provision` intended to refresh the snap ; although we already know that sending two successive requests will return 409. LP:#2061756