### PR TITLE
Add "Erase and Install" support

### DIFF
--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import functools
+import logging
 from typing import List, Tuple
 
 import attr
@@ -29,6 +30,8 @@ from subiquity.models.filesystem import (
     align_down,
     align_up,
 )
+
+log = logging.getLogger("subiquity.common.filesystem.gaps")
 
 
 # should also set on_setattr=None with attrs 20.1.0
@@ -314,10 +317,11 @@ def at_offset(device, offset):
     return None
 
 
-def after(device, offset):
-    """Find the first gap that is after this offset."""
+def after(device, offset, *, only_gap=True):
+    """Find the first gap that is after this offset. If only_gap is False, find
+    the first gap (or partition!) that is after this offset."""
     for pg in parts_and_gaps(device):
-        if isinstance(pg, Gap):
+        if isinstance(pg, Gap) or not only_gap:
             if pg.offset > offset:
                 return pg
     return None
@@ -331,3 +335,43 @@ def includes(device, offset):
         if pg.offset <= offset < (pg.offset + pg.size):
             return pg
     return None
+
+
+def find_gap_after_removal(disk: Disk, removed_partition: Partition) -> Gap:
+    """Assuming that the specified partition was removed from the disk, return
+    the corresponding, resulting gap that "contains" the partition. The offset
+    of the resulting gap can either:
+    * match that of the removed partition
+    * be lower than that of the removed partition (we automatically claim free
+    space prepending the removed partition)
+    * be greater (surprisingly) than that of the removed partition. This is
+    probably a bug."""
+    gap = includes(disk, removed_partition.offset)
+
+    if gap is not None:
+        return gap
+
+    # Sometimes, after removal, the gap will appear slighly *after* where the
+    # partition used to be. This is notably an issue when dealing with logical
+    # partitions.
+    # This is arguably a bug (i.e., we probably block too much space) but let's
+    # try to look harder for the gap since we know it can happen.
+    part_or_gap = after(disk, removed_partition.offset, only_gap=False)
+
+    # Ensure that what we find is actually a gap and ensure that it covers at
+    # least one part of the partition we removed.
+    if (
+        part_or_gap is None
+        or not isinstance(part_or_gap, Gap)
+        or part_or_gap.offset >= removed_partition.offset + removed_partition.size
+    ):
+        raise RuntimeError(
+            f"could not find a gap after removing {removed_partition.id}"
+        )
+
+    gap = part_or_gap
+    log.debug(
+        "no gap found on %s that includes offset %s", disk.id, removed_partition.offset
+    )
+    log.debug("using gap at offset %s instead", gap.offset)
+    return gap

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -321,3 +321,13 @@ def after(device, offset):
             if pg.offset > offset:
                 return pg
     return None
+
+
+def includes(device, offset):
+    """Find the gap that includes the specified offset."""
+    for pg in parts_and_gaps(device):
+        if not isinstance(pg, Gap):
+            continue
+        if pg.offset <= offset < (pg.offset + pg.size):
+            return pg
+    return None

--- a/subiquity/common/filesystem/tests/test_gaps.py
+++ b/subiquity/common/filesystem/tests/test_gaps.py
@@ -232,6 +232,41 @@ class TestAfter(unittest.TestCase):
         self.assertTrue(gap.offset < g1.offset)
 
 
