### PR TITLE
Support "core" variant

### DIFF
--- a/examples/answers/core-desktop.yaml
+++ b/examples/answers/core-desktop.yaml
@@ -7,8 +7,6 @@ Refresh:
   update: no
 Keyboard:
   layout: us
-Zdev:
-  accept-default: yes
 Network:
   accept-default: yes
 Proxy:
@@ -16,9 +14,5 @@ Proxy:
 Filesystem:
   guided: yes
   guided-index: 0
-UbuntuPro:
-  token: ""
 InstallProgress:
   reboot: yes
-Drivers:
-  install: yes

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -95,27 +95,41 @@ class SubiquityClient(TuiApplication):
     def make_ui(self):
         return SubiquityUI(self, self.help_menu)
 
-    controllers = [
-        "Serial",
-        "Welcome",
-        "Refresh",
-        "Keyboard",
-        "Source",
-        "Zdev",
-        "Network",
-        "Proxy",
-        "Mirror",
-        "Refresh",
-        "Filesystem",
-        "Identity",
-        "UbuntuPro",
-        "SSH",
-        "Drivers",
-        "SnapList",
-        "Progress",
-    ]
+    variant_to_controllers: Dict[str, List[str]] = {
+        "server": [
+            "Serial",
+            "Welcome",
+            "Refresh",
+            "Keyboard",
+            "Source",
+            "Zdev",
+            "Network",
+            "Proxy",
+            "Mirror",
+            "Refresh",
+            "Filesystem",
+            "Identity",
+            "UbuntuPro",
+            "SSH",
+            "Drivers",
+            "SnapList",
+            "Progress",
+        ],
+        "core": [
+            "Serial",
+            "Welcome",
+            "Refresh",
+            "Keyboard",
+            "Network",
+            "Refresh",
+            "Source",
+            "Filesystem",
+            "Progress",
+        ],
+    }
 
-    variant_to_controllers: Dict[str, List[str]] = {}
+    # Set default controllerset
+    controllers = variant_to_controllers["server"]
 
     def __init__(self, opts, about_msg=None):
         if is_linux_tty():

--- a/subiquity/client/controllers/tests/test_source.py
+++ b/subiquity/client/controllers/tests/test_source.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from subiquity.client.controllers.source import SourceController
+from subiquity.common.types import SourceSelectionAndSetting
+from subiquitycore.tests import SubiTestCase
+from subiquitycore.tests.mocks import make_app
+from subiquitycore.tests.parameterized import parameterized
+from subiquitycore.tuicontroller import Skip
+
+
+class TestSourceController(SubiTestCase):
+    def setUp(self):
+        self.app = make_app()
+        self.app.client = AsyncMock()
+        self.app.show_error_report = Mock()
+        self.app.show_nonreportable_error = Mock()
+
+        self.controller = SourceController(self.app)
+
+    @parameterized.expand(
+        (
+            ("core", 1, True),  # core is the only driverless variant
+            ("core", 2, False),  # don't skip if core has multiple sources
+            ("server", 1, False),  # Any other variant shouldn't skip
+        )
+    )
+    async def test_make_ui__skip_simple_sources(self, variant, sources, skip):
+        """Test source screen is skipped for single-source, driverless media."""
+
+        self.app.variant = variant
+        resp = SourceSelectionAndSetting(
+            sources=[Mock() for i in range(sources)],
+            current_id=0,
+            search_drivers=None,
+        )
+
+        with (
+            patch("subiquity.client.controllers.source.SourceView"),
+            patch.object(self.controller.endpoint, "GET", return_value=resp),
+        ):
+            if not skip:
+                await self.controller.make_ui()
+            else:
+                with self.assertRaises(Skip):
+                    await self.controller.make_ui()

--- a/subiquity/client/tests/test_client.py
+++ b/subiquity/client/tests/test_client.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import Mock
+
+from subiquity.client.client import SubiquityClient
+from subiquitycore.tests import SubiTestCase
+
+
+class TestClientVariantSupport(SubiTestCase):
+    async def asyncSetUp(self):
+        opts = Mock()
+        opts.dry_run = True
+        opts.output_base = self.tmp_dir()
+        opts.machine_config = "examples/machines/simple.json"
+        opts.answers = None
+        self.client = SubiquityClient(opts, None)
+        self.client.make_apport_report = Mock()
+
+    def test_default_variant(self):
+        expected = SubiquityClient.variant_to_controllers["server"]
+        self.assertEqual(
+            # The controllers attribute is a list of names before init
+            SubiquityClient.controllers,
+            expected,
+            "default controller names do not match names for 'server' variant",
+        )
+        self.assertEqual(
+            # The controllers attribute is a ControllerSet after init
+            self.client.controllers.controller_names,
+            expected,
+            "controllers changed unexpectedly during init",
+        )

