### PR TITLE
geoip: update test data following change in geoip.ubuntu.com/lookup

### DIFF
--- a/subiquity/server/geoip.py
+++ b/subiquity/server/geoip.py
@@ -53,7 +53,7 @@ class DryRunGeoIPStrategy(GeoIPStrategy):
     <Ip>255.255.255.255</Ip>
     <Status>OK</Status>
     <CountryCode>FR</CountryCode>
-    <CountryCode3>FRA</CountryCode3>
+    <CountryCode3>Unknown</CountryCode3>
     <CountryName>France</CountryName>
     <RegionCode>A8</RegionCode>
     <RegionName>Ile-de-France</RegionName>
@@ -61,7 +61,7 @@ class DryRunGeoIPStrategy(GeoIPStrategy):
     <ZipPostalCode>75013</ZipPostalCode>
     <Latitude>48.8151</Latitude>
     <Longitude>2.2182</Longitude>
-    <AreaCode>0</AreaCode>
+    <AreaCode>None</AreaCode>
     <TimeZone>Europe/Paris</TimeZone>
   </Response>
 """

--- a/subiquity/server/tests/test_geoip.py
+++ b/subiquity/server/tests/test_geoip.py
@@ -25,7 +25,7 @@ xml = """
   <Ip>1.2.3.4</Ip>
   <Status>OK</Status>
   <CountryCode>US</CountryCode>
-  <CountryCode3>USA</CountryCode3>
+  <CountryCode3>Unknown</CountryCode3>
   <CountryName>United States</CountryName>
   <RegionCode>CA</RegionCode>
   <RegionName>California</RegionName>


### PR DESCRIPTION
After a recent update of geoip.ubuntu.com/lookup, the value of the `<CountryCode3>` tag is now hardcoded to `Unknown`. The `<AreaCode>` tag also has a slightly different meaning but this should not affect Subiquity in any way.

Update the test data accordingly.