### PR TITLE
Fetch core boot recovery key from snapd

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2519,6 +2519,12 @@ class FilesystemModel:
             else:
                 dm_crypt.recovery_key.generate()
 
+    def set_core_boot_recovery_key(self, key: str) -> None:
+        self.core_boot_recovery_key = RecoveryKeyHandler(
+            live_location=None, backup_location=None
+        )
+        self.core_boot_recovery_key._key = key
+
     def expose_recovery_keys(self) -> None:
         for dm_crypt in self.all_dm_crypts():
             if dm_crypt.recovery_key is None:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1025,7 +1025,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             self.app.snapdapi,
             self.app.snapdapi.v2.systems[label].POST,
             snapdtypes.SystemActionRequest(**kwargs),
-            ann=snapdtypes.SystemActionResponse,
+            ann=snapdtypes.SystemActionResponseSetupEncryption,
         )
         for role, enc_path in result.encrypted_devices.items():
             arb_device = ArbitraryDevice(m=self.model, path=enc_path)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -31,6 +31,7 @@ from curtin import swap
 from curtin.storage_config import ptable_part_type_to_flag
 from curtin.util import human2bytes
 
+from subiquity.common.api.defs import Payload, api, path_parameter
 from subiquity.common.api.recoverable_error import RecoverableError
 from subiquity.common.apidef import API
 from subiquity.common.errorreport import ErrorReportKind
@@ -91,6 +92,8 @@ from subiquity.server.snapd.system_getter import SystemGetter, SystemsDirMounter
 from subiquity.server.snapd.types import (
     StorageEncryptionSupport,
     StorageSafety,
+    SystemActionRequest,
+    SystemActionResponseGenerateRecoveryKey,
     SystemDetails,
 )
 from subiquity.server.types import InstallerChannels
@@ -1035,6 +1038,42 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 if fs.volume == part:
                     fs.volume = arb_device
 
+    async def fetch_core_boot_recovery_key(self):
+        """Fetch the recovery key from snapd and store it in the model."""
+
+        # TODO This is a workaround!
+        # Ideally, we'd want to use self.app.snapdapi here, but SnapdAPI
+        # defines the return type of POST /v2/systems/{system-label} as a
+        # ChangeID (which is only true for async responses) and we don't have
+        # the needed support for Union types.
+        # For now, let's define a fake API definition and create a new snapd
+        # client out of it.
+        @api
+        class AlternateSnapdAPI:
+            class v2:
+                class systems:
+                    @path_parameter
+                    class label:
+                        def POST(
+                            action: Payload[SystemActionRequest],
+                        ) -> SystemActionResponseGenerateRecoveryKey: ...
+
+        snapd_client = snapdapi.make_api_client(
+            self.app.snapd, api_class=AlternateSnapdAPI, log_responses=False
+        )
+
+        label = self._info.label
+
+        result = await snapd_client.v2.systems[label].POST(
+            snapdtypes.SystemActionRequest(
+                action=snapdtypes.SystemAction.INSTALL,
+                step=snapdtypes.SystemActionStep.GENERATE_RECOVERY_KEY,
+                on_volumes={},
+            ),
+        )
+
+        self.model.set_core_boot_recovery_key(result.recovery_key)
+
     @with_context(description="making system bootable")
     async def finish_install(self, context, kernel_components):
         log.debug(f"finish_install: {kernel_components=}")
@@ -1613,14 +1652,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             != GuidedCapability.CORE_BOOT_ENCRYPTED
         ):
             raise StorageRecoverableError("not using core boot encrypted")
-
-        # TODO lean on snapd to obtain the recovery key. This is a stub
-        # implementation.
-        if self.model.core_boot_recovery_key is None:
-            self.model.core_boot_recovery_key = RecoveryKeyHandler(
-                live_location=None, backup_location=None
-            )
-            self.model.core_boot_recovery_key.generate()
 
         key = self.model.core_boot_recovery_key._key
 

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -384,6 +384,7 @@ class InstallController(SubiquityController):
             )
             if fs_controller.use_tpm:
                 await fs_controller.setup_encryption(context=context)
