### PR TITLE
snapd: set Content-Type header appropriately when POSTing to snapd

### DIFF
--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -57,7 +57,7 @@ class SnapdConnection:
         with requests_unixsocket.Session() as session:
             return session.post(
                 self.url_base + path,
-                data=json.dumps(body),
+                json=body,
                 timeout=self.default_timeout_seconds,
             )
 


### PR DESCRIPTION
When POSTing to Snapd, we send it JSON data. Previously, we did not specify a Content-Type header, which is fine with snapd. We now rely on requests to set the Content-Type header appropriately (i.e., to application/json).

When debugging, it makes it easier to work with captured data. It also makes it easier to implement a mock version of snapd with flask.