### PR TITLE
Noble merge 2025 01 08

### DIFF
--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -88,7 +88,7 @@ class Gap:
 
 
 @functools.singledispatch
-def parts_and_gaps(device):
+def parts_and_gaps(device, ignore_disk_fs=False):
     raise NotImplementedError(device)
 
 
@@ -191,8 +191,8 @@ def find_disk_gaps_v2(device, info=None):
 
 @parts_and_gaps.register(Disk)
 @parts_and_gaps.register(Raid)
-def parts_and_gaps_disk(device):
-    if device._fs is not None:
+def parts_and_gaps_disk(device, ignore_disk_fs=False):
+    if device._fs is not None and not ignore_disk_fs:
         return []
     if device._m.storage_version == 1:
         return find_disk_gaps_v1(device)
@@ -201,7 +201,7 @@ def parts_and_gaps_disk(device):
 
 
 @parts_and_gaps.register(LVM_VolGroup)
-def _parts_and_gaps_vg(device):
+def _parts_and_gaps_vg(device, ignore_disk_fs=False):
     used = 0
     r = []
     for lv in device._partitions:
@@ -277,7 +277,7 @@ def movable_trailing_partitions_and_gap_size(partition):
 def _movable_trailing_partitions_and_gap_size_partition(
     partition: Partition,
 ) -> Tuple[List[Partition], int]:
-    pgs = parts_and_gaps(partition.device)
+    pgs = parts_and_gaps(partition.device, ignore_disk_fs=True)
     part_idx = pgs.index(partition)
     trailing_partitions = []
     in_extended = partition.is_logical

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1730,7 +1730,7 @@ class FilesystemModel:
 
     def disk_for_match(
         self, disks: Sequence[_Device], match: MatchDirective | Sequence[MatchDirective]
-    ) -> _Device:
+    ) -> Optional[_Device]:
         log.info(f"considering {disks} for {match}")
         if not isinstance(match, Sequence):
             match = [match]

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -612,6 +612,16 @@ class _Device(_Formattable, ABC):
     def size(self):
         pass
 
+    @property
+    @abstractmethod
+    def sort_key(self) -> Tuple:
+        """return a value that is usable for sorting.  The intent here is
+        that two runs of a specific version of subiquity must produce an
+        identical sort result for _Devices, so that while Subiquity might make
+        an arbitrary choice of disk, it's a consistent arbitrary choice.
+        """
+        pass
+
     # [Partition]
     _partitions: List["Partition"] = attributes.backlink(default=attr.Factory(list))
 
@@ -733,6 +743,10 @@ class Disk(_Device):
 
     _info: StorageInfo = attributes.for_api()
     _has_in_use_partition: bool = attributes.for_api(default=False)
+
+    @property
+    def sort_key(self) -> int:
+        return (self.wwn, self.serial, self.path)
 
     @property
     def available_for_partitions(self):
@@ -875,6 +889,10 @@ class Partition(_Formattable):
                 return
         raise Exception("Exceeded number of available partitions")
 
+    @property
+    def sort_key(self) -> int:
+        return (self.device.sort_key(), self.number)
+
     def available(self):
         if self.flag in ["bios_grub", "prep"] or self.grub_device:
             return False
@@ -960,6 +978,10 @@ class Raid(_Device):
     )
     _info: Optional[StorageInfo] = attributes.for_api(default=None)
     _has_in_use_partition = False
+
+    @property
+    def sort_key(self) -> int:
+        return tuple([dev.sort_key for dev in raid_device_sort(self.devices)])
 
     def serialize_devices(self):
         # Surprisingly, the order of devices passed to mdadm --create
@@ -1055,6 +1077,10 @@ class LVM_VolGroup(_Device):
     def size(self):
         # Should probably query actual size somehow for an existing VG!
         return get_lvm_size(self.devices)
+
+    @property
+    def sort_key(self) -> int:
+        return tuple([dev.sort_key for dev in self.devices])
 
     @property
     def available_for_partitions(self):
@@ -1218,6 +1244,10 @@ class ArbitraryDevice(_Device):
     @property
     def size(self):
         return 0
+
+    @property
+    def sort_key(self) -> int:
+        return (self.path,)
 
     ok_for_raid = False
     ok_for_lvm_vg = False
@@ -1650,6 +1680,13 @@ class FilesystemModel:
         return matchers
 
     def _sorted_matches(self, disks: Sequence[_Device], match: dict):
+        # sort first on the sort_key.  Objective here is that if we are falling
+        # back to arbitrary disk selection, we're at least consistent in what
+        # disk we arbitrarily select across runs
+        disks.sort(key=lambda d: d.sort_key)
+
+        # then sort on size, if requested.  Thanks to stable sort, if disks
+        # (or raids) have the same size, the sort_key will tiebreak.
         if match.get("size") == "smallest":
             disks.sort(key=lambda d: d.size)
         elif match.get("size") == "largest":

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1745,24 +1745,28 @@ class TestDiskForMatch(SubiTestCase):
         d2 = make_disk(m)
 
         # this test relies heavily on the assumptions in make_disk
