### PR TITLE
install: remove previous uuid= and rp-partuuid= in the factory reset grub config

### DIFF
--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -506,6 +506,13 @@ class InstallController(SubiquityController):
                 words = shlex.split(line)
                 if words and words[0] == "linux" and "---" in words:
                     index = words.index("---")
+                    words = [
+                        word
+                        for word in words
+                        if not (
+                            word.startswith("uuid=") or word.startswith("rp-partuuid=")
+                        )
+                    ]
                     words[index - 1 : index - 1] = [
                         "uuid=" + new_casper_uuid,
                         "rp-partuuid=" + rp_uuid,


### PR DESCRIPTION
We received a report that, after creating a USB reset media from the system and reinstalled, the system cannot boot into factory reset partition again.  We found out that there are two uuid= entries in `etc/grub/grub.cfg` in the reinstalled factory reset partition.

This is to remove the additional uuid= and rp-partuuid= entries if they are found in the kernel cmdline we are going to manipulate.