### PR TITLE
Fix some deprecation warnings on core24

### DIFF
--- a/console_conf/ui/views/chooser.py
+++ b/console_conf/ui/views/chooser.py
@@ -128,7 +128,7 @@ class ChooserView(ChooserBaseView):
                     Action(label=act.title.capitalize(), value=act, enabled=True)
                 )
             menu = ActionMenu(actions)
-            connect_signal(menu, "action", self._system_action, s)
+            connect_signal(menu, "action", self._system_action, user_args=[s])
             srow = make_action_menu_row(
                 [
                     Text(s.label),
@@ -162,7 +162,7 @@ class ChooserView(ChooserBaseView):
             ),
         )
 
-    def _system_action(self, sender, action, system):
+    def _system_action(self, system, sender, action):
         self.controller.select(system, action)
 
     def back(self, result):

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -397,7 +397,7 @@ class ErrorReportListStretchy(Stretchy):
         self.report_to_row = {}
         self.app.error_reporter.load_reports()
         for report in self.app.error_reporter.reports:
-            connect_signal(report, "changed", self._report_changed, report)
+            connect_signal(report, "changed", self._report_changed, user_args=[report])
             r = self.report_to_row[report] = self.row_for_report(report)
             rows.append(r)
         self.table = TablePile(rows, colspecs={1: ColSpec(can_shrink=True)})
@@ -410,7 +410,7 @@ class ErrorReportListStretchy(Stretchy):
         ]
         super().__init__("", widgets, 2, 2)
 
-    def open_report(self, sender, report):
+    def open_report(self, report, sender):
         self.app.add_global_overlay(ErrorReportStretchy(self.app, report, False))
 
     def state_for_report(self, report):
@@ -421,7 +421,7 @@ class ErrorReportListStretchy(Stretchy):
     def cells_for_report(self, report):
         date = report.pr.get("Date", "???")
         icon = ClickableIcon(date)
-        connect_signal(icon, "click", self.open_report, report)
+        connect_signal(icon, "click", self.open_report, user_args=[report])
         return [
             Text("["),
             icon,

--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -98,7 +98,7 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
             del self.devices[device]
         self._emit("change", self.devices)
 
-    def _select_active_spare(self, sender, value, device):
+    def _select_active_spare(self, device, sender, value):
         self.devices[device] = value
         self._emit("change", self.devices)
 
@@ -151,7 +151,9 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
                 self.all_rows.append(Color.menu_button(TableRow([box, size])))
                 self.no_selector_rows.append(self.all_rows[-1])
                 selector = Selector(["active", "spare"])
-                connect_signal(selector, "select", self._select_active_spare, device)
+                connect_signal(
+                    selector, "select", self._select_active_spare, user_args=[device]
+                )
                 selector = Toggleable(
                     UrwidPadding(Color.menu_button(selector), left=len(prefix))
                 )

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -113,7 +113,7 @@ class MountList(WidgetWrap):
         )
         super().__init__(self.table)
 
-    def _mount_action(self, sender, action, mount):
+    def _mount_action(self, mount, sender, action):
         log.debug("_mount_action %s %s", action, mount)
         if action == "unmount":
             self.parent.controller.delete_mount(mount)
@@ -168,7 +168,7 @@ class MountList(WidgetWrap):
                         ]
             actions = [(_("Unmount"), mi.mount.can_delete(), "unmount")]
             menu = ActionMenu(actions)
-            connect_signal(menu, "action", self._mount_action, mi.mount)
+            connect_signal(menu, "action", self._mount_action, user_args=[mi.mount])
             cells = [
                 Text("["),
                 Text(path_markup),
@@ -306,7 +306,7 @@ class DeviceList(WidgetWrap):
         lambda parent, gap: PartitionStretchy(parent, gap.device, gap=gap)
     )
 
-    def _action(self, sender, value, device):
+    def _action(self, device, sender, value):
         action, meth = value
         log.debug("_action %s %s", action, device.id)
         meth(device)
@@ -365,7 +365,7 @@ class DeviceList(WidgetWrap):
         if not device_actions:
             return Text("")
         menu = ActionMenu(device_actions)
