### PR TITLE
Small test cleanup for Identity and Userdata controllers

### DIFF
--- a/subiquity/server/controllers/tests/test_identity.py
+++ b/subiquity/server/controllers/tests/test_identity.py
@@ -19,7 +19,6 @@ from jsonschema.validators import validator_for
 from subiquity.server.autoinstall import AutoinstallError
 from subiquity.server.controllers.filesystem import FilesystemController
 from subiquity.server.controllers.identity import IdentityController
-from subiquity.server.controllers.source import SourceController
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
 from subiquitycore.tests.parameterized import parameterized
@@ -44,8 +43,6 @@ class TestControllerUserCreationFlows(SubiTestCase):
         self.app.opts.bootloader = False
         self.app.controllers.Filesystem = FilesystemController(self.app)
         self.ic = IdentityController(self.app)
-        self.app.opts.source_catalog = "examples/sources/install.yaml"
-        self.app.controllers.Source = SourceController(self.app)
         self.ic.model.user = None
 
     # Test cases for 4a1. Copied for 4a2 but all cases should be valid for desktop.


### PR DESCRIPTION
A couple of small fixes to some test code:

- Remove an unnecessary usage of the SoureController in the IdentityController tests
- Update the UserdataController tests so they are testing the expected behavior. Default usage of a mock object for the `base_app` attribute was hiding a failing test.  