### PR TITLE
NVMe/TCP - disable bootfs & ESP restrictions if NVMe/TCP booting is supported

### DIFF
--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -269,7 +269,11 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
             await self.app.next_screen(coro)
             return
         status = await self.app.wait_with_progress(coro)
-        self.model = FilesystemModel(status.bootloader, root="/")
+        # Technically, we don't know if NVMe/TCP support was detected or
+        # specified on CLI ; but that's okay.
+        self.model = FilesystemModel(
+            status.bootloader, root="/", opt_supports_nvme_tcp_booting=False
+        )
         self.model.load_server_data(status)
         if self.model.bootloader == Bootloader.PREP:
             self.supports_resilient_boot = False

--- a/subiquity/client/controllers/filesystem.py
+++ b/subiquity/client/controllers/filesystem.py
@@ -61,6 +61,11 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
             assert self.current_view is not None
             return self.current_view
 
+        # Move somewhere else, maybe?
+        self.supports_nvme_tcp_booting = (
+            await self.endpoint.supports_nvme_tcp_booting.GET(wait=True)
+        )
+
         status: GuidedStorageResponseV2 = await self.endpoint.v2.guided.GET()
         if status.status == ProbeStatus.PROBING:
             run_bg_task(self._wait_for_probing())
@@ -272,7 +277,9 @@ class FilesystemController(SubiquityTuiController, FilesystemManipulator):
         # Technically, we don't know if NVMe/TCP support was detected or
         # specified on CLI ; but that's okay.
         self.model = FilesystemModel(
-            status.bootloader, root="/", opt_supports_nvme_tcp_booting=False
+            status.bootloader,
+            root="/",
+            opt_supports_nvme_tcp_booting=self.supports_nvme_tcp_booting,
         )
         self.model.load_server_data(status)
         if self.model.bootloader == Bootloader.PREP:

--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -336,7 +336,7 @@ def can_be_boot_device(device, *, resize_partition=None, with_reformatting=False
 
 @can_be_boot_device.register(Disk)
 def _can_be_boot_device_disk(disk, *, resize_partition=None, with_reformatting=False):
-    if disk.on_remote_storage():
+    if disk.on_remote_storage() and not disk._m.supports_nvme_tcp_booting:
         return False
     if with_reformatting:
         disk = disk._reformatted()

--- a/subiquity/common/filesystem/tests/test_boot.py
+++ b/subiquity/common/filesystem/tests/test_boot.py
@@ -1,0 +1,51 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest import mock
+
+from subiquity.common.filesystem.boot import _can_be_boot_device_disk
+from subiquity.models.tests.test_filesystem import make_model_and_disk
+from subiquitycore.tests.parameterized import parameterized
+
+
+class TestCanBeBootDevice(unittest.TestCase):
+    @parameterized.expand(
+        (
+            (False, True),
+            (True, False),
+        )
+    )
+    def test__can_be_boot_device_disk(
+        self,
+        on_remote_storage: bool,
+        expect_can_be_boot_device: bool,
+    ):
+        model, disk = make_model_and_disk()
+
+        p_on_remote_storage = mock.patch.object(
+            disk, "on_remote_storage", return_value=on_remote_storage
+        )
+        p_get_boot_device_plan = mock.patch(
+            "subiquity.common.filesystem.boot.get_boot_device_plan", return_value=True
+        )
+
+        with p_on_remote_storage, p_get_boot_device_plan as m_gbdp:
+            self.assertEqual(expect_can_be_boot_device, _can_be_boot_device_disk(disk))
+
+        if not on_remote_storage:
+            m_gbdp.assert_called_once_with(disk, resize_partition=None)
+        else:
+            m_gbdp.assert_not_called()

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1480,11 +1480,22 @@ class FilesystemModel:
         else:
             return Bootloader.BIOS
 
-    def __init__(self, bootloader=None, *, root: str):
+    def __init__(
+        self,
+        bootloader=None,
+        *,
+        root: str,
+        opt_supports_nvme_tcp_booting: bool | None = None,
+        detected_supports_nvme_tcp_booting: bool | None = None,
+    ):
         if bootloader is None:
             bootloader = self._probe_bootloader()
         self.bootloader = bootloader
         self.root = root
+        self.opt_supports_nvme_tcp_booting: bool | None = opt_supports_nvme_tcp_booting
+        self.detected_supports_nvme_tcp_booting: bool | None = (
+            detected_supports_nvme_tcp_booting
+        )
         self.storage_version = 1
         self._probe_data = None
         self.dd_target: Optional[Disk] = None
@@ -1507,11 +1518,25 @@ class FilesystemModel:
         # the original state.  _orig_config plays a similar role, but is
         # expressed in terms of curtin actions, which are not what we want to
         # use on the V2 storage API.
-        orig_model = FilesystemModel(self.bootloader, root=self.root)
+        orig_model = FilesystemModel(
+            self.bootloader,
+            root=self.root,
+            opt_supports_nvme_tcp_booting=self.opt_supports_nvme_tcp_booting,
+            detected_supports_nvme_tcp_booting=self.detected_supports_nvme_tcp_booting,
+        )
+
         orig_model.target = self.target
         if self._probe_data is not None:
             orig_model.load_probe_data(self._probe_data)
         return orig_model
+
+    @property
+    def supports_nvme_tcp_booting(self) -> bool:
+        if self.opt_supports_nvme_tcp_booting is not None:
+            return self.opt_supports_nvme_tcp_booting
+
+        assert self.detected_supports_nvme_tcp_booting is not None
+        return self.detected_supports_nvme_tcp_booting
 
     def process_probe_data(self):
         self._orig_config = storage_config.extract_storage_config(self._probe_data)[

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2291,13 +2291,15 @@ class FilesystemModel:
     def is_bootfs_on_remote_storage(self) -> bool:
         return self._mount_for_path("/boot").device.volume.on_remote_storage()
 
+    def _can_install_remote(self) -> bool:
+        return self.is_boot_mounted() and not self.is_bootfs_on_remote_storage()
+
     def can_install(self) -> bool:
         if not self.is_root_mounted():
             return False
 
-        if self.is_rootfs_on_remote_storage():
-            if not self.is_boot_mounted() or self.is_bootfs_on_remote_storage():
-                return False
+        if self.is_rootfs_on_remote_storage() and not self._can_install_remote():
+            return False
 
         if self.needs_bootloader_partition():
             return False

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2292,6 +2292,15 @@ class FilesystemModel:
         return self._mount_for_path("/boot").device.volume.on_remote_storage()
 
     def _can_install_remote(self) -> bool:
+        """Tells whether installing with the rootfs on remote storage would be
+        a supported use-case with the current configuration.
+        It requires either:
+         * firmware support for booting with NVMe/TCP
+         * the boot FS (i.e., kernel + initramfs) to be stored on local storage.
+        """
+        if self.supports_nvme_tcp_booting:
+            return True
+
         return self.is_boot_mounted() and not self.is_bootfs_on_remote_storage()
 
     def can_install(self) -> bool:

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -170,7 +170,15 @@ class SubiquityModel:
     target = "/target"
     chroot_prefix = ["chroot", target]
 
-    def __init__(self, root, hub, install_model_names, postinstall_model_names):
+    def __init__(
+        self,
+        root,
+        hub,
+        install_model_names,
+        postinstall_model_names,
+        *,
+        opt_supports_nvme_tcp_booting: bool | None = None,
+    ):
         self.root = root
         self.hub = hub
         if root != "/":
@@ -184,7 +192,9 @@ class SubiquityModel:
         self.codecs = CodecsModel()
         self.debconf_selections = DebconfSelectionsModel()
         self.drivers = DriversModel()
-        self.filesystem = FilesystemModel(root=root)
+        self.filesystem = FilesystemModel(
+            root=root, opt_supports_nvme_tcp_booting=opt_supports_nvme_tcp_booting
+        )
         self.identity = IdentityModel()
         self.integrity = IntegrityModel()
         self.kernel = KernelModel()

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -316,14 +316,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
         self.firmware_supports_nvme_tcp_booting: Optional[bool] = None
 
-    @property
-    def supports_nvme_tcp_booting(self) -> bool:
-        if self.app.opts.supports_nvme_tcp_booting is not None:
-            return self.app.opts.supports_nvme_tcp_booting
-
-        assert self.firmware_supports_nvme_tcp_booting is not None
-        return self.firmware_supports_nvme_tcp_booting
-
     def is_core_boot_classic(self):
         return self._info.is_core_boot_classic()
 
@@ -1100,9 +1092,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         return self.model.generate_recovery_key()
 
     async def supports_nvme_tcp_booting_GET(self, wait: bool = False) -> Optional[bool]:
-        if self.app.opts.supports_nvme_tcp_booting is not None:
+        if self.model.opt_supports_nvme_tcp_booting is not None:
             # No need to wait for the task to finish if the CLI arg is present.
-            return self.supports_nvme_tcp_booting
+            return self.model.supports_nvme_tcp_booting
 
         if wait:
             await self._probe_firmware_task.wait()
@@ -1110,7 +1102,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if not self._probe_firmware_task.done():
             return None
 
-        return self.supports_nvme_tcp_booting
+        return self.model.supports_nvme_tcp_booting
 
     async def v2_GET(
         self,
@@ -1469,10 +1461,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             log.debug("firmware does not seem to support booting with NVMe/TCP")
             assume_supported = False
 
-        if self.app.opts.supports_nvme_tcp_booting != assume_supported:
+        if self.model.opt_supports_nvme_tcp_booting != assume_supported:
             log.debug("but CLI argument states otherwise, so ignoring")
 
-        self.firmware_supports_nvme_tcp_booting = assume_supported
+        self.model.detected_supports_nvme_tcp_booting = assume_supported
 
     def get_bootable_matching_disk(
         self, match: dict[str, str] | Sequence[dict[str, str]]

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1461,7 +1461,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             log.debug("firmware does not seem to support booting with NVMe/TCP")
             assume_supported = False
 
-        if self.model.opt_supports_nvme_tcp_booting != assume_supported:
+        if self.model.opt_supports_nvme_tcp_booting not in (None, assume_supported):
             log.debug("but CLI argument states otherwise, so ignoring")
 
         self.model.detected_supports_nvme_tcp_booting = assume_supported

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -145,7 +145,7 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
         with mock.patch.object(self.app.prober, "get_firmware", return_value=fw):
             await self.fsc._probe_firmware()
-        self.assertFalse(self.fsc.firmware_supports_nvme_tcp_booting)
+        self.assertFalse(self.fsc.model.detected_supports_nvme_tcp_booting)
 
     async def test__probe_firmware__nvme_tcp_support(self):
         fw = {
@@ -156,24 +156,7 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
         with mock.patch.object(self.app.prober, "get_firmware", return_value=fw):
             await self.fsc._probe_firmware()
-        self.assertTrue(self.fsc.firmware_supports_nvme_tcp_booting)
-
-    @parameterized.expand(
-        (
-            (None, False, False),
-            (None, True, True),
-            (True, True, True),
-            (True, False, True),
-            (False, True, False),
-            (False, False, False),
-        )
-    )
-    def test_supports_nvme_tcp_booting(
-        self, opt: bool | None, firmware: bool, expected: bool
-    ):
-        self.app.opts.supports_nvme_tcp_booting = opt
-        self.fsc.firmware_supports_nvme_tcp_booting = firmware
-        self.assertEqual(expected, self.fsc.supports_nvme_tcp_booting)
+        self.assertTrue(self.fsc.model.detected_supports_nvme_tcp_booting)
 
     async def test_layout_no_grub_or_swap(self):
         self.fsc.model = model = make_model(Bootloader.UEFI)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -287,7 +287,11 @@ class SubiquityServer(Application):
         if self.opts.dry_run:
             root = os.path.abspath(self.opts.output_base)
         return SubiquityModel(
-            root, self.hub, INSTALL_MODEL_NAMES, POSTINSTALL_MODEL_NAMES
+            root,
+            self.hub,
+            INSTALL_MODEL_NAMES,
+            POSTINSTALL_MODEL_NAMES,
+            opt_supports_nvme_tcp_booting=self.opts.supports_nvme_tcp_booting,
         )
 
     def __init__(self, opts, block_log_dir):

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -488,7 +488,10 @@ class FilesystemView(BaseView):
         todos = []
         if not self.model.is_root_mounted():
             todos.append(_("Mount a filesystem at /"))
-        elif self.model.is_rootfs_on_remote_storage():
+        elif (
+            self.model.is_rootfs_on_remote_storage()
+            and not self.model.supports_nvme_tcp_booting
+        ):
             # We need a /boot partition on local storage
             if (
                 not self.model.is_boot_mounted()


### PR DESCRIPTION
Currently, when installing to a NVMe/TCP drive, the bootfs and ESP must be placed on local storage. When the firmware supports NVMe/TCP booting though, we should drop this restriction. 