### PR TITLE
filesystem: install all optional snaps

### DIFF
--- a/examples/autoinstall/core-installer.yaml
+++ b/examples/autoinstall/core-installer.yaml
@@ -1,0 +1,3 @@
+version: 1
+source:
+  id: ubuntu-core

--- a/examples/snaps/v2-systems-ubuntu-core-24-amd64.json
+++ b/examples/snaps/v2-systems-ubuntu-core-24-amd64.json
@@ -1,0 +1,253 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "label": "ubuntu-core-24-amd64",
+    "model": {
+      "architecture": "amd64",
+      "authority-id": "canonical",
+      "base": "core24",
+      "brand-id": "canonical",
+      "grade": "signed",
+      "model": "ubuntu-core-24-amd64",
+      "series": "16",
+      "sign-key-sha3-384": "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn",
+      "snaps": [
+        {
+          "default-channel": "24/stable",
+          "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+          "name": "pc",
+          "type": "gadget"
+        },
+        {
+          "default-channel": "24/stable",
+          "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+          "name": "pc-kernel",
+          "type": "kernel"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+          "name": "core24",
+          "type": "base"
+        },
+        {
+          "default-channel": "latest/stable",
+          "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+          "name": "snapd",
+          "type": "snapd"
+        },
+        {
+          "default-channel": "24/stable",
+          "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+          "name": "console-conf",
+          "presence": "optional",
+          "type": "app"
+        }
+      ],
+      "timestamp": "2024-04-19T08:42:32+00:00",
+      "type": "model"
+    },
+    "brand": {
+      "id": "canonical",
+      "username": "canonical",
+      "display-name": "Canonical",
+      "validation": "verified"
+    },
+    "actions": [
+      {
+        "title": "Install",
+        "mode": "install"
+      },
+      {
+        "title": "Recover",
+        "mode": "recover"
+      },
+      {
+        "title": "Factory reset",
+        "mode": "factory-reset"
+      }
+    ],
+    "volumes": {
+      "pc": {
+        "schema": "gpt",
+        "bootloader": "grub",
+        "id": "",
+        "structure": [
+          {
+            "name": "mbr",
+            "filesystem-label": "",
+            "offset": 0,
+            "offset-write": null,
+            "min-size": 440,
+            "size": 440,
+            "type": "mbr",
+            "role": "mbr",
+            "id": "",
+            "filesystem": "",
+            "content": [
+              {
+                "source": "",
+                "target": "",
+                "image": "mbr.img",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "BIOS Boot",
+            "filesystem-label": "",
+            "offset": 1048576,
+            "offset-write": null,
+            "min-size": 1048576,
+            "size": 1048576,
+            "type": "21686148-6449-6E6F-744E-656564454649",
+            "role": "",
+            "id": "",
+            "filesystem": "",
+            "content": null,
+            "update": {
+              "edition": 2,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-seed",
+            "filesystem-label": "ubuntu-seed",
+            "offset": 2097152,
+            "offset-write": null,
+            "min-size": 1258291200,
+            "size": 1258291200,
+            "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "role": "system-seed",
+            "id": "",
+            "filesystem": "vfat",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/ubuntu/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/ubuntu/shimx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "boot.csv",
+                "target": "EFI/ubuntu/bootx64.csv",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "fb.efi",
+                "target": "EFI/boot/fbx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              },
+              {
+                "source": "shim.efi.signed",
+                "target": "EFI/boot/bootx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 3,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-boot",
+            "filesystem-label": "ubuntu-boot",
+            "offset": 1260388352,
+            "offset-write": null,
+            "min-size": 786432000,
+            "size": 786432000,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-boot",
+            "id": "",
+            "filesystem": "ext4",
+            "content": [
+              {
+                "source": "grubx64.efi",
+                "target": "EFI/boot/grubx64.efi",
+                "image": "",
+                "offset": null,
+                "size": 0,
+                "unpack": false
+              }
+            ],
+            "update": {
+              "edition": 1,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-save",
+            "filesystem-label": "ubuntu-save",
+            "offset": 2046820352,
+            "offset-write": null,
+            "min-size": 16777216,
+            "size": 33554432,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-save",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          },
+          {
+            "name": "ubuntu-data",
+            "filesystem-label": "ubuntu-data",
+            "offset": null,
+            "offset-write": null,
+            "min-size": 1073741824,
+            "size": 1073741824,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "role": "system-data",
+            "id": "",
+            "filesystem": "ext4",
+            "content": null,
+            "update": {
+              "edition": 0,
+              "preserve": null
+            }
+          }
+        ]
+      }
+    },
+    "storage-encryption": {
+      "support": "unavailable",
+      "storage-safety": "prefer-encrypted",
+      "unavailable-reason": "not encrypting device storage as checking TPM gave: cannot read secure boot variable: cannot read EFI var \"SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c\": open /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c: no such file or directory"
+    },
+    "available-optional": {
+      "snaps": [
+        "console-conf"
+      ]
+    }
+  }
+}

--- a/examples/snaps/v2-systems.json
+++ b/examples/snaps/v2-systems.json
@@ -65,6 +65,34 @@
             "mode": "factory-reset"
           }
         ]
+      },
+      {
+        "label": "ubuntu-core-24-amd64",
+        "model": {
+          "model": "ubuntu-core-24-amd64",
+          "brand-id": "canonical",
+          "display-name": "ubuntu-core-24-amd64"
+        },
+        "brand": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical",
+          "validation": "verified"
+        },
+        "actions": [
+          {
+            "title": "Install",
+            "mode": "install"
+          },
+          {
+            "title": "Recover",
+            "mode": "recover"
+          },
+          {
+            "title": "Factory reset",
+            "mode": "factory-reset"
+          }
+        ]
       }
     ]
   }

