### PR TITLE
Behave more like netplan when multiple configs match the same interface

### DIFF
--- a/subiquitycore/netplan.py
+++ b/subiquitycore/netplan.py
@@ -138,6 +138,7 @@ class _PhysicalDevice:
 
 class _VirtualDevice:
     def __init__(self, name, config):
+        # TODO support match directives?
         self.name = name
         self.config = config
         log.debug("config for %s = %s" % (name, sanitize_interface_config(self.config)))

--- a/subiquitycore/netplan.py
+++ b/subiquitycore/netplan.py
@@ -69,13 +69,16 @@ class Config:
 
     def config_for_device(self, link):
         if link.is_virtual:
-            for dev in self.virtual_devices:
+            for dev in sorted(self.virtual_devices, key=lambda x: x.name):
                 if dev.name == link.name:
                     return copy.deepcopy(dev.config)
         else:
             allowed_matches = ("macaddress",)
             match_key = "match"
-            for dev in self.physical_devices:
+            # Different configs are sorted by section name (using lexical
+            # order). If two config sections match the same interface,
+            # whichever comes first is honored.
+            for dev in sorted(self.physical_devices, key=lambda x: x.name):
                 if dev.matches_link(link):
                     config = copy.deepcopy(dev.config)
                     if match_key in config:
@@ -108,6 +111,10 @@ class Config:
 
 class _PhysicalDevice:
     def __init__(self, name, config):
+        # Name of the config section. If no match statement is present, this
+        # corresponds to the name of the interface. Otherwise, this is
+        # essentially free text (but is important for sorting).
+        self.name = name
         match = config.get("match")
         if match is None:
             self.match_name = name

--- a/subiquitycore/netplan.py
+++ b/subiquitycore/netplan.py
@@ -41,6 +41,9 @@ class Config:
     def __init__(self):
         self.physical_devices = []
         self.virtual_devices = []
+        # TODO we probably want to get rid of self.config.
+        # If we load multiple configs using parse_netplan_config() (which is
+        # the intended behavior), it only stores the last one.
         self.config = {}
 
     def parse_netplan_config(self, config):

--- a/subiquitycore/netplan.py
+++ b/subiquitycore/netplan.py
@@ -89,6 +89,11 @@ class Config:
         return {}
 
     def load_from_root(self, root):
+        # This does something similar to netplan-get, except that it:
+        # * only loads netplan files from /etc, not /lib and /run.
+        # * does not merge configs.
+        # Using netplan-get would have the benefit of merging configs that have
+        # the same name.
         for path in configs_in_root(root):
             try:
                 fp = open(path)


### PR DESCRIPTION
If multiple sections match a given interface name (i.e., ens3 here), netplan (or the backend really) will honor the first matching section ordered by section name.

```yaml
      ethernets:
        cc:
          match: {name: ens3}
          addresses: [2.2.2.2/24]
        bb:
          match: {name: ens3}
          addresses: [1.1.1.1/24]
        aa:
          match: {name: lo}
          addresses: [127.0.0.1/8]
        ens3:
          addresses: [3.3.3.3/24]
```
In this scenario, that would be "bb" because it matches the interface name and "bb" comes before "ens3" in lexical order.

Previously, Subiquity would honor the first matching section (i.e., cc). This would result in `netplan apply` to honor "bb" but subiquity to apply "cc" when reaching the network screen.

Fixed by making Subiquity behave more like netplan. We now sort by section name when determining the right configuration to apply.

LP:#2122583

Context:
----------

Since questing, we now ship `/etc/netplan/00-installer-config.yaml` containing the following config:

```yaml
network:
    version: 2
    ethernets:
        zz-all-en:
            match:
                name: "en*"
            dhcp4: true
            dhcp6: true
            accept-ra: true
        zz-all-eth:
            match:
                name: "eth*"
            dhcp4: true
            dhcp6: true
            accept-ra: true
```

If we are in a scenario where cloud-init (or other) ships a network config in `/etc/netplan/50-cloud-init.yaml`, like the following:
```yaml
network:
  version: 2
  ethernets:
    ens3:
      addresses: [1.1.1.1/24]
```
* `netplan apply` results in `1.1.1.1/24` to be configured on `ens3` - because `ens3` comes before `zz-all-en` in lexical order.
* But upon entering the network screen, Subiquity used to switch to `DHCP` (because `00-*.yaml` comes before `50-*.yaml` in lexical order).