### PR TITLE
Unconditionally run `zpool export -a` / revert systemd-shutdown implementation

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2053,13 +2053,6 @@ class FilesystemModel:
             config["grub"] = self.grub
         return config
 
-    def systemd_shutdown_commands(self) -> list[list[str]]:
-        """Return a list of commands meant to be executed by systemd-shutdown.
-        We entrust the execution of `zpool export` commands to systemd-shutdown
-        instead of subiquity's _pre_shutdown hook, in hope that the commands
-        will more likely succeed."""
-        return [["zpool", "export", zpool.name] for zpool in self._all(type="zpool")]
-
     def load_probe_data(self, probe_data):
         for devname, devdata in probe_data["blockdev"].items():
             if int(devdata["attrs"]["size"]) != 0:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1781,5 +1781,4 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 )
             else:
                 await self.app.command_runner.run(["umount", "--recursive", "/target"])
-        if len(self.model._all(type="zpool")) > 0:
-            await self.app.command_runner.run(["zpool", "export", "-a"])
+        await self.app.command_runner.run(["zpool", "export", "-a"])

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1757,6 +1757,19 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         return r
 
     async def _pre_shutdown(self):
+        """This function is executed just before rebooting and after copying
+        logs to the target. This means bugs reports are unlikely to include
+        execution logs from this function and therefore diagnosing issues is a
+        challenge. Let's try to keep it as simple as possible.
+
+        Another approach to execute commands before reboot is to place scripts in
+        /usr/lib/systemd/system-shutdown and lean on systemd-shutdown(8) to
+        execute them after unmounting most file-systems.
+
+        See this PR for an example (the PR was eventually reverted because it
+        didn't address the issue we tried to solve at the time).
+        https://github.com/canonical/subiquity/pull/2064
+        """
         if not self.reset_partition_only:
             # /target is mounted only if the installation was actually started.
             try:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1768,3 +1768,5 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 )
             else:
                 await self.app.command_runner.run(["umount", "--recursive", "/target"])
+        if len(self.model._all(type="zpool")) > 0:
+            await self.app.command_runner.run(["zpool", "export", "-a"])


### PR DESCRIPTION
storage: export zpools unconditionally

In the _pre_shutdown function, we used to invoke `zpool export -a` if we found the presence of a zpool in the storage model.

That being said, zpools can be implicitly declared by users using {"type": "format", "fstype": "zfsroot"} in the curtin actions. This is valid curtin configuration and unfortunately causes Subiquity to think that there is no zpool.

When that happened, Subiquity did not invoke `zpool export -a` and therefore the target system couldn't boot without a call to `zpool import -f`.

We now do the call to `zpool export -a` unconditionally. Running this command when there is no zpool is a noop so it should not be a problem.

In theory there is a risk that we could export a zpool that was not meant for exporting. However, that would involve somebody importing (or force importing) a zpool in the live installer environment and not wanting it exported at the end. This sounds like an very unlikely use case. Furthermore, this could already be a problem today since we invoke `zpool export` with the `-a` option (which exports all zpools imported on the system).
    
LP:#2073772