-        actual = m.disk_for_match([d1, d2], {})
-        self.assertEqual(d1, actual)
-        actual = m.disk_for_match([d2, d1], {})
-        self.assertEqual(d1, actual)
+        self.assertEqual(d1, m.disk_for_match([d1, d2], {}))
+        self.assertEqual([d1, d2], m.disks_for_match([d1, d2], {}))
+        self.assertEqual(d1, m.disk_for_match([d2, d1], {}))
+        self.assertEqual([d1, d2], m.disks_for_match([d2, d1], {}))
 
     def test_sort_largest(self):
         m = make_model()
         d100 = make_disk(m, size=100 << 30, serial="s1", path="/dev/d1")
         d200 = make_disk(m, size=200 << 30, serial="s2", path="/dev/d2")
-        actual = m.disk_for_match([d100, d200], {"size": "largest"})
-        self.assertEqual(d200, actual)
+        self.assertEqual(d200, m.disk_for_match([d100, d200], {"size": "largest"}))
+        self.assertEqual(
+            [d200, d100], m.disks_for_match([d100, d200], {"size": "largest"})
+        )
 
     def test_sort_smallest(self):
         m = make_model()
         d200 = make_disk(m, size=200 << 30)
         d100 = make_disk(m, size=100 << 30)
-        actual = m.disk_for_match([d200, d100], {"size": "smallest"})
-        self.assertEqual(d100, actual)
+        self.assertEqual(d100, m.disk_for_match([d200, d100], {"size": "smallest"}))
+        self.assertEqual(
+            [d100, d200], m.disks_for_match([d200, d100], {"size": "smallest"})
+        )
 
     @parameterized.expand(match_sort_criteria)
     def test_sort_serial(self, sort_criteria: str):
@@ -1771,48 +1775,48 @@ class TestDiskForMatch(SubiTestCase):
         d2 = make_disk(m, serial="s2", path=None, wwn=None)
         # while the size sort is reversed when doing largest,
         # we pre-sort on the other criteria, and stable sort helps out
-        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
-        self.assertEqual(d1, actual)
+        self.assertEqual(d1, m.disk_for_match([d2, d1], {"size": sort_criteria}))
+        self.assertEqual([d1, d2], m.disks_for_match([d2, d1], {"size": sort_criteria}))
 
     @parameterized.expand(match_sort_criteria)
     def test_sort_path(self, sort_criteria: str):
         m = make_model()
         d1 = make_disk(m, serial=None, path="/dev/d1", wwn=None)
         d2 = make_disk(m, serial=None, path="/dev/d2", wwn=None)
-        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
-        self.assertEqual(d1, actual)
+        self.assertEqual(d1, m.disk_for_match([d2, d1], {"size": sort_criteria}))
+        self.assertEqual([d1, d2], m.disks_for_match([d2, d1], {"size": sort_criteria}))
 
     @parameterized.expand(match_sort_criteria)
     def test_sort_wwn(self, sort_criteria: str):
         m = make_model()
         d1 = make_disk(m, serial=None, path=None, wwn="w1")
         d2 = make_disk(m, serial=None, path=None, wwn="w2")
-        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
-        self.assertEqual(d1, actual)
+        self.assertEqual(d1, m.disk_for_match([d2, d1], {"size": sort_criteria}))
+        self.assertEqual([d1, d2], m.disks_for_match([d2, d1], {"size": sort_criteria}))
 
     @parameterized.expand(match_sort_criteria)
     def test_sort_wwn_wins(self, sort_criteria: str):
         m = make_model()
         d1 = make_disk(m, serial="s2", path="/dev/d2", wwn="w1")
         d2 = make_disk(m, serial="s1", path="/dev/d1", wwn="w2")
-        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
-        self.assertEqual(d1, actual)
+        self.assertEqual(d1, m.disk_for_match([d2, d1], {"size": sort_criteria}))
+        self.assertEqual([d1, d2], m.disks_for_match([d2, d1], {"size": sort_criteria}))
 
     @parameterized.expand(match_sort_criteria)
     def test_sort_serial_wins(self, sort_criteria: str):
         m = make_model()
         d1 = make_disk(m, serial="s1", path="/dev/d2", wwn="w")
         d2 = make_disk(m, serial="s2", path="/dev/d1", wwn="w")
