### PR TITLE
pin/pass: volume auth, plus capability related fixes

### DIFF
--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -179,11 +179,15 @@ class GuidedCapability(enum.Enum):
         return self in [
             GuidedCapability.LVM_LUKS,
             GuidedCapability.CORE_BOOT_ENCRYPTED,
+            GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED,
             GuidedCapability.ZFS_LUKS_KEYSTORE,
         ]
 
     def supports_pin(self) -> bool:
-        return self == GuidedCapability.CORE_BOOT_ENCRYPTED
+        return self in [
+            GuidedCapability.CORE_BOOT_ENCRYPTED,
+            GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED,
+        ]
 
 
 class GuidedDisallowedCapabilityReason(enum.Enum):

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -175,6 +175,12 @@ class GuidedCapability(enum.Enum):
             GuidedCapability.ZFS_LUKS_KEYSTORE,
         ]
 
+    def is_tpm_backed(self) -> bool:
+        return self in [
+            GuidedCapability.CORE_BOOT_ENCRYPTED,
+            GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED,
+        ]
+
     def supports_passphrase(self) -> bool:
         return self in [
             GuidedCapability.LVM_LUKS,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -787,7 +787,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                     "Not using enhanced_secureboot: disabled on commandline"
                 )
             assert isinstance(choice.target, GuidedStorageTargetReformat)
-            self.use_tpm = choice.capability == GuidedCapability.CORE_BOOT_ENCRYPTED
+            self.use_tpm = choice.capability.is_tpm_backed()
             await self.guided_core_boot(disk, choice)
             return
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -322,6 +322,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self._info: Optional[VariationInfo] = None
         self._system_getter = SystemGetter(self.app)
         self._on_volume: Optional[snapdtypes.OnVolume] = None
+        self._volumes_auth: Optional[snapdtypes.VolumesAuth] = None
         self._role_to_device: Dict[Union[str, snapdtypes.Role], _Device] = {}
         self._device_to_structure: Dict[_Device, snapdtypes.OnVolume] = {}
         self._pyudev_context: Optional[pyudev.Context] = None
@@ -787,7 +788,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 )
             assert isinstance(choice.target, GuidedStorageTargetReformat)
             self.use_tpm = choice.capability == GuidedCapability.CORE_BOOT_ENCRYPTED
-            await self.guided_core_boot(disk)
+            await self.guided_core_boot(disk, choice)
             return
 
         gap = self.start_guided(choice.target, disk)
@@ -925,7 +926,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             yield (structure, offset, structure.size)
             offset = offset + structure.size
 
-    async def guided_core_boot(self, disk: Disk):
+    async def guided_core_boot(self, disk: Disk, choice: GuidedChoiceV2):
         if self._info.needs_systems_mount:
             await SystemsDirMounter(self.app, self._info.name).mount()
         # Formatting for a core boot classic system relies on some curtin
@@ -933,6 +934,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self.model.storage_version = 2
         [volume] = self._info.system.volumes.values()
         self._on_volume = snapdtypes.OnVolume.from_volume(volume)
+        self._volumes_auth = snapdtypes.VolumesAuth.from_choice(choice)
 
         preserved_parts = set()
 
@@ -1012,14 +1014,17 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     @with_context(description="configuring TPM-backed full disk encryption")
     async def setup_encryption(self, context):
         label = self._info.label
+        kwargs = dict(
+            action=snapdtypes.SystemAction.INSTALL,
+            step=snapdtypes.SystemActionStep.SETUP_STORAGE_ENCRYPTION,
+            on_volumes=self._on_volumes(),
+        )
+        if self._volumes_auth is not None:
+            kwargs["volumes_auth"] = self._volumes_auth
         result = await snapdapi.post_and_wait(
             self.app.snapdapi,
             self.app.snapdapi.v2.systems[label].POST,
-            snapdtypes.SystemActionRequest(
-                action=snapdtypes.SystemAction.INSTALL,
-                step=snapdtypes.SystemActionStep.SETUP_STORAGE_ENCRYPTION,
-                on_volumes=self._on_volumes(),
-            ),
+            snapdtypes.SystemActionRequest(**kwargs),
             ann=snapdtypes.SystemActionResponse,
         )
         for role, enc_path in result.encrypted_devices.items():

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -2525,6 +2525,7 @@ class TestGuidedChoiceValidation(IsolatedAsyncioTestCase):
             (GuidedCapability.MANUAL, False, False),
             (GuidedCapability.LVM_LUKS, False, True),
             (GuidedCapability.CORE_BOOT_ENCRYPTED, True, True),
+            (GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED, True, True),
         )
     )
     def test_capability_pin_pass_validation(self, capability, pin_ok, pass_ok):


### PR DESCRIPTION
* Pass pin / passphrase info along, if supplied in GuidedChoiceV2.
* Fix pin / passphrase validation, which should consider both CORE_BOOT_{,PREFER_}ENCRYPTED.
* Fix use_tpm check to also consider both CORE_BOOT_{,PREFER_}ENCRYPTED.
