### PR TITLE
Entropy calculation against newer snapd (2.71)

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -390,15 +390,12 @@ class API:
                     partition will be deleted as well."""
 
             class calculate_entropy:
-                def POST(
-                    data: Payload[CalculateEntropyRequest],
-                ) -> Optional[EntropyResponse]:
+                def POST(data: Payload[CalculateEntropyRequest]) -> EntropyResponse:
                     """Calculate the entropy associated with the supplied
                     passphrase or pin.  Clients must use this endpoint to
                     confirm that the pin or passphrase is suitable prior to
                     configuring CORE_BOOT_ENCRYPTED, and may use it in other
-                    scenarios.  A null response indicates that the entropy
-                    is sufficient."""
+                    scenarios."""
 
             class core_boot_recovery_key:
                 def GET() -> str: ...

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -412,5 +412,5 @@ class CalculateEntropyRequest:
 
 @attr.s(auto_attribs=True)
 class EntropyResponse:
-    entropy: float
-    minimum_required: float
+    entropy_bits: int
+    min_entropy_bits: int

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -412,6 +412,8 @@ class CalculateEntropyRequest:
 
 @attr.s(auto_attribs=True)
 class EntropyResponse:
+    success: bool
+
     entropy_bits: int
     min_entropy_bits: int
     optimal_entropy_bits: int

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -417,3 +417,6 @@ class EntropyResponse:
     entropy_bits: int
     min_entropy_bits: int
     optimal_entropy_bits: int
+
+    # Set to None if success is True
+    failure_reasons: Optional[List[str]] = None

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -414,3 +414,4 @@ class CalculateEntropyRequest:
 class EntropyResponse:
     entropy_bits: int
     min_entropy_bits: int
+    optimal_entropy_bits: int

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1735,6 +1735,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if result.entropy_bits is not None:
             # Let's consider this a "good" response
             return EntropyResponse(
+                success=True,
                 entropy_bits=result.entropy_bits,
                 min_entropy_bits=result.min_entropy_bits,
                 optimal_entropy_bits=result.optimal_entropy_bits,
@@ -1756,6 +1757,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
         # This is a bad response
         return EntropyResponse(
+            success=False,
             entropy_bits=result.value.entropy_bits,
             min_entropy_bits=result.value.min_entropy_bits,
             optimal_entropy_bits=result.value.optimal_entropy_bits,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1749,8 +1749,8 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         assert result.value is not None
 
         return EntropyResponse(
-            entropy=result.value.entropy_bits,
-            minimum_required=float(result.value.min_entropy_bits),
+            entropy_bits=result.value.entropy_bits,
+            min_entropy_bits=result.value.min_entropy_bits,
         )
 
     async def v2_core_boot_recovery_key_GET(self) -> str:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1761,6 +1761,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             entropy_bits=result.value.entropy_bits,
             min_entropy_bits=result.value.min_entropy_bits,
             optimal_entropy_bits=result.value.optimal_entropy_bits,
+            failure_reasons=[reason.value for reason in result.value.reasons],
         )
 
     async def v2_core_boot_recovery_key_GET(self) -> str:

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1751,6 +1751,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         return EntropyResponse(
             entropy_bits=result.value.entropy_bits,
             min_entropy_bits=result.value.min_entropy_bits,
+            optimal_entropy_bits=result.value.optimal_entropy_bits,
         )
 
     async def v2_core_boot_recovery_key_GET(self) -> str:

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -2783,8 +2783,8 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
 
     @parameterized.expand(
         (
-            ("pin", "012", EntropyResponse(3.0, 4.0), "invalid-pin"),
-            ("passphrase", "asdf", EntropyResponse(8.0, 8.0), "invalid-passphrase"),
+            ("pin", "012", EntropyResponse(3, 4), "invalid-pin"),
+            ("passphrase", "asdf", EntropyResponse(8, 8), "invalid-passphrase"),
         )
     )
     async def test_stub_invalid(self, type_, pin_or_pass, expected_entropy, kind):
@@ -2804,8 +2804,8 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
                     message="did not pass quality checks",
                     value=snapdtypes.InsufficientEntropyDetails(
                         reasons=["low-entropy"],
-                        entropy_bits=expected_entropy.entropy,
-                        min_entropy_bits=int(expected_entropy.minimum_required),
+                        entropy_bits=expected_entropy.entropy_bits,
+                        min_entropy_bits=expected_entropy.min_entropy_bits,
                     ),
                 ),
             ):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -2783,8 +2783,13 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
 
     @parameterized.expand(
         (
-            ("pin", "012", EntropyResponse(3, 4, 5), "invalid-pin"),
-            ("passphrase", "asdf", EntropyResponse(8, 8, 10), "invalid-passphrase"),
+            ("pin", "012", EntropyResponse(False, 3, 4, 5), "invalid-pin"),
+            (
+                "passphrase",
+                "asdf",
+                EntropyResponse(False, 8, 8, 10),
+                "invalid-passphrase",
+            ),
         )
     )
     async def test_stub_invalid(self, type_, pin_or_pass, expected_entropy, kind):