-        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
-        self.assertEqual(d1, actual)
+        self.assertEqual(d1, m.disk_for_match([d2, d1], {"size": sort_criteria}))
+        self.assertEqual([d1, d2], m.disks_for_match([d2, d1], {"size": sort_criteria}))
 
     @parameterized.expand(match_sort_criteria)
     def test_sort_path_wins(self, sort_criteria: str):
         m = make_model()
         d1 = make_disk(m, serial="s", path="/dev/d1", wwn="w")
         d2 = make_disk(m, serial="s", path="/dev/d2", wwn="w")
-        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
-        self.assertEqual(d1, actual)
+        self.assertEqual(d1, m.disk_for_match([d2, d1], {"size": sort_criteria}))
+        self.assertEqual([d1, d2], m.disks_for_match([d2, d1], {"size": sort_criteria}))
 
     def test_sort_raid(self):
         m = make_model()
@@ -1822,8 +1826,8 @@ class TestDiskForMatch(SubiTestCase):
         d2_2 = make_disk(m, size=200 << 30)
         r1 = make_raid(m, disks={d1_1, d1_2})
         r2 = make_raid(m, disks={d2_1, d2_2})
-        actual = m.disk_for_match([r1, r2], {"size": "largest"})
-        self.assertEqual(r2, actual)
+        self.assertEqual(r2, m.disk_for_match([r1, r2], {"size": "largest"}))
+        self.assertEqual([r2, r1], m.disks_for_match([r1, r2], {"size": "largest"}))
 
     @parameterized.expand(match_sort_criteria)
     def test_sort_raid_on_disks(self, sort_criteria: str):
@@ -1834,23 +1838,23 @@ class TestDiskForMatch(SubiTestCase):
         d2_2 = make_disk(m, serial=None, path=None, wwn="w2_2")
         r1 = make_raid(m, disks={d1_1, d1_2})
         r2 = make_raid(m, disks={d2_1, d2_2})
-        actual = m.disk_for_match([r1, r2], {"size": sort_criteria})
-        self.assertEqual(r1, actual)
+        self.assertEqual(r1, m.disk_for_match([r1, r2], {"size": sort_criteria}))
+        self.assertEqual([r1, r2], m.disks_for_match([r1, r2], {"size": sort_criteria}))
 
     def test_skip_empty(self):
         m = make_model()
         d0 = make_disk(m, size=0)
         d100 = make_disk(m, size=100 << 30)
-        actual = m.disk_for_match([d0, d100], {"size": "smallest"})
-        self.assertEqual(d100, actual)
+        self.assertEqual(d100, m.disk_for_match([d0, d100], {"size": "smallest"}))
+        self.assertEqual([d100], m.disks_for_match([d0, d100], {"size": "smallest"}))
 
     def test_skip_in_use_size(self):
         m = make_model()
         d100 = make_disk(m, size=100 << 30)
         d200 = make_disk(m, size=200 << 30)
         d100._has_in_use_partition = True
-        actual = m.disk_for_match([d100, d200], {"size": "smallest"})
-        self.assertEqual(d200, actual)
+        self.assertEqual(d200, m.disk_for_match([d100, d200], {"size": "smallest"}))
+        self.assertEqual([d200], m.disks_for_match([d100, d200], {"size": "smallest"}))
 
     def test_skip_in_use_ssd(self):
         m = make_model()
@@ -1859,8 +1863,12 @@ class TestDiskForMatch(SubiTestCase):
         d_in_use._has_in_use_partition = True
         d_in_use.info_for_display = Mock(return_value={"rotational": "false"})
         d_not_used.info_for_display = Mock(return_value={"rotational": "false"})
-        actual = m.disk_for_match([d_in_use, d_not_used], {"ssd": True})
-        self.assertEqual(d_not_used, actual)
+        self.assertEqual(
+            d_not_used, m.disk_for_match([d_in_use, d_not_used], {"ssd": True})
+        )
+        self.assertEqual(
+            [d_not_used], m.disks_for_match([d_in_use, d_not_used], {"ssd": True})
+        )
 
     def test_matcher_serial(self):
         m = make_model()
@@ -1868,7 +1876,9 @@ class TestDiskForMatch(SubiTestCase):
         d2 = make_disk(m, serial="2")
         fake_up_blockdata(m)
         self.assertEqual(d1, m.disk_for_match([d1, d2], {"serial": "1"}))
+        self.assertEqual([d1], m.disks_for_match([d1, d2], {"serial": "1"}))
         self.assertEqual(d2, m.disk_for_match([d1, d2], {"serial": "2"}))
+        self.assertEqual([d2], m.disks_for_match([d1, d2], {"serial": "2"}))
 
     def test_matcher_model(self):
         m = make_model()
@@ -1877,7 +1887,9 @@ class TestDiskForMatch(SubiTestCase):
         d2 = make_disk(m)
         fake_up_blockdata_disk(d2, ID_MODEL="m2")
         self.assertEqual(d1, m.disk_for_match([d1, d2], {"model": "m1"}))
