### PR TITLE
Make relevant filesystem controller errors "user errors" and categorize them

### DIFF
--- a/subiquity/common/api/recoverable_error.py
+++ b/subiquity/common/api/recoverable_error.py
@@ -15,4 +15,16 @@
 
 
 class RecoverableError(Exception):
-    """An error type that should not be treated as fatal."""
+    """An API-only error type that denotes a non-fatal error in a HTTP request
+    handler."""
+
+    # This field tells Subiquity what to do if an instance of this exception is
+    # raised in a request handler.
+    # By default we produce a crash report but one can decide otherwise by
+    # changing this value to False. This can be done globally or by setting
+    # produce_crash_report=False in a subclass. See
+    # subiquity.server.controllers.filesystem.set_user_error_reportable for an
+    # example.
+    # Currently, this value also controls whether the error would lead to a 500
+    # or 422 HTTP status.
+    produce_crash_report = True

--- a/subiquity/common/api/recoverable_error.py
+++ b/subiquity/common/api/recoverable_error.py
@@ -16,7 +16,19 @@
 
 class RecoverableError(Exception):
     """An API-only error type that denotes a non-fatal error in a HTTP request
-    handler."""
+    handler.
+
+    The intention of this class is to provide enough information about the
+    error to make it serializable into a Problem Details Object defined in RFC
+    9457 (Problem Details for HTTP APIs).
+
+    * The "code" attribute would be used as part of the "type" member of the
+    Problem Details Object. Maybe using the tag URI scheme:
+      tag:subiquity,2024-08-28:<code>
+    * The "title" attribute would be used as the "title" member of the Problem
+    Details Object.
+    * As for the message of the exception, it could be used as the "detail"
+    member of the Problem Details object."""
 
     # This field tells Subiquity what to do if an instance of this exception is
     # raised in a request handler.
@@ -28,3 +40,17 @@ class RecoverableError(Exception):
     # Currently, this value also controls whether the error would lead to a 500
     # or 422 HTTP status.
     produce_crash_report = True
+
+    # One must override title and code in subclasses with meaningful values.
+    # Note that different instances of the same class will have the same title
+    # and code. This is by design.
+    code: str = ""
+    title: str = ""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if not self.title or not self.code:
+            raise NotImplementedError(
+                "Please do not instantiate directly. Use subclasses"
+                " having a title and a user code properly set."
+            )

--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -169,9 +169,13 @@ def _make_handler(
                 )
             except Exception as exc:
                 tb = traceback.TracebackException.from_exception(exc)
+                if not isinstance(exc, RecoverableError) or exc.produce_crash_report:
+                    status = 500
+                else:
+                    status = 422
                 resp = web.Response(
                     text="".join(tb.format()),
-                    status=422 if isinstance(exc, RecoverableError) else 500,
+                    status=status,
                     headers={
                         "x-status": "error",
                         "x-error-type": type(exc).__name__,

--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -168,22 +168,31 @@ def _make_handler(
                     headers={"x-status": "ok"},
                 )
             except Exception as exc:
+                # NOTE: HTTP headers are a bit restrictive when it comes to storing
+                # free text (e.g., they cannot store newline characters). The
+                # workaround we use is to JSON "minify" content that we don't
+                # fully control. Ideally though, we should store most content
+                # in the body of the response, and include an
+                # "application/json" content type header.
                 tb = traceback.TracebackException.from_exception(exc)
+                headers = {
+                    "x-status": "error",
+                    "x-error-type": type(exc).__name__,
+                    # aiohttp will reject a header if its value contains a
+                    # "\r" or "\n" character. By using compact JSON, we
+                    # ensure those characters are escaped.
+                    "x-error-msg": json.dumps(str(exc), indent=None),
+                }
                 if not isinstance(exc, RecoverableError) or exc.produce_crash_report:
                     status = 500
                 else:
                     status = 422
+                    headers["x-error-code"] = exc.code
+                    headers["x-error-title"] = json.dumps(exc.title, indent=None)
                 resp = web.Response(
                     text="".join(tb.format()),
                     status=status,
-                    headers={
-                        "x-status": "error",
-                        "x-error-type": type(exc).__name__,
-                        # aiohttp will reject a header if its value contains a
-                        # "\r" or "\n" character. By using compact JSON, we
-                        # ensure those characters are escaped.
-                        "x-error-msg": json.dumps(str(exc), indent=None),
-                    },
+                    headers=headers,
                 )
                 resp["exception"] = exc
             context.description = "{} {}".format(resp.status, trim(resp.text))

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -133,6 +133,9 @@ class StorageRecoverableError(RecoverableError):
 class StorageInvalidUsageError(StorageRecoverableError):
     """Exception to raise when a storage endpoint is not properly used."""
 
+    code = "storage-invalid-usage"
+    title = _("Invalid use of storage endpoint")
+
 
 class StorageConstraintViolationError(StorageRecoverableError):
     """Exception to raise when a constraint is violated at runtime.
