### PR TITLE
doc: add a note about running ubuntu-image as root or with sudo

### DIFF
--- a/doc/reference/ubuntu-image.rst
+++ b/doc/reference/ubuntu-image.rst
@@ -39,6 +39,7 @@ Basic syntax
 
     ubuntu-image classic [options] image_definition.yaml
 
+.. note:: ``ubuntu-image`` requires **elevated permissions**. Run it as **root** or with ``sudo``.
 
 General options
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
On several occasions recently, users failed to build images with ubuntu-image because it is not made clear the tool must be run as root or with sudo. Clarify this in the doc.

I added this as a `Note` but a `Warning` or something else might be more appropriate/visible.