### PR TITLE
snapcraft: rev curtin for kernel postinstall handling

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "b6eb111371b669b2698de024001979c2c527b4fe"
+    source-commit: "ce8d06668d1b3f7cba6712bf948aa1a995160b78"
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
snapcraft: rev curtin for kernel postinstall handling

canonical/curtin@ce8d0666 curthooks: reconfigure kernel after initrd generated
canonical/curtin@1343ac92 curthooks: move zipl invocation after update-initramfs
canonical/curtin@ab45bb24 curthooks: minor extlinux test cleanup prior to zipl mocking
canonical/curtin@1667812b unittests: remove usage of imp module