### PR TITLE
Merge late-commands status fix to ubuntu/noble

### DIFF
--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -92,6 +92,8 @@ class ApplicationState(enum.Enum):
     UU_RUNNING = enum.auto()
     UU_CANCELLING = enum.auto()
 
+    LATE_COMMANDS = enum.auto()
+
     # Final state
     DONE = enum.auto()
     ERROR = enum.auto()

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -87,10 +87,9 @@ class ApplicationState(enum.Enum):
     WAITING = enum.auto()
     RUNNING = enum.auto()
 
-    # States reported while unattended-upgrades is running.
-    # TODO: check if these should be dropped in favor of RUNNING.
+    # State reported while unattended-upgrades is running.
+    # TODO: check if this should be dropped in favor of RUNNING.
     UU_RUNNING = enum.auto()
-    UU_CANCELLING = enum.auto()
 
     LATE_COMMANDS = enum.auto()
 

--- a/subiquity/server/controllers/cmdlist.py
+++ b/subiquity/server/controllers/cmdlist.py
@@ -21,9 +21,7 @@ from typing import List, Sequence, Union
 import attr
 from systemd import journal
 
-from subiquity.common.types import ApplicationState
 from subiquity.server.controller import NonInteractiveController
-from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.context import with_context
 from subiquitycore.utils import arun_command
 
@@ -128,15 +126,6 @@ class LateController(CmdListController):
         if self.app.base_model.target is not None:
             env["TARGET_MOUNT_POINT"] = self.app.base_model.target
         return env
-
-    def start(self):
-        run_bg_task(self._run())
-
-    async def _run(self):
-        Install = self.app.controllers.Install
-        await Install.install_task
-        if self.app.state == ApplicationState.DONE:
-            await self.run()
 
 
 class ErrorController(CmdListController):

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -624,6 +624,9 @@ class InstallController(SubiquityController):
 
             await self.postinstall(context=context)
 
+            self.app.update_state(ApplicationState.LATE_COMMANDS)
+            await self.app.controllers.Late.run()
+
             self.app.update_state(ApplicationState.DONE)
         except Exception as exc:
             kw = {}

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -42,7 +42,7 @@ from subiquity.server.curtin import run_curtin_command, start_curtin_command
 from subiquity.server.kernel import list_installed_kernels
 from subiquity.server.mounter import Mounter, Mountpoint
 from subiquity.server.types import InstallerChannels