--- a/subiquity/server/controller.py
+++ b/subiquity/server/controller.py
@@ -111,7 +111,7 @@ class SubiquityController(BaseController):
         """
         pass
 
-    def interactive(self):
+    def interactive(self) -> bool:
         if not self.app.autoinstall_config:
             return self._active
         i_sections = self.app.autoinstall_config.get("interactive-sections", [])
@@ -127,6 +127,8 @@ class SubiquityController(BaseController):
             and self.autoinstall_key_alias in i_sections
         ):
             return self._active
+
+        return False
 
     async def configured(self):
         """Let the world know that this controller's model is now configured."""

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -87,6 +87,7 @@ class SourceController(SubiquityController):
         if os.path.exists(path):
             with open(path) as fp:
                 self.model.load_from_file(fp)
+        self._update_variant(self.model.current.variant)
 
     def make_autoinstall(self):
         return {
@@ -148,10 +149,13 @@ class SourceController(SubiquityController):
             handler = TrivialSourceHandler("/")
         return handler
 
+    def _update_variant(self, variant: str) -> None:
+        self.app.set_source_variant(variant)
+
     async def configured(self):
         await super().configured()
         self._configured = True
-        self.app.set_source_variant(self.model.current.variant)
+        self._update_variant(self.model.current.variant)
 
     async def POST(self, source_id: str, search_drivers: bool = False) -> None:
         # Marking the source model configured has an effect on many of the

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -151,7 +151,7 @@ class SourceController(SubiquityController):
     async def configured(self):
         await super().configured()
         self._configured = True
-        self.app.base_model.set_source_variant(self.model.current.variant)
+        self.app.set_source_variant(self.model.current.variant)
 
     async def POST(self, source_id: str, search_drivers: bool = False) -> None:
         # Marking the source model configured has an effect on many of the

--- a/subiquity/server/controllers/tests/test_source.py
+++ b/subiquity/server/controllers/tests/test_source.py
@@ -92,22 +92,28 @@ class TestSourceController(SubiTestCase):
         self._set_source_catalog(catalog)
         self.controller.load_autoinstall_data(ai_data)
         self.assertEqual(self.controller.model.current.variant, expected)
+        self.assertEqual(
+            self.controller.app.base_model.source.current.variant, expected
+        )
 
-    async def test_on_configure_update_variant(self):
-        """Test update variant through server on configure.
-
-        Ensure the source controller doesn't update variant on the base
-        model directly.
-        """
+    def test_update_variant_through_server(self):
+        """Test update variant through server on configure."""
         app = self.controller.app = unittest.mock.Mock()
         model = self.controller.app.base_model = unittest.mock.Mock()
 
-        self.controller.model.current.variant = "mock-variant"
-
-        with unittest.mock.patch(
-            "subiquity.server.controller.SubiquityController.configured"
-        ):
-            await self.controller.configured()
+        self.controller._update_variant("mock-variant")
 
         app.set_source_variant.assert_called_with("mock-variant")
         model.set_source_variant.assert_not_called()
+
+    async def test_on_configure_update_variant(self):
+        """Test variant is updated on configure."""
+        self.controller.model.current.variant = "mock-variant"
+        with (
+            unittest.mock.patch(
+                "subiquity.server.controller.SubiquityController.configured"
+            ),
+            unittest.mock.patch.object(self.controller, "_update_variant"),
+        ):
+            await self.controller.configured()
+            self.controller._update_variant.assert_called_with("mock-variant")

--- a/subiquity/server/controllers/tests/test_source.py
+++ b/subiquity/server/controllers/tests/test_source.py
@@ -92,3 +92,22 @@ class TestSourceController(SubiTestCase):
         self._set_source_catalog(catalog)
         self.controller.load_autoinstall_data(ai_data)
         self.assertEqual(self.controller.model.current.variant, expected)
+
+    async def test_on_configure_update_variant(self):
+        """Test update variant through server on configure.
+
+        Ensure the source controller doesn't update variant on the base
+        model directly.
+        """
+        app = self.controller.app = unittest.mock.Mock()
+        model = self.controller.app.base_model = unittest.mock.Mock()
+
+        self.controller.model.current.variant = "mock-variant"
+
+        with unittest.mock.patch(
+            "subiquity.server.controller.SubiquityController.configured"
+        ):
+            await self.controller.configured()
+
+        app.set_source_variant.assert_called_with("mock-variant")
+        model.set_source_variant.assert_not_called()

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -114,6 +114,8 @@ class MetaController:
             if controller.endpoint in endpoints:
                 await controller.configured()
 
+    # TODO: Make post to /meta/client_variant a RecoverableError (it doesn't
+    # have to be fatal and it's currently only pseudo-fatal).
     async def client_variant_POST(self, variant: str) -> None:
         if variant not in self.app.supported_variants:
             raise ValueError(f"unrecognized client variant {variant}")

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -119,7 +119,6 @@ class MetaController:
     async def client_variant_POST(self, variant: str) -> None:
         if variant not in self.app.supported_variants:
             raise ValueError(f"unrecognized client variant {variant}")
-        self.app.base_model.set_source_variant(variant)
         self.app.set_source_variant(variant)
 
     async def client_variant_GET(self) -> str:
@@ -355,6 +354,11 @@ class SubiquityServer(Application):
 
     def set_source_variant(self, variant):
         self.variant = variant
+
+        # Update the model variant too.
+        # Guard for init. The "base_model" attribute isn't set until .run() is called.
+        if getattr(self, "base_model", None) is not None:
+            self.base_model.set_source_variant(variant)
 
     def load_serialized_state(self):
         for controller in self.controllers.instances:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -285,7 +285,7 @@ class SubiquityServer(Application):
         "Shutdown",
     ]
 
