### PR TITLE
Fix bug/typo in snaplist.py

### DIFF
--- a/subiquity/models/snaplist.py
+++ b/subiquity/models/snaplist.py
@@ -62,7 +62,7 @@ class SnapListModel:
         if snap is None:
             return
         if snap not in self.complete_snaps:
-            self.update_snap(snap, info)
+            self.update(snap, info)
         channel_map = info["channels"]
         for track in info["tracks"]:
             for risk in risks:


### PR DESCRIPTION
`update_snap` doesn't exist; this PR calls the existing `update` (which was used to replace snap.update by the commit linked below).

Commit that introduced the typo: https://github.com/canonical/subiquity/commit/e43e3cca1493679e7e3cbd69ffb97b49ee4659ea (CC @mwhudson)
Relevant launchpad bug: https://bugs.launchpad.net/subiquity/+bug/2067253

I didn't test this change, at least not yet.

LP: #2067253