### PR TITLE
storage: set backlinks only if other post-init methods succeed

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -252,10 +252,11 @@ def _do_post_inits(obj):
 def fsobj(typ):
     def wrapper(c):
         c.__attrs_post_init__ = _do_post_inits
-        c._post_inits = [_set_backlinks]
+        c._post_inits = []
         class_post_init = getattr(c, "__post_init__", None)
         if class_post_init is not None:
             c._post_inits.append(class_post_init)
+        c._post_inits.append(_set_backlinks)
         c.type = attributes.const(typ)
         c.id = attr.ib(default=None)
         c._m = attr.ib(repr=None, default=None)


### PR DESCRIPTION
When creating a fsobj, e.g., a partition, we automatically modify associated fsobj-s (e.g., the underlying disk) to make them aware of the newly created object.

We do this through the use of backlinks and more specifically the function _set_backlinks. Currently, this function is automatically called first when entering the fsobj's `__post_init__` method.

If a fsobj defines its own `__post_init__` method (let's called it user-defined), it gets called after `_set_backlinks`. This is usually fine.

However if the user-defined `__post_init__` raises an exception, we end up with backlinks referencing an object that was not successfully initialized.

This is what happens with the Partition fsobj. In its user-defined `__post_init__`, we determine the partition number by looking at the underlying disk. If the number could not be determined (because there is no more number available), we raise an exception "Exceeded number of available partitions". However, at this point, the underlying disk is already aware of the new partition - through the use of backlinks.

Iterating over the list of partitions will then raise a TypeError when trying to use partition.number - which has not been successfully assigned.

```python
  File "/snap/ubuntu-desktop-installer/1269/bin/subiquity/subiquity/common/filesystem/manipulator.py", line 230, in reformat
    self.delete_partition(p, True)
  File "/snap/ubuntu-desktop-installer/1269/bin/subiquity/subiquity/common/filesystem/manipulator.py", line 117, in delete_partition
    self.model.remove_partition(part)
  File "/snap/ubuntu-desktop-installer/1269/bin/subiquity/subiquity/models/filesystem.py", line 2041, in remove_partition
    part.device.renumber_logical_partitions(part)
  File "/snap/ubuntu-desktop-installer/1269/bin/subiquity/subiquity/models/filesystem.py", line 688, in renumber_logical_partitions
    for p in self.partitions_by_number()
  File "/snap/ubuntu-desktop-installer/1269/bin/subiquity/subiquity/models/filesystem.py", line 638, in partitions_by_number
    return sorted(self._partitions, key=lambda p: p.number)
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

Fixed by calling _set_backlinks after the user-defined `__post_init__`, so that we only set the backlinks on success.

LP:#2095159

This was causing double pain to people who were already affected by the installer suggesting buggy guided scenarios (e.g., LP:#2081724). If a user selects a buggy scenario, it would fail and leave the system in a bad state, making other scenarios more likely to fail too.