### PR TITLE
docs: Update Sphinx extensions and RTD config.

### DIFF
--- a/doc/.sphinx/requirements.txt
+++ b/doc/.sphinx/requirements.txt
@@ -6,7 +6,7 @@ sphinx-tabs
 sphinx-reredirects
 pyspelling
 sphinxext-opengraph
-lxd-sphinx-extensions
+canonical-sphinx-extensions
 sphinx-copybutton
 myst-parser
 sphinxcontrib-jquery

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -159,7 +159,7 @@ disable_feedback_button = False
 
 intersphinx_mapping = {
     'cloud-init': (
-        'https://canonical-cloud-init.readthedocs-hosted.com/en/latest',
+        'https://docs.cloud-init.io/en/latest/',
          None
     )
 }


### PR DESCRIPTION
Quick update:

- Change to `canonical-sphinx-extensions` (new name); also allows latest Sphinx to be used.
- Update intersphinx URL for cloud-init docs.