### PR TITLE
In the presence of a NBFT, assume the firmware supports NVMe/TCP booting

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -314,8 +314,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         # If needed, this can be moved outside of the storage/filesystem stuff.
         self._probe_firmware_task = SingleInstanceTask(self._probe_firmware)
 
-        self.firmware_supports_nvme_tcp_booting: Optional[bool] = None
-
     def is_core_boot_classic(self):
         return self._info.is_core_boot_classic()
 


### PR DESCRIPTION
Checking for known-good firmware models/versions is one way to determine if the system supports NVMe/TCP booting. That said, if a NBFT is present on the system, it is a much stronger hint that NVMe/TCP booting will be possible.
    
We can't completely replace the mechanism because sometimes, the NBFT will not be there during installation ; even though the system can boot using NVMe/TCP.
