### PR TITLE
storage: add endpoint to check if the TPM key can be encrypted

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -70,6 +70,7 @@ from subiquity.common.types import (
 from subiquity.common.types.storage import (
     AddPartitionV2,
     CalculateEntropyRequest,
+    CoreBootEncryptionFeatures,
     Disk,
     EntropyResponse,
     GuidedChoiceV2,
@@ -399,6 +400,9 @@ class API:
 
             class core_boot_recovery_key:
                 def GET() -> str: ...
+
+            class core_boot_encryption_features:
+                def GET() -> List[CoreBootEncryptionFeatures]: ...
 
     class codecs:
         def GET() -> CodecsData: ...

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -420,3 +420,8 @@ class EntropyResponse:
 
     # Set to None if success is True
     failure_reasons: Optional[List[str]] = None
+
+
+class CoreBootEncryptionFeatures(enum.Enum):
+    PASSPHRASE_AUTH = "passphrase-auth"
+    PIN_AUTH = "pin-auth"

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -197,12 +197,19 @@ class EncryptionType(enum.Enum):
     DEVICE_SETUP_HOOK = "device-setup-hook"
 
 
+class EncryptionFeature(enum.Enum):
+    PASSPHRASE_AUTH = "passphrase-auth"
+    PIN_AUTH = "pin-auth"
+
+
 @snapdtype
 class StorageEncryption:
     support: StorageEncryptionSupport
     storage_safety: StorageSafety
     encryption_type: EncryptionType = EncryptionType.NONE
     unavailable_reason: str = ""
+    # Since snapd 2.68
+    features: Optional[List[EncryptionFeature]] = None
 
 
 @snapdtype


### PR DESCRIPTION
This introduces a new endpoint:
```
GET /storage/v2/core_boot_encryption_features
```

e.g.:

```sh
curl --unix-socket /run/subiquity/socket http://a/storage/v2/core_boot_encryption_features
["PASSPHRASE_AUTH"]
curl --unix-socket /run/subiquity/socket http://a/storage/v2/core_boot_encryption_features
["PASSPHRASE_AUTH", "PIN_AUTH"]
```

Which returns a list of encryption "features" supported by a TPM/FDE variation.
When booting a TPM/FDE system, different authentication methods are supported.

NOTE: This change was originally part of a larger change that included a rework of how we handle variations info.