### PR TITLE
ui: fix journal parsing in ProgressView

### DIFF
--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -123,7 +123,7 @@ class ProgressView(BaseView):
         #
         # and we want to insert the event type between the colon and the
         # event description
-        context, text = message.split(":")
+        context, text = message.split(":", maxsplit=1)
         text = text.lstrip()
         message = f"{context}: {event_type.upper()}: {text}"
 


### PR DESCRIPTION
The ProgressView.other_event function splits messages on the ":" character to get the context type and the message from journal messages. This code will crash if the message has more than one ":" character. When passing cloud-config with invalid top level keys, subiquity will check these keys and report on the journal with a message: "cloud-init schema validation failure for: <key1> [, <key2>, ...]", which was causing the UI to crash repeatedly.

[LP: #2080918](https://pad.lv/2080918)