-from subiquitycore.async_helpers import run_bg_task, run_in_thread
+from subiquitycore.async_helpers import run_in_thread
 from subiquitycore.context import with_context
 from subiquitycore.file_util import (
     generate_config_yaml,
@@ -83,17 +83,10 @@ class InstallController(SubiquityController):
         super().__init__(app)
         self.model = app.base_model
 
-        self.unattended_upgrades_cmd = None
-        self.unattended_upgrades_ctx = None
         self.tb_extractor = TracebackExtractor()
 
     def interactive(self):
         return True
-
-    def stop_uu(self):
-        if self.app.state == ApplicationState.UU_RUNNING:
-            self.app.update_state(ApplicationState.UU_CANCELLING)
-            run_bg_task(self.stop_unattended_upgrades())
 
     def start(self):
         journald_listen([self.app.log_syslog_id], self.log_event)
@@ -757,8 +750,7 @@ class InstallController(SubiquityController):
         apt_conf_path = Path(aptdir) / "zzzz-temp-installer-unattended-upgrade"
         apt_conf_path.write_bytes(apt_conf_contents)
         try:
-            self.unattended_upgrades_ctx = context
-            self.unattended_upgrades_cmd = await start_curtin_command(
+            uu_cmd = await start_curtin_command(
                 self.app,
                 context,
                 "in-target",
@@ -770,29 +762,12 @@ class InstallController(SubiquityController):
                 private_mounts=True,
             )
             try:
-                await self.unattended_upgrades_cmd.wait()
+                await uu_cmd.wait()
             except subprocess.CalledProcessError as cpe:
                 log_process_streams(logging.ERROR, cpe, "Unattended upgrades")
                 context.description = f"FAILED to apply {policy} updates"
         finally:
             apt_conf_path.unlink()
-        self.unattended_upgrades_cmd = None
-        self.unattended_upgrades_ctx = None
-
-    async def stop_unattended_upgrades(self):
-        with self.unattended_upgrades_ctx.parent.child(
-            "stop_unattended_upgrades", "cancelling update"
-        ):
-            await self.app.command_runner.run(
-                [
-                    "chroot",
-                    self.tpath(),
-                    "/usr/share/unattended-upgrades/unattended-upgrade-shutdown",
-                    "--stop-only",
-                ]
-            )
-            if self.app.opts.dry_run and self.unattended_upgrades_cmd is not None:
-                self.unattended_upgrades_cmd.proc.terminate()
 
 
 uu_apt_conf = b"""\

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -38,7 +38,7 @@ from subiquity.common.types import ApplicationState, PackageInstallState
 from subiquity.journald import journald_listen
 from subiquity.models.filesystem import ActionRenderMode, Partition
 from subiquity.server.controller import SubiquityController
-from subiquity.server.curtin import run_curtin_command, start_curtin_command
+from subiquity.server.curtin import run_curtin_command
 from subiquity.server.kernel import list_installed_kernels
 from subiquity.server.mounter import Mounter, Mountpoint
 from subiquity.server.types import InstallerChannels
@@ -750,7 +750,7 @@ class InstallController(SubiquityController):
         apt_conf_path = Path(aptdir) / "zzzz-temp-installer-unattended-upgrade"
         apt_conf_path.write_bytes(apt_conf_contents)
         try:
-            uu_cmd = await start_curtin_command(
+            await run_curtin_command(
                 self.app,
                 context,
                 "in-target",
@@ -761,11 +761,9 @@ class InstallController(SubiquityController):
                 "-v",
                 private_mounts=True,
             )
-            try:
-                await uu_cmd.wait()
-            except subprocess.CalledProcessError as cpe:
-                log_process_streams(logging.ERROR, cpe, "Unattended upgrades")
-                context.description = f"FAILED to apply {policy} updates"
+        except subprocess.CalledProcessError as cpe:
+            log_process_streams(logging.ERROR, cpe, "Unattended upgrades")
+            context.description = f"FAILED to apply {policy} updates"
         finally:
             apt_conf_path.unlink()
 

--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -56,7 +56,6 @@ class ShutdownController(SubiquityController):
 
     async def POST(self, mode: ShutdownMode, immediate: bool = False):
         self.mode = mode
-        self.app.controllers.Install.stop_uu()
         self.user_shutdown_event.set()
         if immediate:
             self.server_reboot_event.set()

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -188,6 +188,9 @@ class ProgressView(BaseView):
                 self.view_log_btn,
                 self.reboot_btn,
             ]
+        elif state == ApplicationState.LATE_COMMANDS:
+            self.title = _("Running late-commands")
+            btns = [self.view_log_btn]
         elif state == ApplicationState.DONE:
             self.title = _("Installation complete!")
             self.reboot_btn.base_widget.set_label(_("Reboot Now"))

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -174,20 +174,8 @@ class ProgressView(BaseView):
             self.title = _("Installing system")
             btns = [self.view_log_btn]
         elif state == ApplicationState.UU_RUNNING:
-            self.title = _("Installation complete!")
-            self.reboot_btn.base_widget.set_label(_("Cancel update and reboot"))
-            btns = [
-                self.view_log_btn,
-                self.reboot_btn,
-            ]
-        elif state == ApplicationState.UU_CANCELLING:
-            self.title = _("Installation complete!")
-            self.reboot_btn.base_widget.set_label(_("Rebooting..."))
-            self.reboot_btn.enabled = False
-            btns = [
-                self.view_log_btn,
-                self.reboot_btn,
-            ]
+            self.title = _("Updating system")
+            btns = [self.view_log_btn]
         elif state == ApplicationState.LATE_COMMANDS:
             self.title = _("Running late-commands")
             btns = [self.view_log_btn]

--- a/system_setup/server/controllers/configure.py
+++ b/system_setup/server/controllers/configure.py
@@ -448,6 +448,9 @@ class ConfigureController(SubiquityController):
                 wsl_config_update(self.model.wslconfbase.wslconfbase, root_dir)
                 wsl_config_update(self.model.wslconfadvanced.wslconfadvanced, root_dir)
 
+            self.app.update_state(ApplicationState.LATE_COMMANDS)
+            await self.app.controllers.Late.run()
+
             self.app.update_state(ApplicationState.DONE)
 
         except Exception:


### PR DESCRIPTION
This is a cherry pick of patches from https://github.com/canonical/subiquity/pull/2013

Essentially, this introduces a new state "LATE_COMMANDS" before moving to "DONE" ; so that a reboot is not performed while late commands are still executing.

It also removes the ability to cancel the unattended-upgrades step. We can choose not to include this change if needed.