### PR TITLE
Noble probert network fixes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -223,7 +223,8 @@ parts:
 
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: f34ae3c3f942a9c479fe928911053a302e146251
+    # Tracks the ubuntu/noble branch
+    source-commit: ee45ec6103d235884828ad7aca5018fafdfc4a62
 
     override-build: *pyinstall
 

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -139,6 +139,12 @@ def make_server_args_parser():
     parser.add_argument("--storage-version", action="store", type=int)
     parser.add_argument("--use-os-prober", action="store_true", default=False)
     parser.add_argument(
+        "--no-wlan-listener",
+        action="store_false",
+        dest="with_wlan_listener",
+        default=True,
+    )
+    parser.add_argument(
         "--postinst-hooks-dir", default="/etc/subiquity/postinst.d", type=pathlib.Path
     )
     return parser

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -181,7 +181,8 @@ class BaseNetworkController(BaseController):
     def start(self):
         self._observer_handles = []
         self.observer, self._observer_fds = self.app.prober.probe_network(
-            self.network_event_receiver
+            self.network_event_receiver,
+            with_wlan_listener=self.app.opts.with_wlan_listener,
         )
         self.start_watching()
 

--- a/subiquitycore/prober.py
+++ b/subiquitycore/prober.py
@@ -32,11 +32,15 @@ class Prober:
         self.debug_flags = debug_flags
         log.debug("Prober() init finished, data:{}".format(self.saved_config))
 
-    def probe_network(self, receiver):
+    def probe_network(self, receiver, *, with_wlan_listener: bool):
         if self.saved_config is not None:
-            observer = StoredDataObserver(self.saved_config["network"], receiver)
+            observer = StoredDataObserver(
+                self.saved_config["network"],
+                receiver,
+                with_wlan_listener=with_wlan_listener,
+            )
         else:
-            observer = UdevObserver(receiver)
+            observer = UdevObserver(receiver, with_wlan_listener=with_wlan_listener)
         return observer, observer.start()
 
     async def get_storage(self, probe_types=None):

--- a/subiquitycore/ssh.py
+++ b/subiquitycore/ssh.py
@@ -130,7 +130,7 @@ def get_ips_standalone():
     from subiquitycore.models.network import NETDEV_IGNORED_IFACE_TYPES
 
     prober = Prober()
-    prober.probe_network()
+    prober.probe_network(with_wlan_listener=False)
     links = prober.get_results()["network"]["links"]
     ips = []
     for link in sorted(links, key=lambda link: link["netlink_data"]["name"]):


### PR DESCRIPTION
Backport to noble of probert network fixes (and the ability to disable use of nl80211 C module for desktop)

  * canonical/probert@ee45ec6 Merge pull request canonical/probert#158 from ogayot/noble-network-fixes
  * canonical/probert@13e6f51 _nl80211: fix warning for signed / unsigned pointer conversions
  * canonical/probert@9be3763 network: handle missing SSID information element
  * canonical/probert@4982a00 nl80211: handle information elements with length > 0x7F
  * canonical/probert@fd1124d network: only try to load _nl80211 if required
  * canonical/probert@4adbbe8 network: instantiate the WLAN listener earlier
  * canonical/probert@035eb25 network: make the wlan_listener support optional

Also cherry-picks eca1827b1f43b7ee9db81588b7ef6ab6e2581df4 network: add command line arg to control the presence of the WLAN listener

Depends on canonical/probert#158