### PR TITLE
Entropy fix when response is {"type": "error"} (and fix entropy expected type)

### DIFF
--- a/subiquity/common/api/client.py
+++ b/subiquity/common/api/client.py
@@ -51,7 +51,8 @@ def _wrap(make_request, path, meth, serializer, serialize_query_args):
             params=query_args,
             raise_for_status=raise_for_status,
         ) as resp:
-            resp.raise_for_status()
+            if raise_for_status:
+                resp.raise_for_status()
             return serializer.deserialize(r_ann, await resp.json())
 
     return impl

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1720,9 +1720,21 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if result is None:
             return None
 
+        assert isinstance(result, snapdtypes.EntropyCheckResponse)
+
         if result.kind == EntropyCheckResponseKind.UNSUPPORTED:
-            log.debug("v2_calculate_entropy_POST: unsupported by snapd")
-            return None
+            # TODO determine why we're running into UNSUPPORTED sometimes.
+            log.warning(
+                'v2/systems/%s action="%s" returned "%s"',
+                info.label,
+                request.action,
+                result.kind,
+            )
+            raise StorageRecoverableError(
+                'entropy check failed: snapd returned "unsupported"'
+            )
+
+        assert result.value is not None
 
         return EntropyResponse(
             entropy=result.value.entropy_bits,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1726,7 +1726,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
         return EntropyResponse(
             entropy=result.value.entropy_bits,
-            minimum_required=result.value.min_entropy_bits,
+            minimum_required=float(result.value.min_entropy_bits),
         )
 
     async def v2_core_boot_recovery_key_GET(self) -> str:

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -2805,7 +2805,7 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
                     value=snapdtypes.InsufficientEntropyDetails(
                         reasons=["low-entropy"],
                         entropy_bits=expected_entropy.entropy,
-                        min_entropy_bits=expected_entropy.minimum_required,
+                        min_entropy_bits=int(expected_entropy.minimum_required),
                     ),
                 ),
             ):

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -358,4 +358,6 @@ class InsufficientEntropyDetails:
 class EntropyCheckResponse:
     kind: EntropyCheckResponseKind
     message: str
-    value: InsufficientEntropyDetails
+
+    # Set to None if kind="unsupported"
+    value: Optional[InsufficientEntropyDetails] = None

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -351,7 +351,7 @@ class InsufficientEntropyReasons(enum.Enum):
 class InsufficientEntropyDetails:
     reasons: List[InsufficientEntropyReasons]
     entropy_bits: float
-    min_entropy_bits: float
+    min_entropy_bits: int
 
 
 @snapdtype

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -168,8 +168,10 @@ class FakeSnapdConnection:
                         "kind": kind,
                         "message": "did not pass quality checks",
                         "value": {
+                            # In snapd 2.68, entropy-bits is a float, but
+                            # min-entropy-bits is an int.
                             "entropy-bits": float(entropy_bits),
-                            "min-entropy-bits": float(min_entropy_bits),
+                            "min-entropy-bits": int(min_entropy_bits),
                             "reasons": ["low-entropy"],
                         },
                     },

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -23,6 +23,7 @@ from functools import partial
 from typing import Any
 from urllib.parse import quote_plus, urlencode
 
+import attrs
 import requests_unixsocket
 
 from subiquitycore.async_helpers import run_in_thread
@@ -90,9 +91,9 @@ class _FakeFileResponse:
             return json.load(fp)
 
 
+@attrs.define
 class _FakeMemoryResponse:
-    def __init__(self, data):
-        self.data = data
+    data: Any
 
     def raise_for_status(self):
         pass
@@ -147,7 +148,7 @@ class FakeSnapdConnection:
         log.debug("pretending to restart snapd to pick up proxy config")
         time.sleep(2 / self.scale_factor)
 
-    def _fake_entropy(self, body) -> dict[str, Any] | None:
+    def _fake_entropy(self, body) -> _FakeMemoryResponse:
         if body["action"] == "check-passphrase":
             entropy_bits = len(body["passphrase"])
             min_entropy_bits = 8
@@ -158,17 +159,31 @@ class FakeSnapdConnection:
             kind = "invalid-pin"
 
         if entropy_bits < min_entropy_bits:
-            return {
-                "kind": kind,
-                "message": "did not pass quality checks",
-                "value": {
-                    "entropy-bits": float(entropy_bits),
-                    "min-entropy-bits": float(min_entropy_bits),
-                    "reasons": ["low-entropy"],
-                },
-            }
+            return _FakeMemoryResponse(
+                {
+                    "type": "error",
+                    "status-code": 400,
+                    "status": "Bad Request",
+                    "result": {
+                        "kind": kind,
+                        "message": "did not pass quality checks",
+                        "value": {
+                            "entropy-bits": float(entropy_bits),
+                            "min-entropy-bits": float(min_entropy_bits),
+                            "reasons": ["low-entropy"],
+                        },
+                    },
+                }
+            )
 
-        return None
+        return _FakeMemoryResponse(
+            {
+                "type": "sync",
+                "status-code": 200,
+                "status": "OK",
+                "result": None,
+            }
+        )
 
     def post(self, path, body, *, raise_for_status=True, **args):
         if path == "v2/snaps/subiquity" and body["action"] == "refresh":
@@ -185,7 +200,6 @@ class FakeSnapdConnection:
             )
         change = None
         sync_result = None
-        has_sync_result = False
         if path == "v2/snaps/subiquity" and body["action"] == "switch":
             change = "8"
         if path.startswith("v2/systems/") and body["action"] == "install":
