### PR TITLE
storage: fix inability to edit a partition having a GPT name

### DIFF
--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1585,7 +1585,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
             raise ValueError("edit_partition does not support changing size")
         if data.partition.boot is not None and data.partition.boot != partition.boot:
             raise ValueError("edit_partition does not support changing boot")
-        if data.partition.name != partition.name:
+        if data.partition.name != partition.partition_name:
             if data.partition is None:
                 # FIXME Instead of checking if data.partition.name is None,
                 # what we really want to know is whether the name field is

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1586,7 +1586,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         if data.partition.boot is not None and data.partition.boot != partition.boot:
             raise ValueError("edit_partition does not support changing boot")
         if data.partition.name != partition.partition_name:
-            if data.partition is None:
+            if data.partition.name is None:
                 # FIXME Instead of checking if data.partition.name is None,
                 # what we really want to know is whether the name field is
                 # present in the request. Unfortunately, None is the default

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -553,12 +553,13 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.assertTrue(self.fsc.locked_probe_data)
         handler.assert_not_called()
 
-    async def test_v2_edit_partition_POST_preserve_pname(self):
+    @parameterized.expand(((None,), ("Foobar",)))
+    async def test_v2_edit_partition_POST_preserve_pname(self, name):
         self.fsc.locked_probe_data = False
         self.fsc.model, d = make_model_and_disk()
         data = ModifyPartitionV2(
             disk_id=d.id,
-            partition=Partition(number=1, name="Foobar"),
+            partition=Partition(number=1, name=name),
         )
 
         existing = make_partition(

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -543,13 +543,32 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
             partition=Partition(number=1, name="Foobar"),
         )
 
-        existing = make_partition(self.fsc.model, d, size=1000 << 20)
+        existing = make_partition(
+            self.fsc.model, d, size=1000 << 20, partition_name="MyPart"
+        )
         with mock.patch.object(self.fsc, "partition_disk_handler") as handler:
             with mock.patch.object(self.fsc, "get_partition", return_value=existing):
                 with self.assertRaisesRegex(ValueError, r"changing partition name"):
                     await self.fsc.v2_edit_partition_POST(data)
         self.assertTrue(self.fsc.locked_probe_data)
         handler.assert_not_called()
+
+    async def test_v2_edit_partition_POST_preserve_pname(self):
+        self.fsc.locked_probe_data = False
+        self.fsc.model, d = make_model_and_disk()
+        data = ModifyPartitionV2(
+            disk_id=d.id,
+            partition=Partition(number=1, name="Foobar"),
+        )
+
+        existing = make_partition(
+            self.fsc.model, d, size=1000 << 20, partition_name="Foobar"
+        )
+        with mock.patch.object(self.fsc, "partition_disk_handler") as handler:
+            with mock.patch.object(self.fsc, "get_partition", return_value=existing):
+                await self.fsc.v2_edit_partition_POST(data)
+        self.assertTrue(self.fsc.locked_probe_data)
+        handler.assert_called_once()
 
     async def test_v2_edit_partition_POST_unsupported_ptable(self):
         self.fsc.locked_probe_data = False


### PR DESCRIPTION
Subiquity does not support changing the name of a GPT partition. However, Subiquity intends to support preserving the name if it is already set. To do so, the user has in theory two ways:
* they can set the "name" field of the /storage/v2/edit_partition request to the original name
* they can omit the "name" field from the /storage/v2/edit_partition request

Unfortunately, both options were broken. When trying each, Subiquity would fail with the following error:

```
ValueError: edit_partition does not support changing partition name
```

Indeed, there was a flow when comparing the original name and the new name.

The Partition API object has a "name" field which corresponds to the (GPT) partition name. But in the Partition model object, the "name" field is different. It is inherited from curtin and controls the presence of a /dev/disk/by-dname/<name> symlink.

And there was also a flow when checking if the name field exists.

https://github.com/canonical/ubuntu-desktop-provision/issues/1117
LP:#2117025