### PR TITLE
docs: Update autoinstall-reference.rst to better reflect reporting behaviour

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -1392,7 +1392,6 @@ The configuration is similar to that used by curtin. See the `Reporting <https:/
 Each key in the ``reporting`` mapping in the configuration defines a destination where the ``type`` sub-key is one of:
 
 * ``print``: print progress information on ``tty1`` and any configured serial console. There is no other configuration.
-* ``rsyslog``: report progress via rsyslog. The ``destination`` key specifies where to send output. (The rsyslog reporter does not yet exist.)
 * ``webhook``: report progress by sending JSON reports to a URL using POST requests. Accepts the same `configuration as curtin <https://curtin.readthedocs.io/en/latest/topics/reporting.html#webhook-reporter>`_.
 * ``none``: do not report progress. Only useful to inhibit the default output.
 
@@ -1406,16 +1405,6 @@ The default configuration is:
      reporting:
        builtin:
          type: print
-
-Report to rsyslog:
-
-.. code-block:: yaml
-
-   autoinstall:
-     reporting:
-       central:
-         type: rsyslog
-         destination: "@192.168.0.1"
 
 
 Suppress the default output:
@@ -1440,7 +1429,6 @@ Report to a curtin-style webhook:
          consumer_secret: "cs_value"
          token_key: "tk_value"
          token_secret: "tk_secret"
-         level: INFO
 
 .. _ai-user-data:
 


### PR DESCRIPTION
Update autoinstall-reference.rst to more accurately depict actual behaviour. 
- Remove reference to `rsyslog`, due to not being implemented.
- Remove reference to `level` in webhook handler, as webhook handler does not support level filtering or setting despite it being a param. See https://github.com/canonical/curtin/blob/master/curtin/reporter/handlers.py#L74, where it is unused