### PR TITLE
kernel: fix install hang with autoinstall + kernel

### DIFF
--- a/subiquity/server/controllers/kernel.py
+++ b/subiquity/server/controllers/kernel.py
@@ -47,6 +47,13 @@ class KernelController(NonInteractiveController):
 
     def start(self):
         if self.model.metapkg_name is not None:
+            # if we're exiting early here, we have made a decision on the
+            # kernel already - probably autoinstall - and are skipping the
+            # bridge_kernel logic.  We must still broadcast
+            # BRIDGE_KERNEL_DECIDED though, otherwise we'll hang in
+            # curtin_install before curthooks waiting for
+            # bridge_kernel_decided.set().
+            self.app.hub.broadcast(InstallerChannels.BRIDGE_KERNEL_DECIDED)
             # if we have set the desired kernel already, use that.
             return
         # the ISO may have been configured to tell us what kernel to use

--- a/subiquity/server/controllers/tests/test_kernel.py
+++ b/subiquity/server/controllers/tests/test_kernel.py
@@ -143,7 +143,7 @@ class TestMetapackageSelection(SubiTestCase):
             [None, {"flavor": "bbbb"}, "linux-bbbb-20.04"],
         ]
     )
-    def test_ai(self, mpfile_data, ai_data, metapkg_name):
+    async def test_ai(self, mpfile_data, ai_data, metapkg_name):
         if mpfile_data is not None:
             self.setup_mpfile("etc/subiquity", mpfile_data)
         self.controller.load_autoinstall_data(ai_data)


### PR DESCRIPTION
Fix an install hang that is reproducible today on main branch (oracular and earlier not affected) when supplying a kernel to install via autoinstall.