### PR TITLE
snapcraft: add python3-packaging in the snap to satisfy curtin

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -136,6 +136,7 @@ parts:
       - python3-minimal
       - python3-more-itertools
       - python3-oauthlib
+      - python3-packaging
       - python3-passlib
       - python3-pkg-resources
       - python3-pyroute2


### PR DESCRIPTION
Curtin now requires python3-packaging to be installed to work properly. See https://code.launchpad.net/~sjg1/curtin/+git/curtin/+merge/480712

Add that package to the snap.