### PR TITLE
snapcraft.yaml: unstage cloud-init

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -119,7 +119,6 @@ parts:
     stage-packages:
       # This list includes the dependencies for curtin and probert as well,
       # there doesn't seem to be any real benefit to listing them separately.
-      - cloud-init
       - iso-codes
       - libpython3-stdlib
       - libpython3.10-minimal


### PR DESCRIPTION
Requires #2079. With those changes, we can safely unstage cloud-init from the snap. I ran test installs on jammy, focal, noble, and oracular injected with a snap with #2079's changes, as well as unstaging cloud-init, and ran into no problems.