### PR TITLE
doc: fix use of "flavour" (GB spelling) in examples instead of "flavor"

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -1188,7 +1188,7 @@ Example:
    autoinstall:
       # Install a particular kernel flavour.
       kernel:
-        flavour: hwe
+        flavor: hwe
 
 .. _ai-kernel-crash-dumps:
 


### PR DESCRIPTION
This bug was reported at:

https://bugs.launchpad.net/subiquity/+bug/2088366