### PR TITLE
merge "snapcraft: rev curtin for wipefs fix" for noble

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: c66faffeea657c70374479d62fce32965ff7ac31
+    source-commit: 7fbc96a413ed4a85370edbdb4e7bfa456c350346
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Obtain a newer version of curtin for fixes for LP:#2061073, which involve a fix for a failed sysfs read after a data race with the kernel.

(cherry picked from commit ed0eb4c32580e943eac81eeb2e77ab470ae01941)

Merging this picks up additional changes to curtin (c66faff..7fbc96a):
* support for removing kernels (unused on this branch as Subiquity does not yet have the matching config opt-in)
* AzureLinux support
* changes related to test runs on Noble that don't affect the curtin runtime
* a readme update
