### PR TITLE
Add CL arg to disable the WLAN listener

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -232,7 +232,7 @@ parts:
 
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: "83d25c873a4a7d93c158d76da86cb9c612c29572"
+    source-commit: "329d4f6af4d183e56f14d33285bf41ff179cca68"
 
     override-build: *pyinstall
 

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -150,6 +150,12 @@ returned. """,
     )
     parser.add_argument("--use-os-prober", action="store_true", default=False)
     parser.add_argument(
+        "--no-wlan-listener",
+        action="store_false",
+        dest="with_wlan_listener",
+        default=True,
+    )
+    parser.add_argument(
         "--postinst-hooks-dir", default="/etc/subiquity/postinst.d", type=pathlib.Path
     )
     parser.add_argument(

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -180,7 +180,8 @@ class BaseNetworkController(BaseController):
     def start(self):
         self._observer_handles = []
         self.observer, self._observer_fds = self.app.prober.probe_network(
-            self.network_event_receiver
+            self.network_event_receiver,
+            with_wlan_listener=self.app.opts.with_wlan_listener,
         )
         self.start_watching()
 

--- a/subiquitycore/prober.py
+++ b/subiquitycore/prober.py
@@ -32,11 +32,15 @@ class Prober:
         self.debug_flags = debug_flags
         log.debug("Prober() init finished, data:{}".format(self.saved_config))
 
-    def probe_network(self, receiver):
+    def probe_network(self, receiver, *, with_wlan_listener: bool):
         if self.saved_config is not None:
-            observer = StoredDataObserver(self.saved_config["network"], receiver)
+            observer = StoredDataObserver(
+                self.saved_config["network"],
+                receiver,
+                with_wlan_listener=with_wlan_listener,
+            )
         else:
-            observer = UdevObserver(receiver)
+            observer = UdevObserver(receiver, with_wlan_listener=with_wlan_listener)
         return observer, observer.start()
 
     async def get_storage(self, probe_types=None):

--- a/subiquitycore/ssh.py
+++ b/subiquitycore/ssh.py
@@ -129,7 +129,7 @@ def get_ips_standalone():
     from subiquitycore.models.network import NETDEV_IGNORED_IFACE_TYPES
 
     prober = Prober()
-    prober.probe_network()
+    prober.probe_network(with_wlan_listener=False)
     links = prober.get_results()["network"]["links"]
     ips = []
     for link in sorted(links, key=lambda link: link["netlink_data"]["name"]):


### PR DESCRIPTION
Since the desktop installer does not rely on the WLAN listener, we expect the ubuntu-desktop-bootstrap snap to run subiquity with `--no-wlan-listener` (CC: @d-loose).

This should be a good way to avoid running into Python crashes, such as LP:#2071620 until we get them addressed.

