### PR TITLE
storage: fix use of ptable parameter when calling reformat

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -22,7 +22,9 @@ LV
 LVM
 LinuxONE
 Mantic
+MBR
 MiB
+MSDOS
 NIC
 Netplan
 NoCloud

--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -602,6 +602,16 @@ By default, these layouts install to the largest disk in a system, but you can s
 
 .. note:: Match spec -- using ``match: {}`` matches an arbitrary disk.
 
+
+By default (except on s390x), the matching disk will be partitioned using a GUID Partition Table (GPT). But you can specifically request a MSDOS (aka. MBR) partition table:
+
+.. code-block:: yaml
+    autoinstall:
+      storage:
+        layout:
+          name: direct
+          ptable: msdos
+
 When using the ``lvm`` layout, LUKS encryption can be enabled by supplying a password.
 
 .. code-block:: yaml

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import Optional
 
 from curtin.block import get_resize_fstypes
 
@@ -268,12 +269,13 @@ class FilesystemManipulator:
         for subobj in obj.fs(), obj.constructed_device():
             self.delete(subobj)
 
-    def reformat(self, disk, ptable=None, wipe=None):
+    def reformat(self, disk, ptable: Optional[str], wipe=None):
+        """Reformat the specified disk. If ptable is None, use the default
+        partition table type."""
         disk.grub_device = False
         for p in list(disk.partitions()):
             self.delete_partition(p, True)
-        if ptable is not None:
-            disk.ptable = ptable
+        disk.ptable = ptable
         self.clear(disk, wipe)
 
     def can_resize_partition(self, partition, *, wipe=None):

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -270,10 +270,10 @@ class FilesystemManipulator:
 
     def reformat(self, disk, ptable=None, wipe=None):
         disk.grub_device = False
-        if ptable is not None:
-            disk.ptable = ptable
         for p in list(disk.partitions()):
             self.delete_partition(p, True)
+        if ptable is not None:
+            disk.ptable = ptable
         self.clear(disk, wipe)
 
     def can_resize_partition(self, partition, *, wipe=None):

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -715,13 +715,8 @@ class TestReformat(unittest.TestCase):
 
     def test_reformat_default(self):
         disk = make_disk(self.manipulator.model, ptable=None)
-        self.manipulator.reformat(disk)
+        self.manipulator.reformat(disk, ptable=None)
         self.assertEqual(None, disk.ptable)
-
-    def test_reformat_keep_current(self):
-        disk = make_disk(self.manipulator.model, ptable="msdos")
-        self.manipulator.reformat(disk)
-        self.assertEqual("msdos", disk.ptable)
 
     def test_reformat_to_gpt(self):
         disk = make_disk(self.manipulator.model, ptable=None)

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -733,6 +733,16 @@ class TestReformat(unittest.TestCase):
         self.manipulator.reformat(disk, "msdos")
         self.assertEqual("msdos", disk.ptable)
 
+    def test_reformat_with_partitions(self):
+        """We had a bug earlier where the ptable parameter of reformat would be
+        essentially ignored when the disk to reformat had partitions.  Ensure
+        this isn't the case anymore.
+        """
+        disk = make_disk(self.manipulator.model, ptable="gpt")
+        make_partition(self.manipulator.model, disk)
+        self.manipulator.reformat(disk, "msdos")
+        self.assertEqual("msdos", disk.ptable)
+
 
 class TestCanResize(unittest.TestCase):
     def setUp(self):

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -236,6 +236,8 @@ class GuidedResizeValues:
 @attr.s(auto_attribs=True)
 class GuidedStorageTargetReformat:
     disk_id: str
+    # ptable=None means to use the default (GPT in most scenarios)
+    ptable: Optional[str] = None
     allowed: List[GuidedCapability] = attr.Factory(list)
     disallowed: List[GuidedDisallowedCapability] = attr.Factory(list)
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -669,6 +669,8 @@ class _Device(_Formattable, ABC):
         # deleted as possible.
         new_disk = attr.evolve(self)
         new_disk._partitions = [p for p in self.partitions() if p._is_in_use]
