### PR TITLE
[Noble]: oem: fix kernel metapackage name for OEM kernel

### DIFF
--- a/subiquity/server/controllers/oem.py
+++ b/subiquity/server/controllers/oem.py
@@ -183,11 +183,18 @@ class OEMController(SubiquityController):
         for pkg in self.model.metapkgs:
             if pkg.wants_oem_kernel:
                 kernel_model = self.app.base_model.kernel
+                # flavor_to_pkgname expects a value such as "oem", "generic",
+                # or "generic-hwe", not a package name in any case.
+                # The return value of the function should look something like
+                # linux-oem-24.04
                 kernel_model.metapkg_name_override = flavor_to_pkgname(
-                    pkg.name, dry_run=self.app.opts.dry_run
+                    "oem", dry_run=self.app.opts.dry_run
                 )
 
-                log.debug("overriding kernel flavor because of OEM")
+                log.debug(
+                    'overriding kernel flavor to "oem"'
+                    " according to the OEM metapkg info"
+                )
 
         log.debug("OEM meta-packages to install: %s", self.model.metapkgs)
 


### PR DESCRIPTION
This is a port to noble of #2230.

> On certified devices, when we are offline and the OEM metapackage declares that it should be used with the OEM kernel (i.e., Ubuntu-Oem-Kernel-Flavour: oem), we store the name of the kernel package to install in the kernel model.
> 
> However, the flavor_to_pkgname() function was used incorrectly. We were meant to give it the name of a flavor (e.g., oem, generic, ...) but instead we gave it the name of the OEM metapackage.
> 
> As a consequence, we ended up trying to install kernel package with names such as "linux-oem-somerville-treckoo-meta-24.04". Instead it should have been "linux-oem-24.04".

LP:#2114780

(cherry picked from commit 0c997768bc4a0a94ef123298d37fe953d6499976)