### PR TITLE
snapcraft: rev for extlinux / update-initramfs changes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "148b02f5f4027ca508727110604e376f325a1078"
+    source-commit: "a1ac7294f1f6904f359cdd8735cfa5a3727f8d8e"
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
This includes the curtin changes from https://code.launchpad.net/~mwhudson/curtin/+git/curtin/+merge/482870 along with the continued work on extlinux at https://code.launchpad.net/~sjg1/curtin/+git/curtin/+merge/484176 (not yet sufficient to enable extlinux installs).