### PR TITLE
Replace calls to v1 guided and v1 reset with v2 equivalents

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -301,7 +301,11 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         run_bg_task(reset_and_redraw())
 
     async def _reset(self, refresh_view: bool) -> None:
-        status = await self.endpoint.reset.POST()
+        async def v2_reset_with_v1_response() -> StorageResponse:
+            await self.endpoint.v2.reset.POST()
+            return await self.endpoint.GET()
+
+        status = await v2_reset_with_v1_response()
         self.app.ui.block_input = False
         self.model.load_server_data(status)
         if refresh_view:

--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -290,7 +290,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
 
         run_bg_task(guided_and_redraw())
 
-    def reset(self, refresh_view):
+    def reset(self, refresh_view: bool) -> None:
         async def reset_and_redraw():
             await self._reset(refresh_view)
             await self.app.redraw_screen()
@@ -300,7 +300,7 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
 
         run_bg_task(reset_and_redraw())
 
-    async def _reset(self, refresh_view):
+    async def _reset(self, refresh_view: bool) -> None:
         status = await self.endpoint.reset.POST()
         self.app.ui.block_input = False
         self.model.load_server_data(status)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -35,7 +35,7 @@ from curtin.swap import can_use_swapfile
 from curtin.util import human2bytes
 from probert.storage import StorageInfo
 
-from subiquity.common.types import Bootloader, OsProber, RecoveryKey
+from subiquity.common.types import Bootloader, OsProber, RecoveryKey, StorageResponse
 from subiquity.server.autoinstall import AutoinstallError
 from subiquitycore.utils import write_named_tempfile
 
@@ -1578,7 +1578,7 @@ class FilesystemModel:
                         Filesystem(m=self, fstype="swap", volume=o, preserve=True)
                     )
 
-    def load_server_data(self, status):
+    def load_server_data(self, status: StorageResponse):
         log.debug("load_server_data %s", status)
         self._all_ids = set()
         self.storage_version = status.storage_version

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1207,6 +1207,12 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         log.debug(data)
         self.locked_probe_data = True
         await self.guided(data)
+        if not data.capability.supports_manual_customization():
+            # Going forward, we probably want the client to call POST
+            # /storage/v2 when they are done ; rather than conditionally
+            # marking the model configured here. This requires a way to tell
+            # the client whether manual customization is possible though.
+            await self.configured()
         return await self.v2_guided_GET()
 
     async def v2_reformat_disk_POST(self, data: ReformatDisk) -> StorageResponseV2:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1004,10 +1004,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             await self.configured()
         return self._done_response()
 
-    async def reset_POST(self, context, request) -> StorageResponse:
-        log.info("Resetting Filesystem model")
-        self.model.reset()
-        return await self.GET(context)
+    async def reset_POST(self) -> StorageResponse:
+        raise NotImplementedError
 
     async def has_rst_GET(self) -> bool:
         search = "/sys/module/ahci/drivers/pci:ahci/*/remapped_nvme"

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -998,11 +998,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         )
 
     async def guided_POST(self, data: GuidedChoiceV2) -> StorageResponse:
-        log.debug(data)
-        await self.guided(data)
-        if not data.capability.supports_manual_customization():
-            await self.configured()
-        return self._done_response()
+        raise NotImplementedError
 
     async def reset_POST(self) -> StorageResponse:
         raise NotImplementedError

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -1551,7 +1551,9 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         choice = GuidedChoiceV2(
             target=response.targets[0], capability=GuidedCapability.CORE_BOOT_ENCRYPTED
         )
-        await self.fsc.v2_guided_POST(choice)
+        with mock.patch.object(self.fsc, "configured") as m_configured:
+            await self.fsc.v2_guided_POST(choice)
+        m_configured.assert_called_once()
 
         self.assertEqual(model.storage_version, 2)
 

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -441,8 +441,8 @@ class FilesystemView(BaseView):
         self.controller = controller
 
         self.mount_list = MountList(self)
-        self.avail_list = DeviceList(self, True)
-        self.used_list = DeviceList(self, False)
+        self.avail_list = DeviceList(self, show_available=True)
+        self.used_list = DeviceList(self, show_available=False)
         self.avail_list.table.bind(self.used_list.table)
         self._create_raid_btn = Toggleable(
             menu_btn(label=_("Create software RAID (md)"), on_press=self.create_raid)

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -233,7 +233,7 @@ def _whynot_shower(view, action, whynot):
 
 
 class DeviceList(WidgetWrap):
-    def __init__(self, parent, show_available):
+    def __init__(self, parent, show_available: bool):
         self.parent = parent
         self.show_available = show_available
         self.table = TablePile(


### PR DESCRIPTION
This is a first step in the switch from v1 storage API to the v2 alternative.

This also demonstrates the use of GET /storage (which is a v1 storage endpoint) as a way to introduce a compatibility layer during development. Going forward, we should drop calls to v1 GET /storage as well but going step by step should make the whole process simpler.