### PR TITLE
doc: move custom words to custom_wordlist

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -11,6 +11,8 @@ GPT
 GUID
 GiB
 GiB
+ISO
+ISOs
 Kylin
 Libera
 LPAR
@@ -44,6 +46,7 @@ authorized
 autoinstall
 autoinstaller
 autoinstalls
+boolean
 bootable
 bootloader
 bootloaders
@@ -51,6 +54,7 @@ codecs
 config
 conf
 curtin
+datasource
 debconf
 debian
 dir
@@ -79,6 +83,7 @@ rootfs
 rsyslog
 runtime
 snapd
+stdin
 subvolume
 subvolumes
 superset
@@ -89,6 +94,7 @@ tty
 ubuntu
 udev
 unformatted
+validator
 VLAN
 webhook
 workdir

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -8,8 +8,6 @@ EBS
 EKS
 Grafana
 IAM
-ISO
-ISOs
 JSON
 Jira
 Juju
@@ -27,8 +25,6 @@ VM
 YAML
 addons
 balancer
-boolean
-datasource
 dropdown
 favicon
 installable
@@ -37,8 +33,6 @@ namespaces
 observability
 reST
 reStructuredText
-stdin
 subdirectories
 subfolders
 subtree
-validator


### PR DESCRIPTION
The intention of .wordlist.txt is to match the general wordlist, so make future merges easier by moving custom words to the intended custom_wordlist location.