### PR TITLE
storage: don't suggest use-gap if we can't fit more partitions

### DIFF
--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -63,6 +63,9 @@ class MakeBootDevicePlan(abc.ABC):
     this a boot device" in sync.
     """
 
+    def new_partition_count(self) -> int:
+        return 0
+
     @abc.abstractmethod
     def apply(self, manipulator):
         pass
@@ -76,6 +79,10 @@ class CreatePartPlan(MakeBootDevicePlan):
 
     spec: dict = attr.ib(factory=dict)
     args: dict = attr.ib(factory=dict)
+
+    # TODO add @typing.override decorator when we switch to core24.
+    def new_partition_count(self) -> int:
+        return 1
 
     def apply(self, manipulator):
         manipulator.create_partition(self.gap.device, self.gap, self.spec, **self.args)
@@ -155,6 +162,10 @@ class MultiStepPlan(MakeBootDevicePlan):
     def apply(self, manipulator):
         for plan in self.plans:
             plan.apply(manipulator)
+
+    # TODO add @typing.override decorator when we switch to core24.
+    def new_partition_count(self) -> int:
+        return sum([plan.new_partition_count() for plan in self.plans])
 
 
 def get_boot_device_plan_bios(device) -> Optional[MakeBootDevicePlan]:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1154,6 +1154,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if probe_resp is not None:
             return probe_resp
 
+        # TODO We should probably use temporary copies of the storage model and
+        # try to apply each scenario that we want to return. If an error is
+        # encountered when applying a scenario, we should skip it and log why.
+        # This should avoid problems such as "Exceeded number of available
+        # partitions" that we struggle to manually anticipate.
         scenarios = []
         install_min = self.calculate_suggested_install_min()
 


### PR DESCRIPTION
If a disk has already reached its limit of (primary) partitions, suggesting a use-gap scenario can only lead to failures. In the same vein, if a disk only has room for one more partition but we also need to add an ESP, the scenario would fail to apply too.

We now try to prevent Subiquity from suggesting such, bad, use-gap scenarios ; by guessing the number of primary partitions needed ; and comparing it with the limit.

Although it isn't a perfect solution (see below), this change should hopefully address the most common problems.

What makes it difficult to properly suggest scenarios is that we do not have all the cards in hand with the current API. For instance, the user can choose to add a recovery partition, which of course influences the number of partitions required. Sadly, we don't have a way with the current API to allow a scenario without recovery partition ; while rejecting the same scenario with a recovery partition. Capabilities can also influence the number of required partitions, supposedly.

LP:#2073378