### PR TITLE
make: fix coverage report generation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+; The default data_file location is .coverage, and we want to use .coverage as
+; a directory so that TICS finds the coverage report at .coverage/cobertura.xml
+; The value chosen here doesn't matter very much, as it's only kept until the
+; report is generated anyhow.
+data_file = .coverage.tmp

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,11 @@ flake8:
 
 .PHONY: unit
 unit: gitdeps
-	mkdir -p .coverage
 	timeout 120 \
 	$(PYTHON) -m pytest --ignore curtin --ignore probert \
 		--ignore subiquity/tests/api \
-		--cov-report xml:.coverage/cobertura.xml
+		--cov-report xml:.coverage/cobertura.xml \
+		--cov=subiquity --cov=subiquitycore --cov=console_conf
 
 .PHONY: api
 api: gitdeps


### PR DESCRIPTION
pytest-cov, which uses coverage.py underneath, had trouble writing a report in the TICS default location .coverage/cobertura.xml due to coverage.py expecting to use .coverage as a temporary file in sqlite3 format.  If we set an alternate location for the data_file instead of .coverage, we can generate the report.

Also, pytest-cov is cool with .coverage not existing as a directory so simplify the makefile a bit.