### PR TITLE
Tics deps

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -1,8 +1,9 @@
 name: TICS
+
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '17 5 * * 6'  # Run at 5:17a (arbitrary) on Saturday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,12 +11,21 @@ concurrency:
 
 jobs:
   TICS:
-    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+    runs-on: [self-hosted, linux, amd64, tiobe, noble]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Dependencies
+        run: |
+          sudo ./scripts/installdeps.sh
+          sudo apt install pylint
+
+      - name: Coverage
+        run: |
+          make unit
 
       - name: Run TICS analysis with github-action
         uses: tiobe/tics-github-action@v3

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,11 @@ flake8:
 
 .PHONY: unit
 unit: gitdeps
+	mkdir -p .coverage
 	timeout 120 \
 	$(PYTHON) -m pytest --ignore curtin --ignore probert \
-		--ignore subiquity/tests/api
+		--ignore subiquity/tests/api \
+		--cov-report xml:.coverage/cobertura.xml
 
 .PHONY: api
 api: gitdeps

--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -45,6 +45,7 @@ python3-pycountry
 python3-pyflakes
 python3-pyroute2
 python3-pytest
+python3-pytest-cov
 python3-pytest-xdist
 python3-pyudev
 python3-requests


### PR DESCRIPTION
* The request is to trigger on a cron basis, rather than more frequently
* Run the tests so we can show the coverage report
* Install the dependencies, both for tests and so we can reduce warnings of unrecognized stuff