### PR TITLE
filesystem: swap options

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -180,11 +180,19 @@ class FilesystemManipulator:
 
     delete_lvm_partition = delete_logical_volume
 
+    cryptoswap_options = [
+        "cipher=aes-cbc-essiv:sha256",
+        "initramfs",
+        "plain",
+        "size=256",
+        "swap",
+    ]
+
     def create_cryptoswap(self, device):
         dmc = self.model.add_dm_crypt(
             device,
             keyfile="/dev/urandom",
-            options=["swap", "initramfs"],
+            options=self.cryptoswap_options,
         )
         self.create_filesystem(dmc, dict(fstype="swap"))
         return dmc

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -466,6 +466,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.controller = FilesystemController(self.app)
         self.controller.supports_resilient_boot = True
         self.controller._examine_systems_task.start_sync()
+        self.controller.cryptoswap_options = ["a", "b"]
         self.app.dr_cfg = DRConfig()
         self.app.base_model.source.current.type = "fsimage"
         self.app.base_model.source.current.variations = {
@@ -657,7 +658,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertIsNone(swap.fs())
         [dmc] = self.model.all_dm_crypts()
         self.assertEqual("/dev/urandom", dmc.keyfile)
-        self.assertEqual(["swap", "initramfs"], dmc.options)
+        self.assertEqual(["a", "b"], dmc.options)
         self.assertEqual("swap", dmc.fs().fstype)
         [rpool] = self.model._all(type="zpool", pool="rpool")
         self.assertIsNone(rpool.path)


### PR DESCRIPTION
Under some plymouth configs, cryptsetup shows warnings on boot for underspecified cryptoswap options.  This makes the warnings go away, but we've hardcoded some options that may change in the future.

LP:#2063252