-    supported_variants = ["server", "desktop"]
+    supported_variants = ["server", "desktop", "core"]
 
     def make_model(self):
         root = "/"

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -744,3 +744,18 @@ class TestEventReporting(SubiTestCase):
         (message,) = journal_send_mock.call_args.args
         self.assertIn("message", message)
         self.assertNotIn("description", message)
+
+
+class TestVariantHandling(SubiTestCase):
+    async def asyncSetUp(self):
+        opts = Mock()
+        opts.dry_run = True
+        opts.output_base = self.tmp_dir()
+        opts.machine_config = NOPROBERARG
+        self.server = SubiquityServer(opts, None)
+
+    def test_set_source_variant(self):
+        self.server.base_model = Mock()
+        self.server.set_source_variant("mock-variant")
+        self.assertEqual(self.server.variant, "mock-variant")
+        self.server.base_model.set_source_variant.assert_called_with("mock-variant")

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -2330,3 +2330,19 @@ class TestServerVariantSupport(TestAPI):
                     "unrecognized client variant foo-bar",
                     json.loads(cre.headers["x-error-msg"]),
                 )
+
+    async def test_post_source_update_server_variant(self):
+        """Test POSTing to source will correctly update Server variant."""
+
+        extra_args = ["--source-catalog", "examples/sources/mixed.yaml"]
+        async with start_server(
+            "examples/machines/simple.json",
+            extra_args=extra_args,
+        ) as inst:
+            resp = await inst.get("/meta/client_variant")
+            self.assertEqual(resp, "server")
+
+            await inst.post("/source", source_id="ubuntu-desktop")
+
+            resp = await inst.get("/meta/client_variant")
+            self.assertEqual(resp, "desktop")

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -31,6 +31,7 @@ import yaml
 from aiohttp.client_exceptions import ClientResponseError
 
 from subiquitycore.tests import SubiTestCase
+from subiquitycore.tests.parameterized import parameterized
 from subiquitycore.utils import astart_command, matching_dicts
 
 default_timeout = 10
@@ -2304,3 +2305,27 @@ class TestNetwork(TestAPI):
 
             ethernets = conf_data["network"]["ethernets"]
             self.assertIn("ens4", ethernets)
+
+
+class TestServerVariantSupport(TestAPI):
+    @parameterized.expand(
+        (
+            ("server", True),
+            ("desktop", True),
+            ("foo-bar", False),
+        )
+    )
+    async def test_supported_variants(self, variant, is_supported):
+        async with start_server("examples/machines/simple.json") as inst:
+            if is_supported:
+                await inst.post("/meta/client_variant", variant=variant)
+            else:
+                with self.assertRaises(ClientResponseError) as ctx:
+                    await inst.post("/meta/client_variant", variant=variant)
+                cre = ctx.exception
+                self.assertEqual(500, cre.status)
+                self.assertIn("x-error-report", cre.headers)
+                self.assertEqual(
+                    "unrecognized client variant foo-bar",
+                    json.loads(cre.headers["x-error-msg"]),
+                )

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -2312,6 +2312,7 @@ class TestServerVariantSupport(TestAPI):
         (
             ("server", True),
             ("desktop", True),
+            ("core", True),
             ("foo-bar", False),
         )
     )

--- a/subiquitycore/tests/mocks.py
+++ b/subiquitycore/tests/mocks.py
@@ -13,6 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from unittest import mock
 
+from subiquity.server.server import SubiquityServer
 from subiquitycore.context import Context
 from subiquitycore.pubsub import MessageHub
 
@@ -23,6 +24,7 @@ class MockedApplication:
     autoinstall_config = {}
     answers = {}
     opts = None
+    set_source_variant = SubiquityServer.set_source_variant
 
     def make_autoinstall(self):
         return {"mock_key": "mock_data"}


### PR DESCRIPTION
Introduce support for a "core" variant in Subiquity Server and the TUI. The changes here can be broadly summarized into two parts:

1. Refactor and update some server logic around variant handling.
2. Give the TUI a list of controllers to use for the "core" variant and add it as a supported variant in the server.

With these changes, we should be able to construct an `ubuntu-core-installer` ISO and have it display only the desired screens:
- Language
- Keyboard
- (Refresh)
- Network
- Disk

Instead of merging the changes here, I would like to open smaller PRs for each of the above changes and keep this PR for any meta-discussion around the necessary changes.

See #2128 for the first part, updating the variant handling. 
See #2129 for the second, adding support for core in the TUI.

I have performed ISO testing with these changes on Plucky dailies for Server and Desktop, as well as with the available core-installer ISO, with success.