### PR TITLE
storage: also allow raid devices to match install-media: true

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1663,8 +1663,11 @@ class FilesystemModel:
             log.debug("%s is mounted", obj.path)
             work = [obj]
             while work:
+                # Go through the chain of dependencies, starting from the
+                # partition (or LV). We mark involved disks and raids as having
+                # in-use partitions.
                 o = work.pop(0)
-                if isinstance(o, Disk):
+                if isinstance(o, (Disk, Raid)):
                     o._has_in_use_partition = True
                 work.extend(dependencies(o))
 


### PR DESCRIPTION
If the installation media is a RAID (this is a mostly a OEM use-case), using `{"install-media": true}` as a disk matcher fails to find the expected RAID device.

This is because in the previous implementation, only `Disk` objects could have `_has_in_use_partitions=True`.

We now also set `_has_in_use_partitions=True` on involved `Raid` objects.

In theory, this means that for a given RAID, the matcher can return one `Raid` object + N * `Disk` objects.

In practice though, we only use disk matchers on "potential boot disks". This should exclude from the equation `Disk` objects that are part of a `Raid`. So we can reliably expect a single match.

LP:#2094966