### PR TITLE
network: fix missing with_wlan_listener var when running console-conf

### DIFF
--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -95,6 +95,7 @@ class NetworkController(BaseNetworkController, SubiquityController):
         self.clients = {}
         self.install_wpasupplicant_task = None
         self.pending_wlan_devices = set()
+        self.with_wlan_listener = app.opts.with_wlan_listener
 
     def maybe_start_install_wpasupplicant(self):
         log.debug("maybe_start_install_wpasupplicant")

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -173,6 +173,8 @@ class BaseNetworkController(BaseController):
         self.network_event_receiver = SubiquityNetworkEventReceiver.create(
             self, self.opts.dry_run
         )
+        # We override this in subclasses when relevant.
+        self.with_wlan_listener = True
 
     def parse_netplan_configs(self):
         self.model.parse_netplan_configs(self.root)
@@ -181,7 +183,7 @@ class BaseNetworkController(BaseController):
         self._observer_handles = []
         self.observer, self._observer_fds = self.app.prober.probe_network(
             self.network_event_receiver,
-            with_wlan_listener=self.app.opts.with_wlan_listener,
+            with_wlan_listener=self.with_wlan_listener,
         )
         self.start_watching()
 


### PR DESCRIPTION
When we introduced the `--no-wlan-listener` option (see PR #2180), we relied on its value in subiquitycore.controllers.network.BaseNetworkController as part of the `probe_network` method.

However, BaseNetworkController is not just used by Subiquity server. It is also used by Subiquity client and console-conf, where the `--no-wlan-listener` option does not exist.

The subiquity client does not invoke `probe_network` so that's okayish. But console-conf does and crashes with:

```python
    File "subiquitycore/core.py", line 119, in start_controllers
      controller.start()
      ~~~~~~~~~~~~~~~~^^
    File "subiquitycore/controllers/network.py", line 184, in start
      with_wlan_listener=self.app.opts.with_wlan_listener,
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  AttributeError: 'Namespace' object has no attribute 'with_wlan_listener'
```
Fixed by:
 * having a `with_wlan_listener` variable at the `BaseNetworkController` level, so that calling `probe_network` is always fine.
 * overriding the value in the Subiquity server's network controller.

Generally speaking, it seems wrong to use `app.opts` anywhere in subiquitycore.

LP:#2122027