### PR TITLE
types: add missing enumerations values for TaskStatus

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -819,9 +819,11 @@ class TaskStatus(enum.Enum):
     DO = "Do"
     DOING = "Doing"
     DONE = "Done"
+    WAIT = "Wait"
     ABORT = "Abort"
     UNDO = "Undo"
     UNDOING = "Undoing"
+    UNDONE = "Undone"
     HOLD = "Hold"
     ERROR = "Error"
 


### PR DESCRIPTION
In a bug report, Subiquity failed during a refresh because it received an unexpected status.

```python
  File "subiquity/common/api/server.py", line 164, in handler
    result = await implementation(**args)
  File "subiquity/server/controllers/refresh.py", line 240, in progress_GET
    return await self.get_progress(change_id)
  File "subiquity/server/controllers/refresh.py", line 224, in get_progress
    change = await self.app.snapdapi.v2.changes[change_id].GET()
  [...]
  File "subiquity/common/serialize.py", line 252, in _deserialize_attr
    args[field.name] = self._deserialize(
  File "subiquity/common/serialize.py", line 277, in _deserialize
    return self._deserialize_enum(annotation, context)
  File "subiquity/common/serialize.py", line 261, in _deserialize_enum
    return annotation(context.cur)
  File "/usr/lib/python3.10/enum.py", line 385, in __call__
    return cls.__new__(cls, value)
  File "usr/lib/python3.10/enum.py", line 710, in __new__
    raise ve_exc
ValueError: 'Undone' is not a valid TaskStatus
```

According to snapd's upstream repository, "Undone" existed before "Undoing", so I'm not sure why we didn't have the former but had the latter. Maybe we just overlooked it because the name is similar.

As for more recently, the "Wait" status was also introduced [1]

Fixed by adding the two missing values (i.e., "Wait" and "Undone").

[1] https://github.com/snapcore/snapd/commit/7734ffd127199586990b54904e5017b0e475614d