### PR TITLE
Add TPM-backed encryption instructions

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -81,6 +81,7 @@ subvolume
 subvolumes
 superset
 sysfs
+TPM
 traceback
 tty
 ubuntu

--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -539,6 +539,16 @@ When using the ``lvm`` layout, LUKS encryption can be enabled by supplying a pas
 
 The default is to use the ``lvm`` layout.
 
+Additionally, TPM-backed encryption can be enabled by using the ``hybrid`` layout with ``encrypted`` set to yes.
+
+.. code-block:: yaml
+
+    autoinstall:
+      storage:
+        layout:
+          name: hybrid
+          encrypted: yes
+
 Sizing-policy
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
Add instructions for using TPM-backed encryption to the docs.

Reference: https://github.com/canonical/subiquity/releases#:~:text=TPMFDE%20can%20be%20triggered%20with%20autoinstall%3A

Additionally, it may be prudent to resolve [2058147](https://bugs.launchpad.net/subiquity/+bug/2058147) as it currently blocks usage of these instructions on some devices.