@@ -204,10 +218,7 @@ class FakeSnapdConnection:
             "check-passphrase",
             "check-pin",
         ):
-            # This is required because self._fake_entropy() might return None,
-            # which should still be considered a response.
-            has_sync_result = True
-            sync_result = self._fake_entropy(body)
+            return self._fake_entropy(body)
 
         if change is not None:
             return _FakeMemoryResponse(
@@ -218,7 +229,7 @@ class FakeSnapdConnection:
                     "status": "Accepted",
                 }
             )
-        elif sync_result is not None or has_sync_result:
+        elif sync_result:
             return _FakeMemoryResponse(
                 {
                     "type": "sync",

--- a/subiquitycore/tests/test_snapd.py
+++ b/subiquitycore/tests/test_snapd.py
@@ -31,7 +31,7 @@ class TestFakeSnapdConnection(unittest.TestCase):
                 "result": {
                     "value": {
                         "entropy-bits": 3.0,
-                        "min-entropy-bits": 4.0,
+                        "min-entropy-bits": 4,
                         "reasons": ["low-entropy"],
                     },
                     "message": "did not pass quality checks",
@@ -65,7 +65,7 @@ class TestFakeSnapdConnection(unittest.TestCase):
                 "result": {
                     "value": {
                         "entropy-bits": 3.0,
-                        "min-entropy-bits": 8.0,
+                        "min-entropy-bits": 8,
                         "reasons": ["low-entropy"],
                     },
                     "message": "did not pass quality checks",

--- a/subiquitycore/tests/test_snapd.py
+++ b/subiquitycore/tests/test_snapd.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import Mock
 
-from subiquitycore.snapd import FakeSnapdConnection
+from subiquitycore.snapd import FakeSnapdConnection, _FakeMemoryResponse
 
 
 class TestFakeSnapdConnection(unittest.TestCase):
@@ -23,34 +23,56 @@ class TestFakeSnapdConnection(unittest.TestCase):
         self.snapd = FakeSnapdConnection(Mock(), Mock(), Mock())
 
     def test__fake_entropy__pin_bad(self):
-        expected = {
-            "value": {
-                "entropy-bits": 3.0,
-                "min-entropy-bits": 4.0,
-                "reasons": ["low-entropy"],
-            },
-            "message": "did not pass quality checks",
-            "kind": "invalid-pin",
-        }
+        expected = _FakeMemoryResponse(
+            {
+                "type": "error",
+                "status": "Bad Request",
+                "status-code": 400,
+                "result": {
+                    "value": {
+                        "entropy-bits": 3.0,
+                        "min-entropy-bits": 4.0,
+                        "reasons": ["low-entropy"],
+                    },
+                    "message": "did not pass quality checks",
+                    "kind": "invalid-pin",
+                },
+            }
+        )
         self.assertEqual(
             expected, self.snapd._fake_entropy({"action": "check-pin", "pin": "123"})
         )
 
     def test__fake_entropy__pin_good(self):
-        self.assertIsNone(
-            self.snapd._fake_entropy({"action": "check-pin", "pin": "12345"})
+        expected = _FakeMemoryResponse(
+            {
+                "type": "sync",
+                "status": "OK",
+                "status-code": 200,
+                "result": None,
+            }
+        )
+        self.assertEqual(
+            expected, self.snapd._fake_entropy({"action": "check-pin", "pin": "12345"})
         )
 
     def test__fake_entropy__passphrase_bad(self):
-        expected = {
-            "value": {
-                "entropy-bits": 3.0,
-                "min-entropy-bits": 8.0,
-                "reasons": ["low-entropy"],
-            },
-            "message": "did not pass quality checks",
-            "kind": "invalid-passphrase",
-        }
+        expected = _FakeMemoryResponse(
+            {
+                "type": "error",
+                "status": "Bad Request",
+                "status-code": 400,
+                "result": {
+                    "value": {
+                        "entropy-bits": 3.0,
+                        "min-entropy-bits": 8.0,
+                        "reasons": ["low-entropy"],
+                    },
+                    "message": "did not pass quality checks",
+                    "kind": "invalid-passphrase",
+                },
+            }
+        )
         self.assertEqual(
             expected,
             self.snapd._fake_entropy(
@@ -59,8 +81,17 @@ class TestFakeSnapdConnection(unittest.TestCase):
         )
 
     def test__fake_entropy__passphrase_good(self):
-        self.assertIsNone(
+        expected = _FakeMemoryResponse(
+            {
+                "type": "sync",
+                "status": "OK",
+                "status-code": 200,
+                "result": None,
+            }
+        )
+        self.assertEqual(
+            expected,
             self.snapd._fake_entropy(
                 {"action": "check-passphrase", "passphrase": "abcdefghijkl"}
-            )
+            ),
         )


### PR DESCRIPTION
The `/v2/systems/{label}` action="check-passphrase|check-pin" endpoint doesn't return `{"type": "sync"}` on error, it returns `{"type": "error"}` instead. This code path in Subiquity was untested and there were several issues with it:

* The `make_request` context manager yields a `_FakeError` instance, but then could yield `_FakeResponse` subsequently. This caused a:
```python
RuntimeError: "generator didn't stop"
```
* The caller or `_FakeError` didn't provide the data argument that the initializer expected.
* If `raise_for_status` is False, then `_FakeError`.json gets called, but the method didn't exist.

I also adapted the dry-run implementation so that it returns `{"type": "error"}`

Last, it turned out during testing that snapd 2.68 returns `min-entropy-bits` as an integer and `entropy-bits` as a floating point number. Adapt the code to match that. In the future, both values should be int though.

LP:#2114918