### PR TITLE
 Introduce support for "core" variant in TUI

### DIFF
--- a/examples/answers/core-desktop.yaml
+++ b/examples/answers/core-desktop.yaml
@@ -7,8 +7,6 @@ Refresh:
   update: no
 Keyboard:
   layout: us
-Zdev:
-  accept-default: yes
 Network:
   accept-default: yes
 Proxy:
@@ -16,9 +14,5 @@ Proxy:
 Filesystem:
   guided: yes
   guided-index: 0
-UbuntuPro:
-  token: ""
 InstallProgress:
   reboot: yes
-Drivers:
-  install: yes

--- a/subiquity/client/client.py
+++ b/subiquity/client/client.py
@@ -95,27 +95,41 @@ class SubiquityClient(TuiApplication):
     def make_ui(self):
         return SubiquityUI(self, self.help_menu)
 
-    controllers = [
-        "Serial",
-        "Welcome",
-        "Refresh",
-        "Keyboard",
-        "Source",
-        "Zdev",
-        "Network",
-        "Proxy",
-        "Mirror",
-        "Refresh",
-        "Filesystem",
-        "Identity",
-        "UbuntuPro",
-        "SSH",
-        "Drivers",
-        "SnapList",
-        "Progress",
-    ]
+    variant_to_controllers: Dict[str, List[str]] = {
+        "server": [
+            "Serial",
+            "Welcome",
+            "Refresh",
+            "Keyboard",
+            "Source",
+            "Zdev",
+            "Network",
+            "Proxy",
+            "Mirror",
+            "Refresh",
+            "Filesystem",
+            "Identity",
+            "UbuntuPro",
+            "SSH",
+            "Drivers",
+            "SnapList",
+            "Progress",
+        ],
+        "core": [
+            "Serial",
+            "Welcome",
+            "Refresh",
+            "Keyboard",
+            "Network",
+            "Refresh",
+            "Source",
+            "Filesystem",
+            "Progress",
+        ],
+    }
 
-    variant_to_controllers: Dict[str, List[str]] = {}
+    # Set default controllerset
+    controllers = variant_to_controllers["server"]
 
     def __init__(self, opts, about_msg=None):
         if is_linux_tty():

--- a/subiquity/client/controllers/tests/test_source.py
+++ b/subiquity/client/controllers/tests/test_source.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from subiquity.client.controllers.source import SourceController
+from subiquity.common.types import SourceSelectionAndSetting
+from subiquitycore.tests import SubiTestCase
+from subiquitycore.tests.mocks import make_app
+from subiquitycore.tests.parameterized import parameterized
+from subiquitycore.tuicontroller import Skip
+
+
+class TestSourceController(SubiTestCase):
+    def setUp(self):
+        self.app = make_app()
+        self.app.client = AsyncMock()
+        self.app.show_error_report = Mock()
+        self.app.show_nonreportable_error = Mock()
+
+        self.controller = SourceController(self.app)
+
+    @parameterized.expand(
+        (
+            ("core", 1, True),  # core is the only driverless variant
+            ("core", 2, False),  # don't skip if core has multiple sources
+            ("server", 1, False),  # Any other variant shouldn't skip
+        )
+    )
+    async def test_make_ui__skip_simple_sources(self, variant, sources, skip):
+        """Test source screen is skipped for single-source, driverless media."""
+
+        self.app.variant = variant
+        resp = SourceSelectionAndSetting(
+            sources=[Mock() for i in range(sources)],
+            current_id=0,
+            search_drivers=None,
+        )
+
+        with (
+            patch("subiquity.client.controllers.source.SourceView"),
+            patch.object(self.controller.endpoint, "GET", return_value=resp),
+        ):
+            if not skip:
+                await self.controller.make_ui()
+            else:
+                with self.assertRaises(Skip):
+                    await self.controller.make_ui()

