### PR TITLE
remove fstype property from mount class, adds new unit tests

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1335,7 +1335,7 @@ class ArbitraryDevice(_Device):
 
 @fsobj("format")
 class Filesystem:
-    fstype: str
+    fstype: str = None
     volume: _Formattable = attributes.ref(backlink="_fs")
 
     label: Optional[str] = None
@@ -1365,10 +1365,6 @@ class Mount:
     device: Filesystem = attributes.ref(backlink="_mount", default=None)
     options: Optional[str] = None
     spec: Optional[str] = None
-
-    @property
-    def fstype(self):
-        return self.device.fstype
 
     def can_delete(self):
         from subiquity.common.filesystem import boot
@@ -1538,6 +1534,7 @@ class ActionRenderMode(enum.Enum):
 
 class FilesystemModel:
     target = None
+    fstype = None 
 
     _partition_alignment_data = {
         "gpt": PartitionAlignmentData(
@@ -2454,7 +2451,7 @@ class FilesystemModel:
     def should_add_swapfile(self):
         mount = self._mount_for_path("/")
         if mount is not None:
-            if not can_use_swapfile("/", mount.fstype):
+            if not can_use_swapfile("/", mount.device.volume._fs.fstype):
                 return False
         for swap in self._all(type="format", fstype="swap"):
             if swap.mount():

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1327,6 +1327,51 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertTrue(disk2p1.id in rendered_ids)
 
 
+    def test_bind_mount_fstype_tmpfs(self):
+        model = make_model(Bootloader.NONE, storage_version=2)
+        disk = make_disk(model, path="/tmp", preserve=True)
+        fake_up_blockdata(model)
+        fs = model.add_filesystem(volume=disk, fstype="tmpfs", preserve=False)
+        actions = model._render_actions(ActionRenderMode.DEFAULT)
+        rendered_by_id = {action["id"]: action for action in actions}
+        mount = model.add_mount(fs=fs, path="/tmp")
+        model.apply_autoinstall_config(
+            [
+                {
+                    "id": "tmpfs1",
+                    "type": "mount",
+                    "spec": "none",
+                    "path": "/tmp",
+                    "size": "4194304",
+                    "fstype": "tmpfs",
+                    "options": "mode=1777,nosuid,nodev",
+                },
+            ]
+        )
+        self.assertEqual(rendered_by_id["format-0"]["fstype"], "tmpfs")
+
+    def test_bind_mount_fstype_zfs(self):
+        model = make_model(Bootloader.NONE, storage_version=2)
+        disk = make_disk(model, path="/tmp", preserve=True)
+        fake_up_blockdata(model)
+        fs = model.add_filesystem(volume=disk, fstype="zfs", preserve=False)
+        actions = model._render_actions(ActionRenderMode.DEFAULT)
+        rendered_by_id = {action["id"]: action for action in actions}
+        mount = model.add_mount(fs=fs, path="/tmp")
+        model.apply_autoinstall_config(
+            [
+                {
+                    "id": "zfs1",
+                    "type": "mount",
+                    "spec": "none",
+                    "path": "/tmp",
+                    "size": "4194304",
+                    "fstype": "zfs",
+                },
+            ]
+        )
+        self.assertEqual(rendered_by_id["format-0"]["fstype"], "zfs")
+
 class TestPartitionNumbering(unittest.TestCase):
     def setUp(self):
         self.cur_idx = 1


### PR DESCRIPTION
resolves (LP: #[2061732](https://bugs.launchpad.net/subiquity/+bug/2061732))

fixing regression from [0cc4fdf34893d7420cd3bf5d227b273791dbcdfb](https://github.com/canonical/subiquity/commit/0cc4fdf34893d7420cd3bf5d227b273791dbcdfb)

remove fstype property from mount class.

adds two new unit tests
1. tmpfs filesystem types [0]
3. bind mount zfs fstype 

[0] https://curtin.readthedocs.io/en/latest/topics/storage.html 

