### PR TITLE
List of matchers

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -576,6 +576,18 @@ To match a Seagate drive:
      match:
        model: Seagate
 
+As of Subiquity 24.08.1, match specs may optionally be specified in an ordered
+list, and will use the first match spec that matches one or more unused disks:
+
+.. code-block:: yaml
+
+   # attempt first to match by serial, then by path
+   - type: disk
+     id: data-disk
+     match:
+       - serial: Foodisk_1TB_ABC123_1
+       - path: /dev/nvme0n1
+
 Partition/logical volume extensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1591,8 +1591,6 @@ class FilesystemModel:
         )
 
     def _make_matchers(self, match):
-        matchers = []
-
         def _udev_val(disk, key):
             return self._probe_data["blockdev"].get(disk.path, {}).get(key, "")
 
@@ -1621,6 +1619,11 @@ class FilesystemModel:
         def match_install_media(disk):
             return disk._has_in_use_partition
 
+        def match_nonzero_size(disk):
+            return disk.size != 0
+
+        matchers = [match_nonzero_size]
+
         if match.get("install-media", False):
             matchers.append(match_install_media)
 
@@ -1646,8 +1649,6 @@ class FilesystemModel:
         matchers = self._make_matchers(match)
         candidates = []
         for candidate in disks:
-            if candidate.size == 0:
-                continue
             for matcher in matchers:
                 if not matcher(candidate):
                     break

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1619,6 +1619,9 @@ class FilesystemModel:
         def match_install_media(disk):
             return disk._has_in_use_partition
 
+        def match_not_in_use(disk):
+            return not disk._has_in_use_partition
+
         def match_nonzero_size(disk):
             return disk.size != 0
 
@@ -1641,6 +1644,8 @@ class FilesystemModel:
             matchers.append(match_devpath)
         if "ssd" in match:
             matchers.append(match_ssd)
+        if "size" in match or "ssd" in match:
+            matchers.append(match_not_in_use)
 
         return matchers
 
@@ -1654,8 +1659,6 @@ class FilesystemModel:
                     break
             else:
                 candidates.append(candidate)
-        if "size" in match or "ssd" in match:
-            candidates = [c for c in candidates if not c._has_in_use_partition]
         if match.get("size") == "smallest":
             candidates.sort(key=lambda d: d.size)
         if match.get("size") == "largest":

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -25,7 +25,7 @@ import platform
 import secrets
 import tempfile
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import attr
 import more_itertools
@@ -1649,6 +1649,13 @@ class FilesystemModel:
 
         return matchers
 
+    def _sorted_matches(self, disks: Sequence[_Device], match: dict):
+        if match.get("size") == "smallest":
+            disks.sort(key=lambda d: d.size)
+        elif match.get("size") == "largest":
+            disks.sort(key=lambda d: d.size, reverse=True)
+        return disks
+
     def disk_for_match(self, disks, match):
         log.info(f"considering {disks} for {match}")
         matchers = self._make_matchers(match)
@@ -1659,10 +1666,7 @@ class FilesystemModel:
                     break
             else:
                 candidates.append(candidate)
-        if match.get("size") == "smallest":
-            candidates.sort(key=lambda d: d.size)
-        if match.get("size") == "largest":
-            candidates.sort(key=lambda d: d.size, reverse=True)
+        candidates = self._sorted_matches(candidates, match)
         if candidates:
             log.info(f"For match {match}, using the first candidate from {candidates}")
             return candidates[0]

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -25,7 +25,7 @@ import platform
 import secrets
 import tempfile
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import attr
 import more_itertools
@@ -1590,7 +1590,7 @@ class FilesystemModel:
             status.config, blockdevs=None, is_probe_data=False
         )
 
-    def _make_matchers(self, match):
+    def _make_matchers(self, match: dict) -> Sequence[Callable]:
         def _udev_val(disk, key):
             return self._probe_data["blockdev"].get(disk.path, {}).get(key, "")
 
@@ -1658,14 +1658,7 @@ class FilesystemModel:
 
     def _filtered_matches(self, disks: Sequence[_Device], match: dict):
         matchers = self._make_matchers(match)
