### PR TITLE
storage: use probert to determine if firmware supports NVMe/TCP booting

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -212,7 +212,7 @@ parts:
 
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: f34ae3c3f942a9c479fe928911053a302e146251
+    source-commit: 83d25c873a4a7d93c158d76da86cb9c612c29572
 
     override-build: *pyinstall
 

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -152,6 +152,15 @@ returned. """,
     parser.add_argument(
         "--postinst-hooks-dir", default="/etc/subiquity/postinst.d", type=pathlib.Path
     )
+    parser.add_argument(
+        "--supports-nvme-tcp-booting", action="store_true", default=None
+    )
+    parser.add_argument(
+        "--no-supports-nvme-tcp-booting",
+        action="store_false",
+        default=None,
+        dest="supports_nvme_tcp_booting",
+    )
     return parser
 
 

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -323,6 +323,16 @@ class API:
             def GET() -> str:
                 ...
 
+        class supports_nvme_tcp_booting:
+            def GET(wait: bool = False) -> Optional[bool]:
+                """Tells whether the firmware supports booting with NVMe/TCP.
+                If Subiquity hasn't yet determined if NVMe/TCP booting is
+                supported, the response will vary based on the value of wait:
+                * if wait is True, then Subiquity will send the response once
+                it has figured out.
+                * if wait is False, then Subiquity will return None.
+                """
+
         class v2:
             def GET(
                 wait: bool = False,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1099,6 +1099,19 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def generate_recovery_key_GET(self) -> str:
         return self.model.generate_recovery_key()
 
+    async def supports_nvme_tcp_booting_GET(self, wait: bool = False) -> Optional[bool]:
+        if self.app.opts.supports_nvme_tcp_booting is not None:
+            # No need to wait for the task to finish if the CLI arg is present.
+            return self.supports_nvme_tcp_booting
+
+        if wait:
+            await self._probe_firmware_task.wait()
+
+        if not self._probe_firmware_task.done():
+            return None
+
+        return self.supports_nvme_tcp_booting
+
     async def v2_GET(
         self,
         wait: bool = False,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -311,6 +311,19 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.queued_probe_data: Optional[Dict[str, Any]] = None
         self.reset_partition_only: bool = False
 
+        # If needed, this can be moved outside of the storage/filesystem stuff.
+        self._probe_firmware_task = SingleInstanceTask(self._probe_firmware)
+
+        self.firmware_supports_nvme_tcp_booting: Optional[bool] = None
+
+    @property
+    def supports_nvme_tcp_booting(self) -> bool:
+        if self.app.opts.supports_nvme_tcp_booting is not None:
+            return self.app.opts.supports_nvme_tcp_booting
+
+        assert self.firmware_supports_nvme_tcp_booting is not None
+        return self.firmware_supports_nvme_tcp_booting
+
     def is_core_boot_classic(self):
         return self._info.is_core_boot_classic()
 
@@ -520,6 +533,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def apply_autoinstall_config(self, context=None):
         await self._start_task
         await self._probe_task.wait()
+        await self._probe_firmware_task.wait()
         await self._examine_systems_task.wait()
         if False in self._errors:
             raise self._errors[False][0]
@@ -822,6 +836,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             if wait:
                 await self._start_task
                 await self._probe_task.wait()
+                await self._probe_firmware_task.wait()
             else:
                 return resp_cls(status=ProbeStatus.PROBING)
         if True in self._errors:
@@ -1423,6 +1438,29 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 self.start_monitor()
             break
 
+    async def _probe_firmware(self) -> None:
+        fw = await self.app.prober.get_firmware()
+
+        log.debug("detected firmware information: %s", fw)
+
+        edk2_timberland_sig = {
+            "bios-vendor": "EFI Development Kit II / OVMF",
+            "bios-version": "0.0.0",
+            "bios-release-date": "02/06/2015",
+        }
+
+        if set(edk2_timberland_sig.items()).issubset(set(fw.items())):
+            log.debug("firmware seems to support booting with NVMe/TCP")
+            assume_supported = True
+        else:
+            log.debug("firmware does not seem to support booting with NVMe/TCP")
+            assume_supported = False
+
+        if self.app.opts.supports_nvme_tcp_booting != assume_supported:
+            log.debug("but CLI argument states otherwise, so ignoring")
+
+        self.firmware_supports_nvme_tcp_booting = assume_supported
+
     def get_bootable_matching_disk(
         self, match: dict[str, str] | Sequence[dict[str, str]]
     ):
@@ -1613,6 +1651,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
     async def _start(self):
         await self._probe_task.start()
+        await self._probe_firmware_task.start()
 
     def start_monitor(self):
         if self._configured:

--- a/subiquitycore/prober.py
+++ b/subiquitycore/prober.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import logging
+from typing import Any
 
 import yaml
 from probert.network import StoredDataObserver, UdevObserver
@@ -63,3 +64,9 @@ class Prober:
             )
 
         return await run_in_thread(run_probert, probe_types)
+
+    async def get_firmware(self) -> dict[str, Any]:
+        from probert.firmware import FirmwareProber
+
+        prober = FirmwareProber()
+        return await prober.probe()


### PR DESCRIPTION
Using the new probert-firmware, we now check if the firmware happens to be EDK II built using the timberland-sig tree. Of course, this won't be enough going forward because not all firmware that support NVMe/TCP booting will be EDK II ; but it should be enough for the PoC with EDK2.

Alternatively, one can supply the --[no-]supports-nvme-tcp-booting to act as if the firmware did/did not support NVMe/TCP booting.

Depends on canonical/probert#149