### PR TITLE
guided: set _netdev more consistently (including when doing guided)

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -56,9 +56,7 @@ class FilesystemManipulator:
     def create_mount(self, fs, spec: FileSystemSpec):
         if spec.get("mount") is None:
             return
-        mount = self.model.add_mount(
-            fs, spec["mount"], on_remote_storage=spec.get("on-remote-storage", False)
-        )
+        mount = self.model.add_mount(fs, spec["mount"])
         if self.model.needs_bootloader_partition():
             vol = fs.volume
             if vol.type == "partition" and boot.can_be_boot_device(vol.device):
@@ -290,9 +288,6 @@ class FilesystemManipulator:
     ):
         log.debug("partition_disk_handler: %s %s %s %s", disk, spec, partition, gap)
 
-        if disk.on_remote_storage():
-            spec["on-remote-storage"] = True
-
         if partition is not None:
             if "size" in spec and spec["size"] != partition.size:
                 trailing, gap_size = gaps.movable_trailing_partitions_and_gap_size(
@@ -346,9 +341,6 @@ class FilesystemManipulator:
         lv = partition
 
         log.debug("logical_volume_handler: %s %s %s", vg, lv, spec)
-
-        if vg.on_remote_storage():
-            spec["on-remote-storage"] = True
 
         if lv is not None:
             if "name" in spec:

--- a/subiquity/common/filesystem/spec.py
+++ b/subiquity/common/filesystem/spec.py
@@ -64,7 +64,6 @@ FileSystemSpec = TypedDict(
         "mount": str | None,
         "wipe": str | None,  # NOTE: no wipe is different from wipe=None
         "use_swap": bool,
-        "on-remote-storage": bool,
     },
     total=False,
 )

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2241,11 +2241,11 @@ class FilesystemModel:
             raise Exception("can only remove unmounted filesystem")
         self._remove(fs)
 
-    def add_mount(self, fs, path, *, on_remote_storage=False):
+    def add_mount(self, fs: Filesystem, path):
         if fs._mount is not None:
             raise Exception(f"{fs} is already mounted")
         options = None
-        if on_remote_storage:
+        if fs.volume.on_remote_storage():
             options = "defaults,_netdev"
         m = Mount(m=self, device=fs, path=path, options=options)
         self._actions.append(m)


### PR DESCRIPTION
When using the text-installer with NVMe/TCP, selecting a NVMe drive in the guided page results in the absence of _netdev option for the filesystems. This makes curtin unaware that we want a NVMe/TCP setup and therefore eventually prevents booting.

~~Ensure _netdev is properly set in this scenario.~~

~~Going forward, we should set this option in every scenarios where we create a filesystem on remote storage. But for now, let's keep things simple.~~

~~Marking as a draft because I want to experiment with encryption and LVM~~