### PR TITLE
Add a way to forward user errors to the client when consuming /storage/v2 POST endpoints

### DIFF
--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -23,6 +23,7 @@ import sys
 
 import attr
 
+from subiquity.server.controllers.filesystem import set_user_error_reportable
 from subiquitycore.log import setup_logger
 
 from .common import LOGDIR, setup_environment
@@ -137,6 +138,16 @@ def make_server_args_parser():
     )
 
     parser.add_argument("--storage-version", action="store", type=int)
+    parser.add_argument(
+        "--no-report-storage-user-errors",
+        action="store_true",
+        help="""\
+When False (the default), exceptions raised by /storage/v2/ POST handlers when
+the client sends bad information will cause the creation of a crash report and
+a HTTP 500 error to be returned.
+When True, no crash report will be created and a HTTP 422 error will be
+returned. """,
+    )
     parser.add_argument("--use-os-prober", action="store_true", default=False)
     parser.add_argument(
         "--postinst-hooks-dir", default="/etc/subiquity/postinst.d", type=pathlib.Path
@@ -158,6 +169,7 @@ def main():
         opts.storage_version = int(
             opts.kernel_cmdline.get("subiquity-storage-version", 1)
         )
+    set_user_error_reportable(not opts.no_report_storage_user_errors)
     logdir = LOGDIR
     if opts.dry_run:
         if opts.dry_run_config:

--- a/subiquity/common/api/recoverable_error.py
+++ b/subiquity/common/api/recoverable_error.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class RecoverableError(Exception):
+    """An error type that should not be treated as fatal."""

--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -21,8 +21,8 @@ import traceback
 
 from aiohttp import web
 
+from subiquity.common.api.recoverable_error import RecoverableError
 from subiquity.common.serialize import Serializer
-from subiquity.server.nonreportable import NonReportableException
 
 from .defs import Payload
 
@@ -171,7 +171,7 @@ def _make_handler(
                 tb = traceback.TracebackException.from_exception(exc)
                 resp = web.Response(
                     text="".join(tb.format()),
-                    status=422 if isinstance(exc, NonReportableException) else 500,
+                    status=422 if isinstance(exc, RecoverableError) else 500,
                     headers={
                         "x-status": "error",
                         "x-error-type": type(exc).__name__,
@@ -181,10 +181,7 @@ def _make_handler(
                         "x-error-msg": json.dumps(str(exc), indent=None),
                     },
                 )
-                # We could use a more specific type but this should be good for
-                # a start.
-                if not isinstance(exc, NonReportableException):
-                    resp["exception"] = exc
+                resp["exception"] = exc
             context.description = "{} {}".format(resp.status, trim(resp.text))
             return resp
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -60,6 +60,7 @@ from subiquity.server.autoinstall import AutoinstallError
 from subiquity.server.controllers.filesystem import (
     DRY_RUN_RESET_SIZE,
     FilesystemController,
+    StorageValueError,
     VariationInfo,
 )
 from subiquity.server.dryrun import DRConfig
@@ -220,7 +221,9 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
     async def test_v2_add_boot_partition_POST_existing_bootloader(self):
         self.fsc.locked_probe_data = False
         with mock.patch.object(self.fsc, "add_boot_disk") as add_boot_disk:
-            with self.assertRaisesRegex(ValueError, r"already\ has\ bootloader"):
+            with self.assertRaises(
+                StorageValueError, msg="device already has bootloader"
+            ):
                 await self.fsc.v2_add_boot_partition_POST("dev-sda")
         self.assertTrue(self.fsc.locked_probe_data)
         add_boot_disk.assert_not_called()
@@ -230,7 +233,7 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
     async def test_v2_add_boot_partition_POST_not_supported(self):
         self.fsc.locked_probe_data = False
         with mock.patch.object(self.fsc, "add_boot_disk") as add_boot_disk:
-            with self.assertRaisesRegex(ValueError, r"does\ not\ support\ boot"):
+            with self.assertRaises(StorageValueError, msg="disk does not support boot"):
                 await self.fsc.v2_add_boot_partition_POST("dev-sda")
         self.assertTrue(self.fsc.locked_probe_data)
         add_boot_disk.assert_not_called()

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -60,7 +60,7 @@ from subiquity.server.autoinstall import AutoinstallError
 from subiquity.server.controllers.filesystem import (
     DRY_RUN_RESET_SIZE,
     FilesystemController,
-    StorageValueError,
+    StorageRecoverableError,
     VariationInfo,
 )
 from subiquity.server.dryrun import DRConfig
@@ -222,7 +222,7 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.fsc.locked_probe_data = False
         with mock.patch.object(self.fsc, "add_boot_disk") as add_boot_disk:
             with self.assertRaises(
-                StorageValueError, msg="device already has bootloader"
+                StorageRecoverableError, msg="device already has bootloader"
             ):
                 await self.fsc.v2_add_boot_partition_POST("dev-sda")
         self.assertTrue(self.fsc.locked_probe_data)
@@ -233,7 +233,9 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
     async def test_v2_add_boot_partition_POST_not_supported(self):
         self.fsc.locked_probe_data = False
         with mock.patch.object(self.fsc, "add_boot_disk") as add_boot_disk:
-            with self.assertRaises(StorageValueError, msg="disk does not support boot"):
+            with self.assertRaises(
+                StorageRecoverableError, msg="disk does not support boot"
+            ):
                 await self.fsc.v2_add_boot_partition_POST("dev-sda")
         self.assertTrue(self.fsc.locked_probe_data)
         add_boot_disk.assert_not_called()

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -545,6 +545,12 @@ class SubiquityServer(Application):
                 exc=exc,
             )
             resp.headers["x-error-report"] = to_json(ErrorReportRef, report.ref())
+        if resp.status == 422:
+            log.debug(
+                "request to %s failed with status 422: %s",
+                request.raw_path,
+                resp.headers["x-error-msg"],
+            )
         return resp
 
     @with_context()

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -538,19 +538,20 @@ class SubiquityServer(Application):
             resp.headers["x-updated"] = "no"
         if resp.get("exception"):
             exc = resp["exception"]
-            log.debug("request to {} crashed".format(request.raw_path), exc_info=exc)
-            report = self.make_apport_report(
-                ErrorReportKind.SERVER_REQUEST_FAIL,
-                "request to {}".format(request.raw_path),
-                exc=exc,
-            )
-            resp.headers["x-error-report"] = to_json(ErrorReportRef, report.ref())
-        if resp.status == 422:
             log.debug(
-                "request to %s failed with status 422: %s",
+                "request to %s failed with status %d: %s",
                 request.raw_path,
+                resp.status,
                 resp.headers["x-error-msg"],
+                exc_info=exc,
             )
+            if not isinstance(exc, NonReportableException):
+                report = self.make_apport_report(
+                    ErrorReportKind.SERVER_REQUEST_FAIL,
+                    "request to {}".format(request.raw_path),
+                    exc=exc,
+                )
+                resp.headers["x-error-report"] = to_json(ErrorReportRef, report.ref())
         return resp
 
     @with_context()

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -2221,3 +2221,37 @@ class TestMountDetection(TestAPI):
             self.assertTrue(disk1["has_in_use_partition"])
             disk1p2 = disk1["partitions"][1]
             self.assertTrue(disk1p2["is_in_use"])
+
+
+class TestFilesystemUserErrors(TestAPI):
+    @timeout()
+    async def test_add_boot_partition__with_error_report(self):
+        cfg = "examples/machines/simple.json"
+        extra = ["--storage-version", "2"]
+        async with start_server(cfg, extra_args=extra) as inst:
+            await inst.post("/storage/v2/add_boot_partition", disk_id="disk-sda")
+            try:
+                await inst.post("/storage/v2/add_boot_partition", disk_id="disk-sda")
+            except ClientResponseError as cre:
+                self.assertEqual(500, cre.status)
+                self.assertIn("x-error-report", cre.headers)
+                self.assertEqual(
+                    "device already has bootloader partition",
+                    json.loads(cre.headers["x-error-msg"]),
+                )
+
+    @timeout()
+    async def test_add_boot_partition__no_error_report(self):
+        cfg = "examples/machines/simple.json"
+        extra = ["--storage-version", "2", "--no-report-storage-user-error"]
+        async with start_server(cfg, extra_args=extra) as inst:
+            await inst.post("/storage/v2/add_boot_partition", disk_id="disk-sda")
+            try:
+                await inst.post("/storage/v2/add_boot_partition", disk_id="disk-sda")
+            except ClientResponseError as cre:
+                self.assertEqual(422, cre.status)
+                self.assertNotIn("x-error-report", cre.headers)
+                self.assertEqual(
+                    "device already has bootloader partition",
+                    json.loads(cre.headers["x-error-msg"]),
+                )


### PR DESCRIPTION
Today, when a client sends a POST request to /storage/v2/ endpoints, if the data is inconsistent with the current state of the model, the Subiquity server process creates an error report and returns with HTTP status 500.

This is what makes the desktop installer display so many crash dialogs. We would want to a way to:
* display a user-friendly error in a dialog of the UI
* avoid creating a crash report every time

This PR allow to configure Subiquity in such a way that, in case of a user-error in /storage/v2:

* the error is sent back to the client with a 422 HTTP status (Unprocessable Content).
* no crash report is created

Here's the code we could use when consuming /storage/v2/add_boot_partition

```python
try:
    await self.endpoint.v2.add_boot_partition.POST(disk.id)
except RecoverableClientError as exc:
    self.ui.body.show_recoverable_error(str(exc)))  # Basically a function that shows an overlay
```

This is very similar that what I did for https://github.com/canonical/subiquity/pull/1227 at the time