### PR TITLE
Only associate os information to existing partitions

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -998,6 +998,11 @@ class Partition(_Formattable):
 
     @property
     def os(self):
+        if not self.preserve:
+            # Only associate the OS information with existing partitions.
+            # If /dev/sda4 was deleted and a new partition on sda with number 4
+            # is created, we should not pretend it contains anything of value.
+            return None
         os_data = self._m._probe_data.get("os", {}).get(self._path())
         if not os_data:
             return None

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1586,6 +1586,29 @@ class TestPartition(unittest.TestCase):
         self.assertTrue(p6.is_logical)
         self.assertTrue(p7.is_logical)
 
+    def test_os(self):
+        m = make_model(storage_version=2)
+        d = make_disk(m, ptable="gpt")
+
+        p1 = make_partition(m, d, preserve=True)
+        p2 = make_partition(m, d, preserve=True)
+
+        os_info = {
+            "label": "Ubuntu",
+            "long": "Ubuntu 22.04.1 LTS",
+            "type": "linux",
+            "version": "22.04.1",
+        }
+
+        m._probe_data["os"] = {p1._path(): os_info}
+
+        self.assertEqual("Ubuntu", p1.os.label)
+        self.assertEqual("Ubuntu 22.04.1 LTS", p1.os.long)
+        self.assertEqual("linux", p1.os.type)
+        self.assertEqual("22.04.1", p1.os.version)
+        self.assertIsNone(p1.os.subpath)
+        self.assertIsNone(p2.os)
+
 
 class TestCanmount(SubiTestCase):
     @parameterized.expand(

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1609,6 +1609,25 @@ class TestPartition(unittest.TestCase):
         self.assertIsNone(p1.os.subpath)
         self.assertIsNone(p2.os)
 
+    def test_os__recreated_partition(self):
+        m = make_model(storage_version=2)
+        d = make_disk(m, ptable="gpt")
+
+        # We do not mark the partition preserved, which means we either
+        # formatted the disk or deleted / recreated the partition.
+        p = make_partition(m, d)
+
+        os_info = {
+            "label": "Ubuntu",
+            "long": "Ubuntu 22.04.1 LTS",
+            "type": "linux",
+            "version": "22.04.1",
+        }
+
+        m._probe_data["os"] = {p._path(): os_info}
+
+        self.assertIsNone(p.os)
+
 
 class TestCanmount(SubiTestCase):
     @parameterized.expand(


### PR DESCRIPTION
If os-prober reports that Ubuntu is installed on e.g., sda4 (i.e., partition 4 of disk sda), then we should make that info available in the API.
    
However, if we remove sda4 and then create another partition with number 4, we should not assume that it contains anything of value.
    
This is only a partial fix for LP:#2091172

One easy way to recreate the situation is to use threebuntu-on-msdos.json and then:

* run `make dryrun-debug-sv2`
* navigate to the partitioning screen and select "Install to disk-sda after wiping it"
* in another terminal, query /storage/v2 and look at the result. Before the patch it would show that the newly created ESP has an OS installed:

```json
      "partitions": [
        {
          "size": 1127219200,
          "number": 1,
          "preserve": false,
          "wipe": "superblock",
          "annotations": [
            "new",
            "primary ESP",
            "to be formatted as fat32",
            "mounted at /boot/efi"
          ],
          "mount": "/boot/efi",
          "format": "fat32",
          "grub_device": true,
          "boot": true,
          "os": {
            "long": "Ubuntu 20.04.4 LTS",
            "label": "Ubuntu",
            "type": "linux",
            "subpath": null,
            "version": "20.04.4"
          },
          "offset": 1048576,
          "estimated_min_size": 10364125184,
          "resize": null,
          "path": "/dev/sda1",
          "is_in_use": false,
          "$type": "Partition"
        },
```
