### PR TITLE
No double kernel

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: b3b075c820dd744070ba287874719a2a7dd093b3
+    source-commit: 364b719e189708255ff63b95078bc4f6bcf70540
 
     override-pull: |
       craftctl default

--- a/subiquity/models/kernel.py
+++ b/subiquity/models/kernel.py
@@ -43,6 +43,88 @@ class KernelModel:
             return self.metapkg_name_override
         return self.metapkg_name
 
+    # For the purposes of size and install speed, we want the default kernel
+    # preinstalled in the source image.  There are several use cases to support
+    # around this:
+    # 1. no preinstall, no OEM kernel:
+    #    Older ISOs do not have a kernel pre-installed, so we need to continue
+    #    to be able to provide information about what kernel to install.
+    #    Curtin manages this kernel installation historically, and we aren't
+    #    changing that.
+    # 2. yes preinstall, preinstalled kernel is wrong, no OEM kernel:
+    #    Newer ISOs may have the wrong kernel pre-installed, so we need to
+    #    install the correct kernel and remove the pre-installed one.  We
+    #    continue to rely on curtin for kernel installation, with the addition
+    #    of support to remove the pre-installed kernel.  remove_existing does
+    #    the right thing here.
+    # 3. yes preinstall, preinstalled kernel is right, no OEM kernel:
+    #    Almost identical to case #2 but this time the preinstall is correct.
+    #    This is the happy path and a noticeably faster install time.  From the
+    #    subiquity perspective this is literally identical to #2, and how this
+    #    plays out is that apt has nothing to install during curthooks.
+    # 4. no preinstall, yes OEM kernel:
+    #    This is almost like case #1 but subiquity is managing the kernel
+    #    install, and it just tells curtin that no action is required.
+    # 5. yes preinstall, preinstalled kernel is wrong, yes OEM kernel:
+    #    This is similar to case #2, but the fact that subiquity manages the
+    #    kernel install before curthooks means that calculating which kernel to
+    #    remove is more complicated.  curtin needs to know which kernel was
+    #    preinstalled, and we need to figure that out before the OEM kernel
+    #    install happens.
+    # 6. yes preinstall, preinstalled kernel is right, yes OEM kernel:
+    #    A newer ISO may well have the same kernel installed that the OEM logic
+    #    wants, which means we cannot remove the pre-installed kernel.
+
+    # Understanding the next part is best done after a thorough read of
+    # curtin's ensure_one_kernel() in curtin/distro.py
+
+    # Handling:
+    # 1. no preinstall, no OEM kernel:
+    #    use "package" to specify the desired package, we set "remove_existing"
+    #    but it has nothing to do, so nothing is removed.  Curtin carries out
+    #    the actual kernel install.
+    #    config: {"package": "foo", "remove_existing": True}
+    # 2. yes preinstall, preinstalled kernel is wrong, no OEM kernel:
+    #    use "package" to specify the desired package, we set "remove_existing"
+    #    and this time it has a pre-installed package to remove.  Same config
+    #    as #1, but curtin determines a package does need to be removed and
+    #    does so.
+    #    config: {"package": "foo", "remove_existing": True}
+    # 3. yes preinstall, preinstalled kernel is right, no OEM kernel:
+    #    use "package" to specify the desired package, we set "remove_existing"
+    #    like before.  Same config as #1/#2, but curtin detects via
+    #    ensure_one_kernel that the installed kernel state before/after
+    #    installing the requested package is unchanged, so no kernel is
+    #    removed.
+    #    config: {"package": "foo", "remove_existing": True}
+    # 4. no preinstall, yes OEM kernel:
+    #    This time Subiquity is managing the kernel install, curtin should not
+    #    install anything, and curtin's ensure_one_kernel would do the right
+    #    thing but things are complicated by cases #5 and #6.
+    #    config: {"install": False, "remove": []}
+    # 5. yes preinstall, preinstalled kernel is wrong, yes OEM kernel:
+    #    Again Subiquity has installed an OEM kernel, and again curtin has
+    #    nothing to install but does need to do a remove.  Subiquity answers
+    #    the remove question by listing the kernels preinstalled and supplying
+    #    that to curtin, where ensure_one_kernel notices two kernels present
+    #    and knows which one is preinstalled, so it can do the removal.
+    #    config: {"install": False, "remove": ["foo"]}, where "foo" is the
+    #    preinstalled kernel
+    # 6. yes preinstall, preinstalled kernel is right, yes OEM kernel:
+    #    Subiquity provides the same config here as #5, but in this case the
+    #    OEM kernel install logic run by subiquity adds no new linux-image
+    #    packages, so the functional difference here is curtin's
+    #    ensure_one_kernel, like #3, has nothing to remove, it just needs a
+    #    little help to know the starting (pre-OEM kernel install) state.  This
+    #    is because curthooks run after the OEM kernel install, so the before
+    #    state that ensure_one_kernel wants has to be calculated before the OEM
+    #    kernel install.
+    #    config: {"install": False, "remove": ["foo"]}, where "foo" is the
+    #    preinstalled kernel
+    # cases 4-6 all calculate their "remove" list by listing kernels that may
+    # be present before doing the OEM kernel install, and ensure_one_kernel
+    # handles the rest.
+
     def render(self):
         kernel = {}
         if self.curthooks_install:

