### PR TITLE
Noble / meta: respond to ssh_info queries early

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -126,6 +126,7 @@ class API:
                 """Restart the server process."""
 
         class ssh_info:
+            @allowed_before_start
             def GET() -> Optional[LiveSessionSSHInfo]:
                 ...
 


### PR DESCRIPTION
* Cherry pick 41abc3576ebbf8f0753b7f98bb5c3bac553bdcc8 from https://github.com/canonical/subiquity/pull/2056

Other changes from the mentioned pull request are a bit more involved but this specific change seems pretty harmless.

It prevents the UI from getting stuck if the user opens the [Help] menu when a crash report is shown very early on.
