### PR TITLE
storage: generate the recovery later, so it doesn't expire

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1653,6 +1653,11 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         ):
             raise StorageRecoverableError("not using core boot encrypted")
 
+        if self.model.core_boot_recovery_key is None:
+            # The recovery key only becomes available just before we get to the
+            # finish-install step, which is very late.
+            raise StorageRecoverableError("recovery key is not yet available")
+
         key = self.model.core_boot_recovery_key._key
 
         assert key is not None  # To help the static type checker

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -626,6 +626,16 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         ):
             await self.fsc.v2_core_boot_recovery_key_GET()
 
+    async def test_v2_core_boot_recovery_GET__not_yet_available(self):
+        self.fsc.model = make_model()
+        self.fsc.model.guided_configuration = mock.Mock(
+            capability=GuidedCapability.CORE_BOOT_ENCRYPTED
+        )
+        with self.assertRaises(
+            StorageRecoverableError, msg="recovery key is not yet available"
+        ):
+            await self.fsc.v2_core_boot_recovery_key_GET()
+
     @parameterized.expand(((True,), (False,)))
     async def test__pre_shutdown_install_started(self, zfsutils_linux_installed: bool):
         self.fsc.reset_partition_only = False


### PR DESCRIPTION
When calling `/v2/systems/{label}` with `action="generate-recovery-key"`, a recovery key is created with an expire duration of 5 minutes (defined in snapd).

Snapd expects that the `/v2/systems/{label}` with `action="finish-install"` gets called before the key expires.

In case the installer doesn't, we end up with:

```
    File "subiquity/server/snapd/api.py", line 142, in post_and_wait
      raise aiohttp.ClientError(result.err)
  aiohttp.client_exceptions.ClientError: cannot perform the following tasks:
  - Finish setup of run system for "enhanced-secureboot-desktop" (recovery key has expired)
```

We now move the "generate-recovery-key" step just before the "finish-install" step. This should drastically lower the window for key expiration.

The drawback is that subiquity's `/v2/storage/core_boot_recovery_key` endpoint can now only be used late during the installation, but UDB consumes it at the very end so that is ok.

LP:#2114738