### PR TITLE
ci: +questing -plucky and dry-run fix for `localectl`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         image:
           - ubuntu-daily:noble
-          - ubuntu-daily:plucky
+          - ubuntu-daily:questing
     steps:
     - uses: actions/checkout@v4
     - name: run
@@ -31,7 +31,7 @@ jobs:
       matrix:
         image:
           - ubuntu-daily:noble     # match the core snap we're running against
-          - ubuntu-daily:plucky    # latest
+          - ubuntu-daily:questing  # latest
     steps:
     - uses: actions/checkout@v4
     - name: lint

--- a/subiquity/server/controllers/locale.py
+++ b/subiquity/server/controllers/locale.py
@@ -67,5 +67,6 @@ class LocaleController(SubiquityController):
     async def POST(self, data: str):
         log.debug(data)
         self.model.switch_language(data)
-        async_helpers.run_bg_task(self.model.try_localectl_set_locale())
+        if not self.app.opts.dry_run:
+            async_helpers.run_bg_task(self.model.try_localectl_set_locale())
         await self.configured()


### PR DESCRIPTION
Update CI to run on `questing` instead of `plucky`.

Doing so produced many failures in the answers integration tests, like so:
```
Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x788856adf600>
Traceback (most recent call last):
  File "/usr/lib/python3.13/asyncio/base_subprocess.py", line 130, in __del__
    self.close()
  File "/usr/lib/python3.13/asyncio/base_subprocess.py", line 107, in close
    proto.pipe.close()
  File "/usr/lib/python3.13/asyncio/unix_events.py", line 603, in close
    self._close(None)
  File "/usr/lib/python3.13/asyncio/unix_events.py", line 627, in _close
    self._loop.call_soon(self._call_connection_lost, exc)
  File "/usr/lib/python3.13/asyncio/base_events.py", line 827, in call_soon
    self._check_closed()
  File "/usr/lib/python3.13/asyncio/base_events.py", line 550, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

After modifying BaseSubprocessTransport to dump info on the subprocesses being cleaned up, I found that `localectl`  is run in dry-run cases, so let's not do that.