-        connect_signal(menu, "action", self._action, device)
+        connect_signal(menu, "action", self._action, user_args=[device])
         return menu
 
     def refresh_model_inputs(self):

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -84,7 +84,7 @@ class ProgressView(BaseView):
         at_end = len(walker) == 0 or lb.focus_position == len(walker) - 1
         walker.append(line)
         if at_end:
-            lb.set_focus(len(walker) - 1)
+            lb.focus_position = len(walker) - 1
             lb.set_focus_valign("bottom")
 
     def event_start(self, context_id, context_parent_id, message):

--- a/subiquity/ui/views/ssh.py
+++ b/subiquity/ui/views/ssh.py
@@ -407,11 +407,11 @@ class SSHView(BaseView):
                     menu,
                 )
             )
-            connect_signal(menu, "action", self._action, key)
+            connect_signal(menu, "action", self._action, user_args=[key])
 
         self.keys_table.set_contents(rows)
 
-    def _action(self, sender, value, key):
+    def _action(self, key, sender, value):
         if value == "delete":
             self.remove_key_from_table(key)
             self.refresh_keys_table()

--- a/subiquity/ui/views/zdev.py
+++ b/subiquity/ui/views/zdev.py
@@ -69,7 +69,7 @@ class ZdevList(WidgetWrap):
         self.update(new_zdevinfos)
         self.parent.request_redraw_if_visible()
 
-    def zdev_action(self, sender, action, zdevinfo):
+    def zdev_action(self, zdevinfo, sender, action):
         run_bg_task(self._zdev_action(action, zdevinfo))
 
     def update(self, zdevinfos):
@@ -120,7 +120,7 @@ class ZdevList(WidgetWrap):
                 (_("Disable"), zdevinfo.on, "disable"),
             ]
             menu = ActionMenu(actions)
-            connect_signal(menu, "action", self.zdev_action, zdevinfo)
+            connect_signal(menu, "action", self.zdev_action, user_args=[zdevinfo])
             cells = [
                 Text(zdevinfo.id),
                 status(zdevinfo),

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -585,7 +585,7 @@ class NetworkAnswersMixin:
             table = self._action_get(action["obj"])
             meth = getattr(self.ui.body, "_action_{}".format(action["action"]))
             action_obj = getattr(NetDevAction, action["action"])
-            self.ui.body._action(None, (action_obj, meth), table)
+            self.ui.body._action(table, None, (action_obj, meth))
             yield
             body = self.ui.body._w
             if action["action"] == "DELETE":

--- a/subiquitycore/ui/actionmenu.py
+++ b/subiquitycore/ui/actionmenu.py
@@ -15,7 +15,7 @@
 import attr
 from urwid import (
     ACTIVATE,
-    AttrWrap,
+    AttrMap,
     Button,
     LineBox,
     PopUpLauncher,
@@ -83,7 +83,7 @@ class _ActionMenuDialog(WidgetWrap):
                     ],
                     dividechars=1,
                 )
-                btn = AttrWrap(btn, "info_minor")
+                btn = AttrMap(btn, "info_minor")
             group.append(btn)
         self.width = width
         super().__init__(Color.body(LineBox(ListBox(group))))

--- a/subiquitycore/ui/actionmenu.py
+++ b/subiquitycore/ui/actionmenu.py
@@ -63,7 +63,9 @@ class _ActionMenuDialog(WidgetWrap):
                 else:
                     btn = Color.menu_button(ActionMenuButton(action.label))
                 width = max(width, len(btn.base_widget.label))
-                connect_signal(btn.base_widget, "click", self.click, action.value)
+                connect_signal(
+                    btn.base_widget, "click", self.click, user_args=[action.value]
+                )
             else:
                 label = action.label
                 if isinstance(label, Widget):
@@ -89,7 +91,7 @@ class _ActionMenuDialog(WidgetWrap):
     def close(self, sender):
         self.parent.close_pop_up()
 
-    def click(self, btn, value):
+    def click(self, value, btn):
         self.parent._action(value)
         self.parent.close_pop_up()
 

