### PR TITLE
Replace crypt module with passlib

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -36,6 +36,7 @@ python3-more-itertools
 python3-mypy
 python3-nose
 python3-parameterized
+python3-passlib
 python3-pip
 python3-pyflakes
 python3-pyroute2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -136,6 +136,7 @@ parts:
       - python3-minimal
       - python3-more-itertools
       - python3-oauthlib
+      - python3-passlib
       - python3-pkg-resources
       - python3-pyroute2
       - python3-pyrsistent

--- a/subiquitycore/tests/test_utils.py
+++ b/subiquitycore/tests/test_utils.py
@@ -23,7 +23,6 @@ from subiquitycore.utils import (
     crypt_password,
     gen_zsys_uuid,
     orig_environ,
-    passlib_crypt,
     system_scripts_env,
 )
 
@@ -134,36 +133,7 @@ class TestZsysUUID(SubiTestCase):
 
 
 class TestCryptPassword(SubiTestCase):
-    @patch("subiquitycore.utils._generate_salt")
     @patch("passlib.utils.handlers.HasSalt._generate_salt")
-    def test_compare_passlib_with_crypt(self, subi_salt_mock, pass_salt_mock):
-        """Test passlib module output is equivalent with python crypt module."""
-
-        # Test SHA-512
-        subi_salt_mock.return_value = pass_salt_mock.return_value = "mock.salt"
-        python = crypt_password("ubuntu", "SHA-512")
-        passlib = passlib_crypt("ubuntu", "SHA-512")
-        self.assertEqual(python, passlib)
-
-        # Test SHA-256
-        subi_salt_mock.return_value = pass_salt_mock.return_value = "mock.salt"
-        python = crypt_password("ubuntu", "SHA-256")
-        passlib = passlib_crypt("ubuntu", "SHA-256")
-        self.assertEqual(python, passlib)
-
-        # Test MD5
-        subi_salt_mock.return_value = pass_salt_mock.return_value = "mock.sal"
-        python = crypt_password("ubuntu", "MD5")
-        passlib = passlib_crypt("ubuntu", "MD5")
-        self.assertEqual(python, passlib)
-
-        # Test DES
-        subi_salt_mock.return_value = pass_salt_mock.return_value = "mo"
-        python = crypt_password("ubuntu", "DES")
-        passlib = passlib_crypt("ubuntu", "DES")
-        self.assertEqual(python, passlib)
-
-    @patch("subiquitycore.utils._generate_salt")
     def test_canary_output_changed(self, salt_mock):
         """Test known outputs to track any changes to hash function"""
         # Test SHA-512

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -13,7 +13,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-import crypt
 import logging
 import os
 import random
@@ -236,30 +235,7 @@ def log_process_streams(
     log.log(level, "--------------------------------------------------")
 
 
-def _generate_salt() -> str:
-    salt_set = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./"
-    salt = 16 * " "
-    salt = "".join([random.choice(salt_set) for c in salt])
-
-    return salt
-
-
-# FIXME: replace with passlib and update package deps
 def crypt_password(passwd, algo="SHA-512"):
-    # encryption algo - id pairs for crypt()
-    algos = {"SHA-512": "$6$", "SHA-256": "$5$", "MD5": "$1$", "DES": ""}
-    if algo not in algos:
-        raise Exception(
-            "Invalid algo({}), must be one of: {}. ".format(
-                algo, ",".join(algos.keys())
-            )
-        )
-
-    salt = _generate_salt(algo)
-    return crypt.crypt(passwd, algos[algo] + salt)
-
-
-def passlib_crypt(passwd, algo="SHA-512"):
     # Use rounds=5000 where possible to be equivalent w/ crypt.
     algos = {
         "SHA-512": passlib.hash.sha512_crypt.using(rounds=5000),

--- a/subiquitycore/utils.py
+++ b/subiquitycore/utils.py
@@ -234,6 +234,14 @@ def log_process_streams(
     log.log(level, "--------------------------------------------------")
 
 
+def _generate_salt() -> str:
+    salt_set = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./"
+    salt = 16 * " "
+    salt = "".join([random.choice(salt_set) for c in salt])
+
+    return salt
+
+
 # FIXME: replace with passlib and update package deps
 def crypt_password(passwd, algo="SHA-512"):
     # encryption algo - id pairs for crypt()
@@ -245,9 +253,7 @@ def crypt_password(passwd, algo="SHA-512"):
             )
         )
 
-    salt_set = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./"
-    salt = 16 * " "
-    salt = "".join([random.choice(salt_set) for c in salt])
+    salt = _generate_salt(algo)
     return crypt.crypt(passwd, algos[algo] + salt)
 
 


### PR DESCRIPTION
~~In python3.13, the crypt submodule will be removed from the standard library. This won't affect snap builds until core26, but makes dryrun testing difficult. This PR introduces some logic to shell out to perl to compute the hash in dry-run mode only.~~

Replace `crypt` module usage with the `passlib` module, which is provided by the  `python3-passlib` package. The package is already in Main and doesn't appear to have any open CVEs. This will fix the issue when trying to import the `crypt` module in python3.13 or later, where it was finally removed.