### PR TITLE
pre-commit: don't pass file names to spell check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
         language: system
         entry: make -C doc spelling
         files: "doc/.*rst"
+        pass_filenames: false


### PR DESCRIPTION
With "pass_filenames: True" (the default) the spell check entry will be invoked as "make -C doc spelling file1 file2 ..." which will cause the default Make target to be run for the specified files, leading to errors like:

. .sphinx/venv/bin/activate; sphinx-build -M doc/some_file "." "_build" Running Sphinx v7.3.7

Sphinx error:
Builder name doc/some_file not registered or available through entry point

Since the spelling target will check all files, we can suppress sending any filenames.