--- a/subiquitycore/ui/container.py
+++ b/subiquitycore/ui/container.py
@@ -465,12 +465,11 @@ class ScrollBarListBox(urwid.WidgetDecoration):
 
             seen_focus = False
             height = height_before_focus = 0
-            focus_widget, focus_pos = lb.body.get_focus()
             # Scan through the rows calculating total height and the
             # height of the rows before the focus widget.
             for widget in lb.body:
                 rows = widget.rows((maxcol - 1,))
-                if widget is focus_widget:
+                if widget is lb.focus:
                     seen_focus = True
                 elif not seen_focus:
                     height_before_focus += rows

--- a/subiquitycore/ui/container.py
+++ b/subiquitycore/ui/container.py
@@ -131,7 +131,7 @@ class TabCyclingPile(urwid.Pile):
         """Select first selectable child (possibily recursively)."""
         for i, (w, o) in enumerate(self.contents):
             if w.selectable():
-                self.set_focus(i)
+                self.focus_position = i
                 _maybe_call(w, "_select_first_selectable")
                 return
 
@@ -139,7 +139,7 @@ class TabCyclingPile(urwid.Pile):
         """Select last selectable child (possibily recursively)."""
         for i, (w, o) in reversed(list(enumerate(self.contents))):
             if w.selectable():
-                self.set_focus(i)
+                self.focus_position = i
                 _maybe_call(w, "_select_last_selectable")
                 return
 
@@ -189,7 +189,7 @@ class TabCyclingPile(urwid.Pile):
             next_fp = self.focus_position + 1
             for i, (w, o) in enumerate(self._contents[next_fp:], next_fp):
                 if w.selectable():
-                    self.set_focus(i)
+                    self.focus_position = i
                     _maybe_call(w, "_select_first_selectable")
                     return
             if not key.endswith(" no wrap"):
@@ -199,7 +199,7 @@ class TabCyclingPile(urwid.Pile):
             positions = self._contents[: self.focus_position]
             for i, (w, o) in reversed(list(enumerate(positions))):
                 if w.selectable():
-                    self.set_focus(i)
+                    self.focus_position = i
                     _maybe_call(w, "_select_last_selectable")
                     return
             if not key.endswith(" no wrap"):
@@ -265,7 +265,7 @@ class OneSelectableColumns(urwid.Columns):
         """Select first selectable child (possibily recursively)."""
         for i, (w, o) in enumerate(self.contents):
             if w.selectable():
-                self.set_focus(i)
+                self.focus_position = i
                 _maybe_call(w, "_select_first_selectable")
                 return
 
@@ -273,7 +273,7 @@ class OneSelectableColumns(urwid.Columns):
         """Select last selectable child (possibily recursively)."""
         for i, (w, o) in reversed(list(enumerate(self.contents))):
             if w.selectable():
-                self.set_focus(i)
+                self.focus_position = i
                 _maybe_call(w, "_select_last_selectable")
                 return
 
@@ -289,14 +289,14 @@ class TabCyclingListBox(urwid.ListBox):
         super().__init__(body)
 
     def _set_focus_no_move(self, i):
-        # We call set_focus twice because otherwise the listbox
-        # attempts to do the minimal amount of scrolling required to
+        # We set the focus_position property twice because otherwise the
+        # listbox attempts to do the minimal amount of scrolling required to
         # get the new focus widget into view, which is not what we
         # want, as if our first widget is a compound widget it results
         # its last widget being focused -- in fact the opposite of
         # what we want!
-        self.set_focus(i)
-        self.set_focus(i)
+        self.focus_position = i
+        self.focus_position = i
         # I don't really understand why this is required but it seems it is.
         self._invalidate()
 
@@ -334,7 +334,7 @@ class TabCyclingListBox(urwid.ListBox):
             next_fp = self.focus_position + 1
             for i, w in enumerate(self.body[next_fp:], next_fp):
                 if w.selectable():
-                    self.set_focus(i)
+                    self.focus_position = i
                     _maybe_call(w, "_select_first_selectable")
                     return None
             if not key.endswith(" no wrap"):
