### PR TITLE
snapcraft: explicitly pull python3-more-itertools for core24

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -134,6 +134,7 @@ parts:
       - python3-distro-info
       - python3-jsonschema
       - python3-minimal
+      - python3-more-itertools
       - python3-oauthlib
       - python3-pkg-resources
       - python3-pyroute2


### PR DESCRIPTION
Subiquity relies on the more_itertools Python module. However, python3-more-itertools was not listed as a staged package in snnapcraft.yaml.

When running Subiquity on core24, this leads to a ModuleNotFoundError. For earlier core versions, python3-more-itertools was pulled as a transitive dependency so it was working ok.