### PR TITLE
Disable TPM/FDE if snapd is too old

### DIFF
--- a/examples/snaps/v2-snaps-snapd.json
+++ b/examples/snaps/v2-snaps-snapd.json
@@ -1,0 +1,77 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+    "title": "snapd",
+    "summary": "Daemon and tooling that enable snap packages",
+    "description": "Install, configure, refresh and remove snap packages. Snaps are\n'universal' packages that work across many different Linux systems,\nenabling secure distribution of the latest apps and utilities for\ncloud, servers, desktops and the internet of things.\n\nStart with 'snap list' to see installed snaps.",
+    "icon": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/snapd.png",
+    "installed-size": 53366784,
+    "install-date": "2025-04-29T11:08:17.008084903+02:00",
+    "name": "snapd",
+    "publisher": {
+      "id": "canonical",
+      "username": "canonical",
+      "display-name": "Canonical",
+      "validation": "verified"
+    },
+    "developer": "canonical",
+    "status": "active",
+    "type": "snapd",
+    "version": "2.68.4",
+    "channel": "latest/stable",
+    "tracking-channel": "latest/stable",
+    "ignore-validation": false,
+    "revision": "24505",
+    "confinement": "strict",
+    "private": false,
+    "devmode": false,
+    "jailmode": false,
+    "license": "GPL-3.0",
+    "mounted-from": "/var/lib/snapd/snaps/snapd_24505.snap",
+    "links": {
+      "contact": [
+        "https://github.com/snapcore/snapd/issues"
+      ],
+      "website": [
+        "https://snapcraft.io"
+      ]
+    },
+    "contact": "https://github.com/snapcore/snapd/issues",
+    "website": "https://snapcraft.io",
+    "media": [
+      {
+        "type": "icon",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/snapd.png",
+        "width": 460,
+        "height": 460
+      },
+      {
+        "type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115756_hLcyetO.png",
+        "width": 956,
+        "height": 648
+      },
+      {
+        "type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115824_2v3y6l8.png",
+        "width": 956,
+        "height": 648
+      },
+      {
+        "type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_115055_Uuq7KIb.png",
+        "width": 1023,
+        "height": 834
+      },
+      {
+        "type": "screenshot",
+        "url": "https://dashboard.snapcraft.io/site_media/appmedia/2019/09/Screenshot_20190924_125944.png",
+        "width": 956,
+        "height": 648
+      }
+    ]
+  }
+}

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -368,6 +368,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         return layout.get("reset-partition-only", False)
 
     async def configured(self):
+        # set_info_capability() requires variations info to be populated, so
+        # wait for it.
+        await self._examine_systems_task.wait()
         self._configured = True
         if self._info is None:
             self.set_info_for_capability(GuidedCapability.DIRECT)

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -382,7 +382,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         await super().configured()
         self.stop_monitor()
 
-    def info_for_system(self, name: str, label: str, system: SystemDetails):
+    def info_for_system(
+        self, name: str, label: str, system: SystemDetails, has_beta_entropy_check: bool
+    ):
         if len(system.volumes) > 1:
             log.error("Skipping uninstallable system: %s", system_multiple_volumes_text)
             return None
@@ -427,6 +429,10 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             info.capability_info.disallowed = [
                 disallowed_encryption(se.unavailable_reason)
             ]
+        elif not has_beta_entropy_check:
+            info.capability_info.allowed = [GuidedCapability.CORE_BOOT_UNENCRYPTED]
+            msg = _("snapd version is too old, please refresh")
+            info.capability_info.disallowed = [disallowed_encryption(msg)]
         else:
             if se.storage_safety == StorageSafety.ENCRYPTED:
                 info.capability_info.allowed = [GuidedCapability.CORE_BOOT_ENCRYPTED]
@@ -472,6 +478,15 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     async def _examine_systems(self):
         self._variation_info.clear()
         catalog_entry = self.app.base_model.source.current
+
+        try:
+            has_beta_entropy_check = await self.app.snapdinfo.has_beta_entropy_check()
+        except ValueError as exc:
+            log.debug(
+                "cannot check if snapd has beta entropy check, assuming yes: %s", exc
+            )
+            has_beta_entropy_check = True
+
         for name, variation in catalog_entry.variations.items():
             system = None
             label = variation.snapd_system_label
@@ -508,7 +523,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 if not self.app.opts.enhanced_secureboot:
                     log.debug("Not offering enhanced_secureboot: commandline disabled")
                     continue
