### PR TITLE
kvm-test: replace crypt with passlib

### DIFF
--- a/scripts/kvm-test.py
+++ b/scripts/kvm-test.py
@@ -12,7 +12,6 @@ See kvm-test -h for options and more examples.
 import argparse
 import contextlib
 import copy
-import crypt
 import dataclasses
 import enum
 import os
@@ -26,6 +25,7 @@ import tempfile
 from typing import List, Optional, Tuple
 
 import yaml
+from passlib.hash import sha512_crypt
 
 cfg = '''
 iso:
@@ -78,8 +78,8 @@ class Profile:
 
 def salted_crypt(plaintext_password):
     # match subiquity documentation
-    salt = '$6$exDY1mhS4KUYCE/2'
-    return crypt.crypt(plaintext_password, salt)
+    salt = 'exDY1mhS4KUYCE/2'
+    return sha512_crypt.hash(plaintext_password, salt=salt, rounds=5000)
 
 
 class Tap:


### PR DESCRIPTION
Follow up to #2108 to also replace the usage of `crypt` in kvm-test with `passlib`.

This means kvm-test will require the `python3-passlib` package. I omitted the changes to `apt-deps.txt` in this PR since we'll take care of that in the other one.