### PR TITLE
Fix switching back from console-conf to getty

### DIFF
--- a/bin/console-conf-check-error
+++ b/bin/console-conf-check-error
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+if [ "${SERVICE_RESULT}" == "exit-code" ] && [ "${EXIT_STATUS}" -eq 22 ]; then
+  systemctl start --no-block "${1}"
+fi

--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -17,9 +17,10 @@ if [ -e /run/snapd-recovery-chooser-triggered ]; then
         # when recovery chooser is invoked it takes over the terminal
         exec /usr/lib/snapd/snap-recovery-chooser
     fi
-    if [ -e /var/lib/console-conf/complete ]; then
-        exit 0
-    fi
+fi
+
+if [ -e /var/lib/console-conf/complete ]; then
+    exit 22
 fi
 
 # always prefer to use modeevn if it is available
@@ -80,6 +81,7 @@ if [ "$(snap managed)" = "true" ]; then
         done
     else
         touch /var/lib/console-conf/complete
+        exit 22
     fi
     exit 0
 fi

--- a/debian/console-conf-serial.conf
+++ b/debian/console-conf-serial.conf
@@ -1,2 +1,0 @@
-[Unit]
-ConditionPathExists=/var/lib/console-conf/complete

--- a/debian/console-conf.conf
+++ b/debian/console-conf.conf
@@ -1,3 +1,0 @@
-[Unit]
-ConditionPathExists=/var/lib/console-conf/complete
-ConditionPathExists=!/run/snapd-recovery-chooser-triggered

--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -18,7 +18,10 @@ Conflicts=getty@%i.service
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStart=/sbin/agetty -i -n --noclear -l /usr/share/subiquity/console-conf-wrapper %I $TERM
+RestartPreventExitStatus=22
+ExecStopPost=/usr/share/subiquity/console-conf-check-error getty@%i.service
 Type=idle
+OnFailure=getty@%i.service
 Restart=always
 RestartSec=0
 UtmpIdentifier=%I

--- a/debian/console-conf.install
+++ b/debian/console-conf.install
@@ -1,3 +1,4 @@
+debian/tmp/usr/bin/console-conf-check-error         usr/share/subiquity
 debian/tmp/usr/bin/console-conf-tui                 usr/share/subiquity
 debian/tmp/usr/bin/console-conf-wait                usr/share/subiquity
 debian/tmp/usr/bin/console-conf-wrapper             usr/share/subiquity

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -9,13 +9,14 @@ After=core18.start-snapd.service core.start-snapd.service
 # on core20 the user may invoke a recovery chooser, make sure the detection
 # service runs before
 After=snapd.recovery-chooser-trigger.service
-ConditionPathExists=!/var/lib/console-conf/complete
 StartLimitInterval=0
 Conflicts=serial-getty@%i.service
 
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStart=/sbin/agetty -i -n --keep-baud -l /usr/share/subiquity/console-conf-wrapper --login-options "--serial" 115200,38400,9600 %I $TERM
+RestartPreventExitStatus=22
+ExecStopPost=/usr/share/subiquity/console-conf-check-error serial-getty@%i.service
 Type=idle
 Restart=always
 RestartSec=0

--- a/debian/rules
+++ b/debian/rules
@@ -26,10 +26,6 @@ override_dh_python3:
 override_dh_installinit:
 	dh_installsystemd --no-start --name=console-conf@
 	dh_installsystemd --no-start --name=serial-console-conf@
-	mkdir $(CURDIR)/debian/console-conf/lib/systemd/system/getty@.service.d/
-	install -m 0644 $(CURDIR)/debian/console-conf.conf $(CURDIR)/debian/console-conf/lib/systemd/system/getty@.service.d/
-	mkdir $(CURDIR)/debian/console-conf/lib/systemd/system/serial-getty@.service.d/
-	install -m 0644 $(CURDIR)/debian/console-conf-serial.conf $(CURDIR)/debian/console-conf/lib/systemd/system/serial-getty@.service.d/
 	install -D -m 0755 -t $(CURDIR)/debian/console-conf/lib/systemd/system-generators $(CURDIR)/debian/serial-console-generator
 
 override_dh_auto_test:

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(name='subiquity',
       license="AGPLv3+",
       packages=find_packages(exclude=["tests"]),
       scripts=[
+          'bin/console-conf-check-error',
           'bin/console-conf-wait',
           'bin/console-conf-wrapper',
           'bin/subiquity-debug',


### PR DESCRIPTION
When a password for a user is set, then we should use getty rather than console-conf. Unit conditions did not work along conflicts, because conflicts are resolved during loading of systemd, and conditions are resolved right before executing the unit.

Instead we always use console-conf. If we find that we should have switched to getty, then we return a special value that is marked as not restarting (we always restart otherwise). An ExecStopPost also matches that exit status to start getty (the default job mode is "replace", which means the conflict will also kick console-conf out).