### PR TITLE
console-conf: capture warnings emitted using warnings.warn()

### DIFF
--- a/console_conf/cmd/tui.py
+++ b/console_conf/cmd/tui.py
@@ -84,6 +84,7 @@ def main():
     if opts.dry_run:
         LOGDIR = opts.output_base
     setup_logger(dir=LOGDIR)
+    logging.captureWarnings(True)
     logger = logging.getLogger("console_conf")
     logger.info("Starting console-conf v{}".format(VERSION))
     logger.info("Arguments passed: {}".format(sys.argv))


### PR DESCRIPTION
In patch dfea4471363c0904b784fb0e78b5d1b30085e27e, we ensured warnings are captured by the logging system in subiquity so that they don't show up over the UI, rendering it barely usable.

However, only the warnings emitted when running subiquity (client & server) were captured. The warnings emitted by console-conf were not affected by that change. Therefore, they could still show up and "break" the UI.

Fixed by capturing the warnings as well for console-conf.

LP:#2121857

NOTE: to test this on main, one also needs https://github.com/canonical/subiquity/pull/2252