### PR TITLE
Replace cloud-init validation with external script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(name='subiquity',
           'bin/subiquity-cmd',
           'system_scripts/subiquity-umockdev-wrapper',
           'system_scripts/subiquity-legacy-cloud-init-extract',
+          'system_scripts/subiquity-legacy-cloud-init-validate',
       ],
       entry_points={
           'console_scripts': [

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -157,6 +157,7 @@ parts:
       bin/subiquity-cmd: usr/bin/subiquity-cmd
       bin/subiquity-umockdev-wrapper: system_scripts/subiquity-umockdev-wrapper
       bin/subiquity-legacy-cloud-init-extract: system_scripts/subiquity-legacy-cloud-init-extract
+      bin/subiquity-legacy-cloud-init-validate: system_scripts/subiquity-legacy-cloud-init-validate
 
     build-attributes:
       - enable-patchelf

--- a/subiquity/cloudinit.py
+++ b/subiquity/cloudinit.py
@@ -5,7 +5,9 @@ import json
 import logging
 import re
 import secrets
+import tempfile
 from collections.abc import Awaitable, Sequence
+from pathlib import Path
 from string import ascii_letters, digits
 from subprocess import CalledProcessError, CompletedProcess
 from typing import Any, Optional
@@ -108,7 +110,11 @@ async def get_unknown_keys() -> list[str]:
     """Retrieve top-level keys causing schema failures, if any."""
 
     cmd: list[str] = ["cloud-init", "schema", "--system"]
-    status_coro: Awaitable = arun_command(cmd, clean_locale=True)
+    status_coro: Awaitable = arun_command(
+        cmd,
+        clean_locale=True,
+        env=system_scripts_env(),
+    )
     try:
         sp: CompletedProcess = await asyncio.wait_for(status_coro, 10)
     except asyncio.TimeoutError:
@@ -171,6 +177,67 @@ async def validate_cloud_init_top_level_keys() -> None:
         raise CloudInitSchemaTopLevelKeyError(keys=causes)
 
     return None
+
+
+def validate_cloud_config_schema(data: dict[str, Any], data_source: str) -> None:
+    """Validate data config adheres to strict cloud-config schema
+
+    Log warnings on any deprecated cloud-config keys used.
+
+    :param data: dict of cloud-config
+    :param data_source: str to present in logs/errors describing
+        where this config came from: autoinstall.user-data or system info
+    :raises CloudInitSchemaValidationError: If cloud-config did not validate
+        successfully.
+    :raises CalledProcessError: In the legacy code path if calling the helper
+        script fails.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "test-cloud-config.yaml"
+        path.write_text(yaml.dump(data))
+        # Eventually we may want to move to using the CLI when available,
+        # but we can rely on the "legacy" script for now.
+        legacy_cloud_init_validation(str(path), data_source)
+
+
+def legacy_cloud_init_validation(config_path: str, data_source: str) -> None:
+    """Validate cloud-config using helper script.
+
+    :param config_path: path to cloud-config to validate
+    :param data_source: str to present in logs/errors describing
+        where this config came from: autoinstall.user-data or system info
+    :raises CloudInitSchemaValidationError: If cloud-config did not validate
+        successfully.
+    :raises CalledProcessError: If calling the helper script fails.
+    """
+
+    try:
+        proc: CompletedProcess = run_command(
+            [
+                "subiquity-legacy-cloud-init-validate",
+                "--config",
+                config_path,
+                "--source",
+                data_source,
+            ],
+            env=system_scripts_env(),
+            check=True,
+        )
+    except CalledProcessError as cpe:
+        log_process_streams(
+            logging.DEBUG,
+            cpe,
+            "subiquity-legacy-cloud-init-validate",
+        )
+        raise cpe
+
+    results: dict[str, str] = yaml.safe_load(proc.stdout)
+
+    if warnings := results.get("warnings"):
+        log.warning(warnings)
+
+    if errors := results.get("errors"):
+        raise CloudInitSchemaValidationError(errors)
 
 
 async def legacy_cloud_init_extract() -> tuple[dict[str, Any], str]:

--- a/subiquity/cloudinit.py
+++ b/subiquity/cloudinit.py
@@ -87,6 +87,10 @@ def supports_recoverable_errors() -> bool:
     return cloud_init_version() >= "23.4"
 
 
+def supports_schema_subcommand() -> bool:
+    return cloud_init_version() >= "22.2"
+
+
 def read_json_extended_status(stream):
     try:
         status = json.loads(stream)
@@ -171,6 +175,13 @@ async def validate_cloud_init_top_level_keys() -> None:
     :raises CloudInitSchemaTopLevelKeyError: If cloud-init schema did not
             validate successfully.
     """
+    if not supports_schema_subcommand():
+        log.debug(
+            "Host cloud-config doesn't support 'schema' subcommand. "
+            "Skipping top-level key cloud-config validation."
+        )
+        return None
+
     causes: list[str] = await get_unknown_keys()
 
     if causes:

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -206,6 +206,9 @@ def main():
         logdir = opts.output_base
         if opts.bootloader is None:
             opts.bootloader = "uefi"
+        # Set for system_scripts support in dry run
+        if not os.environ.get("SNAP"):
+            os.environ["SNAP"] = str(pathlib.Path(__file__).parents[2])
     else:
         dr_cfg = None
     if opts.socket is None:

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -23,22 +23,9 @@ from collections import OrderedDict
 from typing import Any, Dict, List, Set, Tuple
 
 import yaml
-from cloudinit.config.schema import (
-    SchemaValidationError,
-    get_schema,
-    validate_cloudconfig_schema,
-)
-
-try:
-    from cloudinit.config.schema import SchemaProblem
-except ImportError:
-
-    def SchemaProblem(x, y):
-        return (x, y)  # TODO(drop on cloud-init 22.3 SRU)
-
-
 from curtin.config import merge_config
 
+from subiquity.cloudinit import validate_cloud_config_schema
 from subiquity.common.pkg import TargetPkg
 from subiquity.common.resources import get_users_and_groups
 from subiquity.server.types import InstallerChannels
@@ -321,44 +308,8 @@ class SubiquityModel:
         await self.hub.abroadcast(InstallerChannels.INSTALL_CONFIRMED)
 
     def validate_cloudconfig_schema(self, data: dict, data_source: str):
-        """Validate data config adheres to strict cloud-config schema
-
-        Log warnings on any deprecated cloud-config keys used.
-
-        :param data: dict of valid cloud-config
-        :param data_source: str to present in logs/errors describing
-            where this config came from: autoinstall.user-data or system info
-
-        :raise SchemaValidationError: on invalid cloud-config schema
-        """
-        # cloud-init v. 22.3 will allow for log_deprecations=True to avoid
-        # raising errors on deprecated keys.
-        # In the meantime, iterate over schema_deprecations to log warnings.
-        try:
-            validate_cloudconfig_schema(data, schema=get_schema(), strict=True)
-        except SchemaValidationError as e:
-            if hasattr(e, "schema_deprecations"):
-                warnings = []
-                deprecations = getattr(e, "schema_deprecations")
-                if deprecations:
-                    for schema_path, message in deprecations:
-                        warnings.append(message)
-                if warnings:
-                    log.warning(
-                        "The cloud-init configuration for %s contains"
-                        " deprecated values:\n%s",
-                        data_source,
-                        "\n".join(warnings),
-                    )
-            if e.schema_errors:
-                if data_source == "autoinstall.user-data":
-                    errors = [
-                        SchemaProblem(f"{data_source}.{path}", message)
-                        for (path, message) in e.schema_errors
-                    ]
-                else:
-                    errors = e.schema_errors
-                raise SchemaValidationError(schema_errors=errors)
+        """Validate data config adheres to strict cloud-config schema."""
+        validate_cloud_config_schema(data, data_source)
 
     def _cloud_init_config(self):
         config = {

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -28,12 +28,12 @@ from jsonschema.exceptions import ValidationError
 from systemd import journal
 
 from subiquity.cloudinit import (
-    CloudInitSchemaValidationError,
+    CloudInitSchemaTopLevelKeyError,
     cloud_init_status_wait,
     get_host_combined_cloud_config,
     legacy_cloud_init_extract,
     rand_user_password,
-    validate_cloud_init_schema,
+    validate_cloud_init_top_level_keys,
 )
 from subiquity.common.api.server import bind, controller_for_request
 from subiquity.common.apidef import API
@@ -790,8 +790,8 @@ class SubiquityServer(Application):
         context.enter()  # publish start event
 
         try:
-            await validate_cloud_init_schema()
-        except CloudInitSchemaValidationError as exc:
+            await validate_cloud_init_top_level_keys()
+        except CloudInitSchemaTopLevelKeyError as exc:
             bad_keys: list[str] = exc.keys
             raw_keys: list[str] = [f"{key!r}" for key in bad_keys]
             context.warning(

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -23,7 +23,7 @@ import jsonschema
 import yaml
 from jsonschema.validators import validator_for
 
-from subiquity.cloudinit import CloudInitSchemaValidationError
+from subiquity.cloudinit import CloudInitSchemaTopLevelKeyError
 from subiquity.common.types import NonReportableError, PasswordKind
 from subiquity.server.autoinstall import AutoinstallError, AutoinstallValidationError
 from subiquity.server.nonreportable import NonReportableException
@@ -442,11 +442,13 @@ class TestAutoinstallValidation(SubiTestCase):
         cloud_data.pop("valid-cloud", None)
         cloud_data.pop("autoinstall", None)
 
-        with patch("subiquity.server.server.validate_cloud_init_schema") as val_mock:
+        with patch(
+            "subiquity.server.server.validate_cloud_init_top_level_keys"
+        ) as val_mock:
             if len(cloud_data) == 0:
                 val_mock.return_value = True
             else:
-                val_mock.side_effect = CloudInitSchemaValidationError(
+                val_mock.side_effect = CloudInitSchemaTopLevelKeyError(
                     keys=list(cloud_data.keys())
                 )
 
@@ -468,8 +470,10 @@ class TestAutoinstallValidation(SubiTestCase):
         self.server.base_schema = SubiquityServer.base_schema
         self.pseudo_load_controllers()
 
-        with patch("subiquity.server.server.validate_cloud_init_schema") as val_mock:
-            val_mock.side_effect = CloudInitSchemaValidationError(
+        with patch(
+            "subiquity.server.server.validate_cloud_init_top_level_keys"
+        ) as val_mock:
+            val_mock.side_effect = CloudInitSchemaTopLevelKeyError(
                 keys=["broadcast", "foobar"],
             )
 

--- a/subiquity/tests/test_cloudinit.py
+++ b/subiquity/tests/test_cloudinit.py
@@ -24,16 +24,19 @@ import yaml
 from subiquity.cloudinit import (
     CLOUD_INIT_PW_SET,
     CloudInitSchemaTopLevelKeyError,
+    CloudInitSchemaValidationError,
     cloud_init_status_wait,
     cloud_init_version,
     get_unknown_keys,
     legacy_cloud_init_extract,
+    legacy_cloud_init_validation,
     rand_password,
     rand_user_password,
     read_json_extended_status,
     read_legacy_status,
     supports_format_json,
     supports_recoverable_errors,
+    validate_cloud_config_schema,
     validate_cloud_init_top_level_keys,
 )
 from subiquitycore.tests import SubiTestCase
@@ -144,6 +147,7 @@ class TestCloudInitVersion(SubiTestCase):
         self.assertEqual((True, "done"), await cloud_init_status_wait())
 
 
+@patch("subiquity.cloudinit.system_scripts_env", new=Mock())
 class TestCloudInitTopLevelKeyValidation(SubiTestCase):
     @parameterized.expand(
         (
@@ -254,6 +258,25 @@ class TestCloudInitRandomStrings(SubiTestCase):
         self.assertEqual("a" * 32, rand_password(select_from=choices))
 
 
+class TestCloudInitSchemaValidation(SubiTestCase):
+    """Test cloud-init schema Validation."""
+
+    @patch("subiquity.cloudinit.legacy_cloud_init_validation")
+    @patch("subiquity.cloudinit.Path")
+    @patch("subiquity.cloudinit.tempfile.TemporaryDirectory")
+    async def test_config_dump(self, tempdir_mock, path_mock, legacy_validate_mock):
+        """Test the config and source passed correctly."""
+        test_config = {"mock key": "mock value"}
+        validate_cloud_config_schema(test_config, "mock source")
+
+        # Config is the same
+        result_path = path_mock.return_value.__truediv__.return_value
+        result_path.write_text.assert_called_with(yaml.dump(test_config))
+
+        # Source is the same
+        legacy_validate_mock.assert_called_with(str(result_path), "mock source")
+
+
 @patch("subiquity.cloudinit.arun_command")
 @patch("subiquity.cloudinit.system_scripts_env")
 class TestCloudInitLegacyExtract(SubiTestCase):
@@ -306,3 +329,82 @@ class TestCloudInitLegacyExtract(SubiTestCase):
         log_mock.assert_called_with(
             logging.DEBUG, cpe, "subiquity-legacy-cloud-init-extract"
         )
+
+
+@patch("subiquity.cloudinit.run_command")
+@patch("subiquity.cloudinit.system_scripts_env")
+class TestCloudInitLegacyValidation(SubiTestCase):
+    """Test subiquity-legacy-cloud-init-validation helper function."""
+
+    def test_called_with_correct_env(
+        self,
+        scripts_env_mock,
+        arun_mock,
+    ):
+        """Test legacy script is called with correct parameters and env."""
+        prog_output = {"warnings": "", "errors": ""}
+        arun_mock.return_value.stdout = yaml.dump(prog_output)
+
+        mock_env = {"mock": "env"}
+        scripts_env_mock.return_value = mock_env
+
+        legacy_cloud_init_validation("mock_config", "mock source")
+
+        scripts_env_mock.assert_called_once()
+        arun_mock.assert_called_with(
+            [
+                "subiquity-legacy-cloud-init-validate",
+                "--config",
+                "mock_config",
+                "--source",
+                "mock source",
+            ],
+            env=mock_env,
+            check=True,
+        )
+
+    def test_useful_cpe_error(
+        self,
+        scripts_env_mock,
+        arun_mock,
+    ):
+        """Test reports CalledProcessError usefully."""
+        arun_mock.side_effect = cpe = CalledProcessError(
+            1, ["validate"], "stdout", "stderr"
+        )
+
+        with (
+            self.assertRaises(CalledProcessError),
+            patch("subiquity.cloudinit.log_process_streams") as log_mock,
+        ):
+            legacy_cloud_init_validation("", "")
+
+        log_mock.assert_called_with(
+            logging.DEBUG, cpe, "subiquity-legacy-cloud-init-validate"
+        )
+
+    def test_raise_schema_error(
+        self,
+        scripts_env_mock,
+        arun_mock,
+    ):
+        """Test raise CloudInitSchemaValidationError on errors encountered."""
+        prog_output = {"warnings": "", "errors": "bad config!"}
+        arun_mock.return_value.stdout = yaml.dump(prog_output)
+
+        with self.assertRaises(CloudInitSchemaValidationError):
+            legacy_cloud_init_validation("", "")
+
+    async def test_log_warnings(
+        self,
+        scripts_env_mock,
+        arun_mock,
+    ):
+        """Test raise CloudInitSchemaValidationError on errors encountered."""
+        prog_output = {"warnings": "deprecated key!", "errors": ""}
+        arun_mock.return_value.stdout = yaml.dump(prog_output)
+
+        with self.assertLogs("subiquity.cloudinit") as log_mock:
+            legacy_cloud_init_validation("", "")
+
+        self.assertIn("deprecated key!", log_mock.output[0])

--- a/system_scripts/subiquity-legacy-cloud-init-validate
+++ b/system_scripts/subiquity-legacy-cloud-init-validate
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Legacy script for compatibility on systems where the 'cloud-init schema'
+is unsupported.
+"""
+
+import argparse
+import sys
+from typing import Any, Dict
+
+import yaml
+from cloudinit import safeyaml
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
+
+try:
+    from cloudinit.config.schema import SchemaProblem
+except ImportError:
+
+    def SchemaProblem(x, y):
+        return (x, y)  # (not available before cloud-init 22.3)
+
+
+def validate(data: Dict[str, Any], data_source: str) -> Dict[str, str]:
+    """Validate that `data` adheres to strict cloud-config schema.
+
+    Collect warnings on any deprecated cloud-config keys used, and any errors
+    generated while trying to validate the cloud-config.
+
+    :param data: dict of valid cloud-config
+    :param data_source: str to present in logs/errors describing
+        where this config came from: autoinstall.user-data or system info
+
+    :return: A dict with keys "warnings" and "errors", containing the respective
+        data as a string.
+    """
+    # cloud-init v. 22.3 will allow for log_deprecations=True to avoid
+    # raising errors on deprecated keys.
+    # In the meantime, iterate over schema_deprecations to log warnings.
+
+    results = {
+        "warnings": "",
+        "errors": "",
+    }
+
+    try:
+        validate_cloudconfig_schema(data, schema=get_schema(), strict=True)
+    except SchemaValidationError as e:
+        if hasattr(e, "schema_deprecations"):
+            warnings = []
+            deprecations = getattr(e, "schema_deprecations")
+            if deprecations:
+                for schema_path, message in deprecations:
+                    warnings.append(f"{schema_path}: {message}")
+            if warnings:
+                combined_warnings = "\n".join(warnings)
+                results["warnings"] = (
+                    f"The cloud-init configuration for {data_source} contains"
+                    f" deprecated values:\n"
+                    f"{combined_warnings}"
+                )
+
+        if e.schema_errors:
+            if data_source == "autoinstall.user-data":
+                errors = [
+                    SchemaProblem(f"{data_source}.{path}", message)
+                    for (path, message) in e.schema_errors
+                ]
+            else:
+                errors = e.schema_errors
+            results["errors"] = str(SchemaValidationError(schema_errors=errors))
+
+    return results
+
+
+def write_data(
+    results: Dict[str, str],
+    location: str,
+) -> None:
+    """Write result of cloud-config validation"""
+
+    output = safeyaml.dumps(results)
+
+    if location == "-":
+        print(output)
+    else:
+        with open(location, "w") as fp:
+            fp.write(output)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+    )
+
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        required=True,
+        help="Location of cloud-config to validate.",
+    )
+
+    parser.add_argument(
+        "-s",
+        "--source",
+        type=str,
+        required=True,
+        help="description of the data source for the config.",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="-",
+        help="Location to write result of validation instead of stdout.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args: argparse.Namespace = parse_args()
+
+    with open(args.config) as fp:
+        config = yaml.safe_load(fp)
+
+    results = validate(config, args.source)
+    write_data(results, args.output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Slightly more changes for one PR than I'd like but everything sort of fell together:
 
- Extract cloud-init schema validation to a new system_script `subiquity-legacy-cloud-init-validate`. This is called "legacy" because, in the future, we likely want to rely on the cloud-init CLI directly to do schema validation, but there isn't a pressing need to rely on it now. For now, all releases will rely on the "legacy" script.

- Rename the old `validate_cloud_init_schema` function to `validate_cloud_init_top_level_keys` (along with some other function and type renaming). The function wasn't really validating the whole cloud-init schema. It's really just parsing the output for any top-level keys that failed to validate. 

- Skip the top-level key validation during autoinstall extraction in cloud-config on releases in which the "schema" subcommand wasn't available.

- Add a default value of the SNAP environment variable for dry-run and tests. This lets code paths that rely on `system_scripts_env` to not fail in dry-run or testing, which is mandatory now that `subiquity-legacy-cloud-init-validate` is used for cloud-init schema validation.