### PR TITLE
Only execute `zpool export -a` if zpool is available

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import pathlib
+import shutil
 import subprocess
 import time
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
@@ -1791,4 +1792,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 )
             else:
                 await self.app.command_runner.run(["umount", "--recursive", "/target"])
-        await self.app.command_runner.run(["zpool", "export", "-a"])
+        # Make sure we only execute the zpool export command if it is
+        # available. By default, zfsutils-linux is not installed in the live
+        # installer environment. It gets dynamically installed by curtin when
+        # needed.
+        if shutil.which("zpool") is not None:
+            await self.app.command_runner.run(["zpool", "export", "-a"])


### PR DESCRIPTION
We recently made the call to `zpool export -a` unconditional to account for "advanced" autoinstall scenarios. However, the zpool command is not always present in the live installer environment ; and it results in a Subiquity crash if the command fails to execute. Today, zpool (provided by zfsutils-linux) is dynamically installed in the live environment by curtin when it handles a ZFS installation.

Let's make sure we don't crash if zpool is not available when shutting down. It just means we're not using ZFS.