### PR TITLE
identity: fix warnings when running unit tests

### DIFF
--- a/subiquity/ui/views/tests/test_installprogress.py
+++ b/subiquity/ui/views/tests/test_installprogress.py
@@ -2,6 +2,8 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
+import urwid
+
 from subiquity.client.controllers.progress import ProgressController
 from subiquity.common.types import ApplicationState
 from subiquity.ui.views.installprogress import ProgressView
@@ -56,7 +58,7 @@ class IdentityViewTests(unittest.TestCase):
         self.assertIsNotNone(btn)
 
     @patch("subiquity.ui.views.installprogress.Columns")
-    @patch("subiquity.ui.views.installprogress.Text")
+    @patch("subiquity.ui.views.installprogress.Text", wraps=urwid.Text)
     def test_event_other_formatting(self, text_mock, columns_mock):
         """Test formatting of the other_event function."""
         view = self.make_view()
@@ -70,7 +72,7 @@ class IdentityViewTests(unittest.TestCase):
             dividechars=1,
         )
 
-    @patch("subiquity.ui.views.installprogress.Text")
+    @patch("subiquity.ui.views.installprogress.Text", wraps=urwid.Text)
     def test_event_other_robust_splitting(self, text_mock):
         """Test that messages containing a colon don't fail to split.
 


### PR DESCRIPTION
When running the unit tests, the following warnings are raised:

```
  subiquity/ui/views/tests/test_installprogress.py::IdentityViewTests::test_event_other_formatting
    subiquity/ui/views/installprogress.py:69: PileWarning: <MagicMock name='Text()' id='136247309836912'> is not a Widget
      self.event_pile = Pile(event_body)

  subiquity/ui/views/tests/test_installprogress.py::IdentityViewTests::test_event_other_robust_splitting
    subiquity/ui/views/installprogress.py:69: PileWarning: <MagicMock name='Text()' id='136247310463200'> is not a Widget
      self.event_pile = Pile(event_body)

  subiquity/ui/views/tests/test_installprogress.py::IdentityViewTests::test_event_other_robust_splitting
    subiquitycore/ui/container.py:368: ColumnsWarning: <MagicMock name='Text()' id='136247310463200'> is not a Widget
      super().__init__(*args, **kw)
```

We patch urwid.Text so we can use assert_has_calls() and similar functions. But as a result, the objects returned by urwid.Text(...) are not urwid widgets - which makes urwid complain.

Fixed by ensuring that the mock actually returns urwid Text widgets using the wraps construct.