### PR TITLE
vmtests: create

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
-files: "(console_conf|subiquity|subiquitycore|doc)"
+files: "(console_conf|subiquity|subiquitycore|vmtests|doc)"
 repos:
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:
       - id: black
-        files: "(console_conf|subiquity|subiquitycore)"
+        files: "(console_conf|subiquity|subiquitycore|vmtests)"
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
     hooks:
       - id: isort
         name: isort
-        files: "(console_conf|subiquity|subiquitycore)"
+        files: "(console_conf|subiquity|subiquitycore|vmtests)"
   - repo: local
     hooks:
       - id: doc-spelling

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ flake8:
 .PHONY: unit
 unit: gitdeps
 	timeout 120 \
-	$(PYTHON) -m pytest --ignore curtin --ignore probert \
+	$(PYTHON) -m pytest console_conf subiquity subiquitycore \
 		--ignore subiquity/tests/api \
 		$(UNITTESTARGS)
 

--- a/vmtests/README.md
+++ b/vmtests/README.md
@@ -1,0 +1,21 @@
+
+# vmtests
+
+vmtests for subiquity work by way of virt-install and autoinstall.  SSH is
+setup with a passwordless authentication key so that, both at install time and
+first boot, the system under test can be automated and analyzed.
+
+See `vmtests/tests/test_basic.py` for a simple example of a vmtest.
+See the VMM and VM classes in `vmtests/tests/conftest.py` for more details and
+API.
+
+## run
+
+The vmtests expect to run from the subiquity top-level directory. The `--iso`
+argument is mandatory.  With python3-xdist and enough memory, the `-n` option
+can be used to run multiple tests in parallel - but you probably don't want
+`-n auto`.
+
+```
+PYTHONPATH=. pytest-3 --iso=$iso vmtests
+```

--- a/vmtests/base-cloud-config.yaml
+++ b/vmtests/base-cloud-config.yaml
@@ -1,0 +1,33 @@
+#cloud-config
+
+# the users section here sets up the live environment with what we need to be
+# able to ssh in.  At test runtime, a ssh key is added.
+users:
+  - default
+  - name: ubuntu
+    plain_text_passwd: ubuntu
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: users, admin
+    shell: /bin/bash
+    lock_passwd: false
+
+bootcmd:
+  - apt install -y openssh-server
+
+autoinstall:
+  version: 1
+
+  # create a default user.  Tests may override if desired.
+  identity:
+    realname: ''
+    hostname: ubuntu
+    username: ubuntu
+    password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+
+  # this sets up the target system with the ability to ssh in, for first boot
+  # testing.  At test runtime, a ssh key is added.
+  ssh:
+    install-server: true
+    allow-pw: false
+
+  shutdown: poweroff

--- a/vmtests/tests/__init__.py
+++ b/vmtests/tests/__init__.py
@@ -1,0 +1,19 @@
+import contextlib
+from enum import Enum, auto
+
+import pytest
+
+MiB = 1 << 20
+GiB = 1 << 30
+
+
+class Firmware:
+    UEFI = "UEFI"
+    BIOS = "BIOS"
+
+
+@contextlib.contextmanager
+def assert_install_error():
+    with pytest.raises(pytest.fail.Exception) as ex:
+        yield
+    ex.match("install failed and reached ERROR state")

