### PR TITLE
Fix installation of OEM kernel when installing Ubuntu offline on a certified device

### DIFF
--- a/subiquity/server/controllers/oem.py
+++ b/subiquity/server/controllers/oem.py
@@ -184,11 +184,17 @@ class OEMController(SubiquityController):
         for pkg in self.model.metapkgs:
             if pkg.wants_oem_kernel:
                 kernel_model = self.app.base_model.kernel
+                # flavor_to_pkgname expects a value such as "oem", "generic",
+                # or "generic-hwe", not a package name in any case.
+                # The return value of the function should look something like
+                # linux-oem-24.04
                 kernel_model.metapkg_name_override = flavor_to_pkgname(
-                    pkg.name, dry_run=self.app.opts.dry_run
+                    "oem", dry_run=self.app.opts.dry_run
                 )
 
-                log.debug("overriding kernel flavor because of OEM")
+                log.debug(
+                    'overriding kernel flavor to "oem" according to the OEM metapkg info'
+                )
 
         log.debug("OEM meta-packages to install: %s", self.model.metapkgs)
 


### PR DESCRIPTION
  On certified devices, when we are offline and the OEM metapackage declares that it should be used with the OEM kernel (i.e., Ubuntu-Oem-Kernel-Flavour: oem), we store the name of the kernel package to install in the kernel model.

However, the flavor_to_pkgname() function was used incorrectly. We were meant to give it the name of a flavor (e.g., oem, generic, ...) but instead we gave it the name of the OEM metapackage.

As a consequence, we ended up trying to install kernel package with names such as "linux-oem-somerville-trecko-meta-24.04". Instead it should have been "linux-oem-24.04".

Later in #2034, we attempted to fix the issue by setting the kernel package name to "oem-somerville-treecko-meta". But "oem-somerville-treecko-meta" is not the name of a kernel metapackage, it is the name of the OEM metapackage.

LP:#2114780