### PR TITLE
Shutdown/reboot using systemd

### DIFF
--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -138,6 +138,6 @@ class ShutdownController(SubiquityController):
             self.app.exit()
         else:
             if self.mode == ShutdownMode.REBOOT:
-                run_command(["/sbin/reboot"])
+                run_command(["systemctl", "reboot"])
             elif self.mode == ShutdownMode.POWEROFF:
-                run_command(["/sbin/poweroff"])
+                run_command(["systemctl", "poweroff"])

--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -137,7 +137,12 @@ class ShutdownController(SubiquityController):
         if self.opts.dry_run:
             self.app.exit()
         else:
+            # On desktop, a systemd inhibitor is in place to block shutdown.
+            # Starting with systemd 257, the inhibitor also prevents the root
+            # user from shutting down unless the --check-inhibitors=no or the
+            # --force option is used.
+            # See LP: #2092438
             if self.mode == ShutdownMode.REBOOT:
-                run_command(["systemctl", "reboot"])
+                run_command(["systemctl", "reboot", "--check-inhibitors=no"])
             elif self.mode == ShutdownMode.POWEROFF:
-                run_command(["systemctl", "poweroff"])
+                run_command(["systemctl", "poweroff", "--check-inhibitors=no"])


### PR DESCRIPTION
On the desktop installer, there is a shutdown inhibitor setup by gnome-session. On Plucky, it prevents Subiquity from rebooting/shutting down the system.

The shutdown inhibit was already in place in previous versions of Ubuntu ; but was ignored for the root user.

With systemd 257 (present in plucky), the inhibitor is now honored for the root user as well.

We now try to reboot using `systemctl reboot --check-inhibitors=no`. Emphasis on "try" because it currently does not work. The call fails with:

```
"Call to reboot failed: Interactive authentication required."
```

~~Marking as a draft until the issue is somehow resolved or worked around.~~
EDIT: systemd upstream issue is still a thing but the PR does not make the behavior worse. So that's acceptable.

LP:#2092438 / https://github.com/systemd/systemd/issues/36786