### PR TITLE
Raise API recoverable error or autoinstall error if passing an invalid timezone

### DIFF
--- a/subiquity/server/controllers/tests/test_timezone.py
+++ b/subiquity/server/controllers/tests/test_timezone.py
@@ -20,7 +20,10 @@ from jsonschema.validators import validator_for
 
 from subiquity.common.types import TimeZoneInfo
 from subiquity.models.timezone import TimeZoneModel
-from subiquity.server.controllers.timezone import TimeZoneController
+from subiquity.server.controllers.timezone import (
+    TimeZoneController,
+    UnknownTimezoneError,
+)
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
 
@@ -106,7 +109,7 @@ class TestTimeZoneController(SubiTestCase):
             "notatimezone",
         ]
         for b in bads:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(UnknownTimezoneError):
                 self.tzc.deserialize(b)
 
     @mock.patch("subprocess.run")

--- a/subiquity/server/controllers/timezone.py
+++ b/subiquity/server/controllers/timezone.py
@@ -108,7 +108,10 @@ class TimeZoneController(SubiquityController):
         return self.possible
 
     def load_autoinstall_data(self, data):
-        self.deserialize(data)
+        try:
+            self.deserialize(data)
+        except UnknownTimezoneError as exc:
+            raise AutoinstallError(exc.args[0]) from exc
 
     def make_autoinstall(self):
         return self.serialize()


### PR DESCRIPTION
Specifying an invalid timezone in a POST request to `/timezone` will now produce a recoverable error that does not crash the server process:

```bash
curl --unix-socket /run/subiquity/socket http://a/timezone'?tz="Europe/Missing"' -X POST -v
```
```python
< HTTP/1.1 422 Unprocessable Entity
< x-status: error
< x-error-type: UnknownTimezoneError
< x-error-msg: "unknown timezone: Europe/Missing"
< x-error-code: timezone-unknown-tz
< x-error-title: "Unknown timezone"
[...]
Traceback (most recent call last):
  File "/home/olivier.gayot@canonical.com/dev/subiquity/subiquity/common/api/server.py", line 165, in handler
    result = await implementation(**args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "subiquity/server/controllers/timezone.py", line 151, in POST
    self.deserialize(tz)
  File "subiquity/server/controllers/timezone.py", line 125, in deserialize
    raise UnknownTimezoneError(data)
subiquity.server.controllers.timezone.UnknownTimezoneError: unknown timezone: Europe/Missing

```
Also, specifying an invalid timezone through autoinstall will now produce an autoinstall error:
```yaml
timezone: Europe/Kiev
```

```
finish: subiquity/TimeZone/load_autoinstall_data: unknown timezone: Europe/Kiev
finish: subiquity/load_autoinstall_config: unknown timezone: Europe/Kiev
```

If running in semi interactive mode, it gives:
<img width="738" height="292" alt="Screenshot from 2026-02-24 15-00-51" src="https://github.com/user-attachments/assets/57e58ceb-6bef-47c0-ad63-4e6f75cd4dd7" />

LP:#2141845