--- a/vmtests/tests/conftest.py
+++ b/vmtests/tests/conftest.py
@@ -1,0 +1,463 @@
+import contextlib
+import json
+import re
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+from subprocess import DEVNULL, PIPE, CompletedProcess
+from tempfile import TemporaryDirectory
+from typing import Optional, Sequence
+
+import pytest
+import yaml
+
+from subiquity.models.source import SourceModel
+
+from . import Firmware
+
+
+class VM:
+    def __init__(
+        self,
+        vmm,
+        firmware=Firmware.UEFI,
+        memory_GiB=4,
+        disk_sizes_GiB=[10],
+        cloud_config=None,
+    ):
+        self.vmm = vmm
+        self.firmware = firmware
+        self.memory_GiB = memory_GiB
+        self.disk_sizes_GiB = disk_sizes_GiB
+        self.cloud_config = cloud_config
+        self.parent_tempdir = vmm.tempdir
+        self.live_boot = True
+        self.ip = None
+
+    def __enter__(self):
+        self.exit_stack = es = contextlib.ExitStack()
+        dir = self.parent_tempdir
+        self.tempdir = Path(es.enter_context(TemporaryDirectory(dir=dir)))
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.exit_stack.close()
+
+    def ssh(self, cmd: Sequence[str], check=True) -> CompletedProcess:
+        """
+        SSH to system and run the command, either the installation environment
+        if before first reboot, or to the target system.
+        """
+        if self.ip is None:
+            raise RuntimeError("attempted to ssh prior to SUT having an IP")
+        cmd = ["ssh", *self._ssh_common(), f"ubuntu@{self.ip}", "--", *cmd]
+        return _runcmd(cmd, stdout=PIPE, stderr=DEVNULL, check=check)
+
+    def in_target(self, cmd: Sequence[str]) -> CompletedProcess:
+        """
+        Run the supplied command underneath `curtin in-target`.  Only
+        meaningful during the live install boot, use ssh() instead if testing
+        the first boot of the target system.
+        """
+        assert self.live_boot
+
+        in_target = [
+            "sudo",
+            *self._curtin_cmd(),
+            "in-target",
+            "-i",
+            "-t",
+            "/target",
+            "--",
+        ]
+        return self.ssh(in_target + cmd)
+
+    def lsblk(self) -> dict:
+        """
+        The dictionary representation of `lsblk -Jb`.
+        """
+        sp = self.ssh(["lsblk", "-Jb", "/dev/vda"])
+        return json.loads(sp.stdout.decode())
+
+    def reboot(self) -> None:
+        """
+        Reboot the VM.  If this is the live install boot, signal to the
+        installer that the install should finish cleanly.  Wait for poweroff,
+        start the VM again, and wait for SSH to be available.
+        """
+        self._poweroff()
+        _virsh(["start", self.domain], stdout=DEVNULL)
+        self._wait_for_poweron()
+        self._wait_for_ip()
+        self._wait_for_ssh()
+
+    def _merge_cloud_config(self, cloud_config, pubkey) -> Path:
+        """
+        merge test_cloud_config with the base config, write the result to a
+        temp file, add a few additional test requirements, and return that file
+        """
+        with open("vmtests/base-cloud-config.yaml", "r") as fp:
+            base_cc_data = yaml.safe_load(fp)
+
+        # default to the minimal source.  As the id names vary by ISO, we have
+        # to guess that out, but they should be the one that ends in -minimal.
+        # this default to minimal behavior is done before the merge of test
+        # cloud-config data, as it's intended to be part of the
+        # base-cloud-config.
+        source = SourceModel()
+        with _mounter(self.vmm.option_iso) as iso:
+            with Path(iso / "casper/install-sources.yaml").open() as fp:
+                source.load_from_file(fp)
+        for entry in source.catalog.sources:
+            if entry.id.endswith("-minimal"):
+                minimal_id = entry.id
+                break
+        else:
+            ids = [entry.id for entry in source.catalog.sources]
+            raise RuntimeError(f"minimal catalog entry not found in {ids}")
+        base_cc_data["autoinstall"].setdefault("source", {})["id"] = minimal_id
+
+        if cloud_config is None:
+            merged_cc = base_cc_data
+        else:
+            cc_data = yaml.safe_load(cloud_config)
+            merged_cc = _merge_data(cc_data, base_cc_data)
+
+        # add test ssh key for install system.  This, and everything else
+        # below, is done after merge of test cloud-config because it's core
+        # test infrastructure that tests may not overwrite.
+        merged_cc["users"][1]["ssh_authorized_keys"] = pubkey
+
+        # add test ssh key for target system.
+        merged_cc["autoinstall"]["ssh"]["authorized-keys"] = [pubkey]
+
+        late_cmds = merged_cc["autoinstall"].setdefault("late-commands", [])
+        # all tests should run these commands.  The first one allows us to know
+        # that any test-defined late-commands have completed.  We want to run
+        # test assertions after those test defined late-commands have executed.
+        late_cmds.append("touch /run/wait_for_finish")
+        # This second one is a documented trick for autoinstall to not reboot
+        # until we're ready for it.  This holds the reboot and gives us room to
+        # actually run the test assertions.  When we're ready to reboot to the
+        # target system, we touch /run/finish to move things along.
+        late_cmds.append("while [ ! -f /run/finish ] ; do sleep 1 ; done")
+
+        result = self.tempdir / "cloud-config.yaml"
+        result.write_text("#cloud-config\n" + yaml.dump(merged_cc))
+
+        return result
+
+    def _assert_state_late_commands(self, data: dict) -> None:
+        match data["state"]:
+            case "LATE_COMMANDS":
+                # the good scenario - we have done autoinstall almost to the
+                # end, and are only being held up by active late-commands.
+                # Usually this is just waiting for /run/finish to exist, or it
+                # could be late-commands in the test.
+                return
+            case "ERROR":
+                # install failure
+                pytest.fail("install failed and reached ERROR state")
+            case _:
+                # should never happen
+                pytest.fail(f"unexpected state={data['state']}")
+
+    @contextlib.contextmanager
+    def _install(self, **kwargs) -> None:
+        """
+        Actually do the install.  Typically initiated from VMM.install().
+        """
+        cc_file = self._merge_cloud_config(self.cloud_config, self.vmm.ssh_key_data)
+
+        self.domain = f"subiquity-vmtest-{self.vmm.test_name}-{self.tempdir.name}"
+
+        self.empty = self.tempdir / "meta-data"
+        self.empty.touch()
+
+        cmd = [
+            "virt-install",
+            "--os-variant",
+            "ubuntu-lts-latest",
+            "--name",
+            self.domain,
+            "--memory",
+            str(self.memory_GiB << 10),
+            "--disk",
+            f"size={self.disk_sizes_GiB[0]},target.dev=vda",
+            "--location",
+            f"{str(self.vmm.option_iso)},kernel=/casper/vmlinuz,initrd=/casper/initrd",
+            "--cloud-init",
+            f"user-data={cc_file},meta-data={self.empty}",
+            "--extra-args",
+            "autoinstall",
+            "--noautoconsole",
+        ]
+
+        try:
+            print(f"creating install domain {self.domain}")
+            _runcmd(cmd, stdout=DEVNULL)
+
+            self._wait_for_poweron()
+            self._wait_for_ip()
+            self._wait_for_ssh()
+            self._detect_SNAP()
+            self._wait_for_socket()
+            self._wait_for_finish_sentinel()
+            yield
+
+            if self.live_boot:
+                # we haven't done first boot yet, so do that now as a crude
+                # check that first boot works.  Tests with assertions to run at
+                # first boot should call reboot() before those assertions.
+                self.reboot()
+
+        except (Exception, KeyboardInterrupt):
+            now = datetime.now()
+            ts = f"{now:%Y-%m-%d-%H-%M-%S}"
+            label = f"subiquity-vmtest-{self.vmm.test_name}-{ts}"
+            dest = Path(f"/tmp/{label}")
+            dest.mkdir(exist_ok=False)
+            self._collect_logs(label, dest)
+            print(f"logs written to {dest}")
+            raise
+
+        finally:
+            try:
+                _virsh(["destroy", self.domain], check=False)
+
+            finally:
+                undefine = ["undefine", self.domain, "--remove-all-storage"]
+                _virsh(undefine, stdout=DEVNULL)
+
+    def _collect_logs(self, label, dest):
+        self.ssh(
+            [
+                "sudo",
+                "sh -c 'journalctl -b > /var/log/installer/installer-journal.log'",
+            ],
+        )
+        tarball = f"/tmp/{label}.tgz"
+        self.ssh(["sudo", "tar", "zcvf", tarball, "/var/log/installer"], check=False)
+        self._scp_get(tarball, str(dest), check=False)
+
+    def _scp_get(self, infile, dest, check=True) -> None:
+        if self.ip is None:
+            raise RuntimeError("attempted to ssh prior to SUT having an IP")
+        cmd = ["scp", *self._ssh_common(), f"ubuntu@{self.ip}:{infile}", dest]
+        _runcmd(cmd, stdout=PIPE, stderr=DEVNULL, check=check)
+
+    def _get_ip(self) -> Optional[str]:
+        sp = _virsh(["domifaddr", self.domain], stdout=PIPE, check=False)
+        if sp.returncode != 0:
+            return None
+        for line in sp.stdout.decode().splitlines():
+            m = re.fullmatch(r".*ipv4\s+(\d+\.\d+\.\d+\.\d+).*", line)
+            if m is not None:
+                return m.group(1)
+        return None
+
+    def _retry_fn(self, fn, label, wait_seconds=300) -> None:
+        print(f"wait for {label}.", end="", flush=True)
+        for _ in range(wait_seconds):
+            if fn():
+                break
+            time.sleep(1)
+            print(".", end="", flush=True)
+        else:
+            pytest.fail(f"{label} never happened")
+        print("done")
+
+    def _wait_for_ip(self) -> None:
+        def ip_getter() -> bool:
+            self.ip = self._get_ip()
+            return self.ip is not None
+
+        self._retry_fn(ip_getter, "ip")
+
+    def _wait_for_ssh_cmd(self, args, label, **kwargs):
+        def ssh_cmd() -> bool:
+            return self.ssh(args, check=False).returncode == 0
+
+        self._retry_fn(ssh_cmd, label, **kwargs)
+
+    def _wait_for_ssh(self):
+        self._wait_for_ssh_cmd(["/bin/true"], "ssh")
+
+    def _detect_SNAP(self) -> None:
+        """is this subiquity or ubuntu-desktop-bootstrap?"""
+        subscript = """
+            ([ -d /snap/subiquity ] && echo subiquity) ||
+            ([ -d /snap/ubuntu-desktop-bootstrap ] && echo ubuntu-desktop-bootstrap) ||
+            echo UNKNOWN
+        """
+        sp = self.ssh(["sh", "-c", subscript])
+        name = sp.stdout.decode().strip()
+        if name == "UNKNOWN":
+            raise RuntimeError("failed to detect installer snap")
+        else:
+            self.snap = name
+
+    def _wait_for_socket(self):
+        self._wait_for_ssh_cmd(["test", "-S", "/run/subiquity/socket"], "socket")
+
+    def _wait_for_finish_sentinel(self):
+        print("wait for end state.", end="", flush=True)
+        while True:
+            sp = self.ssh(
+                ["curl", "--unix-socket", "/run/subiquity/socket", "a/meta/status"],
+            )
+            data = json.loads(sp.stdout)
+            if data["state"] in ("LATE_COMMANDS", "DONE", "ERROR", "EXITED"):
+                break
+            print(".", end="", flush=True)
+            time.sleep(1)
+        print(f"done: {data['state']}")
+        self._assert_state_late_commands(data)
+
+        # We use late-commands to catch the install nearly being complete but
+        # not 100% done.  If a test uses late commands, wait for those to be
+        # done.  Before waiting on /run/finish, late-commands will create
+        # /run/wait_for_finish, which signifies that that the install is
+        # functionally complete and ready for our test assertions.
+        sentinel_cmd = ["test", "-f", "/run/wait_for_finish"]
+        self._wait_for_ssh_cmd(sentinel_cmd, "install completion")
+
+    def _ssh_common(self) -> Sequence:
+        return [
+            "-i",
+            str(self.vmm.ssh_key),
+            "-F",
+            "none",
+            "-oStrictHostKeyChecking=off",
+            "-oUserKnownHostsFile=/dev/null",
+        ]
+
+    def _wait_for_domstate(self, expected):
+        def check_domstate() -> bool:
+            sp = _virsh(["domstate", self.domain], stdout=PIPE)
+            return expected == sp.stdout.decode().splitlines()[0]
+
+        self._retry_fn(check_domstate, f"domain {expected}")
+
+    def _wait_for_poweroff(self):
+        self._wait_for_domstate("shut off")
+
+    def _wait_for_poweron(self):
+        self._wait_for_domstate("running")
+
+    def _poweroff(self) -> None:
+        if self.live_boot:
+            self.ssh(["sudo", "touch", "/run/finish"])
+            self.live_boot = False
+        else:
+            _virsh(["shutdown", self.domain], stdout=DEVNULL)
+        self._wait_for_poweroff()
+
+    def _curtin_cmd(self) -> Sequence[str]:
+        if self.snap == "subiquity":
+            return ["subiquity.curtin"]
+        if self.snap == "ubuntu-desktop-bootstrap":
+            return [
+                "/snap/ubuntu-desktop-bootstrap/current/bin/subiquity/bin/subiquity-cmd",
+                "curtin",
+            ]
+        raise RuntimeError("failed to detect installer snap")
+
+
+class VMM:
+    """
+    The virtual machine manager is used to create a VM and start an install.
+    """
+
+    def __init__(self, request, option_iso):
+        self.request = request
+        self.option_iso = option_iso
+
+    @property
+    def test_name(self):
+        return self.request.node.name
+
+    def __enter__(self):
+        self.exit_stack = es = contextlib.ExitStack()
+        self.tempdir = Path(es.enter_context(TemporaryDirectory()))
+        self.ssh_key_data = self._create_ssh_key()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.exit_stack.close()
+
+    def install(self, **kwargs) -> VM:
+        """
+        Build a VM, establish the hardware configuration, and start an install.
+        """
+        result = self.exit_stack.enter_context(VM(vmm=self, **kwargs))
+        self.exit_stack.enter_context(result._install())
+        return result
+
+    def _create_ssh_key(self) -> str:
+        self.ssh_key = self.tempdir / "ssh_key"
+        keygen = ["ssh-keygen", "-f", str(self.ssh_key), "-N", ""]
+        _runcmd(keygen, stdout=DEVNULL)
+        return (self.tempdir / "ssh_key.pub").read_text().strip()
+
+
+@pytest.fixture
+def vmm(request, option_iso):
+    assert option_iso is not None, "--iso=/path/to/file.iso must be supplied"
+
+    isofile = Path(option_iso)
+    if not isofile.exists() or not isofile.is_file():
+        pytest.fail(f"{option_iso} is not a valid install iso")
+
+    with VMM(request, isofile) as _vmm:
+        yield _vmm
+
+
+def pytest_addoption(parser):
+    parser.addoption("--iso", action="store")
+
+
+@pytest.fixture
+def option_iso(request):
+    return request.config.getoption("--iso")
+
+
+@contextlib.contextmanager
+def _mounter(src):
+    with TemporaryDirectory() as td:
+        _runcmd(["fuseiso", str(src), td])
+        try:
+            yield Path(td)
+        finally:
+            _runcmd(["fusermount", "-u", td])
+
+
+def _runcmd(cmd, check=True, **kwargs):
+    print(f'running command "{cmd}"')
+    return subprocess.run(cmd, check=check, **kwargs)
+
+
+def _virsh(cmd, **kwargs):
+    return _runcmd(["virsh", "--connect", "qemu:///system"] + cmd, **kwargs)
+
+
+def _merge_data(src: dict, dest: dict) -> dict:
+    """
+    Merge data from src to dest, without modifying src or dst.
+    Return the merged data.
+    """
+    dest = dest.copy()
+    for key, value in src.items():
+        if key in dest and type(value) != type(dest[key]):
+            raise ValueError(
+                f"merge undefined for {key=} src_val={value} dest_val={dest[key]}"
+            )
+
+        if isinstance(value, dict) and key in dest:
+            dest[key] = _merge_data(value, dest[key])
+        elif isinstance(value, list) and key in dest:
+            dest[key].extend(value)
+        else:
+            dest[key] = value
+    return dest

