### PR TITLE
storage: when handling a partition, ignore any FS at the disk level

### DIFF
--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -88,7 +88,7 @@ class Gap:
 
 
 @functools.singledispatch
-def parts_and_gaps(device):
+def parts_and_gaps(device, ignore_disk_fs=False):
     raise NotImplementedError(device)
 
 
@@ -191,8 +191,8 @@ def find_disk_gaps_v2(device, info=None):
 
 @parts_and_gaps.register(Disk)
 @parts_and_gaps.register(Raid)
-def parts_and_gaps_disk(device):
-    if device._fs is not None:
+def parts_and_gaps_disk(device, ignore_disk_fs=False):
+    if device._fs is not None and not ignore_disk_fs:
         return []
     if device._m.storage_version == 1:
         return find_disk_gaps_v1(device)
@@ -201,7 +201,7 @@ def parts_and_gaps_disk(device):
 
 
 @parts_and_gaps.register(LVM_VolGroup)
-def _parts_and_gaps_vg(device):
+def _parts_and_gaps_vg(device, ignore_disk_fs=False):
     used = 0
     r = []
     for lv in device._partitions:
@@ -277,7 +277,7 @@ def movable_trailing_partitions_and_gap_size(partition):
 def _movable_trailing_partitions_and_gap_size_partition(
     partition: Partition,
 ) -> Tuple[List[Partition], int]:
-    pgs = parts_and_gaps(partition.device)
+    pgs = parts_and_gaps(partition.device, ignore_disk_fs=True)
     part_idx = pgs.index(partition)
     trailing_partitions = []
     in_extended = partition.is_logical


### PR DESCRIPTION
The parts_and_gaps function returned no partition nor gap when the disk itself has (or had) a file-system signature. This is to make sure we don't partition a disk that is already used unpartioned.

However, when we are operating on an existing partition of a disk, we should not pretend that the underlying disk has no partition ; even if the disk itself has a FS signature. This leads to a common issue when doing GuidedTargetReformat:

```python
  Traceback (most recent call last):
    File "subiquity/common/api/server.py", line 164, in handler
      result = await implementation(**args)
    File "subiquity/server/controllers/filesystem.py", line 1184, in v2_guided_POST
      await self.guided(data)
    File "subiquity/server/controllers/filesystem.py", line 726, in guided
      gap = self.start_guided(choice.target, disk)
    File "/usr/lib/python3.10/functools.py", line 926, in _method
      return method.__get__(obj, cls)(*args, **kwargs)
    File "subiquity/server/controllers/filesystem.py", line 645, in start_guided_reformat
      self.reformat(disk, wipe="superblock-recursive")
    File "subiquity/common/filesystem/manipulator.py", line 257, in reformat
      self.delete_partition(p, True)
    File "subiquity/common/filesystem/manipulator.py", line 120, in delete_partition
      self.model.remove_partition(part)
    File "subiquity/models/filesystem.py", line 2110, in remove_partition
      for p2 in movable_trailing_partitions_and_gap_size(part)[0]:
    File "/usr/lib/python3.10/functools.py", line 889, in wrapper
      return dispatch(args[0].__class__)(*args, **kw)
    File "subiquity/common/filesystem/gaps.py", line 281, in
         _movable_trailing_partitions_and_gap_size_partition
      part_idx = pgs.index(partition)
  ValueError: Partition(device=disk-sda, ...) is not in list
```
Using this change, I was able to proceed with a Guided-Reformat installation on a disk that had a ZFS signature + partitions. The solution is not perfect though. Going through manual partitioning with such as disk also causes errors:

* the UI does not show the list of existing partitions
* clicking on "New partition table" causes a `ValueError: .... is not in list` exception.

Another approach would be to treat a disk that has a filesystem signature + partitions as a normal partitioned disk, which would translate to using:

```diff
 def parts_and_gaps_disk(device):
-    if device._fs is not None:
+    if device._fs is not None and not device.partitions():
         return []
```
Suggestions are welcome!

LP:#2081738