### PR TITLE
Add read-only access to GPT partition name to /storage/v2 API

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "05217835c0222d4b4b84220b33a0a839549009b0"
+    source-commit: "67b539b9c448e1b2751b01fee8a854b4c369685f"
 
     override-pull: |
       craftctl default

--- a/subiquity/common/filesystem/labels.py
+++ b/subiquity/common/filesystem/labels.py
@@ -352,6 +352,7 @@ def _for_client_partition(partition, *, min_size=0):
         offset=partition.offset,
         resize=partition.resize,
         path=partition._path(),
+        name=partition.partition_name,
         estimated_min_size=partition.estimated_min_size,
         mount=partition.mount,
         format=partition.format,

--- a/subiquity/common/filesystem/tests/test_labels.py
+++ b/subiquity/common/filesystem/tests/test_labels.py
@@ -131,3 +131,15 @@ class TestForClient(unittest.TestCase):
     def test_for_client_disk_unsupported_ptable(self):
         _, disk = make_model_and_disk(ptable="unsupported")
         self.assertTrue(for_client(disk).requires_reformat)
+
+    def test_for_client_partition_no_name(self):
+        model, disk = make_model_and_disk(ptable="gpt")
+        part = make_partition(model, disk, partition_name=None)
+
+        self.assertIsNone(for_client(part).name)
+
+    def test_for_client_partition_with_name(self):
+        model, disk = make_model_and_disk(ptable="gpt")
+        part = make_partition(model, disk, partition_name="Foobar")
+
+        self.assertEqual("Foobar", for_client(part).name)

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -65,6 +65,9 @@ class Partition:
     estimated_min_size: Optional[int] = -1
     resize: Optional[bool] = None
     path: Optional[str] = None
+    # Be careful, this corresponds to the partition_name field (not the name
+    # field) in the associated fsobject
+    name: Optional[str] = None
     # Was this partition mounted when the installer started?
     is_in_use: bool = False
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -916,11 +916,15 @@ class Partition(_Formattable):
     number: Optional[int] = None
     preserve: bool = False
     grub_device: bool = False
+    # This field controls the existence of a /dev/disk/by-dname/<name> symlink.
+    # Not to be confused with "partition_name" below.
     name: Optional[str] = None
     multipath: Optional[str] = None
     offset: Optional[int] = None
     resize: Optional[bool] = None
     partition_type: Optional[str] = None
+    # This is the actual name of the partition, if supported. It maps to the
+    # "name" field in the Partition API object.
     partition_name: Optional[str] = None
     path: Optional[str] = None
     uuid: Optional[str] = None

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -452,11 +452,12 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
     async def test_v2_edit_partition_POST_change_boot(self):
         self.fsc.locked_probe_data = False
+        self.fsc.model, d = make_model_and_disk()
         data = ModifyPartitionV2(
-            disk_id="dev-sda",
+            disk_id=d.id,
             partition=Partition(number=1, boot=True),
         )
-        existing = Partition(number=1, size=1000 << 20, boot=False)
+        existing = make_partition(self.fsc.model, d, size=1000 << 20)
         with mock.patch.object(self.fsc, "partition_disk_handler") as handler:
             with mock.patch.object(self.fsc, "get_partition", return_value=existing):
                 with self.assertRaisesRegex(ValueError, r"changing\ boot"):
@@ -466,12 +467,13 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
     async def test_v2_edit_partition_POST_unsupported_ptable(self):
         self.fsc.locked_probe_data = False
-        self.fsc.model, d = make_model_and_disk(ptable="unsupported")
+        self.fsc.model, d = make_model_and_disk()
         data = ModifyPartitionV2(
             disk_id=d.id,
             partition=Partition(number=1, boot=True),
         )
-        existing = Partition(number=1, size=1000 << 20, boot=False)
+        existing = make_partition(self.fsc.model, d, size=1000 << 20)
+        d.ptable = "unsupported"
         with mock.patch.object(self.fsc, "partition_disk_handler") as handler:
             with mock.patch.object(self.fsc, "get_partition", return_value=existing):
                 with self.assertRaisesRegex(
@@ -483,11 +485,12 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
     async def test_v2_edit_partition_POST(self):
         self.fsc.locked_probe_data = False
+        self.fsc.model, d = make_model_and_disk()
         data = ModifyPartitionV2(
-            disk_id="dev-sda",
+            disk_id=d.id,
             partition=Partition(number=1),
         )
-        existing = Partition(number=1, size=1000 << 20, boot=False)
+        existing = make_partition(self.fsc.model, d, size=1000 << 20)
         with mock.patch.object(self.fsc, "partition_disk_handler") as handler:
             with mock.patch.object(self.fsc, "get_partition", return_value=existing):
                 await self.fsc.v2_edit_partition_POST(data)


### PR DESCRIPTION
This leans on https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/481790 which has been merged.

     * Partition(number=1, name=None)
     * Partition(number=2, name="Microsoft Reserved Partition")
```
GET /storage/v2
[...]
{
    [...]
    "number": 1,
    "name": "Basic data partition",
    "$type": "Partition"
  },
  {
    [...]
    "number": 2,
    "name": "Microsoft Reserved Partition",
    "$type": "Partition"
  },

```

This is a read-only property, the API will reject modifications of the partition name:

```
POST /storage/v2/edit_partition
> {..., "partition": {"number": 1, ...}}
```
-> OK (not trying to change the name)
<br>
```    
POST /storage/v2/edit_partition
> {..., "partition": {"number": 2, ...}}
```
-> OK (not trying to change the name)
<br>
```
POST /storage/v2/edit_partition
> {..., "partition": {"number": 1, "name": null, ...}}
```
-> OK (value of name hasn't changed)
<br>
```
POST /storage/v2/edit_partition
> {..., "partition": {"number": 2, "name": null, ...}}
```
~~-> KO (trying to change the value to None)~~
_-> OK (for now, but in the future, this should be treated as an attempt to reset the partition name)_
<br>
```
POST /storage/v2/edit_partition
> {..., "partition": {"number": 1, "name": "something", ...}}
```
-> KO (trying to change the value to "something")

LP:#2099893