### PR TITLE
Fix the pc-kernel issue

### DIFF
--- a/subiquity/models/source.py
+++ b/subiquity/models/source.py
@@ -147,19 +147,27 @@ class SourceModel:
         raise KeyError
 
     def get_source(
-        self, variation_name: typing.Optional[str] = None
+        self,
+        variation_name: typing.Optional[str] = None,
+        *,
+        source_id: typing.Optional[str] = None,
     ) -> typing.Optional[str]:
-        scheme = self.current.type
+        if source_id is None:
+            source = self.current
+        else:
+            source = self.get_matching_source(source_id)
+
+        scheme = source.type
         if scheme is None:
             return None
         if variation_name is None:
-            variation = next(iter(self.current.variations.values()))
+            variation = next(iter(source.variations.values()))
         else:
-            variation = self.current.variations[variation_name]
+            variation = source.variations[variation_name]
         path = os.path.join(self._dir, variation.path)
-        if self.current.preinstalled_langs:
+        if source.preinstalled_langs:
             base, ext = os.path.splitext(path)
-            if self.lang in self.current.preinstalled_langs:
+            if self.lang in source.preinstalled_langs:
                 suffix = self.lang
             else:
                 suffix = "no-languages"

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -440,7 +440,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 # (see LP: #2084032).
                 # Therefore we use an asyncio.Task (coupled with
                 # asyncio.shield) so we can prevent propagation.
-                task = asyncio.create_task(self._system_getter.get(name, label))
+                task = asyncio.create_task(
+                    self._system_getter.get(name, label, source_id=catalog_entry.id)
+                )
 
                 system, in_live_layer = await asyncio.shield(task)
                 # _system_getter.get is marked async_helpers.exclusive

--- a/subiquity/server/controllers/source.py
+++ b/subiquity/server/controllers/source.py
@@ -139,9 +139,12 @@ class SourceController(SubiquityController):
         )
 
     def get_handler(
-        self, variation_name: Optional[str] = None
+        self,
+        variation_name: Optional[str] = None,
+        *,
+        source_id: Optional[str] = None,
     ) -> Optional[AbstractSourceHandler]:
-        source = self.model.get_source(variation_name)
+        source = self.model.get_source(variation_name, source_id=source_id)
         if source is None:
             return None
         handler = get_handler_for_source(sanitize_source(source))

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -567,7 +567,7 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         getter = SystemGetter(self.app)
 
         @contextlib.asynccontextmanager
-        async def mounted(self):
+        async def mounted(self, *, source_id):
             yield
 
         mount_mock = mock.patch(
@@ -610,7 +610,9 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
                     "subiquity.server.snapd.system_getter", level="WARNING"
                 ) as logs:
                     await getter.get(
-                        variation_name="minimal", label="enhanced-secureboot-desktop"
+                        variation_name="minimal",
+                        label="enhanced-secureboot-desktop",
+                        source_id="default",
                     )
 
             self.assertIn("cannot load assertions for label", logs.output[0])
@@ -2008,7 +2010,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.fsc.model = make_model(Bootloader.UEFI)
 
         @contextlib.asynccontextmanager
-        async def mounted(self):
+        async def mounted(self, *, source_id):
             yield
 
         p = mock.patch(

--- a/subiquity/server/snapd/system_getter.py
+++ b/subiquity/server/snapd/system_getter.py
@@ -23,6 +23,7 @@ import requests
 
 from subiquity.server.mounter import Mounter
 from subiquity.server.snapd.types import SystemDetails
+from subiquitycore import async_helpers
 
 log = logging.getLogger("subiquity.server.snapd.system_getter")
 
@@ -81,6 +82,7 @@ class SystemGetter:
             log.warning("v2/systems/%s returned %s", label, http_err.response.text)
             raise
 
+    @async_helpers.exclusive
     async def get(
         self, variation_name: str, label: str
     ) -> Tuple[Optional[SystemDetails], bool]:

--- a/subiquitycore/async_helpers.py
+++ b/subiquitycore/async_helpers.py
@@ -117,3 +117,16 @@ class SingleInstanceTask:
         if self.task is None:
             return False
         return self.task.done()
+
+
+def exclusive(coroutine_function):
+    """Can be used to decorate a coroutine function that we do not want to run
+    multiple times concurrently. It uses a lock internally.
+    """
+    lock = asyncio.Lock()
+
+    async def wrapped(*args, **kwargs):
+        async with lock:
+            return await coroutine_function(*args, **kwargs)
+
+    return wrapped


### PR DESCRIPTION
**Initial problem** 

The `SystemGetter.get` method essentially does 3 important things:
 * it mounts stuff in `/var/lib/snapd/seed`
 * it queries snapd (and expect it to read contents from `/var/lib/snapd/seed`)
 * it then tries to cleanup by unmounting what it previously mounted
    
Unfortunately, if we cancel this task in the middle, especially while it is querying snapd, the cleanup code will fail to unmount things because snapd is still using `/var/lib/snapd/seed` (cancelling the query does not mean that snapd will immediately release the resources - or even stop processing the query). Typically this results in a failure to unmount pc-kernel.snap with EBUSY.
```
umount: /var/lib/snapd/seed/snaps/pc-kernel_2010.snap: target is busy.
```
    
Effectively, if `SystemGetter.get` gets cancelled, we would need to wait until the query to snapd finishes before we run the cleanup code.

But the approach that this PR takes is to make sure `SystemGetter.get` is not cancelled in the first place.

`SystemGetter.get` was subject to cancellation because it runs as part of  `_examine_systems` - which is cancelled and restarted when the source changes.

We now make sure that we shield `SystemGetter.get` from cancellation when we execute it from `_examine_systems`. If `_examine_system` gets cancelled, `SystemGetter.get` will now continue running in the background.

**Which leads to problem 2**

If we cancel `_examine_system` and rerun it, we end up with two concurrent calls to `SystemGetter.get` (the new one + the one we want to finish). Obviously, things go sideways if this happens. 

To avoid the problem, we now acquire a lock at the beginning of `SystemGetter.get` - so that only one task runs the critical section at a given time.

**Which leads to problem 3**

Internally, `SystemGetter.get(variation)` expects that the variation exists for the currently configured source.

However, because of the lock we added to `SystemGetter.get`, it is now more likely that the configured source has changed by the time we start mounting stuff and querying snapd.
    
When that happens, `SystemGetter.get(variation)` fails with `KeyError` ; because the variation is no longer present in the currently configured source.

Fixed by making sure that we use the source handler that was configured when `SystemGetter.get(variation)` was first invoked.

This bug was already present but way more difficult to reproduce timing-wise.

**Which leads to problem 4**
    
With the lock added to `SystemGetter.get`, when we change the source multiple times quickly, we create a "queue" of `SystemGetter`.get tasks. This can take a long time to consume, and really we only care about the result of the last query.

When `_examine_systems` gets cancelled, we now check if the `SystemGetter.get` task has successfully acquired the lock. If it hasn't, then we cancel it.

LP:#2084032