### PR TITLE
Erase install - disable renumbering instead of excluding scenarios

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -120,7 +120,7 @@ class FilesystemManipulator:
         self.create_filesystem(part, spec)
         return part
 
-    def delete_partition(self, part, override_preserve=False):
+    def delete_partition(self, part, override_preserve=False, allow_renumbering=True):
         if (
             not override_preserve
             and part.device.preserve
@@ -128,7 +128,7 @@ class FilesystemManipulator:
         ):
             raise Exception("cannot delete partitions from preserved disks")
         self.clear(part)
-        self.model.remove_partition(part)
+        self.model.remove_partition(part, allow_renumbering=allow_renumbering)
 
     def create_raid(self, spec: RaidSpec):
         for d in spec["devices"] | spec["spare_devices"]:

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2246,7 +2246,7 @@ class FilesystemModel:
         self._actions.append(p)
         return p
 
-    def remove_partition(self, part):
+    def remove_partition(self, part, allow_renumbering=True):
         if part._fs or part._constructed_device:
             raise Exception("can only remove empty partition")
         from subiquity.common.filesystem.gaps import (
@@ -2256,7 +2256,7 @@ class FilesystemModel:
         for p2 in movable_trailing_partitions_and_gap_size(part)[0]:
             p2.offset -= part.size
         self._remove(part)
-        if part.is_logical:
+        if part.is_logical and allow_renumbering:
             part.device.renumber_logical_partitions(part)
         if len(part.device._partitions) == 0:
             part.device.ptable = None

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -487,13 +487,19 @@ class TestFilesystemModel(unittest.TestCase):
 
     @parameterized.expand(
         (
-            (1, False),
-            (2, False),
-            (5, True),
-            (6, True),
+            (1, True, False),
+            (2, True, False),
+            (5, True, True),
+            (6, True, True),
+            (1, False, False),
+            (2, False, False),
+            (5, False, False),
+            (6, False, False),
         )
     )
-    def test_remove_partition__renumbers(self, pnumber: int, expect_call: bool):
+    def test_remove_partition__renumbers(
+        self, pnumber: int, allow_renumbering: bool, expect_call: bool
+    ):
         m, d = make_model_and_disk(ptable="dos", storage_version=2)
 
         make_partition(m, d, preserve=True)
@@ -505,7 +511,7 @@ class TestFilesystemModel(unittest.TestCase):
         part = next(iter([p for p in d.partitions() if p.number == pnumber]))
 
         with mock.patch.object(d, "renumber_logical_partitions") as m_renumber:
-            m.remove_partition(part)
+            m.remove_partition(part, allow_renumbering=allow_renumbering)
 
         if expect_call:
             m_renumber.assert_called_once_with(part)

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -1831,12 +1831,10 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         sorted_scenarios = sorted(
             scenarios, key=lambda sc: (sc.disk_id, sc.partition_number)
         )
-        # Currently we expect only two scenarios because of the workaround for
-        # LP: #2091172. If we drop the workaround, we will have a third
-        # scenario for partition p5.
         self.assertEqual(1, sorted_scenarios[0].partition_number)
-        self.assertEqual(6, sorted_scenarios[1].partition_number)
-        self.assertEqual(2, len(sorted_scenarios))
+        self.assertEqual(5, sorted_scenarios[1].partition_number)
+        self.assertEqual(6, sorted_scenarios[2].partition_number)
+        self.assertEqual(3, len(sorted_scenarios))
 
     async def test_resize_has_enough_room_for_partitions__one_primary(self):
         await self._setup(Bootloader.NONE, "gpt", fix_bios=True)


### PR DESCRIPTION
This is another option to address the issue with partition renumbering. Instead of completely hiding a erase-and-install scenario just because renumbering is a problem, we disable it for erase-and-install scenarios only.

The (possibly weak) assumption is that because we are erasing one partition and installing a new system **at the same place**, we will never end up with less logical partitions that we had before (and therefore we can avoid renumbering).

This makes it possible to do erase-and-install on a logical partition that is not at the end (e.g., p5 on threebuntu-on-msdos.json).