### PR TITLE
components: fix version matching

### DIFF
--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -675,15 +675,29 @@ class InstallController(SubiquityController):
             return []
         info: VariationInfo = self.app.controllers.Filesystem._info
         kernel_components = info.available_kernel_components
+        nvidia_driver_offered: bool = False
+        # for first pass, accept the matching version, if that's an option
         for driver in sorted(self.app.controllers.Drivers.drivers, reverse=True):
             m = re.fullmatch("nvidia-driver-([0-9]+)", driver)
             if not m:
                 continue
+            nvidia_driver_offered = True
             v = m.group(1)
             ko = f"nvidia-{v}-ko"
             user = f"nvidia-{v}-user"
             if ko in kernel_components and user in kernel_components:
                 return [ko, user]
+        # if we don't match there, accept the newest reasonable version
+        if nvidia_driver_offered:
+            for component in sorted(kernel_components, reverse=True):
+                m = re.fullmatch("nvidia-([0-9]+)-ko", component)
+                if not m:
+                    continue
+                ko = component
+                v = m.group(1)
+                user = f"nvidia-{v}-user"
+                if user in kernel_components:
+                    return [ko, user]
         return []
 
     @with_context(

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -676,6 +676,11 @@ class InstallController(SubiquityController):
         info: VariationInfo = self.app.controllers.Filesystem._info
         kernel_components = info.available_kernel_components
         nvidia_driver_offered: bool = False
+        # so here we make the jump from the `ubuntu-drivers` recommendation and
+        # map that, as close as we can, to kernel components.  Currently just
+        # handling nvidia.  Note that it's highly likely that the version
+        # offered in archive will be newer than what is offered by pc-kernel
+        # (570 in plucky archive vs 550 in noble pc-kernel at time of writing).
         # for first pass, accept the matching version, if that's an option
         for driver in sorted(self.app.controllers.Drivers.drivers, reverse=True):
             m = re.fullmatch("nvidia-driver-([0-9]+)", driver)

--- a/subiquity/server/controllers/tests/test_install.py
+++ b/subiquity/server/controllers/tests/test_install.py
@@ -396,8 +396,12 @@ class TestInstallControllerDriverMatch(unittest.TestCase):
             (["nvidia-510-ko"], ["nvidia-driver-510"], []),
             # missing ko component
             (["nvidia-510-user"], ["nvidia-driver-510"], []),
-            # wrong driver version
-            (["nvidia-510-ko", "nvidia-510-user"], ["nvidia-driver-999"], []),
+            # mismatched component versions, nothing usable available
+            (
+                ["nvidia-2-ko", "nvidia-1-user"],
+                ["nvidia-driver-999"],
+                [],
+            ),
             # match
             (
                 ["nvidia-510-ko", "nvidia-510-user"],
@@ -414,6 +418,24 @@ class TestInstallControllerDriverMatch(unittest.TestCase):
                 ["nvidia-1-ko", "nvidia-1-user", "nvidia-2-ko", "nvidia-2-user"],
                 ["nvidia-driver-2", "nvidia-driver-1"],
                 ["nvidia-2-ko", "nvidia-2-user"],
+            ),
+            # wrong driver version
+            (
+                ["nvidia-510-ko", "nvidia-510-user"],
+                ["nvidia-driver-999"],
+                ["nvidia-510-ko", "nvidia-510-user"],
+            ),
+            # wrong driver version, use newer
+            (
+                ["nvidia-1-ko", "nvidia-2-user", "nvidia-2-ko", "nvidia-1-user"],
+                ["nvidia-driver-999"],
+                ["nvidia-2-ko", "nvidia-2-user"],
+            ),
+            # mismatched component versions, something usable available
+            (
+                ["nvidia-1-ko", "nvidia-2-ko", "nvidia-1-user"],
+                ["nvidia-driver-999"],
+                ["nvidia-1-ko", "nvidia-1-user"],
             ),
         )
     )

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -242,11 +242,8 @@ class Model:
     architecture: str
     snaps: List[ModelSnap]
 
-    def snap_of_type(self, typ: ModelSnapType) -> Optional[ModelSnap]:
-        for snap in self.snaps:
-            if snap.type == typ:
-                return snap
-        return None
+    def snaps_of_type(self, typ: ModelSnapType) -> List[ModelSnap]:
+        return [snap for snap in self.snaps if snap.type == typ]
 
 
 @snapdtype


### PR DESCRIPTION
 ~~Prerequisite PR: https://github.com/canonical/subiquity/pull/2166~~

install: handle nvidia driver version != component version

Often (always?) the `ubuntu-drivers list --recommended` version is going
to be newer than what's actually available as a pc-kernel component.
Handle that version mismatch.

