### PR TITLE
Fixes related to debug shell in non-async context

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -571,7 +571,7 @@ class SubiquityClient(TuiApplication):
             if not self.ui.right_icon.current_help:
                 self.ui.right_icon.open_pop_up()
         elif key in ["ctrl z", "f2"]:
-            self.debug_shell()
+            self.request_debug_shell()
         elif self.opts.dry_run:
             self.unhandled_input_dry_run(key)
         else:

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -370,6 +370,7 @@ class SubiquityClient(TuiApplication):
                 )
             if not status.cloud_init_ok:
                 self.add_global_overlay(CloudInitFail(self))
+                run_bg_task(self.redraw_screen())
             self.error_reporter.load_reports()
             for report in self.error_reporter.reports:
                 if report.kind == ErrorReportKind.UI and not report.seen:

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -604,6 +604,14 @@ class SubiquityClient(TuiApplication):
             cmd, env=env, before_hook=_before, after_hook=after_hook, cwd="/"
         )
 
+    def request_debug_shell(self, after_hook=None, *, redraw=True) -> None:
+        async def debug_shell_and_redraw():
+            await self.debug_shell(after_hook)
+            if redraw:
+                await self.redraw_screen()
+
+        run_bg_task(debug_shell_and_redraw())
+
     def note_file_for_apport(self, key, path):
         self.error_reporter.note_file_for_apport(key, path)
 

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -515,7 +515,7 @@ class NonReportableErrorStretchy(Stretchy):
         return widgets
 
     def debug_shell(self, sender):
-        self.app.debug_shell()
+        self.app.request_debug_shell()
 
     def restart(self, sender):
         self.app.restart(restart_server=True)

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -339,11 +339,7 @@ class ErrorReportStretchy(Stretchy):
         await self.app.redraw_screen()
 
     def debug_shell(self, sender):
-        async def debug_shell_and_redraw():
-            await self.app.debug_shell()
-            await self.app.redraw_screen()
-
-        run_bg_task(debug_shell_and_redraw())
+        self.app.request_debug_shell()
 
     def restart(self, sender):
         self.app.restart(restart_server=True)

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -509,11 +509,7 @@ class HelpMenu(PopUpLauncher):
         self._show_overlay(GlobalKeyStretchy(self.app))
 
     def debug_shell(self, sender):
-        async def debug_shell_and_redraw():
-            await self.app.debug_shell()
-            await self.app.redraw_screen()
-
-        run_bg_task(debug_shell_and_redraw())
+        self.app.request_debug_shell()
 
     def toggle_rich(self, sender):
         self.app.toggle_rich()

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -326,4 +326,4 @@ class InstallRunning(Stretchy):
         self.btn.enabled = True
 
     def _debug_shell(self, sender):
-        self.app.debug_shell()
+        self.app.request_debug_shell()

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -123,7 +123,7 @@ class CloudInitFail(Stretchy):
         super().__init__("", widgets, stretchy_index=0, focus_index=2)
 
     def _debug_shell(self, sender):
-        self.app.debug_shell()
+        self.app.request_debug_shell()
 
     def _close(self, sender):
         self.app.remove_global_overlay(self)

--- a/subiquitycore/tui.py
+++ b/subiquitycore/tui.py
@@ -252,6 +252,14 @@ class TuiApplication(Application):
             self.ui.set_body(view)
 
     async def redraw_screen(self):
+        if self.urwid_loop is None:
+            # This should only happen very early on ; but there is probably no
+            # point calling redraw_screen that early, right?
+            return
+        if not self.urwid_loop.screen.started:
+            # This can happen if a foreground process (e.g., bash debug shell)
+            # is running or if the installer is shutting down.
+            return
         self.urwid_loop.draw_screen()
 
     async def next_screen(self, coro=None):


### PR DESCRIPTION
If the `redraw_screen` coroutine was called while a debug shell was opened (or more rarely during the Subiquity shutdown sequence) urwid would fail with:

```
AssertionError(self._started).
```

We now ensure that we skip the redraw in that scenario. The screen gets now redrawn after the debug shell is closed anyway.

Also, while making the `debug_shell` function a coroutine function, I forgot to update some of the code that invokes it ; resulting in various `RuntimeWarning: coroutine 'SubiquityClient.debug_shell' was never awaited` errors. That should be fixed now.
