### PR TITLE
add ability to install uc20+ systems

### DIFF
--- a/examples/answers/uc24.yaml
+++ b/examples/answers/uc24.yaml
@@ -1,0 +1,24 @@
+#source-catalog: examples/sources/uc24.yaml
+Source:
+  source: ubuntu-core
+Welcome:
+  lang: en_US
+Refresh:
+  update: no
+Keyboard:
+  layout: us
+Zdev:
+  accept-default: yes
+Network:
+  accept-default: yes
+Proxy:
+  proxy: ""
+Filesystem:
+  guided: yes
+  guided-index: 0
+UbuntuPro:
+  token: ""
+InstallProgress:
+  reboot: yes
+Drivers:
+  install: no

--- a/examples/snaps/v2-systems-20240314.json
+++ b/examples/snaps/v2-systems-20240314.json
@@ -1,0 +1,238 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "current": true,
+    "label": "20240314",
+    "model": {
+      "architecture": "amd64",
+      "authority-id": "canonical",
+      "base": "core24",
+      "brand-id": "canonical",
+      "grade": "dangerous",
+      "model": "ubuntu-core-24-amd64-dangerous",
+      "revision": "2",
+      "series": "16",
+      "sign-key-sha3-384": "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn",
+      "snaps": [
+        {
+          "default-channel": "24/edge",
+          "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+          "name": "pc",
+          "type": "gadget"
+        },
+        {
+          "default-channel": "24/beta",
+          "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+          "name": "pc-kernel",
+          "type": "kernel"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+          "name": "core24",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/edge",
+          "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+          "name": "snapd",
+          "type": "snapd"
+        },
+        {
+          "default-channel": "24/edge",
+          "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+          "name": "console-conf",
+          "presence": "optional",
+          "type": "app"
+        }
+      ],
+      "timestamp": "2024-03-12T08:42:32+00:00",
+      "type": "model"
+    },
+    "brand": {
+      "id": "canonical",
+      "username": "canonical",
+      "display-name": "Canonical",
+      "validation": "verified"
+    },
+    "actions": [
+      {
+        "title": "Reinstall",
+        "mode": "install"
+      },
+      {
+        "title": "Recover",
+        "mode": "recover"
+      },
+      {
+        "title": "Factory reset",
+        "mode": "factory-reset"
+      },
+      {
+        "title": "Run normally",
+        "mode": "run"
+      }
+    ],
+    "volumes": {
+      "pc": {
+        "schema": "gpt",
+        "bootloader": "grub",
+        "id": "",
+        "structure": [
+          {
+            "name": "mbr",
+            "filesystem-label": "",
+            "offset": 0,
+            "offset-write": null,
+            "min-size": 440,
+            "size": 440,
+            "type": "mbr",
+            "role": "mbr",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "mbr.img",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "BIOS Boot",
+            "filesystem-label": "",
+            "offset": 1048576,
+            "offset-write": null,
+            "min-size": 1048576,
+            "size": 1048576,
+            "type": "21686148-6449-6E6F-744E-656564454649",
+            "role": "",
+            "id": "",
+            "filesystem": "",
+            "content": null,
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-seed",
+            "filesystem-label": "ubuntu-seed",
+            "offset": 2097152,
+            "offset-write": null,
+            "min-size": 1258291200,
+            "size": 1258291200,
+            "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "role": "system-seed",
+            "id": "",
+            "filesystem": "vfat",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-boot",
+            "filesystem-label": "ubuntu-boot",
+            "offset": 1260388352,
+            "offset-write": null,
+            "min-size": 786432000,
+            "size": 786432000,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-boot",
+            "id": "",
+            "filesystem": "ext4",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-save",
+            "filesystem-label": "ubuntu-save",
+            "offset": 2046820352,
+            "offset-write": null,
+            "min-size": 33554432,
+            "size": 33554432,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-save",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-data",
+            "filesystem-label": "ubuntu-data",
+            "offset": 2080374784,
+            "offset-write": null,
+            "min-size": 1073741824,
+            "size": 1073741824,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-data",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          }
+        ]
+      }
+    },
+    "storage-encryption": {
+      "support": "unavailable",
+      "storage-safety": "prefer-encrypted",
+      "unavailable-reason": "not encrypting device storage as checking TPM gave: cannot read secure boot variable: cannot read EFI var \"SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c\": open /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c: no such file or directory"
+    }
+  }
+}

--- a/examples/sources/uc24.yaml
+++ b/examples/sources/uc24.yaml
@@ -1,0 +1,10 @@
+- description:
+    en: This test source provides a "Ubuntu Core" base install
+  id: ubuntu-core
+  locale_support: none
+  name:
+    en: Ubuntu Core 24
+  type: null
+  size: 0
+  variant: core
+  snapd_system_label: "20240314"

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -39,7 +39,7 @@ validate () {
             autoinstall-reset-only)
                 python3 scripts/validate-yaml.py --no-root-mount "${cfgs[@]}"
                 ;;
-            answers-core-desktop)
+            answers-core-desktop|answers-uc24)
                 ;;
             *)
                 python3 scripts/validate-yaml.py "${cfgs[@]}"
@@ -50,7 +50,7 @@ validate () {
             exit 1
         fi
         case $testname in
-            answers-core-desktop)
+            answers-core-desktop|answers-uc24)
                 ;;
             *)
                 python3 scripts/validate-autoinstall-user-data.py < $tmpdir/var/log/installer/autoinstall-user-data
