### PR TITLE
Drop reference to discourse

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,7 +55,6 @@ Get started:
 
 Discuss:
   * IRC: `Libera.Chat`_, the *#ubuntu-server* channel
-  * Discourse: `Ubuntu Foundations`_
 
 Contribute:
   * `Contribution guidelines`_ on GitHub


### PR DESCRIPTION
Per https://discourse.ubuntu.com/t/supporting-users/20: "The Ubuntu Discourse is not a space for technical support"