@@ -2818,8 +2823,8 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
 
     @parameterized.expand(
         (
-            ("pin", "01234", EntropyResponse(5, 4, 8)),
-            ("passphrase", "asdfasdf", EntropyResponse(8, 8, 16)),
+            ("pin", "01234", EntropyResponse(True, 5, 4, 8)),
+            ("passphrase", "asdfasdf", EntropyResponse(True, 8, 8, 16)),
         )
     )
     async def test_stub_valid(self, type_, pin_or_pass, expected_entropy):

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -2783,11 +2783,16 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
 
     @parameterized.expand(
         (
-            ("pin", "012", EntropyResponse(False, 3, 4, 5), "invalid-pin"),
+            (
+                "pin",
+                "012",
+                EntropyResponse(False, 3, 4, 5, failure_reasons=["low-entropy"]),
+                "invalid-pin",
+            ),
             (
                 "passphrase",
                 "asdf",
-                EntropyResponse(False, 8, 8, 10),
+                EntropyResponse(False, 8, 8, 10, failure_reasons=["low-entropy"]),
                 "invalid-passphrase",
             ),
         )
@@ -2808,7 +2813,7 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
                     kind=kind,
                     message="did not pass quality checks",
                     value=snapdtypes.InsufficientEntropyDetails(
-                        reasons=["low-entropy"],
+                        reasons=[snapdtypes.InsufficientEntropyReasons.LOW_ENTROPY],
                         entropy_bits=expected_entropy.entropy_bits,
                         min_entropy_bits=expected_entropy.min_entropy_bits,
                         optimal_entropy_bits=expected_entropy.optimal_entropy_bits,

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -2783,8 +2783,8 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
 
     @parameterized.expand(
         (
-            ("pin", "012", EntropyResponse(3, 4), "invalid-pin"),
-            ("passphrase", "asdf", EntropyResponse(8, 8), "invalid-passphrase"),
+            ("pin", "012", EntropyResponse(3, 4, 5), "invalid-pin"),
+            ("passphrase", "asdf", EntropyResponse(8, 8, 10), "invalid-passphrase"),
         )
     )
     async def test_stub_invalid(self, type_, pin_or_pass, expected_entropy, kind):
@@ -2806,6 +2806,7 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
                         reasons=["low-entropy"],
                         entropy_bits=expected_entropy.entropy_bits,
                         min_entropy_bits=expected_entropy.min_entropy_bits,
+                        optimal_entropy_bits=expected_entropy.optimal_entropy_bits,
                     ),
                 ),
             ):

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -352,6 +352,7 @@ class InsufficientEntropyDetails:
     reasons: List[InsufficientEntropyReasons]
     entropy_bits: int
     min_entropy_bits: int
+    optimal_entropy_bits: int
 
 
 @snapdtype

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -350,7 +350,7 @@ class InsufficientEntropyReasons(enum.Enum):
 @snapdtype
 class InsufficientEntropyDetails:
     reasons: List[InsufficientEntropyReasons]
-    entropy_bits: float
+    entropy_bits: int
     min_entropy_bits: int
 
 

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -357,8 +357,13 @@ class InsufficientEntropyDetails:
 
 @snapdtype
 class EntropyCheckResponse:
-    kind: EntropyCheckResponseKind
-    message: str
+    # On success (i.e., response.status-code: 400), these fields will be provided.
+    entropy_bits: Optional[int] = None
+    min_entropy_bits: Optional[int] = None
+    optimal_entropy_bits: Optional[int] = None
 
+    # On failure, these fields will be provided.
+    kind: Optional[EntropyCheckResponseKind] = None
+    message: Optional[str] = None
     # Set to None if kind="unsupported"
     value: Optional[InsufficientEntropyDetails] = None

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -184,7 +184,11 @@ class FakeSnapdConnection:
                 "type": "sync",
                 "status-code": 200,
                 "status": "OK",
-                "result": None,
+                "result": {
+                    "entropy-bits": entropy_bits,
+                    "min-entropy-bits": min_entropy_bits,
+                    "optimal-entropy-bits": optimal_entropy_bits,
+                },
             }
         )
 

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -168,10 +168,8 @@ class FakeSnapdConnection:
                         "kind": kind,
                         "message": "did not pass quality checks",
                         "value": {
-                            # In snapd 2.68, entropy-bits is a float, but
-                            # min-entropy-bits is an int.
-                            "entropy-bits": float(entropy_bits),
-                            "min-entropy-bits": int(min_entropy_bits),
+                            "entropy-bits": entropy_bits,
+                            "min-entropy-bits": min_entropy_bits,
                             "reasons": ["low-entropy"],
                         },
                     },

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -152,10 +152,12 @@ class FakeSnapdConnection:
         if body["action"] == "check-passphrase":
             entropy_bits = len(body["passphrase"])
             min_entropy_bits = 8
+            optimal_entropy_bits = 10
             kind = "invalid-passphrase"
         else:
             entropy_bits = len(body["pin"])
             min_entropy_bits = 4