-                info = self.info_for_system(name, label, system)
+                info = self.info_for_system(
+                    name, label, system, has_beta_entropy_check=has_beta_entropy_check
+                )
                 if info is None:
                     continue
                 if not in_live_layer:

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -76,6 +76,7 @@ from subiquity.server.controllers.filesystem import (
 from subiquity.server.dryrun import DRConfig
 from subiquity.server.snapd import api as snapdapi
 from subiquity.server.snapd import types as snapdtypes
+from subiquity.server.snapd.info import SnapdInfo
 from subiquity.server.snapd.system_getter import SystemGetter
 from subiquity.server.snapd.types import VolumesAuth, VolumesAuthMode
 from subiquitycore.snapd import AsyncSnapd, SnapdConnection, get_fake_connection
@@ -160,6 +161,7 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.app.prober.get_storage = mock.AsyncMock()
         self.app.block_log_dir = "/inexistent"
         self.app.note_file_for_apport = mock.Mock()
+        self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
         self.fsc = FilesystemController(app=self.app)
         self.fsc._configured = True
 
@@ -1039,6 +1041,7 @@ class TestRunAutoinstallGuided(IsolatedAsyncioTestCase):
     def setUp(self):
         self.app = make_app()
         self.app.opts.bootloader = None
+        self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
         self.fsc = FilesystemController(self.app)
         self.model = self.fsc.model = make_model()
 
@@ -1120,6 +1123,7 @@ class TestGuided(IsolatedAsyncioTestCase):
     async def _guided_setup(self, bootloader, ptable, storage_version=None):
         self.app = make_app()
         self.app.opts.bootloader = bootloader.value
+        self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
         self.controller = FilesystemController(self.app)
         self.controller.supports_resilient_boot = True
         self.controller._examine_systems_task.start_sync()
@@ -1529,6 +1533,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
     async def _setup(self, bootloader, ptable, fix_bios=True, **kw):
         self.app = make_app()
         self.app.opts.bootloader = bootloader.value
+        self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
         self.fsc = FilesystemController(app=self.app)
         self.fsc.calculate_suggested_install_min = mock.Mock()
         self.fsc.calculate_suggested_install_min.return_value = 10 << 30
@@ -2330,6 +2335,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
             }
         )
         self.app.snapdapi = snapdapi.make_api_client(AsyncSnapd(get_fake_connection()))
+        self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
         self.app.dr_cfg = DRConfig()
         self.app.dr_cfg.systems_dir_exists = True
         self.app.controllers.Source.get_handler.return_value = TrivialSourceHandler("")

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -59,6 +59,7 @@ from subiquity.server.nonreportable import NonReportableException
 from subiquity.server.pkghelper import get_package_installer
 from subiquity.server.runner import get_command_runner
 from subiquity.server.snapd.api import make_api_client
+from subiquity.server.snapd.info import SnapdInfo
 from subiquity.server.types import InstallerChannels
 from subiquitycore.async_helpers import run_bg_task, run_in_thread
 from subiquitycore.context import Context, with_context
@@ -337,11 +338,13 @@ class SubiquityServer(Application):
             connection = get_fake_connection(self.scale_factor, opts.output_base)
             self.snapd = AsyncSnapd(connection)
             self.snapdapi = make_api_client(self.snapd)
+            self.snapdinfo = SnapdInfo(self.snapdapi)
         elif os.path.exists(self.snapd_socket_path):
             connection = SnapdConnection(self.root, self.snapd_socket_path)
             self.snapd = AsyncSnapd(connection)
             log_snapd = "subiquity-log-snapd" in self.opts.kernel_cmdline
             self.snapdapi = make_api_client(self.snapd, log_responses=log_snapd)
+            self.snapdinfo = SnapdInfo(self.snapdapi)
         else:
             log.info("no snapd socket found. Snap support is disabled")
             self.snapd = None

--- a/subiquity/server/snapd/info.py
+++ b/subiquity/server/snapd/info.py
@@ -58,3 +58,6 @@ class SnapdInfo:
         result = await self.snapdapi.v2.snaps["snapd"].GET()
 
         return self._parse_version(result.version)
+
+    async def has_beta_entropy_check(self) -> bool:
+        return await self.version() >= SnapdVersion(2, 68)

