### PR TITLE
cc-extract: don't unnecessarily access data

### DIFF
--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -783,12 +783,18 @@ class SubiquityServer(Application):
                 log=log,
             )
 
-            # Raise AutoinstallError if we found any autoinstall as a cause
-            # of the schema validation error, otherwise continue
+            # Use filter_autoinstall on bad_keys to find potential autoinstall
+            # keys as the cause of the schema validation error. If so,
+            # raise AutoinstallError; else continue.
+            #
+            # Intentionally not attempting to extract bad key data since it is
+            # not guaranteed that the offending keys will be top-level (or
+            # even in?) in the combined config. Although still constructing
+            # a dict since filter_autoinstall expects a dict.
+            # LP: #2062988
 
-            # Filter only the bad keys
-            potential_autoinstall: dict[str, Any] = dict(
-                ((key, cloud_cfg[key]) for key in bad_keys)
+            potential_autoinstall: dict[str, None] = dict(
+                ((key, None) for key in bad_keys)
             )
             autoinstall, other = self.filter_autoinstall(potential_autoinstall)
 

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -456,6 +456,22 @@ class TestAutoinstallValidation(SubiTestCase):
 
                 self.assertEqual(cfg, expected)
 
+    async def test_cloud_config_extract_KeyError(self):
+        """Test autoinstall extract from cloud config resilient to missing data."""
+
+        self.server.base_schema = SubiquityServer.base_schema
+        self.pseudo_load_controllers()
+
+        with patch("subiquity.server.server.validate_cloud_init_schema") as val_mock:
+            val_mock.side_effect = CloudInitSchemaValidationError(
+                keys=["broadcast", "foobar"],
+            )
+
+            # Don't throw on keys that error but aren't in the combined config
+            cfg = await self.server._extract_autoinstall_from_cloud_config(cloud_cfg={})
+
+            self.assertEqual(cfg, {})
+
     async def test_autoinstall_validation__top_level_autoinstall(self):
         """Test allow autoinstall as top-level key"""
 


### PR DESCRIPTION
We currently don't have plans to do anything with the _data_ of the keys that fail to validate by cloud-init; and trying to access this data has the potential to crash the installer if it doesn't exist, at least at the top level (LP:#2062988).