### PR TITLE
Fix crash for automated installs with zdevs

### DIFF
--- a/subiquity/server/controllers/tests/test_zdev.py
+++ b/subiquity/server/controllers/tests/test_zdev.py
@@ -117,7 +117,7 @@ class TestZdevController(unittest.IsolatedAsyncioTestCase):
     async def test_chzdev_wrong_action(self):
         self.ctrler.done_ai_actions = []
         with self.assertRaises(ValueError):
-            await self.ctrler.chzdev("enAble", self.ctrler.zdevinfos["0.0.1507"])
+            await self.ctrler.chzdev("enAble", self.ctrler.dr_zdevinfos["0.0.1507"])
         self.assertFalse(self.ctrler.done_ai_actions)
 
     @patch("asyncio.sleep", AsyncMock())
@@ -126,7 +126,7 @@ class TestZdevController(unittest.IsolatedAsyncioTestCase):
 
         self.ctrler.app.command_runner = Mock()
         with patch.object(self.ctrler.app.command_runner, "run", AsyncMock()) as m_run:
-            await self.ctrler.chzdev("enable", self.ctrler.zdevinfos["0.0.1507"])
+            await self.ctrler.chzdev("enable", self.ctrler.dr_zdevinfos["0.0.1507"])
 
         m_run.assert_called_once_with(["chzdev", "--enable", "0.0.1507"])
 
@@ -140,7 +140,7 @@ class TestZdevController(unittest.IsolatedAsyncioTestCase):
 
         self.ctrler.app.command_runner = Mock()
         with patch.object(self.ctrler.app.command_runner, "run", AsyncMock()) as m_run:
-            await self.ctrler.chzdev("disable", self.ctrler.zdevinfos["0.0.1507"])
+            await self.ctrler.chzdev("disable", self.ctrler.dr_zdevinfos["0.0.1507"])
 
         self.assertEqual(
             [ZdevAction(id="0.0.1507", enable=False)], self.ctrler.done_ai_actions
@@ -154,10 +154,10 @@ class TestZdevController(unittest.IsolatedAsyncioTestCase):
 
         self.ctrler.app.command_runner = Mock()
         with patch.object(self.ctrler.app.command_runner, "run", AsyncMock()) as m_run:
-            await self.ctrler.chzdev("enable", self.ctrler.zdevinfos["0.0.1507"])
-            await self.ctrler.chzdev("enable", self.ctrler.zdevinfos["0.0.1507"])
-            await self.ctrler.chzdev("disable", self.ctrler.zdevinfos["0.0.1508"])
-            await self.ctrler.chzdev("enable", self.ctrler.zdevinfos["0.0.1508"])
+            await self.ctrler.chzdev("enable", self.ctrler.dr_zdevinfos["0.0.1507"])
+            await self.ctrler.chzdev("enable", self.ctrler.dr_zdevinfos["0.0.1507"])
+            await self.ctrler.chzdev("disable", self.ctrler.dr_zdevinfos["0.0.1508"])
+            await self.ctrler.chzdev("enable", self.ctrler.dr_zdevinfos["0.0.1508"])
 
         expected_calls = [
             unittest.mock.call(["chzdev", "--enable", "0.0.1507"]),

--- a/subiquity/server/controllers/tests/test_zdev.py
+++ b/subiquity/server/controllers/tests/test_zdev.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import subprocess
 import unittest
 from collections import OrderedDict
 from unittest.mock import AsyncMock, Mock, patch
@@ -104,11 +105,15 @@ class TestZdevController(unittest.IsolatedAsyncioTestCase):
             expected_calls = [
                 unittest.mock.call(
                     "enable",
-                    OrderedDict([(i.id, i) for i in self.ctrler.lszdev()])["0.0.1507"],
+                    OrderedDict([(i.id, i) for i in await self.ctrler.lszdev()])[
+                        "0.0.1507"
+                    ],
                 ),
                 unittest.mock.call(
                     "disable",
-                    OrderedDict([(i.id, i) for i in self.ctrler.lszdev()])["0.0.1508"],
+                    OrderedDict([(i.id, i) for i in await self.ctrler.lszdev()])[
+                        "0.0.1508"
+                    ],
                 ),
             ]
 
@@ -176,3 +181,17 @@ class TestZdevController(unittest.IsolatedAsyncioTestCase):
             ],
             self.ctrler.done_ai_actions,
         )
