### PR TITLE
ai-filter: be aware of autoinstall_key_alias

### DIFF
--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -570,6 +570,7 @@ class SubiquityServer(Application):
         # Pop keys of all loaded controllers, if they exists
         for controller in self.controllers.instances:
             invalid_config.pop(controller.autoinstall_key, None)
+            invalid_config.pop(controller.autoinstall_key_alias, None)
 
         # Pop server keys, if they exist
         for key in self.base_schema["properties"]:

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -357,6 +357,12 @@ class TestAutoinstallValidation(SubiTestCase):
                 {},
                 {"some-bad-key": "..."},
             ),
+            (
+                # Case 4: aliased keys are okay too
+                {"ubuntu-advantage": "..."},
+                {"ubuntu-advantage": "..."},
+                {},
+            ),
         )
     )
     async def test_autoinstall_validation__filter_autoinstall(self, config, good, bad):


### PR DESCRIPTION
Make sure we catch autoinstall key name aliases so we don't incorrectly warn (or eventually error) on actually correct key names (LP:#2068603).