### PR TITLE
slimy: fix for where default python != py3.12

### DIFF
--- a/scripts/slimy-update-snap.sh
+++ b/scripts/slimy-update-snap.sh
@@ -75,7 +75,7 @@ rm -rf "${subiquity_dest}/subiquitycore"
 (cd "${src}" && ./scripts/update-part.py probert)
 
 # Build probert for the C extensions
-(cd "${src}"/probert && python3 setup.py build_ext --inplace)
+(cd "${src}"/probert && python3.12 setup.py build_ext --inplace)
 
 rsync -a --chown 0:0 $src/curtin/curtin new/lib/python3.12/site-packages
 rsync -a --chown 0:0 $src/probert/probert new/lib/python3.12/site-packages


### PR DESCRIPTION
slimy ISOs built from questing fail on _rtnetlink due to using python 3.13 instead of 3.12.  fix that.