### PR TITLE
Use TypedDict-s for storage specs

### DIFF
--- a/subiquity/common/filesystem/spec.py
+++ b/subiquity/common/filesystem/spec.py
@@ -1,0 +1,74 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Types defined in this module are deprecated and will at some point be
+replaced by `attr.s` structures or similar. """
+
+
+import typing
+from typing import Any, TypedDict
+
+try:
+    from typing import Required
+except ImportError:
+    # For compability with Python < 3.11.
+    # TODO Keep only what is in the try block when switching to core24.
+    class Required(typing.Generic[typing.TypeVar("T")]):
+        pass
+
+
+from subiquity.models.filesystem import RaidLevel, RecoveryKeyHandler
+
+
+class RaidSpec(TypedDict):
+    name: str
+    level: RaidLevel
+    devices: set[Any]
+    spare_devices: set[Any]
+
+
+VolGroupSpec = TypedDict(
+    "VolGroupSpec",
+    {
+        "name": Required[str],
+        "devices": set[Any],
+        "passphrase": str,
+        "recovery-key": RecoveryKeyHandler | None,
+    },
+    total=False,
+)
+
+
+FileSystemSpec = TypedDict(
+    "FileSystemSpec",
+    {
+        "fstype": str | None,
+        "mount": str | None,
+        "wipe": str | None,
+        "use_swap": bool,
+        "on-remote-storage": bool,
+    },
+    total=False,
+)
+
+
+class LogicalVolumeSpec(FileSystemSpec, total=False):
+    name: str
+    size: int
+
+
+class PartitionSpec(FileSystemSpec, total=False):
+    name: str
+    size: int

--- a/subiquity/common/filesystem/spec.py
+++ b/subiquity/common/filesystem/spec.py
@@ -45,7 +45,7 @@ VolGroupSpec = TypedDict(
         "name": Required[str],
         "devices": set[Any],
         "passphrase": str,
-        "recovery-key": RecoveryKeyHandler | None,
+        "recovery-key": RecoveryKeyHandler,
     },
     total=False,
 )
@@ -54,9 +54,9 @@ VolGroupSpec = TypedDict(
 FileSystemSpec = TypedDict(
     "FileSystemSpec",
     {
-        "fstype": str | None,
+        "fstype": str | None,  # Sometimes, we explicitly do fstype=None
         "mount": str | None,
-        "wipe": str | None,
+        "wipe": str | None,  # NOTE: no wipe is different from wipe=None
         "use_swap": bool,
         "on-remote-storage": bool,
     },

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -587,7 +587,7 @@ class _Formattable(ABC):
         return self._fs.fstype
 
     @property
-    def mount(self):
+    def mount(self) -> Optional[str]:
         if not self._fs or not self._fs._mount:
             return None
         return self._fs._mount.path

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1256,9 +1256,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             requested_size = data.gap.size
         # empty string is an unformatted partition
         fstype = data.partition.format or None
-        spec: FileSystemSpec = {
-            "size": requested_size,
-        }
+        spec: FileSystemSpec = {}
 
         if fstype is not None:
             spec["fstype"] = fstype


### PR DESCRIPTION
Storage "specs" are deprecated but they exist today and it is difficult to know what variables are expected to be present. By using typing.TypedDict, we can make it more explicit what keys are expected and what types.

Running the type checker after the change revealed the following error so I added a FIXME at first (and finally removed the "size" key)

```
subiquity/server/controllers/filesystem.py:1259: error: Extra key "size" for TypedDict "FileSystemSpec"  [typeddict-unknown-key]
```