### PR TITLE
fix serial-getty@.service and getty@.service failed

### DIFF
--- a/debian/console-conf-serial.conf
+++ b/debian/console-conf-serial.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/systemctl start serial-console-conf@%i.service
+ExecStartPre=-/bin/systemctl start serial-console-conf@%i.service

--- a/debian/console-conf.conf
+++ b/debian/console-conf.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/systemctl start console-conf@%i.service
+ExecStartPre=-/bin/systemctl start console-conf@%i.service


### PR DESCRIPTION
This patch ignores the exit status of "ExecStartPre=" in console-conf.conf and console-conf-serial.conf.
This fix the false error state on Ubuntu Core.

In console-conf.conf, we add an "ExecStartPre=" for the "getty@.service". So "console-conf@.service" will be started when "getty@%i.service" starting.
https://github.com/canonical/subiquity/blob/962c11e13e00e04a4fe83af265a9b40708bea9e9/debian/console-conf.conf#L2

We also have a "ExecStartPre=" in "console-conf@.service", it will stop "getty@%i.service".
The two "ExecStartPre=" ensures that we don't have multiple agetty processes using the same tty at the same time.
https://github.com/canonical/subiquity/blob/962c11e13e00e04a4fe83af265a9b40708bea9e9/debian/console-conf.console-conf%40.service#L19

But these two "ExecStartPre=" will cause a timing problem. If someone tries to start getty@tty0.service, the following things may happen:

1. SystemD daemon: start getty@tty0.service
2. SystemD daemon: start a new process A, and run "/bin/systemctl start console-conf@tty0.service" (Due to ExecStartPre= in console-conf.conf)
3. process A: sending message to SystemD daemon to start console-conf@tty0.service
4. process A: blocking on the service start job finished
5. SystemD daemon: start a new process B, and run "/bin/systemctl stop getty@tty0" (Due to ExecStartPre= in console-conf@.service)
6. SystemD daemon: notify process A: the service start job has been finished.
   /* process A now unblocked, but let's assuming it does not get scheduled. */
7. process B: sending message to SystemD daemon to stop getty@tty0.service
8. SystemD daemon: Kill process A, because it is the control process of getty@tty0.service. The control process still alive but service need to go stopped, so it would be killed.
9. process A: killed
10. SystemD daemon: get SIGCHILD. process A exit with signal SIGTERM
11. SystemD daemon: Set the status of getty@tty0.service to "failed" because the control process process exited with unclean status.

So at the end, console-conf@tty0.service will be runing normally, but getty@tty0.service will be in "failed" status, and "systemctl status" will have a "State: degraded".

If process A is able to exit before step 8, systemd will also send a SIGTERM signal. But this time it will be the main process. When the main process exits due to receiving a SIGTERM signal, systemd considers this a clean exit status.
Then, systemd will set the status of the service as **dead** instead of **failed**. (See [service_sigchld_event in systemd](https://github.com/systemd/systemd/blob/10ac85d0da5bd126d02f62523c21427f66e1e6c1/src/core/service.c#L3748))

This patch fix this issue by ignoring the exit status of process A. It forces systemd to not mark the service failed if the process of "ExecStartPre=" failed.