### PR TITLE
Shutdown should use a backwards compatible argument for ignoring inhibitors

### DIFF
--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -139,10 +139,10 @@ class ShutdownController(SubiquityController):
         else:
             # On desktop, a systemd inhibitor is in place to block shutdown.
             # Starting with systemd 257, the inhibitor also prevents the root
-            # user from shutting down unless the --check-inhibitors=no or the
-            # --force option is used.
+            # user from shutting down unless the --check-inhibitors=no,
+            # --ignore-inhibitors, or the --force option is used.
             # See LP: #2092438
             if self.mode == ShutdownMode.REBOOT:
-                run_command(["systemctl", "reboot", "--check-inhibitors=no"])
+                run_command(["systemctl", "reboot", "--ignore-inhibitors"])
             elif self.mode == ShutdownMode.POWEROFF:
-                run_command(["systemctl", "poweroff", "--check-inhibitors=no"])
+                run_command(["systemctl", "poweroff", "--ignore-inhibitors"])


### PR DESCRIPTION
This uses a backwards compatible argument for calling shutdown/reboot as simply using --check-inhibitors will not work for any system using systemd <257

Regression introduced by https://github.com/canonical/subiquity/pull/2182

Relevant systemd code for the given argument:
https://github.com/systemd/systemd/blob/caecff5fa2ebc4ad7470aebd564cf7c1a705f184/src/systemctl/systemctl.c#L484
https://github.com/systemd/systemd/blob/caecff5fa2ebc4ad7470aebd564cf7c1a705f184/src/systemctl/systemctl.c#L280
https://github.com/systemd/systemd/blob/caecff5fa2ebc4ad7470aebd564cf7c1a705f184/src/systemctl/systemctl.c#L849

Discussion:
https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/2092438?comments=all

