### PR TITLE
Revert `69bb830`: "network: do not accept route metric > 20000"

### DIFF
--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -84,17 +84,7 @@ class SubiquityNetworkEventReceiver(NetworkEventReceiver):
         self.controller.update_has_default_route(self.has_default_route)
 
     def _default_route_exists(self, routes):
-        for route in routes:
-            if int(route["table"]) != 254:
-                continue
-            if route["dst"]:
-                continue
-            if int(route["priority"]) >= 20000:
-                # network manager probes routes by creating one at 20000 +
-                # the real metric, but those aren't necessarily valid.
-                continue
-            return True
-        return False
+        return any(route["table"] == 254 and not route["dst"] for route in routes)
 
     def probe_default_routes(self):
         with pyroute2.NDB() as ndb:

--- a/subiquitycore/controllers/tests/test_network.py
+++ b/subiquitycore/controllers/tests/test_network.py
@@ -73,16 +73,6 @@ class TestRoutes(unittest.IsolatedAsyncioTestCase):
                 "priority": 100,
                 "gateway": None,
             },
-            {
-                "target": "localhost",
-                "tflags": 0,
-                "table": 254,
-                "ifname": "ens3",
-                "dst": "10.0.2.0",
-                "dst_len": 24,
-                "priority": 20100,
-                "gateway": None,
-            },
         ]
 
         self.assertTrue(self.er._default_route_exists(routes))
@@ -113,22 +103,6 @@ class TestRoutes(unittest.IsolatedAsyncioTestCase):
                 "dst": "",
                 "dst_len": 0,
                 "priority": 100,
-                "gateway": "10.0.2.2",
-            }
-        ]
-
-        self.assertFalse(self.er._default_route_exists(routes))
-
-    def test_wrong_priority(self):
-        routes = [
-            {
-                "target": "localhost",
-                "tflags": 0,
-                "table": 254,
-                "ifname": "ens3",
-                "dst": "",
-                "dst_len": 0,
-                "priority": 20100,
                 "gateway": "10.0.2.2",
             }
         ]


### PR DESCRIPTION
Fixes [LP#2079222](https://bugs.launchpad.net/subiquity/+bug/2079222).

This reverts commit 69bb8307eb03255ad60fa20ba5d8a148bd726e91.

This behavior was first introduced in #1569. `has_network` is currently used to determine if a mirror check should happen, to decide whether to install drivers, and to display a sensible default Ubuntu Pro setting in the UI. It is possible to use the full functionality provided by all those controllers without access to https://connectivity-check.ubuntu.com/ (via repo mirrors & the airgapped Ubuntu Pro contracts server).

This raises the broader question of whether `has_network` is a sufficient abstraction to capture the nuance of "airgapped environment with a repo mirror and local contracts server", "airgapped environment with no mirror or contracts server", "offline install", or any permutation of those. That conversation is likely out of scope for this bugfix though.