@@ -141,10 +144,16 @@ class StorageConstraintViolationError(StorageRecoverableError):
      - requesting a boot configuration that is not supported by the hardware
     """
 
+    code = "storage-constraint-violated"
+    title = _("Storage constraint violated")
+
 
 class StorageNotFoundError(StorageRecoverableError):
     """Exception to raise when a storage entity declared in a request (e.g., a
     disk, a partition, ...) is not found in the model."""
+
+    code = "storage-not-found"
+    title = _("Storage entity not found")
 
 
 def set_user_error_reportable(reportable: bool) -> None:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -24,7 +24,7 @@ import shutil
 import subprocess
 import time
 from contextlib import AsyncExitStack
-from typing import Any, Callable, Dict, List, Optional, Self, Sequence, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Self, Sequence, Union
 
 import attr
 import pyudev
@@ -88,7 +88,6 @@ from subiquity.models.filesystem import (
 from subiquity.server.autoinstall import AutoinstallError
 from subiquity.server.controller import SubiquityController
 from subiquity.server.controllers.source import SEARCH_DRIVERS_AUTOINSTALL_DEFAULT
-from subiquity.server.nonreportable import NonReportableException
 from subiquity.server.snapd import api as snapdapi
 from subiquity.server.snapd import types as snapdtypes
 from subiquity.server.snapd.system_getter import SystemGetter, SystemsDirMounter
@@ -127,23 +126,13 @@ system_non_gpt_text = _(
 DRY_RUN_RESET_SIZE = 500 * MiB
 
 
-class NonReportableSVE(RecoverableError, NonReportableException):
-    """Non reportable storage value error"""
-
-
-class ReportableSVE(ValueError):
-    """Reportable storage value error"""
-
-    # TODO Inherit from RecoverableError going forward.
-
-
-# Depending on config, we will let the SVE fail on the server side
-StorageRecoverableError: Type[NonReportableSVE | ReportableSVE] = ReportableSVE
+class StorageRecoverableError(RecoverableError):
+    pass
 
 
 def set_user_error_reportable(reportable: bool) -> None:
     global StorageRecoverableError
-    StorageRecoverableError = ReportableSVE if reportable else NonReportableSVE
+    StorageRecoverableError.produce_crash_report = reportable
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1736,9 +1736,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 request.action,
                 result.kind,
             )
-            raise StorageRecoverableError(
-                'entropy check failed: snapd returned "unsupported"'
-            )
+            raise RuntimeError('entropy check failed: snapd returned "unsupported"')
 
         assert result.value is not None
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -764,8 +764,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         gap = gaps.after(disk, partition.offset)
         if gap is None:
             pgs = gaps.parts_and_gaps(disk)
+            log.debug("gap not found after resize, pgs=%s", pgs)
             raise StorageConstraintViolationError(
-                f"gap not found after resize, pgs={pgs}"
+                "failed to locate gap after resizing partition"
             )
         return gap
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -130,6 +130,23 @@ class StorageRecoverableError(RecoverableError):
     pass
 
 
+class StorageInvalidUsageError(StorageRecoverableError):
+    """Exception to raise when a storage endpoint is not properly used."""
+
+
+class StorageConstraintViolationError(StorageRecoverableError):
+    """Exception to raise when a constraint is violated at runtime.
+    Examples:
+     - not enough space on the disk to create a partition
+     - requesting a boot configuration that is not supported by the hardware
+    """
+
+
+class StorageNotFoundError(StorageRecoverableError):
+    """Exception to raise when a storage entity declared in a request (e.g., a
+    disk, a partition, ...) is not found in the model."""
+
+
 def set_user_error_reportable(reportable: bool) -> None:
     global StorageRecoverableError
     StorageRecoverableError.produce_crash_report = reportable
@@ -268,14 +285,14 @@ def validate_pin_pass(
     pin: Optional[str],
 ) -> None:
     if passphrase is not None and pin is not None:
-        raise StorageRecoverableError("must supply at most one of pin and passphrase")
+        raise StorageInvalidUsageError("must supply at most one of pin and passphrase")
     if not pin_allowed and pin is not None:
-        raise StorageRecoverableError("unexpected pin supplied")
+        raise StorageInvalidUsageError("unexpected pin supplied")
     if not passphrase_allowed and passphrase is not None:
-        raise StorageRecoverableError("unexpected passphrase supplied")
+        raise StorageInvalidUsageError("unexpected passphrase supplied")
 
     if pin is not None and not pin.isdecimal():
-        raise StorageRecoverableError("pin is a string of digits")
+        raise StorageInvalidUsageError("pin is a string of digits")
 
 
 class FilesystemController(SubiquityController, FilesystemManipulator):
@@ -597,7 +614,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if choice.password is not None:
             spec["passphrase"] = choice.password
         if choice.recovery_key and not choice.password:
-            raise Exception("Cannot have a recovery key without encryption")
+            raise StorageInvalidUsageError(
+                "Cannot have a recovery key without encryption"
+            )
         recovery_key_handler = RecoveryKeyHandler.from_post_data(
             choice.recovery_key, default_suffix=f"recovery-key-{vg_name}.txt"
         )
@@ -611,7 +630,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         elif choice.sizing_policy == SizingPolicy.ALL:
             lv_size = vg.size
         else:
-            raise Exception(f"Unhandled size policy {choice.sizing_policy}")
+            raise StorageInvalidUsageError(
+                f"Unhandled size policy {choice.sizing_policy}"
+            )
         log.debug(f"lv_size {lv_size} for {choice.sizing_policy}")
         self.create_logical_volume(
             vg=vg,
@@ -723,7 +744,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         part_align = disk.alignment_data().part_align
         new_size = align_up(target.new_size, part_align)
         if new_size > partition.size:
-            raise Exception(f"Aligned requested size {new_size} too large")
+            raise StorageConstraintViolationError(
+                f"Aligned requested size {new_size} too large"
+            )
         partition.size = new_size
         partition.resize = True
         # Calculating where that gap will be can be tricky due to alignment
@@ -732,7 +755,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         gap = gaps.after(disk, partition.offset)
         if gap is None:
             pgs = gaps.parts_and_gaps(disk)
-            raise Exception(f"gap not found after resize, pgs={pgs}")
+            raise StorageConstraintViolationError(
+                f"gap not found after resize, pgs={pgs}"
+            )
         return gap
 
     @start_guided.register
@@ -744,7 +769,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         will be included in the returned gap. Therefore gap.offset and gap.size
         will not necessarily match partition.offset and partition.size."""
         if self.model.storage_version < 2:
