### PR TITLE
update-part: default to main branch for dependencies

### DIFF
--- a/scripts/update-part.py
+++ b/scripts/update-part.py
@@ -24,7 +24,7 @@ with open("snapcraft.yaml") as f:
     config = yaml.safe_load(f)["parts"][part]
 
 
-c = "master"
+c = "main"
 for k in "source-commit", "source-tag", "source-branch":
     if k in config:
         c = config[k]


### PR DESCRIPTION
Now that we have a main branch in probert and curtin, change the default branch that `update-part` uses.