### PR TITLE
snapcraft: bump curtin revision to pickup RAID fixes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -66,7 +66,7 @@ parts:
     source: https://git.launchpad.net/curtin
     source-type: git
     # Tracks the ubuntu/noble branch
-    source-commit: 28dc844eadca33c183dfb1c455b11a38acf4f01d
+    source-commit: e67611532bb84e39980ca60ab37fc08f304a15a5
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
https://code.launchpad.net/~ogayot/curtin/+git/curtin/+ref/noble-raid-fixes

* Fixes LP:#2094979
   * canonical/curtin@e6761153 block: drop legacy multipath detection mechanism
* Fixes LP:#2098075
   * canonical/curtin@52496fc9 storage-config: parse ptable field for RAID if specified
   * canonical/curtin@4db0ef3f storage-config: factorize detection of the partition layout
* Fixes LP:#2095141 (but also addresses LP:#2067178)
   * canonical/curtin@872c8e6b storage_config.py: fix missing uuid entry for RAID partitions
* Fixes CI (needed for the CI to be happy about other changes)
   * canonical/curtin@a9ba65b1 tox: switch to pytest
   * canonical/curtin@6773d81f tox: sitepackages = false