+        if not new_disk._partitions:
+            new_disk.ptable = None
         return new_disk
 
     def _excluding_partition(self, partition: "Partition") -> Self:

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1562,7 +1562,7 @@ class TestDisk(unittest.TestCase):
         self.assertIsNot(d._partitions, d2._partitions)
 
     def test__reformatted__with_partitions(self):
-        m, d = make_model_and_disk()
+        m, d = make_model_and_disk(ptable="gpt")
 
         p1 = make_partition(m, d)
         p2 = make_partition(m, d)
@@ -1573,8 +1573,11 @@ class TestDisk(unittest.TestCase):
         self.assertEqual(d.partitions(), [p1, p2])
         self.assertEqual(d2.partitions(), [])
 
+        self.assertEqual("gpt", d.ptable)
+        self.assertIsNone(d2.ptable)
+
     def test__reformatted__with_in_use_parts(self):
-        m, d = make_model_and_disk()
+        m, d = make_model_and_disk(ptable="gpt")
 
         p1 = make_partition(m, d, is_in_use=True)
         p2 = make_partition(m, d, is_in_use=True)
@@ -1587,6 +1590,9 @@ class TestDisk(unittest.TestCase):
         self.assertIsNot(d, d2)
         self.assertEqual(d.partitions(), [p1, p2, p3, p4, p5])
         self.assertEqual(d2.partitions(), [p1, p2, p4])
+
+        self.assertEqual("gpt", d.ptable)
+        self.assertEqual("gpt", d2.ptable)
 
     def test__excluding_partition(self):
         m, d = make_model_and_disk()

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -672,7 +672,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 if not p._is_in_use:
                     self.delete_partition(p)
         else:
-            self.reformat(disk, wipe="superblock-recursive")
+            self.reformat(disk, ptable=target.ptable, wipe="superblock-recursive")
         return gaps.largest_gap(disk)
 
     @start_guided.register

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1654,6 +1654,14 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         assert matching_disks
         return matching_disks[0]
 
+    def has_valid_non_core_boot_variation(self) -> bool:
+        for variation in self._variation_info.values():
+            if not variation.is_valid():
+                continue
+            if not variation.is_core_boot_classic():
+                return True
+        return False
+
     async def run_autoinstall_guided(self, layout):
         name = layout["name"]
         password = None
@@ -1700,12 +1708,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         else:
             # this check is conceptually unnecessary but results in a
             # much cleaner error message...
-            for variation in self._variation_info.values():
-                if not variation.is_valid():
-                    continue
-                if not variation.is_core_boot_classic():
-                    break
-            else:
+            if not self.has_valid_non_core_boot_variation():
                 raise Exception(
                     "must use name: hybrid when installing core boot classic"
                 )
@@ -1740,8 +1743,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
         if mode == "reformat_disk":
             match = layout.get("match", {"size": "largest"})
+            ptable = layout.get("ptable")
             disk = self.get_bootable_matching_disk(match)
-            target = GuidedStorageTargetReformat(disk_id=disk.id, allowed=[])
+            target = GuidedStorageTargetReformat(
+                disk_id=disk.id, ptable=ptable, allowed=[]
+            )
         elif mode == "use_gap":
             match = layout.get("match", {})
             bootable_disks = self.get_bootable_matching_disks(match)

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -639,7 +639,9 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
                 GuidedStorageTargetReformat(disk_id=disk.id), disk
             )
 
