### PR TITLE
snapcraft: bump curtin for the 25.10 DM partition kname fix

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: "e6806e94b1c1acc6c6df7522ea8f94df301eed99"
+    source-commit: "4ac8207bceba2f93b829ef9c69a556f10621ffc1"
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Full changelog:

 * canonical/curtin@4ac8207b block: drop "first" argument from get_device_mapper_links()
 * canonical/curtin@1be88c0f block: fix logic to determine DM partition kname on Ubuntu 25.10+

LP:#2119429