### PR TITLE
Refactor stages.Init() code path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(name='subiquity',
           'bin/subiquity-server',
           'bin/subiquity-cmd',
           'system_scripts/subiquity-umockdev-wrapper',
+          'system_scripts/subiquity-legacy-cloud-init-extract',
       ],
       entry_points={
           'console_scripts': [

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -156,6 +156,7 @@ parts:
       bin/subiquity-server: usr/bin/subiquity-server
       bin/subiquity-cmd: usr/bin/subiquity-cmd
       bin/subiquity-umockdev-wrapper: system_scripts/subiquity-umockdev-wrapper
+      bin/subiquity-legacy-cloud-init-extract: system_scripts/subiquity-legacy-cloud-init-extract
 
     build-attributes:
       - enable-patchelf

--- a/subiquity/cloudinit.py
+++ b/subiquity/cloudinit.py
@@ -122,7 +122,7 @@ async def get_schema_failure_keys() -> list[str]:
 
 
 async def cloud_init_status_wait() -> (bool, Optional[str]):
-    """Wait for cloud-init completion, and return if timeout ocurred and best
+    """Wait for cloud-init completion, and return if timeout occurred and best
     available status information.
     :return: tuple of (ok, status string or None)
     """
@@ -144,15 +144,15 @@ async def cloud_init_status_wait() -> (bool, Optional[str]):
 
 async def validate_cloud_init_schema() -> None:
     """Check for cloud-init schema errors.
-    Returns (None) if the cloud-config schmea validated OK according to
+    Returns (None) if the cloud-config schema validated OK according to
     cloud-init. Otherwise, a CloudInitSchemaValidationError is thrown
     which contains a list of the keys which failed to validate.
     Requires cloud-init supporting recoverable errors and extended status.
 
-    :return: None if cloud-init schema validated succesfully.
+    :return: None if cloud-init schema validated successfully.
     :rtype: None
     :raises CloudInitSchemaValidationError: If cloud-init schema did not validate
-            succesfully.
+            successfully.
     """
     causes: list[str] = await get_schema_failure_keys()
 

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -31,6 +31,7 @@ from subiquity.cloudinit import (
     CloudInitSchemaValidationError,
     cloud_init_status_wait,
     get_host_combined_cloud_config,
+    legacy_cloud_init_extract,
     rand_user_password,
     validate_cloud_init_schema,
 )
@@ -858,17 +859,8 @@ class SubiquityServer(Application):
 
         else:
             log.debug("loading cloud-config from stages.Init()")
-            from cloudinit import stages
-            from cloudinit.distros import ug_util
 
-            init = stages.Init()
-            init.read_cfg()
-            init.fetch(existing="trust")
-            cloud = init.cloudify()
-            cloud_cfg = cloud.cfg
-
-            users = ug_util.normalize_users_groups(cloud_cfg, cloud.distro)[0]
-            self.installer_user_name = ug_util.extract_default(users)[0]
+            cloud_cfg, self.installer_user_name = await legacy_cloud_init_extract()
 
         autoinstall = await self._extract_autoinstall_from_cloud_config(
             cloud_cfg=cloud_cfg, context=context

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -37,7 +37,7 @@ def _clean_env(env, *, locale=True):
 
 def system_scripts_env() -> dict[str, str]:
     """Generate an environment for running all programs outside of the snap,
-    but also include those vendored in $SNAP/bin.
+    but also include those vendored in $SNAP/system_scripts.
     """
 
     env: dict[str, str] = orig_environ(os.environ)

--- a/system_scripts/subiquity-legacy-cloud-init-extract
+++ b/system_scripts/subiquity-legacy-cloud-init-extract
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Legacy script for compatibility on systems where the combined cloud config
+json is unsupported.
+
+Writes the extracted cloud config data to a yaml dictionary:
+
+    {
+        "cloud_cfg": {...},
+        "installer_user_name": "...",
+    }
+
+"""
+
+import argparse
+import sys
+from typing import Any, Dict
+
+from cloudinit import safeyaml, stages
+from cloudinit.cloud import Cloud
+from cloudinit.distros import ug_util
+
+
+def get_cloud() -> Cloud:
+    """Get Cloud object via stages.Init()."""
+    init = stages.Init()
+    init.read_cfg()
+    init.fetch(existing="trust")
+    return init.cloudify()
+
+
+def write_data(
+    cloud_cfg: Dict[str, Any],
+    user_name: str,
+    location: str,
+) -> None:
+    """Write extracted cloud config and user name."""
+    data = {
+        "cloud_cfg": cloud_cfg,
+        "installer_user_name": user_name,
+    }
+
+    output = safeyaml.dumps(data)
+
+    if location == "-":
+        print(output)
+    else:
+        with open(location, "w") as fp:
+            fp.write(output)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="-",
+        help="Location to write extracted data instead of stdout.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args: argparse.Namespace = parse_args()
+
+    cloud: Cloud = get_cloud()
+
+    cloud_cfg: Dict[str, Any] = cloud.cfg
+
+    users, _groups = ug_util.normalize_users_groups(cloud_cfg, cloud.distro)
+    installer_user_name = ug_util.extract_default(users)[0]
+
+    write_data(cloud_cfg, installer_user_name, args.output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
~~Requires #2026. New changes for this PR are the last four commits.~~ #2026 now part of main. All commits are for this PR.

I pulled out the `stages.Init()` path from the server code and moved it to a helper script in system_scripts. The idea is that we can call this script and parse the output from it for the same information. It currently prints yaml to stdout, which seems robust enough for the kind of data it returns.

I tested this with the Focal release ISO, the 20.04.1 ISO, and the 22.04.1 ISO, all of which would rely on this code path. I tested by:
- passing no cloud-config
- passing cloud-config with autoinstall
- passing cloud-config without autoinstall
- ensuring the ssh login information was correct on the help screen

All scenarios worked as expected.