--- a/subiquity/server/snapd/info.py
+++ b/subiquity/server/snapd/info.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+import attrs
+
+
+@attrs.define(order=True)
+class SnapdVersion:
+    major: int
+    minor: int
+    patch: int = 0
+
+
+class SnapdInfo:
+    def __init__(self, snapdapi) -> None:
+        self.snapdapi = snapdapi
+
+    def _parse_version(self, version: str) -> SnapdVersion:
+        """Parse a snapd version number. Accepted version numbers are of the form:
+         * major.minor (e.g., 2.68)
+         * major.minor.patch (e.g., 2.68.4)
+         * major.minor+extra (e.g., 2.68+git58.6677899)
+         * major.minor.patch+extra (e.g., 2.68.4+git58.6677899)
+        Extra information is ignored.
+        """
+        pattern = re.compile(
+            r"(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?(?P<extra>\+.*)?"
+        )
+
+        if m := pattern.fullmatch(version):
+            fields = {
+                "major": int(m.group("major")),
+                "minor": int(m.group("minor")),
+            }
+
+            if (patch := m.group("patch")) is not None:
+                fields["patch"] = int(patch)
+
+            return SnapdVersion(**fields)
+
+        raise ValueError(f"could not parse snapd version: {version}")
+
+    async def version(self) -> SnapdVersion:
+        result = await self.snapdapi.v2.snaps["snapd"].GET()
+
+        return self._parse_version(result.version)

--- a/subiquity/server/snapd/test/test_info.py
+++ b/subiquity/server/snapd/test/test_info.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import Mock
+
+from subiquity.server.snapd.info import SnapdInfo, SnapdVersion
+
+
+class TestSnapdInfo(unittest.TestCase):
+    def setUp(self):
+        self.info = SnapdInfo(Mock())
+
+    def test_parse_version__major_minor(self):
+        self.assertEqual(SnapdVersion(2, 68), self.info._parse_version("2.68"))
+
+    def test_parse_version__major_minor_patch(self):
+        self.assertEqual(SnapdVersion(2, 68, 4), self.info._parse_version("2.68.4"))
+
+    def test_parse_version__major_minor_git_version(self):
+        self.assertEqual(
+            SnapdVersion(2, 70, 0), self.info._parse_version("2.70+g59.0e89e83")
+        )
+
+    def test_parse_version__major_minor_patch_git_version(self):
+        self.assertEqual(
+            SnapdVersion(2, 68, 1), self.info._parse_version("2.68.1+g59.0e89e83")
+        )
+
+    def test_parse_version__bad_version(self):
+        with self.assertRaises(ValueError):
+            self.info._parse_version("2.+g59.0e89e83")

--- a/subiquity/server/snapd/test/test_info.py
+++ b/subiquity/server/snapd/test/test_info.py
@@ -14,12 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from subiquity.server.snapd.info import SnapdInfo, SnapdVersion
 
 
-class TestSnapdInfo(unittest.TestCase):
+class TestSnapdInfo(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.info = SnapdInfo(Mock())
 
@@ -42,3 +42,15 @@ class TestSnapdInfo(unittest.TestCase):
     def test_parse_version__bad_version(self):
         with self.assertRaises(ValueError):
             self.info._parse_version("2.+g59.0e89e83")
+
+    async def test_has_beta_entropy__yes_equal(self):
+        with patch.object(self.info, "version", return_value=SnapdVersion(2, 68)):
+            self.assertTrue(await self.info.has_beta_entropy_check())
+
+    async def test_has_beta_entropy__yes_greater(self):
+        with patch.object(self.info, "version", return_value=SnapdVersion(2, 68, 4)):
+            self.assertTrue(await self.info.has_beta_entropy_check())
+
+    async def test_has_beta_entropy__no(self):
+        with patch.object(self.info, "version", return_value=SnapdVersion(2, 67)):
+            self.assertFalse(await self.info.has_beta_entropy_check())

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -1683,7 +1683,7 @@ class TestRegression(TestAPI):
         async with start_server(cfg, extra_args=extra) as inst:
             names = ["locale", "keyboard", "source", "network", "proxy", "mirror"]
             await inst.post("/meta/mark_configured", endpoint_names=names)
-            resp = await inst.get("/storage/v2")
+            resp = await inst.get("/storage/v2", wait=True)
             [d] = resp["disks"]
             [g] = d["partitions"]
             data = {


### PR DESCRIPTION
This is to disable TPM/FDE if the snapd version in the live environment is too old. This will typically happen when refreshing the installer from an older ISO.

#### Limitation

This will not prevent the installer from offering features (e.g., recovery key) that are not properly understood by the snapd version that is getting installed on the target system (i.e, the snapd from the squashfs).

#### Notes

Adding more stuff inside _examine_systems() broke some API tests, making it clear that we have race conditions to watch for.  One way to make it obvious is to apply the following patch:
```diff
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -468,6 +468,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
     async def _examine_systems(self):
         self._variation_info.clear()
+        await asyncio.sleep(2)
         catalog_entry = self.app.base_model.source.current
         for name, variation in catalog_entry.variations.items():
             system = None
```
The first two patches are about fixing the tests (one of each being an issue that we can theoretically run into during a real installation).