### PR TITLE
network: drop logic to split out wifi config

### DIFF
--- a/subiquity/models/tests/test_network.py
+++ b/subiquity/models/tests/test_network.py
@@ -52,3 +52,14 @@ class TestNetworkModel(unittest.IsolatedAsyncioTestCase):
         config = self.model.render()
         for file in config["write_files"].values():
             self.assertEqual(file["permissions"], "0600")
+
+    async def test_netplan_wifi_combined(self):
+        """Assert the wifi config is not written separately."""
+
+        mock_config = {"network": {"wifis": "data"}}
+        self.model.render_config = mock.Mock(return_value=mock_config)
+
+        config = self.model.render()
+        self.assertIn(
+            "wifis", config["write_files"]["etc_netplan_installer"]["content"]
+        )


### PR DESCRIPTION
In commit 9ecc4060b (PR #1911), we changed the permissions of the written netplan config files to be stricter but still retained the logic to separate out the wifi information. Since these both are likely to contain secrets and also have the same permissions, we can keep the config merged.