### PR TITLE
kvm-test: add the option to "overwrite" an existing installation without recreating the disk from scratch

### DIFF
--- a/scripts/kvm-test.py
+++ b/scripts/kvm-test.py
@@ -2,7 +2,7 @@
 
 '''kvm-test - boot a kvm with a test iso, possibly building that test iso first
 
-kvm-test -q --install -o --boot
+kvm-test -q --install --recreate-target --boot
    slimy build, install, overwrite existing image if it exists,
    and boot the result after install
 
@@ -14,6 +14,7 @@ import contextlib
 import copy
 import crypt
 import dataclasses
+import enum
 import os
 import pathlib
 import shlex
@@ -50,6 +51,15 @@ profiles:
         disk-size: 20G
         extra-qemu-options: [-device, qxl, -smp, "2"]
 '''
+
+
+class TargetOverwrite(enum.Enum):
+    # Abort if the target already exists
+    PRESERVE = enum.auto()
+    # Recreate the target if it already exists
+    RECREATE = enum.auto()
+    # Reuse the target if it already exists
+    REUSE = enum.auto()
 
 
 @dataclasses.dataclass
@@ -156,7 +166,7 @@ parser = argparse.ArgumentParser(
 Test isos and images written to /tmp/kvm-test
 
 Sample usage:
-    kvm-test --build -q --install -o -a --boot
+    kvm-test --build -q --install --recreate-target -a --boot
         slimy build, run install, overwrite existing image, use autoinstall,
         boot final resulting image
 
@@ -204,8 +214,20 @@ parser.add_argument('--nic', action="append", dest="nics",
                     metavar="argument",
                     help='pass custom -nic argument to QEMU'
                          ' - overrides --nets')
-parser.add_argument('-o', '--overwrite', default=False, action='store_true',
-                    help='allow overwrite of the target image')
+target_overwrite_group = parser.add_mutually_exclusive_group()
+target_overwrite_group.add_argument('--preserve-target',
+                                    dest='target_overwrite',
+                                    action='store_const', const=TargetOverwrite.PRESERVE,
+                                    help='reuse the target image if it exists')
+target_overwrite_group.add_argument('-o', '--overwrite', '--recreate-target',
+                                    dest='target_overwrite',
+                                    action='store_const', const=TargetOverwrite.RECREATE,
+                                    help='recreate the target disk if it already exists')
+target_overwrite_group.add_argument('--reuse-target',
+                                    dest='target_overwrite',
+                                    action='store_const', const=TargetOverwrite.REUSE,
+                                    help='reuse the target image if it exists')
+target_overwrite_group.set_defaults(target_overwrite=TargetOverwrite.PRESERVE)
 parser.add_argument('-q', '--quick', default=False, action='store_true',
                     help='build iso with quick-test-this-branch')
 parser.add_argument('-r', '--release', action='store', help='target release')
@@ -543,11 +565,15 @@ def get_initrd(mntdir):
 
 def install(ctx):
     if os.path.exists(ctx.target):
-        if ctx.args.overwrite:
-            os.remove(ctx.target)
-        else:
-            raise Exception('refusing to overwrite existing image, use the ' +
-                            '-o option to allow overwriting')
+        match ctx.args.target_overwrite:
+            case TargetOverwrite.RECREATE:
+                os.remove(ctx.target)
+            case TargetOverwrite.PRESERVE:
+                raise Exception('refusing to overwrite existing image, use the ' +
+                                '--reuse-target or --recreate-target option to ' +
+                                'allow overwriting')
+            case TargetOverwrite.REUSE:
+                pass
 
     # Only copy the files with secureboot, always overwrite on install
     if ctx.args.secureboot:
@@ -589,7 +615,7 @@ def install(ctx):
                         kvm.extend(('-device', 'nvme,drive=localdisk0,serial=deadbeef'))
                     case interface:
                         raise ValueError('unsupported disk interface', interface)
-                if not os.path.exists(ctx.target) or ctx.args.overwrite:
+                if not os.path.exists(ctx.target):
                     disksize = ctx.args.disksize or ctx.default_disk_size
                     run(f'qemu-img create -f qcow2 {ctx.target} {disksize}')
 


### PR DESCRIPTION
When running `kvm-test` with `--install`, we currently have two options related to the target disk:

 * Abort if the target already exists, This is the default behavior.
 * If the `--overwrite` option (or `-o`) is passed, we instead recreate the target image from scratch.

This makes us unable to supply an already partitioned disk to kvm-test, which is a bit of a shame considering the use-cases we have currently.

This change adds 3 new options (well, only one is truly new):

* `--preserve-target` which is an explicit way to abort if the target image already exists (this is the default behavior)
* `--recreate-target` which mimics what `-o` / `--overwrite` does.
* `--reuse-target` which is the new one. When the option is supplied, we will reuse the disk without recreating it (if it already exists).

When we install to an existing disk with `--reuse-target`, we need to ask the firmware to boot from the installation media (or it will prefer booting from the disk if there is something installed to it). In BIOS mode, this means adding the `-boot order=d` option. However, in UEFI mode, it is more difficult to do. For now, I've added a note to stderr to tell how to proceed with UEFI (i.e., mashing ESC and then selecting `Boot Manager` -> `UEFI QEMU DVD-ROM`). Suggestions welcome :)