-        candidates = []
-        for candidate in disks:
-            for matcher in matchers:
-                if not matcher(candidate):
-                    break
-            else:
-                candidates.append(candidate)
-        return candidates
+        return [disk for disk in disks if all(match_fn(disk) for match_fn in matchers)]
 
     def disk_for_match(self, disks, match):
         log.info(f"considering {disks} for {match}")

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1656,8 +1656,7 @@ class FilesystemModel:
             disks.sort(key=lambda d: d.size, reverse=True)
         return disks
 
-    def disk_for_match(self, disks, match):
-        log.info(f"considering {disks} for {match}")
+    def _filtered_matches(self, disks: Sequence[_Device], match: dict):
         matchers = self._make_matchers(match)
         candidates = []
         for candidate in disks:
@@ -1666,6 +1665,11 @@ class FilesystemModel:
                     break
             else:
                 candidates.append(candidate)
+        return candidates
+
+    def disk_for_match(self, disks, match):
+        log.info(f"considering {disks} for {match}")
+        candidates = self._filtered_matches(disks, match)
         candidates = self._sorted_matches(candidates, match)
         if candidates:
             log.info(f"For match {match}, using the first candidate from {candidates}")

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1660,14 +1660,22 @@ class FilesystemModel:
         matchers = self._make_matchers(match)
         return [disk for disk in disks if all(match_fn(disk) for match_fn in matchers)]
 
-    def disk_for_match(self, disks, match):
+    def disk_for_match(
+        self, disks: Sequence[_Device], match: dict | Sequence[dict]
+    ) -> _Device:
+        # a match directive is a dict, or a list of dicts, that specify
+        # * zero or more keys to filter on
+        # * an optional sort on size
         log.info(f"considering {disks} for {match}")
-        candidates = self._filtered_matches(disks, match)
-        candidates = self._sorted_matches(candidates, match)
-        if candidates:
-            log.info(f"For match {match}, using the first candidate from {candidates}")
-            return candidates[0]
-        log.info(f"For match {match}, no devices match")
+        if isinstance(match, dict):
+            match = [match]
+        for m in match:
+            candidates = self._filtered_matches(disks, m)
+            candidates = self._sorted_matches(candidates, m)
+            if candidates:
+                log.info(f"For match {m}, using the first candidate from {candidates}")
+                return candidates[0]
+        log.info(f"No devices satisfy criteria {match}")
         return None
 
     def assign_omitted_offsets(self):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1834,3 +1834,25 @@ class TestDiskForMatch(SubiTestCase):
         fake_up_blockdata(m)
         actual = m.disk_for_match([iso, disk], {"install-media": True})
         self.assertEqual(iso, actual)
+
+    def test_match_from_list_first(self):
+        m = make_model()
+        vda = make_disk(m, path="/dev/vda", serial="s1")
+        vdb = make_disk(m, path="/dev/vdb", serial="s2")
+        fake_up_blockdata(m)
+        match = [
+            {"serial": "s1"},
+            {"path": "/dev/vdb"},
+        ]
+        self.assertEqual(vda, m.disk_for_match([vda, vdb], match))
+
+    def test_match_from_list_second(self):
+        m = make_model()
+        vda = make_disk(m, path="/dev/vda", serial="s1")
+        vdb = make_disk(m, path="/dev/vdb", serial="s2")
+        fake_up_blockdata(m)
+        match = [
+            {"serial": "not-found"},
+            {"path": "/dev/vdb"},
+        ]
+        self.assertEqual(vdb, m.disk_for_match([vda, vdb], match))

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -22,7 +22,7 @@ import os
 import pathlib
 import subprocess
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import attr
 import pyudev
@@ -1360,7 +1360,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 self.start_monitor()
             break
 
-    def get_bootable_matching_disk(self, match: dict[str, str]):
+    def get_bootable_matching_disk(
+        self, match: dict[str, str] | Sequence[dict[str, str]]
+    ):
         """given a match directive, find disks or disk-like devices for which
         we have a plan to boot, and return the best matching one of those.
         As match directives are autoinstall-supplied, raise AutoinstallError if


### PR DESCRIPTION
Add unit tests for existing functionality (some overlap with `TestAutoInstallConfig` but some is new)
Permit match specs to be done as a list of match rules.
Refactor `disk_for_match` as well to make it simpler to follow.