### PR TITLE
storage: fix display of potential devices for MD or LVM

### DIFF
--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -123,7 +123,7 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
                 self.all_rows.append(
                     TableRow(
                         [
-                            Text("    " + labels.label(device), wrap="ellipsis"),
+                            Text("    " + labels.label(device)),
                             Text(humanize_size(device.size), align="right"),
                         ]
                     )

--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -24,7 +24,7 @@ from subiquity.models.filesystem import humanize_size
 from subiquitycore.ui.container import WidgetWrap
 from subiquitycore.ui.form import Form, Toggleable, WantsToKnowFormField, simple_field
 from subiquitycore.ui.selector import Selector
-from subiquitycore.ui.table import TablePile, TableRow
+from subiquitycore.ui.table import ColSpec, TablePile, TableRow
 from subiquitycore.ui.utils import Color
 
 log = logging.getLogger("subiquity.ui.views.filesystem.compound")
@@ -37,7 +37,8 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
     signals = ["change"]
 
     def __init__(self):
-        self.table = TablePile([], spacing=1)
+        colspecs = {0: ColSpec(can_shrink=True, rpad=1)}
+        self.table = TablePile([], spacing=1, colspecs=colspecs)
         self.device_to_checkbox = {}
         self.device_to_selector = {}
         self.devices = {}  # {device:active|spare}
@@ -122,7 +123,7 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
                 self.all_rows.append(
                     TableRow(
                         [
-                            Text("    " + labels.label(device)),
+                            Text("    " + labels.label(device), wrap="ellipsis"),
                             Text(humanize_size(device.size), align="right"),
                         ]
                     )


### PR DESCRIPTION
When creating or editing an LVM or MD container, the list of potential devices is shown. Unfortunately, when one of the devices has an overly long label (> 50 chars), all of the devices became invisible, making it challenging to create a RAID / LVM properly.

Ensure, the list of devices is now visible no matter the length of labels.

The actual fix is the `can_shrink=True` property. But we can also clip the name of the device using `wrap="ellipsis"` if we want a cleaner (but less detailed) output.

LP:#2045688

**Current behavior when a device has a long label:**

![Screenshot from 2025-04-08 12-38-58](https://github.com/user-attachments/assets/77e6dac1-f4e2-4694-b514-c1ed5067ae22)

**New behavior with the `wrap="ellipsis"`**

![Screenshot from 2025-04-08 12-37-44](https://github.com/user-attachments/assets/ee2f8e30-6829-450e-ab34-3f44cc172385)

**Alternative new behavior without the `wrap="ellipsis"`**

![Screenshot from 2025-04-08 12-37-06](https://github.com/user-attachments/assets/5659c795-e0f1-4035-a38b-e3f733d2e7f6)
