### PR TITLE
snapcraft: bump curtin revision for nvme-o-tcp fix (netplan + dracut)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "67b539b9c448e1b2751b01fee8a854b4c369685f"
+    source-commit: "b6eb111371b669b2698de024001979c2c527b4fe"
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Full commit log:

* canonical/curtin@b6eb1113 nvme-o-tcp: add function to adapt netplan config for dracut
* canonical/curtin@161d1767 nvme-o-tcp: add function to iterate over NVME TCP controllers
* canonical/curtin@4a0f9568 block: fix string interpolation when building RuntimeError