### PR TITLE
Various fixes for error reports

### DIFF
--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -30,7 +30,7 @@ from subiquity.client.controller import Confirm
 from subiquity.client.keycodes import KeyCodesFilter, NoOpKeycodesFilter
 from subiquity.common.api.client import make_client_for_conn
 from subiquity.common.apidef import API
-from subiquity.common.errorreport import ErrorReporter
+from subiquity.common.errorreport import ErrorReport, ErrorReporter
 from subiquity.common.serialize import from_json
 from subiquity.common.types import (
     ApplicationState,
@@ -619,7 +619,9 @@ class SubiquityClient(TuiApplication):
     def note_data_for_apport(self, key, value):
         self.error_reporter.note_data_for_apport(key, value)
 
-    def make_apport_report(self, kind, thing, *, interrupt, wait=False, **kw):
+    def make_apport_report(
+        self, kind: ErrorReportKind, thing, *, interrupt, wait=False, **kw
+    ) -> ErrorReport:
         report = self.error_reporter.make_apport_report(kind, thing, wait=wait, **kw)
 
         if report is not None and interrupt:
@@ -627,7 +629,7 @@ class SubiquityClient(TuiApplication):
 
         return report
 
-    def show_error_report(self, error_ref):
+    def show_error_report(self, error_ref: ErrorReportRef) -> None:
         log.debug("show_error_report %r", error_ref.base)
         if isinstance(self.ui.body, BaseView):
             w = getattr(self.ui.body._w, "stretchy", None)
@@ -636,6 +638,6 @@ class SubiquityClient(TuiApplication):
                 return
         self.add_global_overlay(ErrorReportStretchy(self, error_ref))
 
-    def show_nonreportable_error(self, error: NonReportableError):
+    def show_nonreportable_error(self, error: NonReportableError) -> None:
         log.debug("show_non_reportable_error %r", error.cause)
         self.add_global_overlay(NonReportableErrorStretchy(self, error))

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -552,6 +552,7 @@ class API:
                 ...
 
     class integrity:
+        @allowed_before_start
         def GET() -> CasperMd5Results:
             ...
 

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -120,6 +120,7 @@ class API:
                 """Restart the server process."""
 
         class ssh_info:
+            @allowed_before_start
             def GET() -> Optional[LiveSessionSSHInfo]:
                 ...
 

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -553,7 +553,7 @@ class API:
 
     class integrity:
         @allowed_before_start
-        def GET() -> CasperMd5Results:
+        def GET(wait=False) -> CasperMd5Results:
             ...
 
     class active_directory:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -475,7 +475,9 @@ class SubiquityServer(Application):
     def note_data_for_apport(self, key, value):
         self.error_reporter.note_data_for_apport(key, value)
 
-    def make_apport_report(self, kind, thing, *, wait=False, **kw):
+    def make_apport_report(
+        self, kind: ErrorReportKind, thing, *, wait=False, **kw
+    ) -> ErrorReport:
         return self.error_reporter.make_apport_report(kind, thing, wait=wait, **kw)
 
     async def _run_error_cmds(self, report: Optional[ErrorReport] = None) -> None:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -744,6 +744,8 @@ class SubiquityServer(Application):
         if only_early:
             self.controllers.Reporting.setup_autoinstall()
             self.controllers.Reporting.start()
+            self.controllers.Integrity.setup_autoinstall()
+            self.controllers.Integrity.start()
             self.controllers.Error.setup_autoinstall()
             self.validate_autoinstall()
             self.controllers.Early.setup_autoinstall()

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -15,11 +15,12 @@
 
 import asyncio
 import logging
+from typing import Optional
 
 from urwid import AttrMap, Padding, ProgressBar, Text, connect_signal, disconnect_signal
 
-from subiquity.common.errorreport import ErrorReportKind, ErrorReportState
-from subiquity.common.types import CasperMd5Results, NonReportableError
+from subiquity.common.errorreport import ErrorReport, ErrorReportKind, ErrorReportState
+from subiquity.common.types import CasperMd5Results, ErrorReportRef, NonReportableError
 from subiquitycore.async_helpers import run_bg_task
 from subiquitycore.ui.buttons import other_btn
 from subiquitycore.ui.container import Pile
@@ -185,11 +186,11 @@ retrying the install.
 
 
 class ErrorReportStretchy(Stretchy):
-    def __init__(self, app, ref, interrupting=True):
+    def __init__(self, app, ref: ErrorReportRef, interrupting=True):
         self.app = app
-        self.error_ref = ref
+        self.error_ref: ErrorReportRef = ref
         self.integrity_check_result = None
-        self.report = app.error_reporter.get(ref)
+        self.report: Optional[ErrorReport] = app.error_reporter.get(ref)
         self.pending = None
         if self.report is None:
             run_bg_task(self._wait())
@@ -452,7 +453,7 @@ nonreportable_footers: dict[str, str] = {
 
 
 class NonReportableErrorStretchy(Stretchy):
-    def __init__(self, app, error):
+    def __init__(self, app, error: NonReportableError):
         self.app = app  # A SubiquityClient
         self.error: NonReportableError = error
 


### PR DESCRIPTION
1. On the development branch, when showing a crash dialog early (e.g., after an early-command fails), the installer would often raise an exception because the report is not yet loaded on the client side ; although it has finished generating on the server side. See LP:#2076914 
-> Fixed by showing the "Loading report..." animation in this scenario

2.  When showing a crash dialog early, the md5check result is not shown because the Integrity controller:
   a. is not yet started
   b. does not respond to GET requests until all controllers are started
-> Fixed by starting the Integrity controller earlier ; and allowing it to respond to GET requests before all controllers have started. LP:#2076997

3. If the result of the MD5 check was not yet available by the time the crash report was shown, the result will not be refreshed after it becomes available.
-> fixed by adding the option to GET /integrity?wait=True and refresh the report when the call returns.

4. When showing a crash dialog early, if the user clicks on the [Help] menu, the installer will get stuck fetching the SSH information. This happens because the meta/ssh_info GET endpoint blocks until all controllers are started.
-> Fixed by allowing the controller to respond to GET requests before all controllers have started.