### PR TITLE
revert changes on fstype from mount

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1258,12 +1258,9 @@ class Filesystem:
 class Mount:
     path: str
     device: Filesystem = attributes.ref(backlink="_mount", default=None)
+    fstype: Optional[str] = None
     options: Optional[str] = None
     spec: Optional[str] = None
-
-    @property
-    def fstype(self):
-        return self.device.fstype
 
     def can_delete(self):
         from subiquity.common.filesystem import boot
@@ -2318,8 +2315,9 @@ class FilesystemModel:
     def should_add_swapfile(self):
         mount = self._mount_for_path("/")
         if mount is not None:
-            if not can_use_swapfile("/", mount.fstype):
-                return False
+            if mount.type != "zfs":
+                if not can_use_swapfile("/", mount.device.fstype):
+                    return False
         for swap in self._all(type="format", fstype="swap"):
             if swap.mount():
                 return False

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1279,6 +1279,24 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertTrue(disk2.id in rendered_ids)
         self.assertTrue(disk2p1.id in rendered_ids)
 
+    def test_bind_mount(self):
+        model = make_model()
+        make_disk(model, path="/dev/vda")
+        fake_up_blockdata(model)
+        model.apply_autoinstall_config(
+            [
+                {
+                    "id": "tmpfs1",
+                    "type": "mount",
+                    "spec": "none",
+                    "path": "/tmp",
+                    "size": "4194304",
+                    "fstype": "tmpfs",
+                },
+            ]
+        )
+        self.assertEqual(model.render()["storage"]["config"][0]["fstype"], "tmpfs")
+
 
 class TestPartitionNumbering(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Revert the changes made on commit 0cc4fdf3.
A mount point might not be associated with a device, such as a bind mount, and the property will return None in those cases and fail the installer.

Resolves: LP#2061732