### PR TITLE
Update variant handling in SubiquityServer

### DIFF
--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -87,6 +87,7 @@ class SourceController(SubiquityController):
         if os.path.exists(path):
             with open(path) as fp:
                 self.model.load_from_file(fp)
+        self._update_variant(self.model.current.variant)
 
     def make_autoinstall(self):
         return {
@@ -148,10 +149,13 @@ class SourceController(SubiquityController):
             handler = TrivialSourceHandler("/")
         return handler
 
+    def _update_variant(self, variant: str) -> None:
+        self.app.set_source_variant(variant)
+
     async def configured(self):
         await super().configured()
         self._configured = True
-        self.app.set_source_variant(self.model.current.variant)
+        self._update_variant(self.model.current.variant)
 
     async def POST(self, source_id: str, search_drivers: bool = False) -> None:
         # Marking the source model configured has an effect on many of the

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -151,7 +151,7 @@ class SourceController(SubiquityController):
     async def configured(self):
         await super().configured()
         self._configured = True
-        self.app.base_model.set_source_variant(self.model.current.variant)
+        self.app.set_source_variant(self.model.current.variant)
 
     async def POST(self, source_id: str, search_drivers: bool = False) -> None:
         # Marking the source model configured has an effect on many of the

--- a/subiquity/server/controllers/tests/test_source.py
+++ b/subiquity/server/controllers/tests/test_source.py
@@ -92,3 +92,22 @@ class TestSourceController(SubiTestCase):
         self._set_source_catalog(catalog)
         self.controller.load_autoinstall_data(ai_data)
         self.assertEqual(self.controller.model.current.variant, expected)
+
+    async def test_on_configure_update_variant(self):
+        """Test update variant through server on configure.
+
+        Ensure the source controller doesn't update variant on the base
+        model directly.
+        """
+        app = self.controller.app = unittest.mock.Mock()
+        model = self.controller.app.base_model = unittest.mock.Mock()
+
+        self.controller.model.current.variant = "mock-variant"
+
+        with unittest.mock.patch(
+            "subiquity.server.controller.SubiquityController.configured"
+        ):
+            await self.controller.configured()
+
+        app.set_source_variant.assert_called_with("mock-variant")
+        model.set_source_variant.assert_not_called()

--- a/subiquity/server/controllers/tests/test_source.py
+++ b/subiquity/server/controllers/tests/test_source.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import functools
 import unittest
 
 from subiquity.common.serialize import Serializer
@@ -20,7 +21,11 @@ from subiquity.models.source import CatalogEntry
 from subiquity.models.subiquity import SubiquityModel
 from subiquity.models.tests.test_source import make_entry as make_raw_entry
 from subiquity.server.controllers.source import SourceController, convert_source
-from subiquity.server.server import INSTALL_MODEL_NAMES, POSTINSTALL_MODEL_NAMES
+from subiquity.server.server import (
+    INSTALL_MODEL_NAMES,
+    POSTINSTALL_MODEL_NAMES,
+    SubiquityServer,
+)
 from subiquitycore.pubsub import MessageHub
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
@@ -58,6 +63,12 @@ class TestSourceController(SubiTestCase):
             "test", MessageHub(), INSTALL_MODEL_NAMES, POSTINSTALL_MODEL_NAMES
         )
         self.app = make_app(model=self.base_model)
+        self.app.set_source_variant = functools.partial(
+            SubiquityServer.set_source_variant, self.app
+        )
+        self.app._set_source_variant = functools.partial(
+            SubiquityServer._set_source_variant, self.app
+        )
         self.app.opts.source_catalog = "examples/sources/install.yaml"
         self.controller = SourceController(self.app)
 
@@ -92,22 +103,28 @@ class TestSourceController(SubiTestCase):
         self._set_source_catalog(catalog)
         self.controller.load_autoinstall_data(ai_data)
         self.assertEqual(self.controller.model.current.variant, expected)
+        self.assertEqual(
+            self.controller.app.base_model.source.current.variant, expected
+        )
 
-    async def test_on_configure_update_variant(self):
-        """Test update variant through server on configure.
-
-        Ensure the source controller doesn't update variant on the base
-        model directly.
-        """
+    def test_update_variant_through_server(self):
+        """Test update variant through server on configure."""
         app = self.controller.app = unittest.mock.Mock()
         model = self.controller.app.base_model = unittest.mock.Mock()
 
-        self.controller.model.current.variant = "mock-variant"
-
-        with unittest.mock.patch(
-            "subiquity.server.controller.SubiquityController.configured"
-        ):
-            await self.controller.configured()
+        self.controller._update_variant("mock-variant")
 
         app.set_source_variant.assert_called_with("mock-variant")
         model.set_source_variant.assert_not_called()
