### PR TITLE
snapcraft: bump curtin rev for ZFS string interpolation fix

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: e4c7d7186c59ade359652db5accb6cb7156df499
+    source-commit: c66faffeea657c70374479d62fce32965ff7ac31
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
```
$ git whatchanged e4c7d7186c59ade359652db5accb6cb7156df499..c66faffeea657c70374479d62fce32965ff7ac31 --oneline
c66faffe (HEAD -> master, origin/master, origin/HEAD) util: fix lack of string interpolation when raising TiemoutError
:100644 100644 d9b7962b a10f1bfc M      curtin/util.py
```

* canonical/curtin@c66faffeea657c70374479d62fce32965ff7ac31