+        self.assertEqual([d1], m.disks_for_match([d1, d2], {"model": "m1"}))
         self.assertEqual(d2, m.disk_for_match([d1, d2], {"model": "m2"}))
+        self.assertEqual([d2], m.disks_for_match([d1, d2], {"model": "m2"}))
 
     def test_matcher_vendor(self):
         m = make_model()
@@ -1886,7 +1898,9 @@ class TestDiskForMatch(SubiTestCase):
         d2 = make_disk(m)
         fake_up_blockdata_disk(d2, ID_VENDOR="v2")
         self.assertEqual(d1, m.disk_for_match([d1, d2], {"vendor": "v1"}))
+        self.assertEqual([d1], m.disks_for_match([d1, d2], {"vendor": "v1"}))
         self.assertEqual(d2, m.disk_for_match([d1, d2], {"vendor": "v2"}))
+        self.assertEqual([d2], m.disks_for_match([d1, d2], {"vendor": "v2"}))
 
     def test_matcher_path(self):
         m = make_model()
@@ -1894,7 +1908,9 @@ class TestDiskForMatch(SubiTestCase):
         vdb = make_disk(m, path="/dev/vdb")
         fake_up_blockdata(m)
         self.assertEqual(vda, m.disk_for_match([vda, vdb], {"path": "/dev/vda"}))
+        self.assertEqual([vda], m.disks_for_match([vda, vdb], {"path": "/dev/vda"}))
         self.assertEqual(vdb, m.disk_for_match([vda, vdb], {"path": "/dev/vdb"}))
+        self.assertEqual([vdb], m.disks_for_match([vda, vdb], {"path": "/dev/vdb"}))
 
     def test_matcher_id_path(self):
         m = make_model()
@@ -1902,10 +1918,10 @@ class TestDiskForMatch(SubiTestCase):
         fake_up_blockdata_disk(vda, ID_PATH="pci-0000:00:00.0-nvme-vda")
         vdb = make_disk(m)
         fake_up_blockdata_disk(vdb, ID_PATH="pci-0000:00:00.0-nvme-vdb")
-        actual = m.disk_for_match([vda, vdb], {"id_path": "*vda"})
-        self.assertEqual(vda, actual)
-        actual = m.disk_for_match([vda, vdb], {"id_path": "*vdb"})
-        self.assertEqual(vdb, actual)
+        self.assertEqual(vda, m.disk_for_match([vda, vdb], {"id_path": "*vda"}))
+        self.assertEqual([vda], m.disks_for_match([vda, vdb], {"id_path": "*vda"}))
+        self.assertEqual(vdb, m.disk_for_match([vda, vdb], {"id_path": "*vdb"}))
+        self.assertEqual([vdb], m.disks_for_match([vda, vdb], {"id_path": "*vdb"}))
 
     def test_matcher_install_media(self):
         m = make_model()
@@ -1913,8 +1929,8 @@ class TestDiskForMatch(SubiTestCase):
         iso._has_in_use_partition = True
         disk = make_disk(m)
         fake_up_blockdata(m)
-        actual = m.disk_for_match([iso, disk], {"install-media": True})
-        self.assertEqual(iso, actual)
+        self.assertEqual(iso, m.disk_for_match([iso, disk], {"install-media": True}))
+        self.assertEqual([iso], m.disks_for_match([iso, disk], {"install-media": True}))
 
     def test_match_from_list_first(self):
         m = make_model()
@@ -1926,6 +1942,7 @@ class TestDiskForMatch(SubiTestCase):
             {"path": "/dev/vdb"},
         ]
         self.assertEqual(vda, m.disk_for_match([vda, vdb], match))
+        self.assertEqual([vda], m.disks_for_match([vda, vdb], match))
 
     def test_match_from_list_second(self):
         m = make_model()
@@ -1937,3 +1954,4 @@ class TestDiskForMatch(SubiTestCase):
             {"path": "/dev/vdb"},
         ]
         self.assertEqual(vdb, m.disk_for_match([vda, vdb], match))
+        self.assertEqual([vdb], m.disks_for_match([vda, vdb], match))

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -207,9 +207,11 @@ def make_model_and_partition(bootloader=None):
     return model, make_partition(model, disk)
 
 
-def make_raid(model, **kw):
+def make_raid(model, disks=None, **kw):
     name = "md%s" % len(model._actions)
-    r = model.add_raid(name, "raid1", {make_disk(model), make_disk(model)}, set())
+    if disks is None:
+        disks = {make_disk(model), make_disk(model)}
+    r = model.add_raid(name, "raid1", disks, set())
     size = r.size
     for k, v in kw.items():
         setattr(r, k, v)

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1737,17 +1737,23 @@ class TestOnRemoteStorage(SubiTestCase):
 
 
 class TestDiskForMatch(SubiTestCase):
