### PR TITLE
Remove simple cloudinit utilies

### DIFF
--- a/subiquity/cloudinit.py
+++ b/subiquity/cloudinit.py
@@ -3,8 +3,8 @@
 import asyncio
 import json
 import logging
-import random
 import re
+import secrets
 from collections.abc import Awaitable, Sequence
 from string import ascii_letters, digits
 from subprocess import CompletedProcess
@@ -162,8 +162,8 @@ async def validate_cloud_init_schema() -> None:
     return None
 
 
-def rand_str(strlen: int = 32, select_from: Optional[Sequence] = None) -> str:
-    r: random.SystemRandom = random.SystemRandom()
+def rand_password(strlen: int = 32, select_from: Optional[Sequence] = None) -> str:
+    r: secrets.SystemRandom = secrets.SystemRandom()
     if not select_from:
         select_from: str = ascii_letters + digits
     return "".join([r.choice(select_from) for _x in range(strlen)])
@@ -172,4 +172,4 @@ def rand_str(strlen: int = 32, select_from: Optional[Sequence] = None) -> str:
 # Generate random user passwords the same way cloud-init does
 # https://github.com/canonical/cloud-init/blob/6e4153b346bc0d3f3422c01a3f93ecfb28269da2/cloudinit/config/cc_set_passwords.py#L249  # noqa: E501
 def rand_user_password(pwlen: int = 20) -> str:
-    return rand_str(strlen=pwlen, select_from=CLOUD_INIT_PW_SET)
+    return rand_password(strlen=pwlen, select_from=CLOUD_INIT_PW_SET)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -24,7 +24,6 @@ from typing import Any, List, Optional
 import jsonschema
 import yaml
 from aiohttp import web
-from cloudinit.config.cc_set_passwords import rand_user_password
 from jsonschema.exceptions import ValidationError
 from systemd import journal
 
@@ -32,6 +31,7 @@ from subiquity.cloudinit import (
     CloudInitSchemaValidationError,
     cloud_init_status_wait,
     get_host_combined_cloud_config,
+    rand_user_password,
     validate_cloud_init_schema,
 )
 from subiquity.common.api.server import bind, controller_for_request

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -873,9 +873,18 @@ class SubiquityServer(Application):
         if autoinstall != {}:
             log.debug("autoinstall found in cloud-config")
             target = self.base_relative(cloud_autoinstall_path)
-            from cloudinit import safeyaml
 
-            write_file(target, safeyaml.dumps(autoinstall))
+            ai_yaml: str = yaml.dump(
+                autoinstall,
+                line_break="\n",
+                indent=4,
+                explicit_start=True,
+                explicit_end=True,
+                default_flow_style=False,
+                Dumper=yaml.dumper.SafeDumper,
+            )
+
+            write_file(target, ai_yaml)
         else:
             log.debug("no autoinstall found in cloud-config")
 

--- a/subiquity/tests/test_cloudinit.py
+++ b/subiquity/tests/test_cloudinit.py
@@ -24,7 +24,7 @@ from subiquity.cloudinit import (
     cloud_init_status_wait,
     cloud_init_version,
     get_schema_failure_keys,
-    rand_str,
+    rand_password,
     rand_user_password,
     read_json_extended_status,
     read_legacy_status,
@@ -238,13 +238,13 @@ class TestCloudInitRandomStrings(SubiTestCase):
 
     def test_rand_string_generation(self):
         # random string is 32 characters by default
-        password = rand_str()
+        password = rand_password()
         self.assertEqual(len(password), 32)
 
         # password is requested length
-        password = rand_str(strlen=20)
+        password = rand_password(strlen=20)
         self.assertEqual(len(password), 20)
 
         # password characters sampled from provided set
         choices = ["a"]
-        self.assertEqual("a" * 32, rand_str(select_from=choices))
+        self.assertEqual("a" * 32, rand_password(select_from=choices))

--- a/subiquity/tests/test_cloudinit.py
+++ b/subiquity/tests/test_cloudinit.py
@@ -19,10 +19,13 @@ from unittest import skipIf
 from unittest.mock import Mock, patch
 
 from subiquity.cloudinit import (
+    CLOUD_INIT_PW_SET,
     CloudInitSchemaValidationError,
     cloud_init_status_wait,
     cloud_init_version,
     get_schema_failure_keys,
+    rand_str,
+    rand_user_password,
     read_json_extended_status,
     read_legacy_status,
     supports_format_json,
@@ -215,3 +218,33 @@ class TestCloudInitSchemaValidation(SubiTestCase):
         sources = await get_schema_failure_keys()
         log_mock.warning.assert_called()
         self.assertEqual([], sources)
+
+
+class TestCloudInitRandomStrings(SubiTestCase):
+    def test_passwd_constraints(self):
+        # password is 20 characters by default
+        password = rand_user_password()
+        self.assertEqual(len(password), 20)
+
+        # password is requested length
+        password = rand_user_password(pwlen=32)
+        self.assertEqual(len(password), 32)
+
+        # passwords contain valid chars
+        # sample passwords
+        for _i in range(100):
+            password = rand_user_password()
+            self.assertTrue(all(char in CLOUD_INIT_PW_SET for char in password))
+
+    def test_rand_string_generation(self):
+        # random string is 32 characters by default
+        password = rand_str()
+        self.assertEqual(len(password), 32)
+
+        # password is requested length
+        password = rand_str(strlen=20)
+        self.assertEqual(len(password), 20)
+
+        # password characters sampled from provided set
+        choices = ["a"]
+        self.assertEqual("a" * 32, rand_str(select_from=choices))


### PR DESCRIPTION
With the goal of removing cloud-init from the subiquity snap, there are two simple utility functions we import from cloudinit that we can very quickly reimplement:

### cloudinit.safeyaml.dumps 

safeyaml.dumps is a simple wrapper around yaml.dump with safe defaults. We only call it in one place, so I've opted to just replace the safeyaml.dumps call with the equivalent yaml.dump call.

### cloudinit.config.cc_set_passwords.rand_user_password 

rand_user_password is an ascii password generator. I just copied over the implementation and added some tests. 

