### PR TITLE
timezone: mock a timedatectl invocation

### DIFF
--- a/subiquity/tests/test_timezonecontroller.py
+++ b/subiquity/tests/test_timezonecontroller.py
@@ -90,7 +90,14 @@ class TestTimeZoneController(SubiTestCase):
                 cloudconfig, self.tzc.model.make_cloudconfig(), self.tzc.model
             )
 
-    def test_bad_tzs(self):
+    @mock.patch("subiquity.server.controllers.timezone.generate_possible_tzs")
+    def test_bad_tzs(self, generate_possible_tzs):
+        generate_possible_tzs.return_value = [
+            "",
+            "geoip",
+            "Pacific/Auckland",
+            "America/Denver",
+        ]
         bads = [
             "dhcp",  # possible future value, not supported yet
             "notatimezone",


### PR DESCRIPTION
FIxes testrunner when the dbus connection isn't available.  Encountered this scenario in a chroot where systemd was present.