-        m_reformat.assert_called_once_with(disk, wipe="superblock-recursive")
+        m_reformat.assert_called_once_with(
+            disk, ptable=None, wipe="superblock-recursive"
+        )
         expected_del_calls = [
             mock.call(p1, True),
             mock.call(p2, True),
@@ -933,7 +935,7 @@ class TestGuided(IsolatedAsyncioTestCase):
     async def test_guided_direct_BIOS_MSDOS(self):
         await self._guided_setup(Bootloader.BIOS, "msdos")
         target = GuidedStorageTargetReformat(
-            disk_id=self.d1.id, allowed=default_capabilities
+            disk_id=self.d1.id, ptable="msdos", allowed=default_capabilities
         )
         await self.controller.guided(
             GuidedChoiceV2(target=target, capability=GuidedCapability.DIRECT)
@@ -967,7 +969,7 @@ class TestGuided(IsolatedAsyncioTestCase):
     async def test_guided_lvm_BIOS_MSDOS(self):
         await self._guided_setup(Bootloader.BIOS, "msdos")
         target = GuidedStorageTargetReformat(
-            disk_id=self.d1.id, allowed=default_capabilities
+            disk_id=self.d1.id, ptable="msdos", allowed=default_capabilities
         )
         await self.controller.guided(
             GuidedChoiceV2(target=target, capability=GuidedCapability.LVM)
@@ -1064,7 +1066,7 @@ class TestGuided(IsolatedAsyncioTestCase):
     async def test_guided_zfs_BIOS_MSDOS(self):
         await self._guided_setup(Bootloader.BIOS, "msdos")
         target = GuidedStorageTargetReformat(
-            disk_id=self.d1.id, allowed=default_capabilities
+            disk_id=self.d1.id, ptable="msdos", allowed=default_capabilities
         )
         await self.controller.guided(
             GuidedChoiceV2(target=target, capability=GuidedCapability.ZFS)

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -1199,6 +1199,37 @@ class TestLayout(IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             self.fsc.validate_layout_mode(mode)
 
+    @parameterized.expand([(True, None), (True, "gpt"), (True, "msdos"), (False, None)])
+    async def test_autoinstall__reformat_with_ptable(self, include_ptable, ptable):
+        self.fsc.model = make_model()
+
+        make_disk(self.fsc.model, id="dev-sdc"),
+
+        layout = {
+            "name": "direct",
+            "mode": "reformat_disk",
+        }
+
+        if include_ptable:
+            layout["ptable"] = ptable
+
+        p_guided = mock.patch.object(self.fsc, "guided")
+        p_reformat = mock.patch(
+            "subiquity.server.controllers.filesystem.GuidedStorageTargetReformat"
+        )
+        p_has_valid_variation = mock.patch.object(
+            self.fsc, "has_valid_non_core_boot_variation", return_value=True
+        )
+
+        with p_guided as m_guided, p_reformat as m_reformat, p_has_valid_variation:
+            await self.fsc.run_autoinstall_guided(layout)
+
+        expected_ptable = ptable if include_ptable else None
+        m_reformat.assert_called_once_with(
+            disk_id="dev-sdc", ptable=expected_ptable, allowed=[]
+        )
+        m_guided.assert_called_once()
+
 
 class TestGuidedV2(IsolatedAsyncioTestCase):
     async def _setup(self, bootloader, ptable, fix_bios=True, **kw):

--- a/subiquity/ui/views/filesystem/delete.py
+++ b/subiquity/ui/views/filesystem/delete.py
@@ -168,7 +168,7 @@ class ConfirmReformatStretchy(Stretchy):
         super().__init__(title, widgets, 0, 2)
 
     def confirm(self, sender=None):
-        self.parent.controller.reformat(self.obj)
+        self.parent.controller.reformat(self.obj, ptable=None)
         self.parent.refresh_model_inputs()
         self.parent.remove_overlay()
 


### PR DESCRIPTION
When reformatting a disk using the following call:

```python
manipulator.reformat(disk, ptable="something")
```

The ptable parameter would only appear to be honored if the disk did not contain any partition. This happened because the `reformat()` function sets the ptable of the disk first and then starts removing partitions using `delete_partition()` in a loop.

However, `delete_partition()` has a mechanism to reset the partition table to `None` when it is invoked on the last partition of a disk.

Therefore, the disk ended up with `None` as the partition table (ignoring the ptable value) if the disk contained any partition.

Fixed by moving the assignment of `disk.ptable` after removing partitions. Arguably, it is a mistake to change the partition table value before removing the partitions anyway.