+                await fs_controller.fetch_core_boot_recovery_key()
             await run_curtin_step(
                 name="formatting",
                 stages=["partitioning"],

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -599,7 +599,8 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.fsc.model.guided_configuration = mock.Mock(
             capability=GuidedCapability.CORE_BOOT_ENCRYPTED
         )
-        await self.fsc.v2_core_boot_recovery_key_GET()
+        self.fsc.model.set_core_boot_recovery_key("recovery")
+        self.assertEqual("recovery", await self.fsc.v2_core_boot_recovery_key_GET())
 
     async def test_v2_core_boot_recovery_GET__not_yet_configured(self):
         self.fsc.model = make_model()
@@ -893,6 +894,18 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
 
         self.assertEqual(leading_gap.offset, gap.offset)
         self.assertEqual(part.size + leading_gap.size + trailing_gap.size, gap.size)
+
+    async def test_fetch_core_boot_recovery_key(self):
+        self.app.snapd = AsyncSnapd(get_fake_connection())
+        self.app.snapdapi = snapdapi.make_api_client(self.app.snapd)
+        self.fsc._info = mock.Mock(label="my-label")
+
+        with mock.patch.object(
+            self.fsc.model, "set_core_boot_recovery_key"
+        ) as m_set_key:
+            await self.fsc.fetch_core_boot_recovery_key()
+
+        m_set_key.assert_called_once_with("my-recovery-key")
 
     async def test_finish_install(self):
         self.app.snapdapi = snapdapi.make_api_client(AsyncSnapd(get_fake_connection()))

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -2482,7 +2482,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         with mock.patch.object(
             snapdapi, "post_and_wait", new_callable=mock.AsyncMock
         ) as mocked:
-            mocked.return_value = snapdtypes.SystemActionResponse(
+            mocked.return_value = snapdtypes.SystemActionResponseSetupEncryption(
                 encrypted_devices={
                     snapdtypes.Role.SYSTEM_DATA: "enc-system-data",
                 },

--- a/subiquity/server/snapd/api.py
+++ b/subiquity/server/snapd/api.py
@@ -90,7 +90,7 @@ class _FakeError:
         raise aiohttp.ClientError(self.data["result"]["message"])
 
 
-def make_api_client(async_snapd, log_responses=False):
+def make_api_client(async_snapd, log_responses=False, *, api_class=SnapdAPI):
     # subiquity.common.api.client is designed around how to make requests
     # with aiohttp's client code, not the AsyncSnapd API but with a bit of
     # effort it can be contorted into shape. Clearly it would be better to
@@ -114,7 +114,7 @@ def make_api_client(async_snapd, log_responses=False):
             yield _FakeError()
         yield _FakeResponse(content)
 
-    client = make_client(SnapdAPI, make_request, serializer=snapd_serializer)
+    client = make_client(api_class, make_request, serializer=snapd_serializer)
     client.log_responses = log_responses
     return client
 

--- a/subiquity/server/snapd/api.py
+++ b/subiquity/server/snapd/api.py
@@ -68,6 +68,9 @@ class SnapdAPI:
             class label:
                 def GET() -> SystemDetails: ...
 
+                # TODO The return type is correct only for async responses, but
+                # not all responses are async. We'd need to extend support for
+                # Union types e.g., Union[ChangeID, SystemActionResponse]
                 def POST(action: Payload[SystemActionRequest]) -> ChangeID: ...
 
 

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -273,6 +273,7 @@ class SystemAction(enum.Enum):
 
 class SystemActionStep(enum.Enum):
     SETUP_STORAGE_ENCRYPTION = "setup-storage-encryption"
+    GENERATE_RECOVERY_KEY = "generate-recovery-key"
     FINISH = "finish"
 
 
@@ -319,3 +320,8 @@ class SystemActionRequest:
 @snapdtype
 class SystemActionResponseSetupEncryption:
     encrypted_devices: Dict[NonExhaustive[Role], str] = attr.Factory(dict)
+
+
+@snapdtype
+class SystemActionResponseGenerateRecoveryKey:
+    recovery_key: str

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -317,5 +317,5 @@ class SystemActionRequest:
 
 
 @snapdtype
-class SystemActionResponse:
+class SystemActionResponseSetupEncryption:
     encrypted_devices: Dict[NonExhaustive[Role], str] = attr.Factory(dict)

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -159,6 +159,7 @@ class FakeSnapdConnection:
                 }
             )
         change = None
+        sync_result = None
         if path == "v2/snaps/subiquity" and body["action"] == "switch":
             change = "8"
         if path.startswith("v2/systems/") and body["action"] == "install":
@@ -171,6 +172,8 @@ class FakeSnapdConnection:
                     change = "5"
             elif step == "setup-storage-encryption":
                 change = "6"
+            elif step == "generate-recovery-key":
+                sync_result = {"recovery-key": "my-recovery-key"}
         if change is not None:
             return _FakeMemoryResponse(
                 {
@@ -178,6 +181,15 @@ class FakeSnapdConnection:
                     "change": change,
                     "status-code": 200,
                     "status": "Accepted",
+                }
+            )
+        elif sync_result is not None:
+            return _FakeMemoryResponse(
+                {
+                    "type": "sync",
+                    "status-code": 200,
+                    "status": "OK",
+                    "result": sync_result,
                 }
             )
         if path in self.post_cb:


### PR DESCRIPTION
Instead of generating a fake recovery key for core boot installations, we now lean on a new feature from snapd to fetch an actual recovery key.

The main problem I ran into is that the Subiquity defines the return type of `/v2/systems/{system-label}` as a `ChangeID`. But this is only correct if the endpoint returns an async response. Depending on the content of the request, the response is sync or async.

I have tried to add support for `Union[str, SystemActionResponse]` as a return type but with no success for now. In the meantime, I introduced a workaround to use an alternative snapd API definition.

~~Marking as a draft since this depends on canonical/snapd#15503~~