@@ -344,7 +344,7 @@ class TabCyclingListBox(urwid.ListBox):
             positions = self.body[: self.focus_position]
             for i, w in reversed(list(enumerate(positions))):
                 if w.selectable():
-                    self.set_focus(i)
+                    self.focus_position = i
                     _maybe_call(w, "_select_last_selectable")
                     return None
             if not key.endswith(" no wrap"):

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from urwid import ACTIVATE, AttrWrap, CompositeCanvas, LineBox
+from urwid import ACTIVATE, AttrMap, CompositeCanvas, LineBox
 from urwid import Padding as UrwidPadding
 from urwid import PopUpLauncher, Text, connect_signal
 
@@ -76,9 +76,9 @@ class _PopUpSelectDialog(WidgetWrap):
                 ]
             )
             if option.enabled:
-                row = AttrWrap(row, "menu_button", "menu_button focus")
+                row = AttrMap(row, "menu_button", "menu_button focus")
             else:
-                row = AttrWrap(row, "info_minor")
+                row = AttrMap(row, "info_minor")
             btn = UrwidPadding(row, width=self.parent._padding.width)
             group.append(btn)
         list_box = ListBox(group)
@@ -162,7 +162,7 @@ class Selector(WidgetWrap):
     def __init__(self, opts, index=0):
         self._icon = ClickableThing(Text(""))
         self._padding = UrwidPadding(
-            AttrWrap(
+            AttrMap(
                 Columns(
                     [
                         (1, Text("[")),

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -60,7 +60,7 @@ class _PopUpSelectDialog(WidgetWrap):
         for i, option in enumerate(self.parent._options):
             if option.enabled:
                 btn = ClickableThing(option.label)
-                connect_signal(btn, "click", self.click, i)
+                connect_signal(btn, "click", self.click, user_args=[i])
                 if i == cur_index:
                     rhs = "\N{BLACK LEFT-POINTING SMALL TRIANGLE} "
                 else:
@@ -85,7 +85,7 @@ class _PopUpSelectDialog(WidgetWrap):
         list_box.base_widget.focus_position = cur_index
         super().__init__(Color.body(LineBox(list_box)))
 
-    def click(self, btn, index):
+    def click(self, index, btn):
         self.parent.index = index
         self.parent.close_pop_up()
 

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -88,7 +88,7 @@ class NetworkDeviceTable(WidgetWrap):
                 actions.append((action.str(), True, (action, meth), opens_dialog))
 
         menu = ActionMenu(actions)
-        connect_signal(menu, "action", self.parent._action, self)
+        connect_signal(menu, "action", self.parent._action, user_args=[self])
 
         trows = [
             make_action_menu_row(
@@ -344,7 +344,7 @@ class NetworkView(BaseView):
             self.controller.delete_link(dev_info.name)
             self.del_link(dev_info)
 
-    def _action(self, sender, action, netdev_table):
+    def _action(self, netdev_table, sender, action):
         action, meth = action
         dev_info = netdev_table.dev_info
         meth("{}/{}".format(dev_info.name, action.name), dev_info)


### PR DESCRIPTION
On oracular, this PR makes `make unit` produce 59 warnings instead of 146. The remaining warnings (emitted multiple times) are:

*  DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
*  /usr/lib/python3/dist-packages/bson/__init__.py:116: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    -> should be addressed with https://launchpad.net/ubuntu/+source/pymongo/4.7.3-1 (won't be addressed for core24 probably though)
*   /usr/lib/python3/dist-packages/cloudinit/config/schema.py:554: DeprecationWarning: Passing a schema to Validator.iter_errors is deprecated and will be removed in a future release. Call validator.evolve(schema=new_schema).iter_errors(...) instead.
    -> to be investigated
*   /usr/lib/python3/dist-packages/urwid/widget/wimp.py:693: DeprecationWarning: Don't use user_arg argument, use user_args instead.
*  /usr/lib/python3/dist-packages/urwid/widget/wimp.py:264: DeprecationWarning: Don't use user_arg argument, use user_args instead.
    -> internal to urwid, when using on_press or on_state_change. Won't be fixed anytime soon.