+    match_sort_criteria = (["smallest"], ["largest"])
+
     def test_empty_match_directive(self):
         m = make_model()
         d1 = make_disk(m)
         d2 = make_disk(m)
+
+        # this test relies heavily on the assumptions in make_disk
         actual = m.disk_for_match([d1, d2], {})
+        self.assertEqual(d1, actual)
+        actual = m.disk_for_match([d2, d1], {})
         self.assertEqual(d1, actual)
 
     def test_sort_largest(self):
         m = make_model()
-        d100 = make_disk(m, size=100 << 30)
-        d200 = make_disk(m, size=200 << 30)
+        d100 = make_disk(m, size=100 << 30, serial="s1", path="/dev/d1")
+        d200 = make_disk(m, size=200 << 30, serial="s2", path="/dev/d2")
         actual = m.disk_for_match([d100, d200], {"size": "largest"})
         self.assertEqual(d200, actual)
 
@@ -1757,6 +1763,79 @@ class TestDiskForMatch(SubiTestCase):
         d100 = make_disk(m, size=100 << 30)
         actual = m.disk_for_match([d200, d100], {"size": "smallest"})
         self.assertEqual(d100, actual)
+
+    @parameterized.expand(match_sort_criteria)
+    def test_sort_serial(self, sort_criteria: str):
+        m = make_model()
+        d1 = make_disk(m, serial="s1", path=None, wwn=None)
+        d2 = make_disk(m, serial="s2", path=None, wwn=None)
+        # while the size sort is reversed when doing largest,
+        # we pre-sort on the other criteria, and stable sort helps out
+        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
+        self.assertEqual(d1, actual)
+
+    @parameterized.expand(match_sort_criteria)
+    def test_sort_path(self, sort_criteria: str):
+        m = make_model()
+        d1 = make_disk(m, serial=None, path="/dev/d1", wwn=None)
+        d2 = make_disk(m, serial=None, path="/dev/d2", wwn=None)
+        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
+        self.assertEqual(d1, actual)
+
+    @parameterized.expand(match_sort_criteria)
+    def test_sort_wwn(self, sort_criteria: str):
+        m = make_model()
+        d1 = make_disk(m, serial=None, path=None, wwn="w1")
+        d2 = make_disk(m, serial=None, path=None, wwn="w2")
+        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
+        self.assertEqual(d1, actual)
+
+    @parameterized.expand(match_sort_criteria)
+    def test_sort_wwn_wins(self, sort_criteria: str):
+        m = make_model()
+        d1 = make_disk(m, serial="s2", path="/dev/d2", wwn="w1")
+        d2 = make_disk(m, serial="s1", path="/dev/d1", wwn="w2")
+        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
+        self.assertEqual(d1, actual)
+
+    @parameterized.expand(match_sort_criteria)
+    def test_sort_serial_wins(self, sort_criteria: str):
+        m = make_model()
+        d1 = make_disk(m, serial="s1", path="/dev/d2", wwn="w")
+        d2 = make_disk(m, serial="s2", path="/dev/d1", wwn="w")
+        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
+        self.assertEqual(d1, actual)
+
+    @parameterized.expand(match_sort_criteria)
+    def test_sort_path_wins(self, sort_criteria: str):
+        m = make_model()
+        d1 = make_disk(m, serial="s", path="/dev/d1", wwn="w")
+        d2 = make_disk(m, serial="s", path="/dev/d2", wwn="w")
+        actual = m.disk_for_match([d2, d1], {"size": sort_criteria})
+        self.assertEqual(d1, actual)
+
+    def test_sort_raid(self):
+        m = make_model()
+        d1_1 = make_disk(m, size=100 << 30)
+        d1_2 = make_disk(m, size=100 << 30)
+        d2_1 = make_disk(m, size=200 << 30)
+        d2_2 = make_disk(m, size=200 << 30)
+        r1 = make_raid(m, disks={d1_1, d1_2})
+        r2 = make_raid(m, disks={d2_1, d2_2})
+        actual = m.disk_for_match([r1, r2], {"size": "largest"})
+        self.assertEqual(r2, actual)
+
+    @parameterized.expand(match_sort_criteria)
+    def test_sort_raid_on_disks(self, sort_criteria: str):
+        m = make_model()
+        d1_1 = make_disk(m, serial=None, path=None, wwn="w1_1")
+        d1_2 = make_disk(m, serial=None, path=None, wwn="w1_2")
+        d2_1 = make_disk(m, serial=None, path=None, wwn="w2_1")
+        d2_2 = make_disk(m, serial=None, path=None, wwn="w2_2")
+        r1 = make_raid(m, disks={d1_1, d1_2})
+        r2 = make_raid(m, disks={d2_1, d2_2})
+        actual = m.disk_for_match([r1, r2], {"size": sort_criteria})
+        self.assertEqual(r1, actual)
 
     def test_skip_empty(self):
         m = make_model()

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -66,6 +66,7 @@ from subiquity.models.filesystem import (
 )
 from subiquity.models.filesystem import Disk as ModelDisk
 from subiquity.models.filesystem import (
+    MatchDirective,
     MiB,
     Raid,
     RecoveryKeyHandler,
@@ -1377,7 +1378,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             break
 
     def get_bootable_matching_disk(
-        self, match: dict[str, str] | Sequence[dict[str, str]]
+        self, match: MatchDirective | Sequence[MatchDirective]
     ):
         """given a match directive, find disks or disk-like devices for which
         we have a plan to boot, and return the best matching one of those.

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1490,8 +1490,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             disk = self.get_bootable_matching_disk(match)
             target = GuidedStorageTargetReformat(disk_id=disk.id, allowed=[])
         elif mode == "use_gap":
-            bootable = self.potential_boot_disks(with_reformatting=False)
-            gap = gaps.largest_gap(bootable)
+            match = layout.get("match", {})
+            bootable_disks = self.get_bootable_matching_disks(match)
+            gap = gaps.largest_gap(bootable_disks)
             if not gap:
                 raise Exception(
                     "autoinstall cannot configure storage "

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1098,7 +1098,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         return sorted(classic_capabilities)
 
     def available_use_gap_scenarios(
-        self, install_min
+        self, install_min: int
     ) -> list[tuple[int, GuidedStorageTargetUseGap]]:
         scenarios: list[tuple[int, GuidedStorageTargetUseGap]] = []
         for disk in self.potential_boot_disks(with_reformatting=False):
@@ -1151,6 +1151,36 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             scenarios.append((gap.size, use_gap))
         return scenarios
 
+    def available_target_resize_scenarios(
+        self, install_min: int
+    ) -> list[tuple[int, GuidedStorageTargetResize]]:
+        scenarios: list[tuple[int, GuidedStorageTargetResize]] = []
+
+        for disk in self.potential_boot_disks(check_boot=False):
+            part_align = disk.alignment_data().part_align
+            for partition in disk.partitions():
+                if partition._is_in_use:
+                    continue
+                vals = sizes.calculate_guided_resize(
+                    partition.estimated_min_size,
+                    partition.size,
+                    install_min,
+                    part_align=part_align,
+                )
+                if vals is None:
+                    # Return a reason here
+                    continue
+                if not boot.can_be_boot_device(
+                    disk, resize_partition=partition, with_reformatting=False
+                ):
+                    # Return a reason here
+                    continue
+                resize = GuidedStorageTargetResize.from_recommendations(
+                    partition, vals, allowed=self.get_classic_capabilities()
+                )
+                scenarios.append((vals.install_max, resize))
+        return scenarios
+
     async def v2_guided_GET(self, wait: bool = False) -> GuidedStorageResponseV2:
         """Acquire a list of possible guided storage configuration scenarios.
         Results are sorted by the size of the space potentially available to
@@ -1182,30 +1212,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             scenarios.append((disk.size, reformat))
 
         scenarios.extend(self.available_use_gap_scenarios(install_min))
-
-        for disk in self.potential_boot_disks(check_boot=False):
-            part_align = disk.alignment_data().part_align
-            for partition in disk.partitions():
-                if partition._is_in_use:
-                    continue
-                vals = sizes.calculate_guided_resize(
-                    partition.estimated_min_size,
-                    partition.size,
-                    install_min,
-                    part_align=part_align,
-                )
-                if vals is None:
-                    # Return a reason here
-                    continue
-                if not boot.can_be_boot_device(
-                    disk, resize_partition=partition, with_reformatting=False
-                ):
-                    # Return a reason here
-                    continue
-                resize = GuidedStorageTargetResize.from_recommendations(
-                    partition, vals, allowed=classic_capabilities
-                )
-                scenarios.append((vals.install_max, resize))
+        scenarios.extend(self.available_target_resize_scenarios(install_min))
 
         scenarios.sort(reverse=True, key=lambda x: x[0])
         return GuidedStorageResponseV2(

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1098,6 +1098,47 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 classic_capabilities.update(info.capability_info.allowed)
         return sorted(classic_capabilities)
 
+    def _guided_has_enough_room_for_partitions(
+        self,
+        disk,
+        *,
+        resized_partition: Optional[Partition] = None,
+        gap: Optional[gaps.Gap] = None,
+    ) -> bool:
+        """Check if we have enough room for all the primary partitions. This
+        isn't failproof but should limit the number of TargetResize/UseGap
+        scenarios that are suggested but can't be applied because we don't have
+        enough room for partitions.
+        """
+        if (resized_partition is None) == (gap is None):
+            raise ValueError("please specify either resized_partition or gap")
+
+        new_primary_parts = 0
+        if resized_partition is not None:
+            install_to_logical = resized_partition.is_logical
+        else:
+            install_to_logical = gap.in_extended
+
+        if not install_to_logical:
+            new_primary_parts += 1
+
+        boot_plan = boot.get_boot_device_plan(disk, resize_partition=resized_partition)
+        new_primary_parts += boot_plan.new_partition_count()
+        # In theory, there could be a recovery partition as well. Not sure
+        # how to account for it since we don't know yet if one will be
+        # requested.
+        return new_primary_parts <= gaps.remaining_primary_partitions(
+            disk, disk.alignment_data()
+        )
+
+    def use_gap_has_enough_room_for_partitions(self, disk, gap: gaps.Gap) -> bool:
+        return self._guided_has_enough_room_for_partitions(disk, gap=gap)
+
+    def resize_has_enough_room_for_partitions(self, disk, resized: Partition) -> bool:
+        return self._guided_has_enough_room_for_partitions(
+            disk, resized_partition=resized
+        )
+
     def available_use_gap_scenarios(
         self, install_min: int
     ) -> list[tuple[int, GuidedStorageTargetUseGap]]:
@@ -1117,21 +1158,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             if gap is None:
                 # Do we return a reason here?
                 continue
-
-            # Now we check if we have enough room for all the primary
-            # partitions. This isn't failproof but should limit the number of
-            # UseGaps scenarios that are suggested but can't be applied because
-            # we don't have enough room for partitions.
-            new_primary_parts = 0
-            if not gap.in_extended:
-                new_primary_parts += 1  # For the rootfs to create.
-            new_primary_parts += boot.get_boot_device_plan(disk).new_partition_count()
-            # In theory, there could be a recovery partition as well. Not sure
-            # how to account for it since we don't know yet if one will be
-            # requested.
-            if new_primary_parts > gaps.remaining_primary_partitions(
-                disk, disk.alignment_data()
-            ):
+            if not self.use_gap_has_enough_room_for_partitions(disk, gap):
                 log.error("skipping UseGap: not enough room for primary partitions")
                 continue
 
@@ -1151,23 +1178,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             )
             scenarios.append((gap.size, use_gap))
         return scenarios
-
-    def resize_has_enough_room_for_partitions(self, disk, resized: Partition) -> bool:
-        """Check if we have enough room for all the primary partitions. This
-        isn't failproof but should limit the number of TargetResize scenarios
-        that are suggested but can't be applied because we don't have enough
-        room for partitions."""
-        new_primary_parts = 0
-        if not resized.is_logical:
-            new_primary_parts += 1
-        boot_plan = boot.get_boot_device_plan(disk, resize_partition=resized)
-        new_primary_parts += boot_plan.new_partition_count()
-        # In theory, there could be a recovery partition as well. Not sure
-        # how to account for it since we don't know yet if one will be
-        # requested.
-        return new_primary_parts <= gaps.remaining_primary_partitions(
-            disk, disk.alignment_data()
-        )
 
     def available_target_resize_scenarios(
         self, install_min: int

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -1692,12 +1692,20 @@ class TestMatchingDisks(IsolatedAsyncioTestCase):
     def test_no_match_raises_AutoinstallError(self):
         with self.assertRaises(AutoinstallError):
             self.fsc.get_bootable_matching_disk({"size": "largest"})
+        with self.assertRaises(AutoinstallError):
+            self.fsc.get_bootable_matching_disks({"size": "largest"})
 
     def test_two_matches(self):
-        make_disk(self.fsc.model, size=10 << 30)
+        d1 = make_disk(self.fsc.model, size=10 << 30)
         d2 = make_disk(self.fsc.model, size=20 << 30)
-        actual = self.fsc.get_bootable_matching_disk({"size": "largest"})
-        self.assertEqual(d2, actual)
+        self.assertEqual(d2, self.fsc.get_bootable_matching_disk({"size": "largest"}))
+        self.assertEqual(d1, self.fsc.get_bootable_matching_disk({"size": "smallest"}))
+        self.assertEqual(
+            [d2, d1], self.fsc.get_bootable_matching_disks({"size": "largest"})
+        )
+        self.assertEqual(
+            [d1, d2], self.fsc.get_bootable_matching_disks({"size": "smallest"})
+        )
 
     @mock.patch("subiquity.common.filesystem.boot.can_be_boot_device")
     def test_actually_match_raid(self, m_cbb):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -1094,17 +1094,19 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             reformat,
         )
 
-        resize = possible.pop(0)
-        expected = GuidedStorageTargetResize(
-            disk_id=self.disk.id,
-            partition_number=p.number,
-            new_size=200 << 30,
-            minimum=50 << 30,
-            recommended=200 << 30,
-            maximum=230 << 30,
-            allowed=default_capabilities,
-        )
-        self.assertEqual(expected, resize)
+        if ptable != "vtoc" or bootloader == Bootloader.NONE:
+            # VTOC has primary_part_limit=3
+            resize = possible.pop(0)
+            expected = GuidedStorageTargetResize(
+                disk_id=self.disk.id,
+                partition_number=p.number,
+                new_size=200 << 30,
+                minimum=50 << 30,
+                recommended=200 << 30,
+                maximum=230 << 30,
+                allowed=default_capabilities,
+            )
+            self.assertEqual(expected, resize)
         self.assertEqual(1, len(possible))
 
     @parameterized.expand(bootloaders_and_ptables)
@@ -1429,6 +1431,86 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             scenarios = self.fsc.available_use_gap_scenarios(install_min)
 
         self.assertEqual(expected_scenario, scenarios != [])
+
+    async def test_resize_has_enough_room_for_partitions__one_primary(self):
+        await self._setup(Bootloader.NONE, "gpt", fix_bios=True)
+
+        p = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
+
+        self.assertTrue(self.fsc.resize_has_enough_room_for_partitions(self.disk, p))
+
+    async def test_resize_has_enough_room_for_partitions__full_primaries(self):
+        await self._setup(Bootloader.NONE, "dos", fix_bios=True)
+
+        p1 = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
+        p2 = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
+        p3 = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
+        p4 = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
+
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(self.disk, p1))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(self.disk, p2))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(self.disk, p3))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(self.disk, p4))
+
+    @mock.patch("subiquity.server.controllers.filesystem.boot.get_boot_device_plan")
+    async def test_resize_has_enough_room_for_partitions__one_more(self, p_boot_plan):
+        await self._setup(Bootloader.NONE, "dos", fix_bios=True)
+
+        model = self.model
+        disk = self.disk
+        # Sizes are irrelevant
+        size = 4 << 20
+        p1 = make_partition(model, disk, preserve=True, size=size)
+        p2 = make_partition(model, disk, preserve=True, size=size)
+        p3 = make_partition(model, disk, preserve=True, size=size)
+
+        p_boot_plan.return_value = boot.CreatePartPlan(
+            mock.Mock(), mock.Mock(), mock.Mock()
+        )
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p1))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p2))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p3))
+
+        p_boot_plan.return_value = boot.NoOpBootPlan()
+        self.assertTrue(self.fsc.resize_has_enough_room_for_partitions(disk, p1))
+        self.assertTrue(self.fsc.resize_has_enough_room_for_partitions(disk, p2))
+        self.assertTrue(self.fsc.resize_has_enough_room_for_partitions(disk, p3))
+
+    @mock.patch("subiquity.server.controllers.filesystem.boot.get_boot_device_plan")
+    async def test_resize_has_enough_room_for_partitions__logical(self, p_boot_plan):
+        await self._setup(Bootloader.NONE, "dos", fix_bios=True)
+
+        model = self.model
+        disk = self.disk
+        # Sizes are irrelevant
+        size = 4 << 20
+        p1 = make_partition(model, disk, preserve=True, size=size)
+        p2 = make_partition(model, disk, preserve=True, size=size, flag="extended")
+        p5 = make_partition(model, disk, preserve=True, size=size, flag="logical")
+        p6 = make_partition(model, disk, preserve=True, size=size, flag="logical")
+        p3 = make_partition(model, disk, preserve=True, size=size)
+        p4 = make_partition(model, disk, preserve=True, size=size)
+
+        p_boot_plan.return_value = boot.CreatePartPlan(
+            mock.Mock(), mock.Mock(), mock.Mock()
+        )
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p1))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p2))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p3))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p4))
+        # we're installing in a logical partition, but we still have not enough
+        # room to apply the boot plan.
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p5))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p6))
+
+        p_boot_plan.return_value = boot.NoOpBootPlan()
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p1))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p2))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p3))
+        self.assertFalse(self.fsc.resize_has_enough_room_for_partitions(disk, p4))
+        # if we're installing in a logical partition, we have enough room
+        self.assertTrue(self.fsc.resize_has_enough_room_for_partitions(disk, p5))
+        self.assertTrue(self.fsc.resize_has_enough_room_for_partitions(disk, p6))
 
 
 class TestManualBoot(IsolatedAsyncioTestCase):


### PR DESCRIPTION
A bunch of bug fixes for noble in no particular order. There are a few cosmetic patches in the batch.

* Arbitrary disk selection more consistent
     * originally part of https://github.com/canonical/subiquity/pull/2050
* LP:#2080608 Honor matches in use-gap autoinstall mode
    * originally part of https://github.com/canonical/subiquity/pull/2083
* LP:#2081738 Fix crash when formatting a disk that has partitions + a filesystem signature
    * originally part of https://github.com/canonical/subiquity/pull/2092
* LP:#2081724 Don't suggest target-resize if there is no more room for primary partitions
    * originally part of #2090