### PR TITLE
Add stub endpoint to get TPM/FDE recovery key

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -399,6 +399,9 @@ class API:
                     configuring CORE_BOOT_ENCRYPTED, and may use it in other
                     scenarios."""
 
+            class core_boot_recovery_key:
+                def GET() -> str: ...
+
     class codecs:
         def GET() -> CodecsData: ...
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -93,7 +93,7 @@ class RecoveryKeyHandler:
     live_location: Optional[pathlib.Path]
     # Where to store the key in the target system. /target will automatically
     # be prefixed.
-    backup_location: pathlib.Path
+    backup_location: Optional[pathlib.Path]
 
     _key: Optional[str] = attr.ib(repr=False, default=None)
 
@@ -158,6 +158,10 @@ class RecoveryKeyHandler:
     def copy_key_to_target_system(self, target: pathlib.Path) -> None:
         """Write the key to the target system - so it can be retrieved after
         the install by an admin."""
+
+        if self.backup_location is None:
+            log.debug("no backup location set: not copying rec-key to target")
+            return
 
         self._expose_key(
             location=self.backup_location,

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1605,6 +1605,12 @@ class FilesystemModel:
         self._probe_data = None
         self.dd_target: Optional[Disk] = None
         self.reset_partition: Optional[Partition] = None
+        # When using the TPM/FDE flow, the recovery key is created by snapd.
+        # For now, we are storing the key directly in the model even though it
+        # is in practise attached to an encrypted device. If at some point,
+        # snapd grows support for multiple encrypted devices, we will need to
+        # find a better way.
+        self.core_boot_recovery_key: Optional[RecoveryKeyHandler] = None
         self.reset()
 
     def reset(self):
@@ -1617,6 +1623,7 @@ class FilesystemModel:
         self.swap = None
         self.grub = None
         self.guided_configuration = None
+        self.core_boot_recovery_key = None
 
     def get_orig_model(self):
         # The purpose of this is to be able to answer arbitrary questions about

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1605,6 +1605,29 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             minimum_required=minimum_required,
         )
 
+    async def v2_core_boot_recovery_key_GET(self) -> str:
+        if not self._configured:
+            raise StorageRecoverableError("storage model is not yet configured")
+        if (self.model.guided_configuration is None) or (
+            self.model.guided_configuration.capability
+            != GuidedCapability.CORE_BOOT_ENCRYPTED
+        ):
+            raise StorageRecoverableError("not using core boot encrypted")
+
+        # TODO lean on snapd to obtain the recovery key. This is a stub
+        # implementation.
+        if self.model.core_boot_recovery_key is None:
+            self.model.core_boot_recovery_key = RecoveryKeyHandler(
+                live_location=None, backup_location=None
+            )
+            self.model.core_boot_recovery_key.generate()
+
+        key = self.model.core_boot_recovery_key._key
+
+        assert key is not None  # To help the static type checker
+
+        return key
+
     async def dry_run_wait_probe_POST(self) -> None:
         if not self.app.opts.dry_run:
             raise NotImplementedError


### PR DESCRIPTION
This introduces a new endpoint meant to be used by the desktop installer at the end of an installation in the TPM/FDE flow when requesting a recovery key.
    
    * GET /v2/storage/core_boot_recovery_key
    
For now, the returned key is not usable, but in the future we will get it from snapd instead - which will associate it to the encrypted device.

The endpoint can only be used after marking the storage model as configured (i.e., after confirming the summary of changes in the desktop installer).

Cc: @d-loose 