### PR TITLE
models: we don't need curtin's grub replace_linux_default=False

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -486,9 +486,6 @@ class SubiquityModel:
             },
         }
 
-        if self.source.current.variant == "desktop":
-            config["grub"]["replace_linux_default"] = False
-
         if os.path.exists("/run/casper-md5check.json"):
             with open("/run/casper-md5check.json") as fp:
                 config["write_files"]["md5check"] = {


### PR DESCRIPTION
Curtin knows to carry forth kernel command line after ---.  We set replace_linux_default=False in subiquity with the goal of having `quiet splash` be in the default grub config, but `--- quiet splash` is already specified in the ISO grub config.

This matters because on arm64 we need more parameters, so we want those to flow through to the default grub config on the target system.

LP:#2104310