### PR TITLE
apport: set the APPORT_DATA_DIR variable in snap yaml definition

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,6 +24,7 @@ apps:
       PYTHON: $SNAP/usr/bin/python3.10
       # APPORT_DATA_DIR must be set before the `apport` python module is
       # imported.
+      APPORT_DATA_DIR_ORIG: $APPORT_DATA_DIR
       APPORT_DATA_DIR: $SNAP/share/apport
   probert:
     command: usr/bin/subiquity-cmd $SNAP/usr/bin/python3.10 $SNAP/bin/probert
@@ -48,6 +49,7 @@ apps:
       PATH: $PATH:$SNAP/bin:$SNAP/sbin
       # APPORT_DATA_DIR must be set before the `apport` python module is
       # imported.
+      APPORT_DATA_DIR_ORIG: $APPORT_DATA_DIR
       APPORT_DATA_DIR: $SNAP/share/apport
   subiquity-service:
     command: usr/bin/subiquity-service
@@ -66,6 +68,7 @@ apps:
       PYTHON: $SNAP/usr/bin/python3.10
       # APPORT_DATA_DIR must be set before the `apport` python module is
       # imported.
+      APPORT_DATA_DIR_ORIG: $APPORT_DATA_DIR
       APPORT_DATA_DIR: $SNAP/share/apport
 
 parts:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -22,6 +22,9 @@ apps:
       SUBIQUITY_ROOT: $SNAP
       PYTHON_ORIG: $PYTHON
       PYTHON: $SNAP/usr/bin/python3.10
+      # APPORT_DATA_DIR must be set before the `apport` python module is
+      # imported.
+      APPORT_DATA_DIR: $SNAP/share/apport
   probert:
     command: usr/bin/subiquity-cmd $SNAP/usr/bin/python3.10 $SNAP/bin/probert
     environment:
@@ -43,6 +46,9 @@ apps:
       PYTHON: $SNAP/usr/bin/python3.10
       PY3OR2_PYTHON: $SNAP/usr/bin/python3.10
       PATH: $PATH:$SNAP/bin:$SNAP/sbin
+      # APPORT_DATA_DIR must be set before the `apport` python module is
+      # imported.
+      APPORT_DATA_DIR: $SNAP/share/apport
   subiquity-service:
     command: usr/bin/subiquity-service
     daemon: simple
@@ -58,6 +64,9 @@ apps:
       SUBIQUITY_ROOT: $SNAP
       PYTHON_ORIG: $PYTHON
       PYTHON: $SNAP/usr/bin/python3.10
+      # APPORT_DATA_DIR must be set before the `apport` python module is
+      # imported.
+      APPORT_DATA_DIR: $SNAP/share/apport
 
 parts:
   curtin:

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -167,8 +167,6 @@ returned. """,
 def main():
     print("starting server")
     setup_environment()
-    # setup_environment sets $APPORT_DATA_DIR which must be set before
-    # apport is imported, which is done by this import:
     from subiquity.server.dryrun import DRConfig
     from subiquity.server.server import SubiquityServer
 

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -83,8 +83,6 @@ AUTO_ANSWERS_FILE = "/subiquity_config/answers.yaml"
 
 def main():
     setup_environment()
-    # setup_environment sets $APPORT_DATA_DIR which must be set before
-    # apport is imported, which is done by this import:
     from subiquity.client.client import SubiquityClient
 
     parser = make_client_args_parser()


### PR DESCRIPTION
The APPORT_DATA_DIR variable must be set before the apport Python module is imported. This was no longer true potentially because of this import:

  from subiquity.server.controllers.filesystem import set_user_error_reportable

The result was:

```
ERROR: hook /usr/share/apport/general-hooks/ubuntu.py crashed
Traceback (most recent call last):
  File "/snap/subiquity/5988/usr/lib/python3/lib/python3/dist-packages/apport/report.py", line 228, in _run_hook
    symb['add_info'](report, ui)
  File "/usr/share/apport/general-hook/ubuntu.py", line 34, in add_info
    _add_release_info(report)
  File "/usr/share/apport/general-hooks/ubuntu.py", line 472, in _add_release_info
    report.add_tags([release_codename])
AttributeError: 'Report' object has no attribute 'add_tags'.
```

Instead of trying to call setup_environment very early; make sure that the variable is set by snapd before Subiquity actually starts.

LP:#2076233