### PR TITLE
storage: always accept to resize a partition that is being wiped

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -276,8 +276,12 @@ class FilesystemManipulator:
             self.delete_partition(p, True)
         self.clear(disk, wipe)
 
-    def can_resize_partition(self, partition):
+    def can_resize_partition(self, partition, *, wipe=None):
+        # For a new partition.
         if not partition.preserve:
+            return True
+        # For an existing partition that is being wiped.
+        if wipe is not None:
             return True
         if partition.format not in get_resize_fstypes():
             return False
@@ -297,7 +301,7 @@ class FilesystemManipulator:
                 size_change = new_size - partition.size
                 if size_change > gap_size:
                     raise Exception("partition size too large")
-                if not self.can_resize_partition(partition):
+                if not self.can_resize_partition(partition, wipe=spec.get("wipe")):
                     raise Exception("partition cannot support resize")
                 partition.size = new_size
                 partition.resize = True

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -754,3 +754,9 @@ class TestCanResize(unittest.TestCase):
         part = make_partition(self.manipulator.model, disk, preserve=True)
         make_filesystem(self.manipulator.model, partition=part, fstype="asdf")
         self.assertFalse(self.manipulator.can_resize_partition(part))
+
+    def test_resize_invalid_but_wipe(self):
+        disk = make_disk(self.manipulator.model, ptable=None)
+        part = make_partition(self.manipulator.model, disk, preserve=True)
+        make_filesystem(self.manipulator.model, partition=part, fstype="asdf")
+        self.assertTrue(self.manipulator.can_resize_partition(part, wipe="superblock"))


### PR DESCRIPTION
If we are wiping a partition, don't bother checking if the filesystem that was on it supports resizing. The filesystem is going to be erased anyway. The new filesystem (if any) will be created using mkfs.* so there is no need for resize support.

LP:#2096799