### PR TITLE
filesystem: probe NVMe controllers when running the restricted probe

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1270,7 +1270,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     @with_context(name="probe_once", description="restricted={restricted}")
     async def _probe_once(self, *, context, restricted):
         if restricted:
-            probe_types = {"blockdev", "filesystem"}
+            probe_types = {"blockdev", "filesystem", "nvme"}
             fname = "probe-data-restricted.json"
             key = "ProbeDataRestricted"
         else:

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -108,7 +108,7 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
     async def test_probe_restricted(self):
         await self.fsc._probe_once(context=None, restricted=True)
-        expected = {"blockdev", "filesystem"}
+        expected = {"blockdev", "filesystem", "nvme"}
         self.app.prober.get_storage.assert_called_with(expected)
 
     async def test_probe_os_prober_false(self):


### PR DESCRIPTION
If block probing times out, we rerun it with the restricted set of probes. Sadly, the restricted set does not include "nvme" so we do not enumerate NVMe controllers. This leads to the following error if NVMe storage devices are present:

```python
  File "subiquity/models/filesystem.py", line 1492, in reset
    self.process_probe_data()
  File "subiquity/models/filesystem.py", line 1512, in process_probe_data
    self._orig_config = storage_config.extract_storage_config(self._probe_data)[
  File "/site-packages/curtin/storage_config.py", line 1420, in extract_storage_config
    tree = get_config_tree(cfg.get('id'), final_config)
  File "/site-packages/curtin/storage_config.py", line 313, in get_config_tree
    for dep in find_item_dependencies(item, sconfig):
  File "/site-packages/curtin/storage_config.py", line 283, in find_item_dependencies
    _validate_dep_type(item_id, dep_key, dep, config)
  File "/site-packages/curtin/storage_config.py", line 230, in _validate_dep_type
    raise ValueError(
ValueError: Invalid dep_id (nvme-controller-nvme0) not in storage config
```
Fixed by also enumerating NVMe controllers as part of the restricted probe operation.

LP:#2063162

I intend to mention this bug in the release notes for 24.04.1.