### PR TITLE
POC: produce Swagger documentation for subiquity's API

### DIFF
--- a/apt-deps.txt
+++ b/apt-deps.txt
@@ -16,6 +16,7 @@ pandoc
 passwd
 pre-commit
 python3-aiohttp
+python3-aiohttp-apispec
 python3-aioresponses
 python3-apport
 python3-async-timeout

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -131,6 +131,7 @@ parts:
       - lsb-release
       - ntfs-3g
       - python3-aiohttp
+      - python3-aiohttp-apispec
       - python3-apport
       - python3-attr
       - python3-bson

--- a/subiquity/common/api/server.py
+++ b/subiquity/common/api/server.py
@@ -200,6 +200,9 @@ def _make_handler(
 
     handler.controller = controller
 
+    if hasattr(definition, "__apispec__"):
+        handler.__apispec__ = definition.__apispec__
+
     return handler
 
 

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -16,6 +16,8 @@
 import enum
 from typing import List, Optional
 
+from aiohttp_apispec import docs
+
 from subiquity.common.api.defs import (
     Payload,
     allowed_before_start,
@@ -492,8 +494,22 @@ class API:
             def GET(username: str) -> UsernameValidation: ...
 
     class ssh:
+        @docs(
+            summary="Get SSH configuration",
+            description="""\
+Return the current SSH configuration, including whether the SSH server is \
+installed and enabled, and the list SSH keys imported.""",
+            responses={200: {"description": "OK"}},
+        )
         def GET() -> SSHData: ...
 
+        @docs(
+            summary="Configure the SSH server",
+            description="""\
+Configure if the SSH server is installed and enabled.
+One can also pass SSH keys to be added as authorized keys for the user.""",
+            responses={200: {"description": "OK"}},
+        )
         def POST(data: Payload[SSHData]) -> None: ...
 
         class fetch_id:

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -25,6 +25,7 @@ from typing import Any, List, Optional
 import jsonschema
 import yaml
 from aiohttp import web
+from aiohttp_apispec import setup_aiohttp_apispec
 from jsonschema.exceptions import ValidationError
 from systemd import journal
 
@@ -803,6 +804,13 @@ class SubiquityServer(Application):
             bind(app.router, API.dry_run, DryRunController(self))
         for controller in self.controllers.instances:
             controller.add_routes(app)
+        setup_aiohttp_apispec(
+            app=app,
+            title="Subiquity API documentation",
+            version="v1",
+            url="/swagger.json",
+            swagger_path="/docs",
+        )
         runner = web.AppRunner(app, keepalive_timeout=0xFFFFFFFF, access_log=None)
         await runner.setup()
         site = web.UnixSite(runner, self.opts.socket)


### PR DESCRIPTION
Using python3-aiohttp-apispec, one can now document our API using `@docs` decorators in `subiquity/common/apidef.py`. I did a very simple example (without specifying the parameters and response schema).

The `swagger.json` file can be downloaded at `/swagger.json`

```json
{
  "paths": {
    "/ssh": {
      "get": {
        "responses": {
          "200": {
            "description": "OK"
          }
        },
        "parameters": [],
        "summary": "Get SSH configuration",
        "description": "Return the current SSH configuration, including whether the SSH server is installed and enabled, and whether SSH keys are imported. ",
        "produces": [
          "application/json"
        ]
      },
      "post": {
        "responses": {
          "200": {
            "description": "OK"
          }
        },
        "parameters": [],
        "summary": "Configure the SSH server",
        "description": "Configure if the SSH server is installed and enabled.\nOne can also pass SSH keys to be added as authorized keys for the user.",
        "produces": [
          "application/json"
        ]
      }
    }
  },
  "info": {
    "title": "Subiquity API documentation",
    "version": "v1"
  },
  "swagger": "2.0"
}
```
It can then be fed to local tools or online tools such as https://editor.swagger.io/

Example on editor.swagger.io:

<img width="1224" height="687" alt="Screenshot from 2026-03-12 19-32-15" src="https://github.com/user-attachments/assets/f1afdf55-0785-4beb-91e9-9ac7bee00d01" />