@@ -223,9 +223,13 @@ for answers in examples/answers/*.yaml; do
             --snaps-from-examples \
             --source-catalog $catalog
         validate install
-        if [ $answers != examples/answers/core-desktop.yaml ]; then
-            grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' $tmpdir/subiquity-server-debug.log
-        fi
+        case $testname in
+            answers-core-desktop|answers-uc24)
+                ;;
+            *)
+                grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' $tmpdir/subiquity-server-debug.log
+                ;;
+        esac
     else
         # The OOBE doesn't exist in WSL < 20.04
         if [ "${RELEASE%.*}" -ge 20 ]; then

--- a/subiquity/models/source.py
+++ b/subiquity/models/source.py
@@ -25,22 +25,22 @@ from subiquity.common.serialize import Serializer
 log = logging.getLogger("subiquity.models.source")
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, kw_only=True)
 class CatalogEntryVariation:
-    path: str
+    path: str = ""
     size: int
     snapd_system_label: typing.Optional[str] = None
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, kw_only=True)
 class CatalogEntry:
     variant: str
     id: str
     name: typing.Dict[str, str]
     description: typing.Dict[str, str]
-    path: str
+    path: str = ""
     size: int
-    type: str
+    type: typing.Optional[str]
     default: bool = False
     locale_support: str = attr.ib(default="locale-only")
     preinstalled_langs: typing.List[str] = attr.Factory(list)
@@ -101,7 +101,12 @@ class SourceModel:
                 return source
         raise KeyError
 
-    def get_source(self, variation_name: typing.Optional[str] = None):
+    def get_source(
+        self, variation_name: typing.Optional[str] = None
+    ) -> typing.Optional[str]:
+        scheme = self.current.type
+        if scheme is None:
+            return None
         if variation_name is None:
             variation = next(iter(self.current.variations.values()))
         else:
@@ -114,7 +119,6 @@ class SourceModel:
             else:
                 suffix = "no-languages"
             path = base + "." + suffix + ext
-        scheme = self.current.type
         return f"{scheme}://{path}"
 
     def render(self):

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -319,6 +319,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
     async def _mount_systems_dir(self, variation_name):
         self._source_handler = self.app.controllers.Source.get_handler(variation_name)
+        if self._source_handler is None:
+            raise NoSnapdSystemsOnSource
         source_path = self._source_handler.setup()
         cur_systems_dir = "/var/lib/snapd/seed/systems"
         source_systems_dir = os.path.join(source_path, cur_systems_dir[1:])

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -289,6 +289,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     def is_core_boot_classic(self):
         return self._info.is_core_boot_classic()
 
+    def use_snapd_install_api(self):
+        return self._on_volume is not None
+
     def load_autoinstall_data(self, data):
         # Log disabled to prevent LUKS password leak
         # log.debug("load_autoinstall_data %s", data)

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -356,7 +356,7 @@ class InstallController(SubiquityController):
                     device_map_path=logs_dir / "device-map.json",
                 ),
             )
-        elif fs_controller.is_core_boot_classic():
+        elif fs_controller.use_snapd_install_api():
             await run_curtin_step(
                 name="partitioning",
                 stages=["partitioning"],

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -375,27 +375,28 @@ class InstallController(SubiquityController):
                     device_map_path=logs_dir / "device-map-format.json",
                 ),
             )
-            await run_curtin_step(
-                name="extract",
-                stages=["extract"],
-                step_config=self.generic_config(),
-                source=source,
-            )
-            await self.create_core_boot_classic_fstab(context=context)
-            await run_curtin_step(
-                name="swap",
-                stages=["swap"],
-                step_config=self.generic_config(
-                    swap_commands={
-                        "subiquity": [
-                            "curtin",
-                            "swap",
-                            "--fstab",
-                            self.tpath("etc/fstab"),
-                        ],
-                    }
-                ),
-            )
+            if source is not None:
+                await run_curtin_step(
+                    name="extract",
+                    stages=["extract"],
+                    step_config=self.generic_config(),
+                    source=source,
+                )
+                await self.create_core_boot_classic_fstab(context=context)
+                await run_curtin_step(
+                    name="swap",
+                    stages=["swap"],
+                    step_config=self.generic_config(
+                        swap_commands={
+                            "subiquity": [
+                                "curtin",
+                                "swap",
+                                "--fstab",
+                                self.tpath("etc/fstab"),
+                            ],
+                        }
+                    ),
+                )
             await fs_controller.finish_install(context=context)
             await self.setup_target(context=context)
         else:

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -135,10 +135,11 @@ class SourceController(SubiquityController):
 
     def get_handler(
         self, variation_name: Optional[str] = None
-    ) -> AbstractSourceHandler:
-        handler = get_handler_for_source(
-            sanitize_source(self.model.get_source(variation_name))
-        )
+    ) -> Optional[AbstractSourceHandler]:
+        source = self.model.get_source(variation_name)
+        if source is None:
+            return None
+        handler = get_handler_for_source(sanitize_source(source))
         if handler is not None and self.app.opts.dry_run:
             handler = TrivialSourceHandler("/")
         return handler


### PR DESCRIPTION
The main thing here is to add support for sources that do not require subiquity to copy anything to the target system (snapd's install API takes care of putting the needed bits in place for core).

Working on this I realised that the handling of the 'size' field is a bit incoherent between classic and core boot classic (and now core). That can be cleaned up independently though!