+
+    async def test_on_configure_update_variant(self):
+        """Test variant is updated on configure."""
+        self.controller.model.current.variant = "mock-variant"
+        with (
+            unittest.mock.patch(
+                "subiquity.server.controller.SubiquityController.configured"
+            ),
+            unittest.mock.patch.object(self.controller, "_update_variant"),
+        ):
+            await self.controller.configured()
+            self.controller._update_variant.assert_called_with("mock-variant")

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -119,7 +119,6 @@ class MetaController:
     async def client_variant_POST(self, variant: str) -> None:
         if variant not in self.app.supported_variants:
             raise ValueError(f"unrecognized client variant {variant}")
-        self.app.base_model.set_source_variant(variant)
         self.app.set_source_variant(variant)
 
     async def client_variant_GET(self) -> str:
@@ -291,6 +290,10 @@ class SubiquityServer(Application):
         root = "/"
         if self.opts.dry_run:
             root = os.path.abspath(self.opts.output_base)
+        # TODO: Set the model source variant before returning it?
+        #       This _will_ eventually get set by the source controller,
+        #       but before then it's in a state that only requires the
+        #       "default" models i.e., the base set all variants require.
         return SubiquityModel(
             root,
             self.hub,
@@ -302,7 +305,7 @@ class SubiquityServer(Application):
     def __init__(self, opts, block_log_dir):
         super().__init__(opts)
         self.dr_cfg: Optional[DRConfig] = None
-        self.set_source_variant(self.supported_variants[0])
+        self._set_source_variant(self.supported_variants[0])
         self.block_log_dir = block_log_dir
         self.cloud_init_ok = None
         self.state_event = asyncio.Event()
@@ -353,8 +356,25 @@ class SubiquityServer(Application):
 
         self.geoip = GeoIP(self, strategy=geoip_strategy)
 
-    def set_source_variant(self, variant):
+    def _set_source_variant(self, variant):
         self.variant = variant
+
+    def set_source_variant(self, variant):
+        """Set the source variant for the install.
+
+        This is the public interface for setting the variant for the install.
+        This ensures that both the server and the model's understanding of the
+        variant is updated in one place.
+
+        Any extra logic for updating the variant in the server should go into
+        the private method _set_source_variant. This is separated out because
+        the sever needs to seed the initial variant state during __init__
+        but the base_model isn't attached to the server object until the .Run()
+        method is called.
+        """
+        self._set_source_variant(variant)
+
+        self.base_model.set_source_variant(variant)
 
     def load_serialized_state(self):
         for controller in self.controllers.instances:

--- a/subiquity/server/tests/test_server.py
+++ b/subiquity/server/tests/test_server.py
@@ -744,3 +744,18 @@ class TestEventReporting(SubiTestCase):
         (message,) = journal_send_mock.call_args.args
         self.assertIn("message", message)
         self.assertNotIn("description", message)
+
+
+class TestVariantHandling(SubiTestCase):
+    async def asyncSetUp(self):
+        opts = Mock()
+        opts.dry_run = True
+        opts.output_base = self.tmp_dir()
+        opts.machine_config = NOPROBERARG
+        self.server = SubiquityServer(opts, None)
+
+    def test_set_source_variant(self):
+        self.server.base_model = Mock()
+        self.server.set_source_variant("mock-variant")
+        self.assertEqual(self.server.variant, "mock-variant")
+        self.server.base_model.set_source_variant.assert_called_with("mock-variant")

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -2330,3 +2330,19 @@ class TestServerVariantSupport(TestAPI):
                     "unrecognized client variant foo-bar",
                     json.loads(cre.headers["x-error-msg"]),
                 )
+
+    async def test_post_source_update_server_variant(self):
+        """Test POSTing to source will correctly update Server variant."""
+
+        extra_args = ["--source-catalog", "examples/sources/mixed.yaml"]
+        async with start_server(
+            "examples/machines/simple.json",
+            extra_args=extra_args,
+        ) as inst:
+            resp = await inst.get("/meta/client_variant")
+            self.assertEqual(resp, "server")
+
+            await inst.post("/source", source_id="ubuntu-desktop")
+
+            resp = await inst.get("/meta/client_variant")
+            self.assertEqual(resp, "desktop")


### PR DESCRIPTION
Part 1 of 2 for adding support for a "core" variant from #2127.

This PR introduces 1 behavior change and 1 bug fix surrounding variant handling, and 1 function signature fix for a semi-related function in the `SubiquityController` class.

- Behavior change: On startup, the server's variant will be set to the variant of the selected source in the catalog. Previously, the source controller would pick the first entry in the source catalog but not update the variant for the server. 
- Bug fix: Fixes a bug where configuring the source controller only updates the SubiquitModel (`app.base_model`) and not the server's notion of the variant (`app.variant`). Now selecting a new source will update both.
- Minor fix: Update `SubiquityController.interactive` to return `False` instead of `None` for non-interactive controllers, since this is always used in truthy contexts.

There is one temporary commit here that adds "core" as a supported variant in `subiquity/server/server.py`, just so that the `examples/sources/core-desktop.yaml` answers test will pass. (The TUI will get "core" as the client and then try to post it to the server, which would otherwise fail without this commit.) We can drop this commit before merging, as the logic to add "core" as a supported variant is handled in the other PR.