--- a/subiquity/models/tests/test_kernel.py
+++ b/subiquity/models/tests/test_kernel.py
@@ -1,0 +1,75 @@
+# Copyright 2022 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from subiquity.models.kernel import KernelModel
+from subiquitycore.tests import SubiTestCase
+
+
+class TestKernelModel(SubiTestCase):
+    def setUp(self):
+        self.model = KernelModel()
+
+    def testInstall(self):
+        kernel = "kernel-a"
+        self.model.metapkg_name = kernel
+        expected = {
+            "kernel": {
+                "package": "kernel-a",
+                "remove_existing": True,
+            }
+        }
+
+        self.assertEqual(expected, self.model.render())
+
+    def testNoInstall(self):
+        kernel = "kernel-a"
+        self.model.metapkg_name = kernel
+        self.model.curthooks_install = False
+        expected = {
+            "kernel": {
+                "install": False,
+                "remove_existing": True,
+            }
+        }
+
+        self.assertEqual(expected, self.model.render())
+
+    def testNoInstallRemoveGeneric(self):
+        kernel = "kernel-a"
+        self.model.metapkg_name = kernel
+        self.model.curthooks_install = False
+        self.model.remove = [kernel]
+        expected = {
+            "kernel": {
+                "install": False,
+                "remove": [kernel],
+            }
+        }
+
+        self.assertEqual(expected, self.model.render())
+
+    def testInstallAndRemove(self):
+        install_kernel = "kernel-a"
+        remove_kernel = "kernel-b"
+        self.model.metapkg_name = install_kernel
+        self.model.remove = [remove_kernel]
+        expected = {
+            "kernel": {
+                "package": install_kernel,
+                "remove": [remove_kernel],
+            }
+        }
+
+        self.assertEqual(expected, self.model.render())

--- a/subiquity/server/controllers/oem.py
+++ b/subiquity/server/controllers/oem.py
@@ -21,6 +21,7 @@ from subiquity.common.apidef import API
 from subiquity.common.types import OEMResponse
 from subiquity.models.oem import OEMMetaPkg
 from subiquity.server.apt import OverlayCleanupError
+from subiquity.server.autoinstall import AutoinstallError
 from subiquity.server.controller import SubiquityController
 from subiquity.server.curtin import run_curtin_command
 from subiquity.server.types import InstallerChannels
@@ -214,7 +215,7 @@ install.
     install: false
 """
                 )
-                raise RuntimeError(msg)
+                raise AutoinstallError(msg)
 
     @with_context()
     async def apply_autoinstall_config(self, context) -> None:

--- a/subiquity/server/controllers/oem.py
+++ b/subiquity/server/controllers/oem.py
@@ -23,7 +23,6 @@ from subiquity.models.oem import OEMMetaPkg
 from subiquity.server.apt import OverlayCleanupError
 from subiquity.server.controller import SubiquityController
 from subiquity.server.curtin import run_curtin_command
-from subiquity.server.kernel import flavor_to_pkgname
 from subiquity.server.types import InstallerChannels
 from subiquity.server.ubuntu_drivers import (
     CommandNotFoundError,
@@ -183,10 +182,7 @@ class OEMController(SubiquityController):
         for pkg in self.model.metapkgs:
             if pkg.wants_oem_kernel:
                 kernel_model = self.app.base_model.kernel
-                kernel_model.metapkg_name_override = flavor_to_pkgname(
-                    pkg.name, dry_run=self.app.opts.dry_run
-                )
-
+                kernel_model.metapkg_name_override = pkg.name
                 log.debug("overriding kernel flavor because of OEM")
 
         log.debug("OEM meta-packages to install: %s", self.model.metapkgs)


### PR DESCRIPTION
Fixes the problem of ending up with 2 kernels installed that can be seen on the OEM codepath if the kernel is preinstalled in the source image.  Works by telling curtin what to remove, since we can get the preinstalled kernel before we start installing the OEM one.

Requires ~~https://code.launchpad.net/~dbungert/curtin/+git/curtin/+merge/469886~~ (meged)

Fixes other unrelated issues
* fix specification of the oem kernel package name - was unused but it should still be the correct value
* fix a corner case where if OEM metapackage installation is requested and a kernel is requested in autoinstall and they match, don't fail that case
* Update the exception where there is an oem/kernel autoinstall conflict to AutoinstallError