--- a/examples/sources/core-installer.yaml
+++ b/examples/sources/core-installer.yaml
@@ -1,0 +1,15 @@
+sources:
+- description:
+    en: Ubuntu Core.
+  id: ubuntu-core
+  locale_support: none
+  name:
+    en: Ubuntu Core 24
+  path: ''
+  size: 0
+  snapd_system_label: ubuntu-core-24-amd64
+  type: null
+  variant: core
+version: 2
+kernel:
+  default: "snap:pc-kernel"

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -35,7 +35,7 @@ validate () {
         autoinstall-reset-only)
             python3 scripts/validate-yaml.py --no-root-mount "${cfgs[@]}"
             ;;
-        answers-core-desktop|answers-uc24)
+        answers-core-desktop|autoinstall-ubuntu-core-installer|answers-uc24)
             ;;
         *)
             python3 scripts/validate-yaml.py "${cfgs[@]}"
@@ -46,7 +46,7 @@ validate () {
         exit 1
     fi
     case $testname in
-        answers-core-desktop|answers-uc24)
+        answers-core-desktop|autoinstall-ubuntu-core-installer|answers-uc24)
             ;;
         answers-bridge)
             python3 scripts/check-yaml-fields.py $tmpdir/var/log/installer/curtin-install/subiquity-curthooks.conf \
@@ -140,7 +140,7 @@ for answers in examples/answers/*.yaml; do
         --source-catalog $catalog
     validate install
     case $testname in
-        answers-core-desktop|answers-uc24)
+        answers-core-desktop|autoinstall-ubuntu-core-installer|answers-uc24)
             ;;
         *)
             grep -q 'finish: subiquity/Install/install/postinstall/run_unattended_upgrades: SUCCESS: downloading and installing security updates' $tmpdir/subiquity-server-debug.log
@@ -232,6 +232,23 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --source-catalog examples/sources/tpm.yaml
 validate
 grep -q "finish_install: kernel_components=\['nvidia-510-ko', 'nvidia-510-user'\]" \
+	$tmpdir/subiquity-server-debug.log
+
+clean
+testname=autoinstall-ubuntu-core-installer
+# ubuntu-core-installer install (check that optional snaps are installed)
+LANG=C.UTF-8 timeout --foreground 60 \
+    python3 -m subiquity.cmd.tui \
+    --dry-run \
+    --output-base "$tmpdir" \
+    --machine-config examples/machines/simple.json \
+    --autoinstall examples/autoinstall/core-installer.yaml \
+    --bootloader uefi \
+    --snaps-from-examples \
+    --kernel-cmdline autoinstall \
+    --source-catalog examples/sources/core-installer.yaml
+validate
+grep -F "finish_install: optional_install=OptionalInstall(snaps=['console-conf'], components={'pc-kernel': []}, all=False)" \
 	$tmpdir/subiquity-server-debug.log
 
 clean

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -236,6 +236,7 @@ class ModelSnap:
     name: str
     type: NonExhaustive[ModelSnapType]
     components: Optional[Dict[str, Presence]] = None
+    presence: PresenceValue = PresenceValue.REQUIRED
 
 
 @snapdtype

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -275,6 +275,8 @@ class SystemActionStep(enum.Enum):
     FINISH = "finish"
 
 
+# Setting all=True and with a non-empty AvailableOptional will result in an
+# error, so set all=False by default.
 @snapdtype
 class OptionalInstall(AvailableOptional):
     all: bool = False
@@ -308,6 +310,7 @@ class SystemActionRequest:
     action: SystemAction
     step: SystemActionStep
     on_volumes: Dict[str, OnVolume]
+    # When optional_install=None it is equivalent to OptionalInstall(all=True)
     optional_install: Optional[OptionalInstall] = None
     volumes_auth: Optional[VolumesAuth] = None
 


### PR DESCRIPTION
The snapd API expects that by specifying a value for `optional_install` on a request to `/v2/systems/` you only want those items installed. Existing logic to support only installing particular components meant that no optional snaps were installed. Update the logic in `finish_install` to always install all of the optional snaps available for the model.

I found the behavior surrounding `optional_install` on the snapd API a little confusing so I added some extra comments surrounding the type definitions in subiquity to document the expected behavior.