-            raise StorageRecoverableError(
+            raise StorageInvalidUsageError(
                 '"Erase and Install" requires storage version 2'
             )
         partition = self.get_partition(disk, target.partition_number)
@@ -780,7 +805,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             if caps & set(info.capability_info.allowed):
                 self._info = info
                 return
-        raise Exception("could not find variation for {}".format(capability))
+        raise StorageConstraintViolationError(
+            "could not find variation for {}".format(capability)
+        )
 
     async def guided(
         self, choice: GuidedChoiceV2, reset_partition_only: bool = False
@@ -799,7 +826,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
         if self.is_core_boot_classic():
             if not self.app.opts.enhanced_secureboot:
-                raise ValueError(
+                raise StorageConstraintViolationError(
                     "Not using enhanced_secureboot: disabled on commandline"
                 )
             assert isinstance(choice.target, GuidedStorageTargetReformat)
@@ -813,7 +840,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         # find what's left of the gap after adding boot
         gap = gap.within()
         if gap is None:
-            raise Exception("failed to locate gap after adding boot")
+            raise StorageConstraintViolationError(
+                "failed to locate gap after adding boot"
+            )
 
         if choice.reset_partition:
             if choice.reset_partition_size is not None:
@@ -848,7 +877,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         elif choice.capability == GuidedCapability.DD:
             self.guided_dd(disk)
         else:
-            raise ValueError("cannot process capability")
+            raise StorageInvalidUsageError("cannot process capability")
 
     async def _probe_response(self, wait, resp_cls):
         if not self._probe_task.done():
@@ -1148,7 +1177,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         for p in disk.partitions():
             if p.number == number:
                 return p
-        raise ValueError(f"Partition {number} on {disk.id} not found")
+        raise StorageNotFoundError(f"Partition {number} on {disk.id} not found")
 
     def calculate_suggested_install_min(self):
         catalog_entry = self.app.base_model.source.current
@@ -1498,13 +1527,15 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.locked_probe_data = True
         disk = self.model._one(id=disk_id)
         if disk.ptable == "unsupported":
-            raise StorageRecoverableError(
+            raise StorageInvalidUsageError(
                 "cannot modify a disk with an unsupported partition table"
             )
         if boot.is_boot_device(disk):
-            raise StorageRecoverableError("device already has bootloader partition")
+            raise StorageConstraintViolationError(
+                "device already has bootloader partition"
+            )
         if DeviceAction.TOGGLE_BOOT not in DeviceAction.supported(disk):
-            raise StorageRecoverableError("disk does not support boot partiton")
+            raise StorageConstraintViolationError("disk does not support boot partiton")
         self.add_boot_disk(disk)
         return await self.v2_GET()
 
@@ -1512,15 +1543,17 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         log.debug(data)
         self.locked_probe_data = True
         if data.partition.boot is not None:
-            raise ValueError("add_partition does not support changing boot")
+            raise StorageInvalidUsageError(
+                "add_partition does not support changing boot"
+            )
         disk = self.model._one(id=data.disk_id)
         if disk.ptable == "unsupported":
-            raise StorageRecoverableError(
+            raise StorageInvalidUsageError(
                 "cannot modify a disk with an unsupported partition table"
             )
         requested_size = data.partition.size or 0
         if requested_size > data.gap.size:
-            raise ValueError("new partition too large")
+            raise StorageConstraintViolationError("new partition too large")
         if requested_size < 1:
             requested_size = data.gap.size
         # empty string is an unformatted partition
@@ -1532,7 +1565,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if data.partition.mount is not None:
             spec["mount"] = data.partition.mount
         if data.partition.name is not None:
-            raise StorageRecoverableError(
+            raise StorageInvalidUsageError(
                 "setting the partition name is not implemented"
             )
 
@@ -1547,7 +1580,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.locked_probe_data = True
         disk = self.model._one(id=data.disk_id)
         if disk.ptable == "unsupported":
-            raise StorageRecoverableError(
+            raise StorageInvalidUsageError(
                 "cannot modify a disk with an unsupported partition table"
             )
         partition = self.get_partition(disk, data.partition.number)
@@ -1561,7 +1594,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.locked_probe_data = True
         disk = self.model._one(id=data.disk_id)
         if disk.ptable == "unsupported":
-            raise StorageRecoverableError(
+            raise StorageInvalidUsageError(
                 "cannot modify a disk with an unsupported partition table"
             )
         partition = self.get_partition(disk, data.partition.number)
@@ -1569,9 +1602,13 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             data.partition.size not in (None, partition.size)
             and self.app.opts.storage_version < 2
         ):
-            raise ValueError("edit_partition does not support changing size")
+            raise StorageInvalidUsageError(
+                "edit_partition does not support changing size"
+            )
         if data.partition.boot is not None and data.partition.boot != partition.boot:
-            raise ValueError("edit_partition does not support changing boot")
+            raise StorageInvalidUsageError(
+                "edit_partition does not support changing boot"
+            )
         if data.partition.name != partition.partition_name:
             if data.partition.name is None:
                 # FIXME Instead of checking if data.partition.name is None,
@@ -1588,14 +1625,16 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                     " partition name or reset it ; assuming they want to keep it"
                 )
             else:
-                raise ValueError(
+                raise StorageInvalidUsageError(
                     "edit_partition does not support changing partition name"
                 )
         spec: PartitionSpec = {"mount": data.partition.mount or partition.mount}
         if data.partition.format is not None:
             if data.partition.format != partition.original_fstype():
                 if data.partition.wipe is None:
-                    raise ValueError("changing partition format requires a wipe value")
+                    raise StorageInvalidUsageError(
+                        "changing partition format requires a wipe value"
+                    )
             spec["fstype"] = data.partition.format
         if data.partition.size is not None:
             spec["size"] = data.partition.size
@@ -1609,7 +1648,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.locked_probe_data = True
 
         if (vg := self.model._one(type="lvm_volgroup", id=id)) is None:
-            raise StorageRecoverableError(f"could not find existing VG '{id}'")
+            raise StorageNotFoundError(f"could not find existing VG '{id}'")
         assert isinstance(vg, LVM_VolGroup)
 
         self.delete_volgroup(vg)
@@ -1620,7 +1659,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.locked_probe_data = True
 
         if (lv := self.model._one(type="lvm_partition", id=id)) is None:
-            raise StorageRecoverableError(f"could not find existing LV '{id}'")
+            raise StorageNotFoundError(f"could not find existing LV '{id}'")
         assert isinstance(lv, LVM_LogicalVolume)
 
         self.delete_logical_volume(lv)
@@ -1632,7 +1671,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.locked_probe_data = True
 
         if (raid := self.model._one(type="raid", id=id)) is None:
-            raise StorageRecoverableError(f"could not find existing RAID '{id}'")
+            raise StorageNotFoundError(f"could not find existing RAID '{id}'")
         assert isinstance(raid, Raid)
 
         self.delete_raid(raid)
@@ -1665,7 +1704,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         )
 
         if data.passphrase is None and data.pin is None:
-            raise StorageRecoverableError("must supply one of pin and passphrase")
+            raise StorageInvalidUsageError("must supply one of pin and passphrase")
 
         # checking entropy requires an encrypted core boot system to refer to
         info = self._info
@@ -1681,7 +1720,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                     break
 
         if info is None:
-            raise StorageRecoverableError("no suitable system found")
+            raise StorageInvalidUsageError("no suitable system found")
 
         if data.pin is not None:
             request = snapdtypes.SystemActionRequest(
@@ -1751,17 +1790,17 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
     async def v2_core_boot_recovery_key_GET(self) -> str:
         if not self._configured:
-            raise StorageRecoverableError("storage model is not yet configured")
+            raise StorageInvalidUsageError("storage model is not yet configured")
         if (self.model.guided_configuration is None) or (
             self.model.guided_configuration.capability
             != GuidedCapability.CORE_BOOT_ENCRYPTED
         ):
-            raise StorageRecoverableError("not using core boot encrypted")
+            raise StorageInvalidUsageError("not using core boot encrypted")
 
         if self.model.core_boot_recovery_key is None:
             # The recovery key only becomes available just before we get to the
             # finish-install step, which is very late.
-            raise StorageRecoverableError("recovery key is not yet available")
+            raise StorageInvalidUsageError("recovery key is not yet available")
 
         key = self.model.core_boot_recovery_key._key
 
@@ -1795,7 +1834,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
             return [CoreBootEncryptionFeatures(feature.value) for feature in features]
 
-        raise StorageRecoverableError("no suitable variation for core boot")
+        raise StorageInvalidUsageError("no suitable variation for core boot")
 
     async def dry_run_wait_probe_POST(self) -> None:
         if not self.app.opts.dry_run:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -35,6 +35,7 @@ from subiquity.cloudinit import (
     rand_user_password,
     validate_cloud_init_top_level_keys,
 )
+from subiquity.common.api.recoverable_error import RecoverableError
 from subiquity.common.api.server import bind, controller_for_request
 from subiquity.common.apidef import API
 from subiquity.common.errorreport import ErrorReport, ErrorReporter, ErrorReportKind
@@ -580,7 +581,11 @@ class SubiquityServer(Application):
                 resp.headers["x-error-msg"],
                 exc_info=exc,
             )
-            if not isinstance(exc, NonReportableException):
+            if isinstance(exc, NonReportableException):
+                pass
+            elif isinstance(exc, RecoverableError) and not exc.produce_crash_report:
+                pass
+            else:
                 report = self.make_apport_report(
                     ErrorReportKind.SERVER_REQUEST_FAIL,
                     "request to {}".format(request.raw_path),


### PR DESCRIPTION
This PR comes with 3 main changes:

* changed the way to configure whether StorageRecoverableError should produce crash reports. The main drawback of the previous implementation (using type aliasing) is that inheriting from StorageRecoverableError is resolved at class creation time, not instance creation time.
* use subclasses of StorageRecoverableErrors to categorize storage errors
* added title and error code to RecoverableError. This is a step towards implementing RFC9457 (Problem Details for HTTP APIs) or something somehow similar to RFC9457.