### PR TITLE
storage: log disk-id in POST /storage/v2/add_boot_partition

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1327,6 +1327,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         return await self.v2_GET()
 
     async def v2_add_boot_partition_POST(self, disk_id: str) -> StorageResponseV2:
+        log.debug("v2_add_boot_partition: disk-id: %s", disk_id)
         self.locked_probe_data = True
         disk = self.model._one(id=disk_id)
         if boot.is_boot_device(disk):


### PR DESCRIPTION
It seems that we have a strange behavior when
/storage/v2/add_boot_partition is called on a disk different from the disk partitioned for installation. However, we did not log the disk ID so post-mortem analysis is very hard.