### PR TITLE
snapcraft: build with new python-only probert-network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ curtin: snapcraft.yaml
 
 probert: snapcraft.yaml
 	./scripts/update-part.py probert
-	(cd probert && $(PYTHON) setup.py build_ext --inplace);
 
 .PHONY: gitdeps
 gitdeps: curtin probert

--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -1,4 +1,3 @@
-build-essential
 cloud-init
 curl
 dctrl-tools
@@ -10,14 +9,10 @@ git
 isolinux
 jq
 language-selector-common
-libnl-3-dev
-libnl-genl-3-dev
-libnl-route-3-dev
 libsystemd-dev
 lsb-release
 os-prober
 pandoc
-pkg-config
 pre-commit
 python3-aiohttp
 python3-aioresponses
@@ -27,7 +22,6 @@ python3-attr
 python3-bson
 python3-coverage
 python3-debian
-python3-dev
 python3-distro-info
 python3-distutils-extra
 python3-dnspython

--- a/scripts/slimy-update-snap.sh
+++ b/scripts/slimy-update-snap.sh
@@ -74,9 +74,6 @@ rm -rf "${subiquity_dest}/subiquitycore"
 (cd "${src}" && ./scripts/update-part.py curtin)
 (cd "${src}" && ./scripts/update-part.py probert)
 
-# Build probert for the C extensions
-(cd "${src}"/probert && python3.12 setup.py build_ext --inplace)
-
 rsync -a --chown 0:0 $src/curtin/curtin new/lib/python3.12/site-packages
 rsync -a --chown 0:0 $src/probert/probert new/lib/python3.12/site-packages
 rsync -a --chown 0:0 $src/subiquity $src/subiquitycore $subiquity_dest

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -232,21 +232,12 @@ parts:
 
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: "36086af03fc4941a8ac219648ce77401743f3ae0"
+    source-commit: "d5a067e79a49fb05117069da106c552c03e9623e"
 
     override-build: *pyinstall
 
     build-packages:
-      - build-essential
-      - libnl-3-dev
-      - libnl-genl-3-dev
-      - libnl-route-3-dev
-      - pkg-config
-      - python3-dev
       - python3-pip
-
-    build-attributes:
-      - enable-patchelf
 
   management-script:
     plugin: nil


### PR DESCRIPTION
Now that canonical/probert#160 has landed, we can use the new probert-network implemented only in python.

FFe was approved https://bugs.launchpad.net/subiquity/+bug/2121429