### PR TITLE
Add way for users to configure block-probing timeout

### DIFF
--- a/bin/subiquity-server
+++ b/bin/subiquity-server
@@ -1,4 +1,19 @@
 #!/bin/sh
 
+. "$SNAP"/management-script
+
 export PYTHONPATH=$PYTHONPATH:$SNAP/lib/python3.10/site-packages
-$PYTHON -m subiquity.cmd.server
+
+block_probing_timeout="$(block_probing_timeout)"
+
+case "${block_probing_timeout}" in
+    no | none | null)
+        $PYTHON -m subiquity.cmd.server --no-block-probing-timeout
+        ;;
+    default)
+        $PYTHON -m subiquity.cmd.server
+        ;;
+    *)
+        $PYTHON -m subiquity.cmd.server --block-probing-timeout "$block_probing_timeout"
+        ;;
+esac

--- a/bin/subiquity-service
+++ b/bin/subiquity-service
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+. "$SNAP"/management-script
+
 port=tty1
 export PYTHONPATH=$SNAP/lib/python3.10/site-packages
 
@@ -15,10 +18,25 @@ fi
 # can result in service status message being written on top of the TUI.
 /bin/kill "-SIGRTMIN+21" 1
 
+block_probing_timeout="$(block_probing_timeout)"
+case "${block_probing_timeout}" in
+    # Remember /bin/sh does not support arrays :(
+    no | none | null)
+        timeout_opts="--no-block-probing-timeout"
+        ;;
+    default)
+        timeout_opts=""
+        ;;
+    *)
+        timeout_opts="--block-probing-timeout ${block_probing_timeout}"
+        ;;
+esac
+
+
 if [ "$port" = "tty1" ]; then
 	$SNAP/bin/subiquity-loadkeys
 	setfont $SNAP/subiquity.psf
-	exec /sbin/agetty -n --noclear -l $PYTHON -o $SNAP/usr/bin/subiquity $port $TERM
+	exec /sbin/agetty -n --noclear -l $PYTHON -o "$SNAP/usr/bin/subiquity ${timeout_opts}" $port $TERM
 else
-	exec /sbin/agetty -n --keep-baud -l $PYTHON -o "$SNAP/usr/bin/subiquity --serial" $port 115200,38400,9600 $TERM
+	exec /sbin/agetty -n --keep-baud -l $PYTHON -o "$SNAP/usr/bin/subiquity --serial ${timeout_opts}" $port 115200,38400,9600 $TERM
 fi

--- a/scripts/management-script
+++ b/scripts/management-script
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+DEFAULT_BLOCK_PROBING_TIMEOUT=default
+
+block_probing_timeout()
+{
+    timeout="$(snapctl get block-probing-timeout)"
+    if [ -z "${timeout}" ]; then
+        timeout="${DEFAULT_BLOCK_PROBING_TIMEOUT}"
+    fi
+    echo "$timeout"
+}
+
+set_block_probing_timeout()
+{
+    if [ "$1" = "$DEFAULT_BLOCK_PROBING_TIMEOUT" ]; then
+        snapctl unset block-probing-timeout
+    else:
+        snapctl set block-probing-timeout
+    fi
+}

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# source the management script
+. "$SNAP"/management-script
+
+
+handle_block_probing_timeout_config()
+{
+    block_probing_timeout="$(block_probing_timeout)"
+
+    case "${block_probing_timeout}" in
+        no | none | null)
+            # Special supported values for no timeout.
+            ;;
+        default)
+            # Special supported values for letting Subiquity decide.
+            ;;
+        "" | *[!0-9]*)
+            # Match everything else that is not an integer.
+            echo "\"${block_probing_timeout}\" is not a valid block probing timeout" >&2
+            return 1
+    esac
+
+    snapctl set block-probing-timeout="${block_probing_timeout}"
+
+    # Restart subiquity-server to apply new config
+    snapctl restart subiquity.subiquity-server
+}
+
+handle_block_probing_timeout_config

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -244,3 +244,12 @@ parts:
 
     build-attributes:
       - enable-patchelf
+
+  management-script:
+    plugin: nil
+
+    override-build:
+      cp $CRAFT_PROJECT_DIR/scripts/management-script $CRAFT_PART_INSTALL/management-script
+
+    stage:
+      - management-script

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -161,6 +161,23 @@ returned. """,
         default=None,
         dest="supports_nvme_tcp_booting",
     )
+    parser.add_argument(
+        "--block-probing-timeout",
+        type=float,
+        default=90.0,
+        dest="block_probing_timeout",
+        help="""\
+The maximum number of seconds to wait for block devices discovery (by default
+90 seconds). Note that this timeout is doubled if os-prober is involved.""",
+    )
+    parser.add_argument(
+        "--no-block-probing-timeout",
+        action="store_const",
+        const=None,
+        dest="block_probing_timeout",
+        help="Wait indefinitely for block devices discovery. " "",
+    )
+
     return parser
 
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1435,11 +1435,14 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             (False, ErrorReportKind.BLOCK_PROBE_FAIL, "block"),
             (True, ErrorReportKind.DISK_PROBE_FAIL, "disk"),
         ]:
-            probert_timeout = 90.0
-            if self.app.opts.use_os_prober:
-                # We know that os-prober is going to be (very) slow on some
-                # systems, let's give probert more time.
-                probert_timeout *= 2
+            if self.app.opts.block_probing_timeout is None:
+                probert_timeout = None
+            else:
+                probert_timeout = self.app.opts.block_probing_timeout
+                if self.app.opts.use_os_prober:
+                    # We know that os-prober is going to be (very) slow on some
+                    # systems, let's give probert more time.
+                    probert_timeout *= 2
             try:
                 start = time.time()
                 await self._probe_once_task.start(

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -1548,6 +1548,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.app = make_app()
         self.app.command_runner = mock.AsyncMock()
         self.app.opts.bootloader = "UEFI"
+        self.app.opts.block_probing_timeout = None
         self.app.prober = mock.Mock()
         self.app.prober.get_storage = mock.AsyncMock()
         self.app.prober.get_firmware = mock.AsyncMock(


### PR DESCRIPTION
Subiquity now supports two new options:

* `--no-block-probing-timeout` to disable the block-probing timeout completely
* `--block-probing-timeout <seconds>` to set the timeout to a specific value

In addition, we now make the subiquity snap configurable so that this CLI options can be used without modifying the snap.

To disable the timeout:

```bash
snap set subiquity block-probing-timeout=no
```

To set the timeout to a different value:

```bash
snap set subiquity block-probing-timeout=180
```

To reset the timeout to the default value:

```bash
snap unset subiquity block-probing-timeout
```

Based on the current snap configuration, the wrapper script (e.g., bin/subiquity-server) will invoke subiquity either with the `--no-block-probing-timeout` option, the `--block-probing-timeout <seconds>` option, or none).