+            optimal_entropy_bits = 6
             kind = "invalid-pin"
 
         if entropy_bits < min_entropy_bits:
@@ -170,6 +172,7 @@ class FakeSnapdConnection:
                         "value": {
                             "entropy-bits": entropy_bits,
                             "min-entropy-bits": min_entropy_bits,
+                            "optimal-entropy-bits": optimal_entropy_bits,
                             "reasons": ["low-entropy"],
                         },
                     },

--- a/subiquitycore/tests/test_snapd.py
+++ b/subiquitycore/tests/test_snapd.py
@@ -50,7 +50,11 @@ class TestFakeSnapdConnection(unittest.TestCase):
                 "type": "sync",
                 "status": "OK",
                 "status-code": 200,
-                "result": None,
+                "result": {
+                    "entropy-bits": 5,
+                    "min-entropy-bits": 4,
+                    "optimal-entropy-bits": 6,
+                },
             }
         )
         self.assertEqual(
@@ -88,7 +92,11 @@ class TestFakeSnapdConnection(unittest.TestCase):
                 "type": "sync",
                 "status": "OK",
                 "status-code": 200,
-                "result": None,
+                "result": {
+                    "entropy-bits": 12,
+                    "min-entropy-bits": 8,
+                    "optimal-entropy-bits": 10,
+                },
             }
         )
         self.assertEqual(

--- a/subiquitycore/tests/test_snapd.py
+++ b/subiquitycore/tests/test_snapd.py
@@ -30,7 +30,7 @@ class TestFakeSnapdConnection(unittest.TestCase):
                 "status-code": 400,
                 "result": {
                     "value": {
-                        "entropy-bits": 3.0,
+                        "entropy-bits": 3,
                         "min-entropy-bits": 4,
                         "reasons": ["low-entropy"],
                     },
@@ -64,7 +64,7 @@ class TestFakeSnapdConnection(unittest.TestCase):
                 "status-code": 400,
                 "result": {
                     "value": {
-                        "entropy-bits": 3.0,
+                        "entropy-bits": 3,
                         "min-entropy-bits": 8,
                         "reasons": ["low-entropy"],
                     },

--- a/subiquitycore/tests/test_snapd.py
+++ b/subiquitycore/tests/test_snapd.py
@@ -32,6 +32,7 @@ class TestFakeSnapdConnection(unittest.TestCase):
                     "value": {
                         "entropy-bits": 3,
                         "min-entropy-bits": 4,
+                        "optimal-entropy-bits": 6,
                         "reasons": ["low-entropy"],
                     },
                     "message": "did not pass quality checks",
@@ -66,6 +67,7 @@ class TestFakeSnapdConnection(unittest.TestCase):
                     "value": {
                         "entropy-bits": 3,
                         "min-entropy-bits": 8,
+                        "optimal-entropy-bits": 10,
                         "reasons": ["low-entropy"],
                     },
                     "message": "did not pass quality checks",


### PR DESCRIPTION
This PR is now based on #2221 and adapts the `/storage/v2/calculate_entropy` endpoint to the current entropy rework in snapd (> 2.70) (see https://github.com/canonical/snapd/pull/15607)

 * The entropy values are expressed as integers, not floats
 * We provide access to the `optimal-entropy-bits` field
 * Successful entropy-checks return a non-null response with entropy information.
 * We provide access to the failure-reasons and a success boolean.

<details>
<summary>Original description (before split):</summary>
Up to 925caabec4fe61562353adbbc5fe5ebc2b02fd5c, this is basically a rework of https://github.com/canonical/subiquity/pull/2181 where the implementation is based on what snapd 2.68 offers.

In subsequent commits though, we lean on future snapd work or work that isn't yet part of "stable" snapd.

If we want to, I can split this PR into two parts:
* the implementation against snapd 2.68.
* the implementation against future snapd work.

#### Main differences from original branch:
* When consuming `/v2/systems/{label} action="check-{passphrase|pin}"`, we expect a sync response from snapd (we use a workaround with an alternative `@api` definition for it).
* When consuming `/v2/systems/{label} action="check-{passphrase|pin}"`, we accept non-success HTTP status codes. Snapd returns HTTP 400 if the entropy is too low.
   * The implementation is definitely not ideal but can be improved later.
   * It currently relies on a new optional boolean kwarg `raise_for_status` that can be passed to `*.POST()` and `*.GET()` methods. When true, this boolean disables the call to `requests.Response.raise_for_status`, therefore parsing the response as if it was a success. The main drawback is that it disable exceptions for all HTTP statuses, not just 400.
 * It supplies the passphrase (or the pin) to snapd.
 * We use a new implementation of `check-passphrase` / `check-pin` (in the last few commits):
    * The entropy values are expressed as integers, not floats
    * We provide access to the `optimal-entropy-bits` field
    * Successful entropy-checks return a non-null response with entropy information.

#### TODO
[ ] Rework how we handle the 400 response. The `raise_for_status=True` implementation feels wrong.
[ ] Do some more testing
[ ] Maybe write tests that use a flask-based implementation of a mini-snapd that returns fake values.
</details>