### PR TITLE
Update curtin Apr 15th 2025

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "3a123215d1f0e47901686c63a5d12c8a1393ecf3"
+    source-commit: "148b02f5f4027ca508727110604e376f325a1078"
 
     override-pull: |
       craftctl default

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "ce8d06668d1b3f7cba6712bf948aa1a995160b78"
+    source-commit: "3a123215d1f0e47901686c63a5d12c8a1393ecf3"
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Full changelog

   * canonical/curtin@148b02f5f4027ca508727110604e376f325a1078 (MP ~~currently~~ merged at https://code.launchpad.net/~ogayot/curtin/+git/curtin/+merge/484500)
   * canonical/curtin@3a123215 several: fix flake re unassigned globals
   * canonical/curtin@ade5432d apt_config: attempt to clean cloud-init-base
   * canonical/curtin@207b0bb8 control: build-dep on python3-packaging
   * canonical/curtin@8ddb9598 curthooks: rename kernel event
   * canonical/curtin@84096412 curthooks: rely on reconfiguring kernel to create initramfs