### PR TITLE
Noble backport - fix display of potential devices for MD or LVM

### DIFF
--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -24,7 +24,7 @@ from subiquity.models.filesystem import humanize_size
 from subiquitycore.ui.container import WidgetWrap
 from subiquitycore.ui.form import Form, Toggleable, WantsToKnowFormField, simple_field
 from subiquitycore.ui.selector import Selector
-from subiquitycore.ui.table import TablePile, TableRow
+from subiquitycore.ui.table import ColSpec, TablePile, TableRow
 from subiquitycore.ui.utils import Color
 
 log = logging.getLogger("subiquity.ui.views.filesystem.compound")
@@ -37,7 +37,8 @@ class MultiDeviceChooser(WidgetWrap, WantsToKnowFormField):
     signals = ["change"]
 
     def __init__(self):
-        self.table = TablePile([], spacing=1)
+        colspecs = {0: ColSpec(can_shrink=True, rpad=1)}
+        self.table = TablePile([], spacing=1, colspecs=colspecs)
         self.device_to_checkbox = {}
         self.device_to_selector = {}
         self.devices = {}  # {device:active|spare}


### PR DESCRIPTION
When creating or editing an LVM or MD container, the list of potential devices is shown. Unfortunately, when one of the devices has a label that is too long, all of the devices used to become invisible, making it challenging to create a RAID / LVM properly.

Ensure, the list of devices is now visible no matter the length of labels.

LP:#2045688

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>
(cherry picked from commit 5604efcbd597f915259918118ba66a65c26ca059)

Adjusted to remove the wrap="ellipsis" since this is what we merged in plucky, see commit 1c97c6d1d2fd28f76ae889e737377873dd709078.