### PR TITLE
Don't crash and allow reformat of a disk with unsupported partition table

### DIFF
--- a/subiquity/common/filesystem/actions.py
+++ b/subiquity/common/filesystem/actions.py
@@ -168,6 +168,8 @@ def _can_edit_generic(device):
 def _can_edit_partition(partition):
     if partition._is_in_use:
         return False
+    if not partition.on_supported_ptable():
+        return False
     return _can_edit_generic(partition)
 
 
@@ -297,6 +299,8 @@ def _can_delete_generic(device):
 @_can_delete.register(Partition)
 def _can_delete_partition(partition):
     if partition._is_in_use:
+        return False
+    if not partition.on_supported_ptable():
         return False
     if partition.device._has_preexisting_partition():
         return _(

--- a/subiquity/common/filesystem/boot.py
+++ b/subiquity/common/filesystem/boot.py
@@ -352,6 +352,8 @@ def _can_be_boot_device_disk(disk, *, resize_partition=None, with_reformatting=F
         return False
     if with_reformatting:
         disk = disk._reformatted()
+    if disk.ptable == "unsupported":
+        return False
     plan = get_boot_device_plan(disk, resize_partition=resize_partition)
     return plan is not None
 

--- a/subiquity/common/filesystem/gaps.py
+++ b/subiquity/common/filesystem/gaps.py
@@ -197,6 +197,8 @@ def find_disk_gaps_v2(device, info=None):
 def parts_and_gaps_disk(device, ignore_disk_fs=False):
     if device._fs is not None and not ignore_disk_fs:
         return []
+    if device.ptable == "unsupported":
+        return device.partitions()
     if device._m.storage_version == 1:
         return find_disk_gaps_v1(device)
     else:

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -334,6 +334,7 @@ def _for_client_disk(disk, *, min_size=0):
         model=getattr(disk, "model", None),
         vendor=getattr(disk, "vendor", None),
         has_in_use_partition=disk._has_in_use_partition,
+        requires_reformat=disk.ptable == "unsupported",
     )
 
 

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -280,7 +280,12 @@ def _usage_labels_partition(partition):
 
 @usage_labels.register(Disk)
 def _usage_labels_disk(disk):
-    return _usage_labels_generic(disk, exclude_final_unused=True)
+    usages = _usage_labels_generic(disk, exclude_final_unused=True)
+
+    if disk.ptable == "unsupported":
+        usages.append(_("unsupported partition table"))
+
+    return usages
 
 
 @usage_labels.register(Raid)

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -121,7 +121,7 @@ class FilesystemManipulator:
         self.create_filesystem(part, spec)
         return part
 
-    def delete_partition(self, part, override_preserve=False, allow_renumbering=True):
+    def delete_partition(self, part, *, override_preserve=False, allow_renumbering=True):
         if (
             not override_preserve
             and part.device.preserve
@@ -146,7 +146,7 @@ class FilesystemManipulator:
         for v in raid._subvolumes:
             self.delete_raid(v)
         for p in list(raid.partitions()):
-            self.delete_partition(p, True)
+            self.delete_partition(p, override_preserve=True)
         for d in set(raid.devices) | set(raid.spare_devices):
             d.wipe = "superblock"
         self.model.remove_raid(raid)
@@ -274,7 +274,7 @@ class FilesystemManipulator:
         partition table type."""
         disk.grub_device = False
         for p in list(disk.partitions()):
-            self.delete_partition(p, True)
+            self.delete_partition(p, override_preserve=True)
         disk.ptable = ptable
         self.clear(disk, wipe)
 

--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -121,7 +121,14 @@ class FilesystemManipulator:
         self.create_filesystem(part, spec)
         return part
 
-    def delete_partition(self, part, *, override_preserve=False, allow_renumbering=True):
+    def delete_partition(
+        self,
+        part,
+        *,
+        override_preserve=False,
+        allow_renumbering=True,
+        allow_moving=True,
+    ):
         if (
             not override_preserve
             and part.device.preserve
@@ -129,7 +136,9 @@ class FilesystemManipulator:
         ):
             raise Exception("cannot delete partitions from preserved disks")
         self.clear(part)
-        self.model.remove_partition(part, allow_renumbering=allow_renumbering)
+        self.model.remove_partition(
+            part, allow_renumbering=allow_renumbering, allow_moving=allow_moving
+        )
 
     def create_raid(self, spec: RaidSpec):
         for d in spec["devices"] | spec["spare_devices"]:
@@ -274,7 +283,9 @@ class FilesystemManipulator:
         partition table type."""
         disk.grub_device = False
         for p in list(disk.partitions()):
-            self.delete_partition(p, override_preserve=True)
+            self.delete_partition(
+                p, override_preserve=True, allow_renumbering=False, allow_moving=False
+            )
         disk.ptable = ptable
         self.clear(disk, wipe)
 

--- a/subiquity/common/filesystem/tests/test_gaps.py
+++ b/subiquity/common/filesystem/tests/test_gaps.py
@@ -83,6 +83,24 @@ class TestGaps(unittest.TestCase):
         self.assertTrue(isinstance(gap, gaps.Gap))
         self.assertEqual(MiB + 20 * MiB, gap.offset)
 
+    def test_disk_with_unsupported_ptable(self):
+        model, disk = make_model_and_disk(ptable="unsupported")
+
+        self.assertEqual([], gaps.parts_and_gaps(disk))
+
+    def test_disk_with_unsupported_ptable_and_partitions(self):
+        # Start with GPT so make_partition does not complain, but we will reset
+        # the ptable before running the actual test.
+        model, disk = make_model_and_disk(ptable="gpt")
+
+        p1 = make_partition(model, disk)
+        p2 = make_partition(model, disk)
+        p3 = make_partition(model, disk)
+
+        disk.ptable = "unsupported"
+
+        self.assertEqual([p1, p2, p3], gaps.parts_and_gaps(disk))
+
 
 class TestSplitGap(GapTestCase):
     def test_equal(self):

--- a/subiquity/common/filesystem/tests/test_labels.py
+++ b/subiquity/common/filesystem/tests/test_labels.py
@@ -123,3 +123,11 @@ class TestForClient(unittest.TestCase):
         model, raid = make_model_and_raid()
         make_partition(model, raid)
         for_client(raid)
+
+    def test_for_client_disk_supported_ptable(self):
+        _, disk = make_model_and_disk(ptable="gpt")
+        self.assertFalse(for_client(disk).requires_reformat)
+
+    def test_for_client_disk_unsupported_ptable(self):
+        _, disk = make_model_and_disk(ptable="unsupported")
+        self.assertTrue(for_client(disk).requires_reformat)

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -738,6 +738,16 @@ class TestReformat(unittest.TestCase):
         self.manipulator.reformat(disk, "msdos")
         self.assertEqual("msdos", disk.ptable)
 
+    def test_reformat_unsupported_disk(self):
+        # Start with a GPT disk so we can call make_partition, but then reset
+        # it to unsupported.
+        disk = make_disk(self.manipulator.model, ptable="gpt")
+        make_partition(self.manipulator.model, disk)
+
+        disk.ptable = "unsupported"
+
+        self.manipulator.reformat(disk, ptable=None)
+
 
 class TestCanResize(unittest.TestCase):
     def setUp(self):

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -114,6 +114,14 @@ class Disk:
     model: Optional[str] = None
     vendor: Optional[str] = None
     has_in_use_partition: bool = False
+    # Going forward, we want the v2 storage responses to return a list of
+    # operations (e.g., reformat, add-partition, delete-partition ...) that can
+    # be performed on a given disk. But we don't have this implemented yet.
+    # The requires_reformat field is essentially a way to tell clients that
+    # only the "reformat" operation is currently possible. No partition can be
+    # added, deleted or otherwise modified on this disk until a reformat is
+    # performed.
+    requires_reformat: Optional[bool] = None
 
 
 class GuidedCapability(enum.Enum):

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -868,6 +868,8 @@ class Disk(_Device):
 
     @property
     def ok_for_raid(self):
+        if self.ptable == "unsupported":
+            return False
         if self._fs is not None:
             if self._fs.preserve:
                 return self._fs._mount is None
@@ -987,6 +989,8 @@ class Partition(_Formattable):
 
     @property
     def ok_for_raid(self):
+        if not self.on_supported_ptable():
+            return False
         if self.boot:
             return False
         if self._fs is not None:
@@ -1032,6 +1036,9 @@ class Partition(_Formattable):
 
     def on_remote_storage(self) -> bool:
         return self.device.on_remote_storage()
+
+    def on_supported_ptable(self) -> bool:
+        return self.device.ptable != "unsupported"
 
 
 @fsobj("raid")

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2252,15 +2252,16 @@ class FilesystemModel:
         self._actions.append(p)
         return p
 
-    def remove_partition(self, part, allow_renumbering=True):
+    def remove_partition(self, part, *, allow_renumbering=True, allow_moving=True):
         if part._fs or part._constructed_device:
             raise Exception("can only remove empty partition")
         from subiquity.common.filesystem.gaps import (
             movable_trailing_partitions_and_gap_size,
         )
 
-        for p2 in movable_trailing_partitions_and_gap_size(part)[0]:
-            p2.offset -= part.size
+        if allow_moving:
+            for p2 in movable_trailing_partitions_and_gap_size(part)[0]:
+                p2.offset -= part.size
         self._remove(part)
         if part.is_logical and allow_renumbering:
             part.device.renumber_logical_partitions(part)

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -976,10 +976,13 @@ class Partition(_Formattable):
         if fs_data is None:
             return -1
         val = fs_data.get("ESTIMATED_MIN_SIZE", -1)
-        if val == 0:
-            return self.device.alignment_data().part_align
         if val == -1:
             return -1
+        if not self.on_supported_ptable():
+            # We don't know the alignment constraints so...
+            return -1
+        if val == 0:
+            return self.device.alignment_data().part_align
         return align_up(val, self.device.alignment_data().part_align)
 
     @property

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1397,6 +1397,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         log.debug("v2_add_boot_partition: disk-id: %s", disk_id)
         self.locked_probe_data = True
         disk = self.model._one(id=disk_id)
+        if disk.ptable == "unsupported":
+            raise StorageRecoverableError(
+                "cannot modify a disk with an unsupported partition table"
+            )
         if boot.is_boot_device(disk):
             raise StorageRecoverableError("device already has bootloader partition")
         if DeviceAction.TOGGLE_BOOT not in DeviceAction.supported(disk):
@@ -1410,6 +1414,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if data.partition.boot is not None:
             raise ValueError("add_partition does not support changing boot")
         disk = self.model._one(id=data.disk_id)
+        if disk.ptable == "unsupported":
+            raise StorageRecoverableError(
+                "cannot modify a disk with an unsupported partition table"
+            )
         requested_size = data.partition.size or 0
         if requested_size > data.gap.size:
             raise ValueError("new partition too large")
@@ -1434,6 +1442,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         log.debug(data)
         self.locked_probe_data = True
         disk = self.model._one(id=data.disk_id)
+        if disk.ptable == "unsupported":
+            raise StorageRecoverableError(
+                "cannot modify a disk with an unsupported partition table"
+            )
         partition = self.get_partition(disk, data.partition.number)
         self.delete_partition(partition)
         return await self.v2_GET()
@@ -1444,6 +1456,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         log.debug(data)
         self.locked_probe_data = True
         disk = self.model._one(id=data.disk_id)
+        if disk.ptable == "unsupported":
+            raise StorageRecoverableError(
+                "cannot modify a disk with an unsupported partition table"
+            )
         partition = self.get_partition(disk, data.partition.number)
         if (
             data.partition.size not in (None, partition.size)

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -643,10 +643,10 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
             disk, ptable=None, wipe="superblock-recursive"
         )
         expected_del_calls = [
-            mock.call(p1, True),
-            mock.call(p2, True),
-            mock.call(p3, True),
-            mock.call(p4, True),
+            mock.call(p1, override_preserve=True),
+            mock.call(p2, override_preserve=True),
+            mock.call(p3, override_preserve=True),
+            mock.call(p4, override_preserve=True),
         ]
         self.assertEqual(expected_del_calls, m_del_part.mock_calls)
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -643,10 +643,18 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
             disk, ptable=None, wipe="superblock-recursive"
         )
         expected_del_calls = [
-            mock.call(p1, override_preserve=True),
-            mock.call(p2, override_preserve=True),
-            mock.call(p3, override_preserve=True),
-            mock.call(p4, override_preserve=True),
+            mock.call(
+                p1, override_preserve=True, allow_renumbering=False, allow_moving=False
+            ),
+            mock.call(
+                p2, override_preserve=True, allow_renumbering=False, allow_moving=False
+            ),
+            mock.call(
+                p3, override_preserve=True, allow_renumbering=False, allow_moving=False
+            ),
+            mock.call(
+                p4, override_preserve=True, allow_renumbering=False, allow_moving=False
+            ),
         ]
         self.assertEqual(expected_del_calls, m_del_part.mock_calls)
 


### PR DESCRIPTION
This PR allows Subiquity to work with partition tables that are marked "unsupported". In the presence of such disk, Subiquity used to crash, either in the UI, or when generating guided scenarios.

### Machine config

**TODO**

Locally, I have been using probe-data from LP:#2065516 but it requires curtin patches to mark the ptable from the dynamic disk as "unsupported". Otherwise, it still crashes. See https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/480694

### API change

Disks that have an unsupported partition table will now be marked `"requires_reformat": true` in the /storage/v2 endpoint:


```json
"disks": [
    {
      "id": "disk-sda",
      "label": "TOSHIBA_HDWD110_999E6AZFS",
      "type": "local disk",
      "size": 1000204886016,
      "usage_labels": [
        "unsupported partition table"
      ],
      "partitions": [
[...]
      ]
      "ptable": "unsupported",
      "requires_reformat": true
```

Technically, looking at `"requires_reformat": true` is the same as looking at `"ptable": "unsupported"` but I assume that,  in the future we might not use the value `"unsupported"` for all the different unsupported ptables.
    
Clients are expected to prevent modifications of a disk which is marked `"requires_reformat": true`. Modifications include:
    
 * creating a new partition
 * removing a partition
 * modifying a partition
 * marking the disk as the boot device
    
Essentially, the only action that the client should support for such disk is to reformat it.

### TUI change

![Screenshot from 2025-02-05 14-40-21](https://github.com/user-attachments/assets/cea6ec1b-1150-42a2-9657-13eded479e4c)
![Screenshot from 2025-02-05 14-40-34](https://github.com/user-attachments/assets/03923dbc-8e19-4063-904a-497bd8bfe556)

### Testing

TODO an actual install that includes reformat