### PR TITLE
storage: add debugging TUI view to debug storage v2 guided scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ i18n:
 dryrun ui-view: probert i18n
 	$(PYTHON) -m subiquity $(DRYRUN) $(MACHARGS)
 
+.PHONY: dryrun-debug-sv2
+dryrun-debug-sv2: probert i18n
+	$(PYTHON) -m subiquity $(DRYRUN) $(MACHARGS) --storage-version=2 --debug-sv2-guided
+
 .PHONY: dryrun-console-conf ui-view-console-conf
 dryrun-console-conf ui-view-console-conf:
 	$(PYTHON) -m console_conf.cmd.tui --dry-run $(MACHARGS)

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -75,6 +75,11 @@ def make_client_args_parser():
         default=".subiquity",
         help="in dryrun, control basedir of files",
     )
+    # Only for debugging - helps to reproduce some storage v2 guided scenarios
+    # issues.
+    parser.add_argument(
+        "--debug-sv2-guided", action="store_true", help=argparse.SUPPRESS
+    )
     return parser
 
 


### PR DESCRIPTION
The TUI gained a new CLI option (i.e., --debug-sv2-guided) causing the normal guided storage view to be replaced by a debugging view.

The debugging view is blunt but offers at least some support for all v2 guided scenarios (target reformat, use_gap, resize, erase & install, ...) which the normal view lacks support for.

The list of scenarios is taken straight from what the API returns. There is no filtering (capabilities are basically ignored) and currently no customization is possible (e.g., resizing always takes the recommended size).

Nevertheless, this new view could be very helpful to reproduce storage bugs that occurred on the desktop installer.

Also, the makefile now has a `dryrun-debug-sv2` target that runs subiquity in dry-run mode with the relevant options to make the new debugging view usable.

Example with threebuntu-on-msdos.json:

![Screenshot from 2025-01-07 13-36-03](https://github.com/user-attachments/assets/8a2b3cab-9da8-431f-9f88-1948eab69280)
