### PR TITLE
storage: when using the @api workaround, inherit the value of log_responses

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1065,7 +1065,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                         ) -> SystemActionResponseGenerateRecoveryKey: ...
 
         snapd_client = snapdapi.make_api_client(
-            self.app.snapd, api_class=AlternateSnapdAPI, log_responses=False
+            self.app.snapd,
+            api_class=AlternateSnapdAPI,
+            log_responses=self.app.snapdapi.log_responses,
         )
 
         label = self._info.label
@@ -1675,7 +1677,9 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                         ) -> Optional[snapdtypes.EntropyCheckResponse]: ...
 
         snapd_client = snapdapi.make_api_client(
-            self.app.snapd, api_class=AlternateSnapdAPI, log_responses=False
+            self.app.snapd,
+            api_class=AlternateSnapdAPI,
+            log_responses=self.app.snapdapi.log_responses,
         )
 
         async with AsyncExitStack() as es:


### PR DESCRIPTION
Currently, when building an alternative snapd API client (i.e., because the types annotations are wrong), the client is created with disabled logging of the snapd responses. But if the standard snapd API client has logging enabled, we should also enable it for the alternative clients.