### PR TITLE
snapcraft: rev curtin to ignore new by-path/.../by-uuid entries

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
-    - uses: snapcore/action-build@v1
+    - uses: canonical/action-build@v1

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "697e83699d493b7491913d822e7f5635d7f10af2"
+    source-commit: "0ded564bde89cbf2ede7a9c3d6e1c260688b37cb"
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
This is to pick up this fix:

canonical/curtin@cf66592a13481c3109f357891be09a2dbaf4830c ([curtin MP](https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/473583)) to address LP:#2081256

Also includes a fix for the CI issue.