### PR TITLE
apt: remove /var/lib/apt/lists from apt runs

### DIFF
--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -263,6 +263,11 @@ class AptConfigurer:
             mode=0o644,
         )
 
+        # workaround LP: #2105480 and many many many like it
+        apt_lists = self.install_tree.pp("var/lib/apt/lists")
+        if apt_lists.exists():
+            shutil.rmtree(str(apt_lists))
+
         await run_curtin_command(
             self.app,
             context,


### PR DESCRIPTION
In testing against a country mirror, apt-get update may fail with:
  File has unexpected size (x != y). Mirror sync in progress?

On inspection, we found that the copy of /var/lib/apt/lists was in a bad state and that further apt-get update invocation would not correct it.

By removing this cached information, we have to download more from the mirror (not great), but the result should be more robust.

LP:#2105480