### PR TITLE
console-conf@.service: Remove left over conditions

### DIFF
--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -10,8 +10,6 @@ After=core18.start-snapd.service core.start-snapd.service
 After=snapd.recovery-chooser-trigger.service
 IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
-ConditionPathExists=|!/var/lib/console-conf/complete
-ConditionPathExists=|/run/snapd-recovery-chooser-triggered
 StartLimitInterval=0
 Conflicts=getty@%i.service
 


### PR DESCRIPTION
Something got lost in patch #2111. This fixes starting login on VT when console-conf got disabled.