--- a/vmtests/tests/test_basic.py
+++ b/vmtests/tests/test_basic.py
@@ -1,0 +1,25 @@
+import pytest
+
+from . import Firmware, GiB, MiB, assert_install_error
+
+
+def test_bios_direct(vmm):
+    # please keep this test simple, it's meant to be an introduction to the
+    # concept.
+    cc = """
+      autoinstall:
+        storage:
+          layout:
+            name: direct
+    """
+
+    sut = vmm.install(
+        firmware=Firmware.BIOS,
+        disk_sizes_GiB=[10],
+        cloud_config=cc,
+    )
+
+    [vda] = sut.lsblk()["blockdevices"]
+    [vda1, vda2] = vda["children"]
+    assert vda1["size"] == MiB
+    assert vda2["size"] == 10 * GiB - 3 * MiB

--- a/vmtests/tests/test_failures.py
+++ b/vmtests/tests/test_failures.py
@@ -1,0 +1,25 @@
+import pytest
+
+from . import assert_install_error
+
+
+def test_bad_early(vmm):
+    cc = """
+      autoinstall:
+        early-commands:
+          - /bin/false
+    """
+
+    with assert_install_error():
+        vmm.install(cloud_config=cc)
+
+
+def test_invalid_source_id(vmm):
+    cc = """
+      autoinstall:
+        source:
+          id: invalid-id
+    """
+
+    with assert_install_error():
+        vmm.install(cloud_config=cc)


### PR DESCRIPTION
Add a vmtests directory with a framework based on pytest, virt-install, and autoinstall to automate test runs in a VM.

Sample invocation:
```
pytest-3 --iso=/srv/iso/resolute/resolute-live-server-amd64.iso
```