+class TestIncludes(unittest.TestCase):
+    def test_one_big_gap(self):
+        d = make_disk()
+        [gap] = gaps.parts_and_gaps(d)
+        self.assertEqual(gap, gaps.includes(d, gap.offset))
+        self.assertEqual(gap, gaps.includes(d, gap.offset + gap.size - 1))
+        self.assertEqual(gap, gaps.includes(d, gap.offset + gap.size // 2))
+
+        self.assertIsNone(gaps.includes(d, gap.offset + gap.size))
+        self.assertIsNone(gaps.includes(d, gap.offset - 1))
+
+    def test_no_gap(self):
+        m, d = make_model_and_disk()
+        make_partition(m, d, size=-1)
+        [part] = gaps.parts_and_gaps(d)
+        self.assertIsNone(gaps.includes(d, part.offset))
+        self.assertIsNone(gaps.includes(d, part.offset + part.size - 1))
+        self.assertIsNone(gaps.includes(d, part.offset + part.size // 2))
+
+        self.assertIsNone(gaps.includes(d, part.offset + part.size))
+        self.assertIsNone(gaps.includes(d, part.offset - 1))
+
+    def test_half_allocated(self):
+        m, d = make_model_and_disk()
+        make_partition(m, d)
+        [part, gap] = gaps.parts_and_gaps(d)
+        self.assertIsNone(gaps.includes(d, part.offset))
+        self.assertIsNone(gaps.includes(d, part.offset + part.size - 1))
+        self.assertIsNone(gaps.includes(d, part.offset + part.size // 2))
+
+        self.assertEqual(gap, gaps.includes(d, gap.offset))
+        self.assertEqual(gap, gaps.includes(d, gap.offset + gap.size - 1))
+        self.assertEqual(gap, gaps.includes(d, gap.offset + gap.size // 2))
+
+
 class TestDiskGaps(unittest.TestCase):
     def test_no_partition_gpt(self):
         size = 1 << 30

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -255,6 +255,14 @@ class GuidedStorageTargetResize:
 
 
 @attr.s(auto_attribs=True)
+class GuidedStorageTargetEraseInstall:
+    disk_id: str
+    partition_number: int
+    allowed: List[GuidedCapability] = attr.Factory(list)
+    disallowed: List[GuidedDisallowedCapability] = attr.Factory(list)
+
+
+@attr.s(auto_attribs=True)
 class GuidedStorageTargetUseGap:
     disk_id: str
     gap: Gap

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -277,6 +277,7 @@ class GuidedStorageTargetManual:
 
 
 GuidedStorageTarget = Union[
+    GuidedStorageTargetEraseInstall,
     GuidedStorageTargetReformat,
     GuidedStorageTargetResize,
     GuidedStorageTargetUseGap,

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -31,6 +31,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Self,
     Sequence,
     Set,
     Tuple,
@@ -666,6 +667,13 @@ class _Device(_Formattable, ABC):
         # deleted as possible.
         new_disk = attr.evolve(self)
         new_disk._partitions = [p for p in self.partitions() if p._is_in_use]
+        return new_disk
+
+    def _excluding_partition(self, partition: "Partition") -> Self:
+        """Return an ephemeral copy of the device with the specific partition
+        removed."""
+        new_disk = attr.evolve(self)
+        new_disk._partitions = [p for p in self.partitions() if p is not partition]
         return new_disk
 
     def dasd(self):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1521,6 +1521,52 @@ class TestDisk(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"^do not renumber"):
             d.renumber_logical_partitions(removed_partition=pp)
 
+    def test__reformatted__empty_disk(self):
+        m, d = make_model_and_disk()
+
+        d2 = d._reformatted()
+        self.assertIsNot(d, d2)
+        self.assertIsNot(d._partitions, d2._partitions)
+
+    def test__reformatted__with_partitions(self):
+        m, d = make_model_and_disk()
+
+        p1 = make_partition(m, d)
+        p2 = make_partition(m, d)
+
+        d2 = d._reformatted()
+
+        self.assertIsNot(d, d2)
+        self.assertEqual(d.partitions(), [p1, p2])
+        self.assertEqual(d2.partitions(), [])
+
+    def test__reformatted__with_in_use_parts(self):
+        m, d = make_model_and_disk()
+
+        p1 = make_partition(m, d, is_in_use=True)
+        p2 = make_partition(m, d, is_in_use=True)
+        p3 = make_partition(m, d)
+        p4 = make_partition(m, d, is_in_use=True)
+        p5 = make_partition(m, d)
+
+        d2 = d._reformatted()
+
+        self.assertIsNot(d, d2)
+        self.assertEqual(d.partitions(), [p1, p2, p3, p4, p5])
+        self.assertEqual(d2.partitions(), [p1, p2, p4])
+
+    def test__excluding_partition(self):
+        m, d = make_model_and_disk()
+
+        p1 = make_partition(m, d)
+        p2 = make_partition(m, d)
+
+        d2 = d._excluding_partition(p1)
+
+        self.assertIsNot(d, d2)
+        self.assertEqual(d.partitions(), [p1, p2])
+        self.assertEqual(d2.partitions(), [p2])
+
 
 class TestPartition(unittest.TestCase):
     def test_is_logical(self):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -167,8 +167,8 @@ def make_disk(fs_model=None, **kw):
     return disk
 
 
-def make_model_and_disk(bootloader=None, **kw):
-    model = make_model(bootloader)
+def make_model_and_disk(bootloader=None, storage_version=None, **kw):
+    model = make_model(bootloader, storage_version)
     return model, make_disk(model, **kw)
 
 

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -179,12 +179,16 @@ def make_partition(
     if device is None:
         device = make_disk(model)
     model = device._m
-    if size is None or offset is None:
-        gap = gaps.largest_gap(device)
+    if size is None or size == -1 or offset is None:
+        if offset is None:
+            gap = gaps.largest_gap(device)
+            offset = gap.offset
+        else:
+            gap = gaps.includes(device, offset)
         if size is None:
             size = gap.size // 2
-        if offset is None:
-            offset = gap.offset
+        elif size == -1:
+            size = gap.size - (offset - gap.offset)
     partition = Partition(
         m=model,
         device=device,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -742,7 +742,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         will not necessarily match partition.offset and partition.size."""
         partition = self.get_partition(disk, target.partition_number)
         self.delete_partition(partition, override_preserve=True)
-        return gaps.includes(disk, partition.offset)
+        return gaps.find_gap_after_removal(disk, removed_partition=partition)
 
     def set_info_for_capability(self, capability: GuidedCapability):
         """Given a request for a capability, select the variation to use."""
@@ -1304,7 +1304,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 if not boot.can_be_boot_device(altered_disk, with_reformatting=False):
                     continue
 
-                gap = gaps.includes(altered_disk, offset=partition.offset)
+                gap = gaps.find_gap_after_removal(
+                    altered_disk, removed_partition=partition
+                )
                 if not self.use_gap_has_enough_room_for_partitions(altered_disk, gap):
                     log.error(
                         "skipping TargetEraseInstall: not enough room for primary"

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -740,6 +740,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         there was free space before or after the partition being removed, it
         will be included in the returned gap. Therefore gap.offset and gap.size
         will not necessarily match partition.offset and partition.size."""
+        if self.model.storage_version < 2:
+            raise StorageRecoverableError(
+                '"Erase and Install" requires storage version 2'
+            )
         partition = self.get_partition(disk, target.partition_number)
         self.delete_partition(partition, override_preserve=True)
         return gaps.find_gap_after_removal(disk, removed_partition=partition)
@@ -1283,6 +1287,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self, install_min: int
     ) -> list[tuple[int, GuidedStorageTargetEraseInstall]]:
         scenarios: list[tuple[int, GuidedStorageTargetEraseInstall]] = []
+        if self.model.storage_version < 2:
+            return []
 
         for disk in self.potential_boot_disks(check_boot=False):
             # Skip RAID until we know how to proceed.

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -890,8 +890,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.model.expose_recovery_keys()
         await self.configured()
 
-    def potential_boot_disks(self, check_boot=True, with_reformatting=False):
-        disks = []
+    def potential_boot_disks(
+        self, check_boot=True, with_reformatting=False
+    ) -> list[ModelDisk | Raid]:
+        disks: list[ModelDisk | Raid] = []
         for raid in self.model._all(type="raid"):
             if check_boot and not boot.can_be_boot_device(
                 raid, with_reformatting=with_reformatting
@@ -1277,6 +1279,58 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 scenarios.append((vals.install_max, resize))
         return scenarios
 
+    def available_erase_install_scenarios(
+        self, install_min: int
+    ) -> list[tuple[int, GuidedStorageTargetEraseInstall]]:
+        scenarios: list[tuple[int, GuidedStorageTargetEraseInstall]] = []
+
+        for disk in self.potential_boot_disks(check_boot=False):
+            # Skip RAID until we know how to proceed.
+            if not isinstance(disk, ModelDisk):
+                continue
+
+            for partition in disk.partitions():
+                if partition._is_in_use:
+                    continue
+
+                if partition.os is None:
+                    continue
+
+                # Make an ephemeral copy of the disk object with the relevant
+                # partition removed. Then it's as if we're installing in the
+                # resulting gap (which will include free space that was
+                # directly before or after the partition that we removed).
+                altered_disk = disk._excluding_partition(partition)
+                if not boot.can_be_boot_device(altered_disk, with_reformatting=False):
+                    continue
+
+                gap = gaps.includes(altered_disk, offset=partition.offset)
+                if not self.use_gap_has_enough_room_for_partitions(altered_disk, gap):
+                    log.error(
+                        "skipping TargetEraseInstall: not enough room for primary"
+                        " partitions after removing %s from %s",
+                        partition.number,
+                        disk.id,
+                    )
+                    continue
+
+                capability_info = CapabilityInfo()
+                for variation in self._variation_info.values():
+                    if variation.is_core_boot_classic():
+                        continue
+                    capability_info.combine(
+                        variation.capability_info_for_gap(gap, install_min)
+                    )
+
+                erase = GuidedStorageTargetEraseInstall(
+                    disk.id,
+                    partition.number,
+                    allowed=capability_info.allowed,
+                    disallowed=capability_info.disallowed,
+                )
+                scenarios.append((gap.size, erase))
+        return scenarios
+
     async def v2_guided_GET(self, wait: bool = False) -> GuidedStorageResponseV2:
         """Acquire a list of possible guided storage configuration scenarios.
         Results are sorted by the size of the space potentially available to
@@ -1314,6 +1368,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
         scenarios.extend(self.available_use_gap_scenarios(install_min))
         scenarios.extend(self.available_target_resize_scenarios(install_min))
+        scenarios.extend(self.available_erase_install_scenarios(install_min))
 
         scenarios.sort(reverse=True, key=lambda x: x[0])
         return GuidedStorageResponseV2(


### PR DESCRIPTION
Steps to try with the TUI + curl:

1. apply this patch
```diff
diff --git a/Makefile b/Makefile
index 87e666ab..5bb0e0de 100644
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ PYTHONSRC=$(NAME)
 PYTHONPATH=$(shell pwd):$(shell pwd)/probert:$(shell pwd)/curtin
 PROBERTDIR=./probert
 PROBERT_REPO=https://github.com/canonical/probert
-DRYRUN?=--dry-run --bootloader uefi --machine-config examples/machines/simple.json \
+DRYRUN?=--dry-run --bootloader uefi --machine-config examples/machines/threebuntu-on-msdos.json \
        --source-catalog examples/sources/install.yaml \
-       --postinst-hooks-dir examples/postinst.d/
+       --postinst-hooks-dir examples/postinst.d/ --storage-version=2
 export PYTHONPATH
 CWD := $(shell pwd)
```
2. run `make dryrun`
3. navigate to the guided screen
4. list the guided scenarios using a GET query to /storage/v2/guided
5. apply a scenario using a POST query to /storage/v2/guided
6. select "Custom storage layout" on the TUI and then [ Done ]. The effect of the POST query should be visible.

I have two scripts that can simplify the process of sending the GET / POST queries:

* [curl.sh](https://paste.ubuntu.com/p/7QrFQJJxH7/)
* [curl-guided.py](https://paste.ubuntu.com/p/RW6NJDY7HT/) (depends on curl.sh)

<details>
<summary>

~~Known issue (fixed)~~
----------------------------
</summary>
With threebuntu-on-msdos.json, one of the scenario seems to mess up with the partition numbers (see partition 2 in the extended partition)


```bash
./curl-guided.py 2
```
```
            MOUNT POINT     SIZE    TYPE           DEVICE TYPE                           
          [ /              46.565G  new ext4       new partition of local disk      ▸ ]  
          [ /boot/efi     512.000M  existing vfat  existing partition of local disk ▸ ]  
                                                                                         
                                                                                         
          AVAILABLE DEVICES                                                              
                                                                                         
            DEVICE                                             TYPE           SIZE       
          [ VBOX_HARDDISK_VB0550ba60-f3975b58                  local disk   150.000G  ▸ ]
            partition 2    existing, extended, unused                       102.931G  ▸  
              partition 1  existing, logical, already formatted as ext4,     46.565G  ▸  
                           not mounted                                                   
              partition 2  existing, logical, already formatted as ext4,     56.365G  ▸  
                           not mounted                                                   
            free space                                                        1.000M  ▸  
                                                                                         
          [ Create software RAID (md) ▸ ]                                                
          [ Create volume group (LVM) ▸ ]                                                
                                                                                         
                                                                                         
          USED DEVICES                                                                   
                                                                                         
            DEVICE                                             TYPE           SIZE       
          [ VBOX_HARDDISK_VB0550ba60-f3975b58                  local disk   150.000G  ▸ ]
            partition 1    new, to be formatted as ext4, mounted at /        46.565G  ▸  
            partition 3    existing, primary ESP, already formatted as      512.000M  ▸  
                           vfat, mounted at /boot/efi      
```

</details>

TODO
--------

- [x] Add some testing for `available_erase_install_scenarios`. Current unit tests do not declare any existing OSes so no `Erase and Install" scenario is advertised.
- [x]  Make it possible for clients to know when an "Erase and Install" scenarios corresponds to a previous Ubuntu installation. Either that, or only advertise these scenarios.
- [x] Ideally fix the issue with partition numbering (see known issue)
- [x] Do some testing with desktop installer (might need assistance for it)
- [x] Ideally find out why after removing a partition, the resulting gap sometimes appears *after* the partition that was removed.