### PR TITLE
scripts: add script to inject ProbeData.txt into existing machine-config

### DIFF
--- a/scripts/inject-probe-data.py
+++ b/scripts/inject-probe-data.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+"""Bugs filed against Subiquity on Launchpad include a file named
+"ProbeData.txt" ; which contains the storage data extracted by probert.
+Some of the bugs can easily be reproduced in dry-run mode if we feed the
+storage data back to Subiquity. To do so, we can replace the "storage" section
+of the machine-config with the contents of ProbeData.txt.
+
+This script is meant to simplify this process.
+"""
+
+import argparse
+import contextlib
+import json
+import sys
+
+
+def parse_cmdline() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                     description=__doc__)
+
+    parser.add_argument("--storage-probe-data", type=argparse.FileType("r"), default="ProbeData.txt",
+                        help="Path to the ProbeData.txt file.")
+    parser.add_argument("--machine-config", type=argparse.FileType("r"), default="examples/machines/simple.json",
+                        help="Read machine-config from the specified file.")
+    parser.add_argument("--overwrite-machine-config", action="store_true",
+                        help="Overwrite machine-config file rather than printing to stdout.")
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_cmdline()
+
+    storage_data = json.load(args.storage_probe_data)
+    machine_config = json.load(args.machine_config)
+
+    machine_config["storage"] = storage_data
+
+    if args.overwrite_machine_config:
+        context = open(args.machine_config.name, mode="w",
+                       encoding=args.machine_config.encoding)
+    else:
+        context = contextlib.nullcontext(sys.stdout)
+
+    with context as stream:
+        json.dump(machine_config, stream, indent=4),
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The script can be used to inject a ProbeData.txt file into an existing machine-config file.

By default, it will:
 * read the storage probe data from a file named ProbeData.txt in the current directory
 * read the machine-config from examples/machines/simple.json
 * write the resulting machine-config to stdout

The path to ProbeData.txt can be specified using the --storage-probe-data option.
The patch to the machine-config can be specified using the --machine-config option.
The --overwrite option can be passed to overwrite the original machine-config.

examples:
```
 $ scripts/inject-probe-data.py \
    --storage-probe-data ProbeData.txt \
    --machine-config examples/machines/virtio.json
    --overwrite
```
```
 $ scripts/inject-probe-data.txt > simple-with-injected-storage.txt
```