--- a/subiquity/client/tests/test_client.py
+++ b/subiquity/client/tests/test_client.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import Mock
+
+from subiquity.client.client import SubiquityClient
+from subiquitycore.tests import SubiTestCase
+
+
+class TestClientVariantSupport(SubiTestCase):
+    async def asyncSetUp(self):
+        opts = Mock()
+        opts.dry_run = True
+        opts.output_base = self.tmp_dir()
+        opts.machine_config = "examples/machines/simple.json"
+        opts.answers = None
+        self.client = SubiquityClient(opts, None)
+        self.client.make_apport_report = Mock()
+
+    def test_default_variant(self):
+        expected = SubiquityClient.variant_to_controllers["server"]
+        self.assertEqual(
+            # The controllers attribute is a list of names before init
+            SubiquityClient.controllers,
+            expected,
+            "default controller names do not match names for 'server' variant",
+        )
+        self.assertEqual(
+            # The controllers attribute is a ControllerSet after init
+            self.client.controllers.controller_names,
+            expected,
+            "controllers changed unexpectedly during init",
+        )

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -114,6 +114,8 @@ class MetaController:
             if controller.endpoint in endpoints:
                 await controller.configured()
 
+    # TODO: Make post to /meta/client_variant a RecoverableError (it doesn't
+    # have to be fatal and it's currently only pseudo-fatal).
     async def client_variant_POST(self, variant: str) -> None:
         if variant not in self.app.supported_variants:
             raise ValueError(f"unrecognized client variant {variant}")

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -285,7 +285,7 @@ class SubiquityServer(Application):
         "Shutdown",
     ]
 
-    supported_variants = ["server", "desktop"]
+    supported_variants = ["server", "desktop", "core"]
 
     def make_model(self):
         root = "/"

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -31,6 +31,7 @@ import yaml
 from aiohttp.client_exceptions import ClientResponseError
 
 from subiquitycore.tests import SubiTestCase
+from subiquitycore.tests.parameterized import parameterized
 from subiquitycore.utils import astart_command, matching_dicts
 
 default_timeout = 10
@@ -2304,3 +2305,27 @@ class TestNetwork(TestAPI):
 
             ethernets = conf_data["network"]["ethernets"]
             self.assertIn("ens4", ethernets)
+
+
+class TestServerVariantSupport(TestAPI):
+    @parameterized.expand(
+        (
+            ("server", True),
+            ("desktop", True),
+            ("foo-bar", False),
+        )
+    )
+    async def test_supported_variants(self, variant, is_supported):
+        async with start_server("examples/machines/simple.json") as inst:
+            if is_supported:
+                await inst.post("/meta/client_variant", variant=variant)
+            else:
+                with self.assertRaises(ClientResponseError) as ctx:
+                    await inst.post("/meta/client_variant", variant=variant)
+                cre = ctx.exception
+                self.assertEqual(500, cre.status)
+                self.assertIn("x-error-report", cre.headers)
+                self.assertEqual(
+                    "unrecognized client variant foo-bar",
+                    json.loads(cre.headers["x-error-msg"]),
+                )

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -2312,6 +2312,7 @@ class TestServerVariantSupport(TestAPI):
         (
             ("server", True),
             ("desktop", True),
+            ("core", True),
             ("foo-bar", False),
         )
     )


### PR DESCRIPTION
Part 2 of 2 for adding support for a "core" variant from #2127. 

This PR:
- Adds "core" as a supported variant in the server.
- Registers a list of controllers (and therefore, screens) to use for the "core" variant in the TUI (Language/Welcome, Keyboard, Refresh, Network, Disk).
- Adds some logic to the client's `SourceController` to auto-configure this section if (1) there is only one source to choose from **and** (2) that source type doesn't have the option of installing drivers, thus skipping this screen since there aren't really any questions to ask. 
- Removes some sections from the ubuntu-core answers tests since it had information about additional screens in it. If these screens come up, we want it to block and fail the test.