+
+    async def test__raw_lszdev(self):
+        with patch(
+            "subiquity.server.controllers.zdev.arun_command",
+            return_value=subprocess.CompletedProcess((), 0, stdout="output"),
+        ):
+            self.assertEqual("output", await self.ctrler._raw_lszdev())
+
+    def test__raw_lszdev_sync(self):
+        with patch(
+            "subiquity.server.controllers.zdev.run_command",
+            return_value=subprocess.CompletedProcess((), 0, stdout="output"),
+        ):
+            self.assertEqual("output", self.ctrler._raw_lszdev_sync())

--- a/subiquity/server/controllers/zdev.py
+++ b/subiquity/server/controllers/zdev.py
@@ -707,7 +707,7 @@ class ZdevController(SubiquityController):
         else:
             return self.lszdev()
 
-    def lszdev(self):
+    def lszdev(self) -> list[ZdevInfo]:
         devices = run_command(lszdev_cmd, universal_newlines=True).stdout
         devices = devices.splitlines()
         devices.sort()

--- a/subiquity/server/controllers/zdev.py
+++ b/subiquity/server/controllers/zdev.py
@@ -650,7 +650,7 @@ class ZdevController(SubiquityController):
                 devices = lszdev_stock.splitlines()
                 devices.sort()
                 zdevinfos = [ZdevInfo.from_row(row) for row in devices]
-            self.zdevinfos = OrderedDict([(i.id, i) for i in zdevinfos])
+            self.dr_zdevinfos = OrderedDict([(i.id, i) for i in zdevinfos])
 
     def load_autoinstall_data(self, data: ZdevAi) -> None:
         self.ai_actions = [ZdevAction.from_ai_item(item) for item in data]
@@ -671,7 +671,7 @@ class ZdevController(SubiquityController):
 
     async def handle_zdevs(self) -> None:
         if self.opts.dry_run:
-            zdevinfos = self.zdevinfos
+            zdevinfos = self.dr_zdevinfos
         else:
             zdevinfos = OrderedDict([(i.id, i) for i in self.lszdev()])
 
@@ -697,8 +697,8 @@ class ZdevController(SubiquityController):
         self.done_ai_actions.append(ZdevAction(id=zdev.id, enable=on))
 
         if self.opts.dry_run:
-            self.zdevinfos[zdev.id].on = on
-            self.zdevinfos[zdev.id].pers = on
+            self.dr_zdevinfos[zdev.id].on = on
+            self.dr_zdevinfos[zdev.id].pers = on
         chzdev_cmd = ["chzdev", "--%s" % action, zdev.id]
         await self.app.command_runner.run(chzdev_cmd)
 
@@ -708,7 +708,7 @@ class ZdevController(SubiquityController):
 
     async def GET(self) -> List[ZdevInfo]:
         if self.opts.dry_run:
-            return self.zdevinfos.values()
+            return self.dr_zdevinfos.values()
         else:
             return self.lszdev()
 


### PR DESCRIPTION
During real installs on s390x, passing a `zdevs` autoinstall section with content leads to the following error:

`ZdevController' object has no attribute 'zdevinfos'`

This happens because the `zdevinfos` variable is only defined when running in dry-run mode, but the tests did not catch that.

The variable is now renamed `dr_zdevinfos` (dr stands for "dry-run") to make it more obvious.

When the list of `zdevinfos` is needed, we now call `lszdev` to populate it. On some hardware, calling `lszdev` takes seconds so we do not invoke it in the initializer of the controller. Instead we delay its use until we know for sure we need it.

We also use an `async` version of `lszdev` so that we don't block the whole event loop when it is running.

LP:#2104267