### PR TITLE
console-conf@.service: do not exit as error when preventing restart

### DIFF
--- a/bin/console-conf-check-error
+++ b/bin/console-conf-check-error
@@ -2,6 +2,6 @@
 
 set -eu
 
-if [ "${SERVICE_RESULT}" == "exit-code" ] && [ "${EXIT_STATUS}" -eq 22 ]; then
+if [ "${SERVICE_RESULT}" == "success" ] && [ "${EXIT_STATUS}" -eq 22 ]; then
   systemctl start --no-block "${1}"
 fi

--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -17,6 +17,7 @@ Conflicts=getty@%i.service
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStart=/sbin/agetty -i -n --noclear -l /usr/share/subiquity/console-conf-wrapper %I $TERM
 RestartPreventExitStatus=22
+SuccessExitStatus=22
 ExecStopPost=/usr/share/subiquity/console-conf-check-error getty@%i.service
 Type=idle
 OnFailure=getty@%i.service

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -16,6 +16,7 @@ Conflicts=serial-getty@%i.service
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStart=/sbin/agetty -i -n --keep-baud -l /usr/share/subiquity/console-conf-wrapper --login-options "--serial" 115200,38400,9600 %I $TERM
 RestartPreventExitStatus=22
+SuccessExitStatus=22
 ExecStopPost=/usr/share/subiquity/console-conf-check-error serial-getty@%i.service
 Type=idle
 Restart=always


### PR DESCRIPTION
Upstreaming of https://github.com/canonical/core-base/pull/296

This does not affect behavior apart from systemctl not showing the service in red.