### PR TITLE
cloud-init: check for cloud-init-base package also

### DIFF
--- a/subiquity/cloudinit.py
+++ b/subiquity/cloudinit.py
@@ -72,11 +72,14 @@ def get_host_combined_cloud_config() -> dict:
 
 def cloud_init_version() -> str:
     # looks like 24.1~3gb729a4c4-0ubuntu1
-    cmd = ["dpkg-query", "-W", "-f=${Version}", "cloud-init"]
-    sp = run_command(cmd, check=False)
-    version = re.split("[-~]", sp.stdout)[0]
-    log.debug(f"cloud-init version: {version}")
-    return version
+    for pkg in "cloud-init", "cloud-init-base":
+        cmd = ["dpkg-query", "-W", "-f=${Version}", pkg]
+        sp = run_command(cmd, check=False)
+        if version := re.split("[-~]", sp.stdout)[0]:
+            log.debug(f"cloud-init version: {version}")
+            return version
+    log.debug("cloud-init not installed")
+    return ""
 
 
 def supports_format_json() -> bool:

--- a/subiquity/cloudinit.py
+++ b/subiquity/cloudinit.py
@@ -76,7 +76,7 @@ def cloud_init_version() -> str:
         cmd = ["dpkg-query", "-W", "-f=${Version}", pkg]
         sp = run_command(cmd, check=False)
         if version := re.split("[-~]", sp.stdout)[0]:
-            log.debug(f"cloud-init version: {version}")
+            log.debug(f"{pkg} version: {version}")
             return version
     log.debug("cloud-init not installed")
     return ""

--- a/subiquity/tests/test_cloudinit.py
+++ b/subiquity/tests/test_cloudinit.py
@@ -53,14 +53,12 @@ class TestCloudInitVersion(SubiTestCase):
     )
     def test_split_version(self, pkgver, expected):
         with patch("subiquity.cloudinit.run_command") as rc:
-            rc.return_value = Mock()
-            rc.return_value.stdout = pkgver
+            rc.return_value = Mock(stdout=pkgver)
             self.assertEqual(expected, cloud_init_version())
 
     def test_cloud_init_not_present(self):
         with patch("subiquity.cloudinit.run_command") as rc:
-            rc.return_value = Mock()
-            rc.return_value.stdout = ""
+            rc.return_value = Mock(stdout="")
             self.assertEqual("", cloud_init_version())
 
     def test_cloud_init_full(self):

--- a/subiquity/tests/test_cloudinit.py
+++ b/subiquity/tests/test_cloudinit.py
@@ -63,6 +63,16 @@ class TestCloudInitVersion(SubiTestCase):
             rc.return_value.stdout = ""
             self.assertEqual("", cloud_init_version())
 
+    def test_cloud_init_full(self):
+        with patch("subiquity.cloudinit.run_command") as rc:
+            rc.side_effect = [Mock(stdout="1.2.3"), Mock(stdout="4.5.6")]
+            self.assertEqual("1.2.3", cloud_init_version())
+
+    def test_cloud_init_base(self):
+        with patch("subiquity.cloudinit.run_command") as rc:
+            rc.side_effect = [Mock(stdout=""), Mock(stdout="4.5.6")]
+            self.assertEqual("4.5.6", cloud_init_version())
+
     @parameterized.expand(
         (
             ("22.3", False),


### PR DESCRIPTION
In the future, cloud-init will be available in a more minimal
`cloud-init-base` package, which is expected to provide the
functionality we expect.  Version check that one, if present, along with
the existing `cloud-init` package.

