### PR TITLE
ci: bump has-signed-canonical-cla version

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -7,6 +7,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
-        with:
-          accept-existing-contributors: true
+        uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
Update the cla-check workflow with an updated version of the `has-signed-canonical-cla` action.

A side effect of this upgrade is that the option for accepting existing contributors was removed from the CLA checker in v2. The following reasoning was provided[1,2]:

	Remove the option for accepting existing contributors, as
	contributors can revoke their CLA agreement. The CLA must
	be checked with every commit.

This seems reasonable IMO and for Subiquity's case, this seems to mostly have been used as a workaround for Canonical employees signing commits with their Ubuntu member emails addresses[3], which the v1 CLA checker had trouble with. This doesn't look like it'll be an issue with v2 so I think we can safely proceed with removing this.

~~Additionally, let's temporarily pin the version to a specific later commit to workaround a regression in v2.0.0 which silently accepts usernames not associated with a github username[4].~~ Edit: This has been resolved upstream and `v2` now contains the fix.

[1] https://github.com/canonical/has-signed-canonical-cla/releases/tag/2.0.0
[2] https://github.com/canonical/has-signed-canonical-cla/commit/82ea789f7b1da38d1fbc82d92fd972d292bd453f
[3] 6b1700bd4766b6a77daf88842ea23172a40b22a2
[4] https://github.com/canonical/has-signed-canonical-cla/issues/73