### PR TITLE
snapcraft: bump curtin revision to pickup RAID fixes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "446c6cb0e2e70f5068d92879bc97198723a5e56b"
+    source-commit: "05217835c0222d4b4b84220b33a0a839549009b0"
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
* canonical/curtin@05217835 Merge remote-tracking branch 'ogayot/raid+multipath-drop-legacy'
* canonical/curtin@d7160fab Merge remote-tracking branch 'ogayot/raid+ptable'
* canonical/curtin@5c54e88e storage-config: parse ptable field for RAID if specified
* canonical/curtin@ee2d6f67 storage-config: factorize detection of the partition layout
* canonical/curtin@5dfa84cf block: drop legacy multipath detection mechanism
* canonical/curtin@c54851d4 storage_config.py: fix missing uuid entry for RAID partitions