### PR TITLE
several: use rsync over cp -T

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -51,6 +51,7 @@ python3-systemd
 python3-urwid
 python3-wheel
 python3-yaml
+rsync
 ssh-import-id
 ubuntu-drivers-common
 umockdev

--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -319,9 +319,9 @@ class AptConfigurer:
             shutil.rmtree(target_mnt.p(dir))
             await self.app.command_runner.run(
                 [
-                    "cp",
-                    "-aT",
-                    self.configured_tree.p(dir),
+                    "rsync",
+                    "-a",
+                    self.configured_tree.p(dir) + "/",
                     target_mnt.p(dir),
                 ]
             )

--- a/subiquity/server/controllers/shutdown.py
+++ b/subiquity/server/controllers/shutdown.py
@@ -111,7 +111,7 @@ class ShutdownController(SubiquityController):
         else:
             await self.copy_cloud_init_logs(target_logs)
             await self.app.command_runner.run(
-                ["cp", "-aT", "/var/log/installer", target_logs]
+                ["rsync", "-a", "/var/log/installer/", target_logs]
             )
             # explicitly setting the expected permissions on this dir
             set_log_perms(target_logs, mode=0o770, group="adm")


### PR DESCRIPTION
`cp -T` in rust-coreutils has partial support for directory handling, but not a case that subiquity uses, where a directory is being copied and the destination version of that directory is currently absent.

When rust-coreutils cp supports this usage of -T I suggest reverting this commit.

LP:#2122363