### PR TITLE
Kvm test swtpm

### DIFF
--- a/scripts/kvm-test.py
+++ b/scripts/kvm-test.py
@@ -189,7 +189,8 @@ boot_group = parser.add_mutually_exclusive_group()
 boot_group.add_argument('-B', '--bios', action='store_true', default=False,
                     help='boot in BIOS mode (default mode is UEFI)')
 boot_group.add_argument('--secure-boot', action='store_true', default=False,
-                    help='Use SecureBoot', dest="secureboot")
+                    help='Use SecureBoot.  Normally off by default, set to true when using with-tpm2',
+                    dest="secureboot")
 
 parser.add_argument('-c', '--channel', action='store',
                     help='build iso with snap from channel')
@@ -291,6 +292,9 @@ def parse_args():
         raise Exception('Obtain a copy of livefs-editor and point ' +
                         'LIVEFS_EDITOR to it\n'
                         'https://github.com/mwhudson/livefs-editor')
+
+    if ctx.args.with_tpm2:
+        ctx.args.secureboot = True
 
     return ctx
 

--- a/scripts/kvm-test.py
+++ b/scripts/kvm-test.py
@@ -676,7 +676,8 @@ def tpm_emulator(ctx: Context):
 
     with tempfile.TemporaryDirectory() as tempdir:
         socket = pathlib.Path(tempdir) / f'kvm-test-{ctx.hostname}.sock'
-        ps = subprocess.Popen(['swtpm', 'socket',
+        ps = subprocess.Popen(['aa-exec', '-p', 'unconfined', '--',
+                               'swtpm', 'socket',
                                '--tpmstate', f'dir={tpmstate}',
                                '--ctrl', f'type=unixio,path={socket}',
                                '--tpm2',


### PR DESCRIPTION
Several fixes to swtpm integration allowing TPMFDE test automation, including having TPM state persist across VM boots, allowing multiple VMs with TPM to run in parallel, and an apparmor integration workaround.

Sample command line
```
./scripts/kvm-test.py -r24.04.1-desktop --install -o -b --boot --profile desktop --with-tpm2
```