### PR TITLE
storage: add a refresh and back buttons when no disk are discovered

### DIFF
--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -377,7 +377,15 @@ class GuidedDiskSelectionView(BaseView):
                 )
             )
         else:
-            super().__init__(screen([Text(rewrap(_(no_disks)))], []))
+            super().__init__(
+                screen(
+                    [Text(rewrap(_(no_disks)))],
+                    [
+                        other_btn(_("Back"), on_press=self.cancel),
+                        other_btn(_("Refresh"), on_press=self.refresh),
+                    ],
+                )
+            )
 
     def local_help(self):
         return (_("Help on guided storage configuration"), rewrap(_(HELP)))
@@ -437,6 +445,9 @@ class GuidedDiskSelectionView(BaseView):
                 capability=GuidedCapability.MANUAL,
             )
         )
+
+    def refresh(self, sender):
+        self.controller.guided()
 
     def cancel(self, btn=None):
         self.controller.cancel()


### PR DESCRIPTION
When no disk are discovered by the storage probing operation, Subiquity used to show a screen that would not allow the user to go back or do anything useful. The screen states something along the lines of "no disks were detected, the installation will not be impossible".

Unfortunately, this means that devices that have been discovered lately cannot be used without restarting the installer. Such devices would include devices that have been hot-plugged (which is rather uncommon on Ubuntu Server) and network storage devices such as NVMe/TCP drives.

Instead of preventing the user to go back, we now show a "Back" button, allowing them to re-enter the storage screen with newly probed disks. We also add a "Refresh" button, which essentially does the does the same as re-entering the screen without going back.

This way, in the NVMe/TCP use-case, if we get to the storage screen before the NVMe drives are connected, we do not need to restart the installer. We can open a shell, run the nvme connect-all commands ; and then hit Refresh.

refs: LP:#2076332

<details>
<summary>Before (click me!)</summary>

![2024-08-08T13:00:18,115908405+02:00](https://github.com/user-attachments/assets/9df8c024-30c1-4a39-9a35-1c7947b78306)

</details>
<details>

<summary>After (click me!)</summary>

![2024-08-08T13:29:39,387599482+02:00](https://github.com/user-attachments/assets/219988e6-9736-4957-a55a-bc17f5e71e07)
-->
![2024-08-08T13:27:16,133926342+02:00](https://github.com/user-attachments/assets/a4c7453d-3379-4a85-8d28-d213d7d64f51)
-->
![2024-08-08T13:04:46,812173662+02:00](https://github.com/user-attachments/assets/f194608c-7701-40d2-9348-a05881b643a7)

</details>
