### PR TITLE
apt: fix invocation of setup_overlay in dry-run mode

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -375,7 +375,7 @@ class DryRunAptConfigurer(AptConfigurer):
 
     @contextlib.asynccontextmanager
     async def overlay(self):
-        yield await self.mounter.setup_overlay(self.install_tree.mountpoint)
+        yield await self.mounter.setup_overlay([self.install_tree.mountpoint])
 
     async def deconfigure(self, context, target):
         await self.cleanup()


### PR DESCRIPTION
`setup_overlay()` expects a list of lower directories. That said, we have one invocation in dry-run mode where we pass it a path (which is a string) directly instead of wrapping the path in a list with one element.

The dry-run implementation of `setup_overlay()` accesses the first element of the list using `lowers[0]`, and expects a path out of it. But when `lowers` is a string, `lowers[0]` returns the first character of string, which usually is `"/"` and therefore corresponds to a valid path.

It makes the code accidentally work, but use a path that is not the one we expected.