### PR TITLE
snapcraft: rev to fix dracut removal and call to missing update-initramfs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "8aa0a9709d280f526c9a7cd62cffb53575a3a5e7"
+    source-commit: "697e83699d493b7491913d822e7f5635d7f10af2"
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
This is to pick up the change from https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/473058 , fixing two bugs:

 * dracut was getting removed when installing the kernel
 * a call to update-initramfs was attempted even if initramfs-tools was replaced with dracut

~~However, as it stands currently, it also brings in the kernel's `remove_existing` vs `remove: existing` change (but only the curtin side of the change). Therefore, this PR depends on #2086 ; and I'm marking it as a draft. I'll rebase once the other PR is merged.~~ [EDIT: rebased on top of main]

LP:#2073125