### PR TITLE
refresh: don't restart server if /refresh/progress change ID is not ours

### DIFF
--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -64,6 +64,13 @@ class RefreshController(SubiquityController):
         self.app.hub.subscribe(
             InstallerChannels.SNAPD_NETWORK_CHANGE, self.snapd_network_changed
         )
+        # List of snapd change IDs for refresh operations that we initiated.
+        # We use a list because refresh operations can fail and be restarted.
+        # This was introduced to avoid accidentally restarting the server when
+        # a client queries progress using a change_id that that it not ours (or
+        # in practice, belongs to a server process that was running before the
+        # refresh.  See LP: #2146422.
+        self.initiated_changes: list[str] = []
 
     def load_autoinstall_data(self, data):
         if data is not None:
@@ -219,15 +226,21 @@ class RefreshController(SubiquityController):
                 "v2/snaps/%s returned %s", self.snap_name, http_err.response.text
             )
             raise
+        self.initiated_changes.append(change_id)
         context.description = "change id: {}".format(change_id)
         return change_id
 
     async def get_progress(self, change_id: str) -> Change:
         change = await self.app.snapdapi.v2.changes[change_id].GET()
         if change.status == TaskStatus.DONE:
-            # Clearly if we got here we didn't get restarted by
-            # snapd/systemctl (dry-run mode)
-            self.app.restart()
+            # TODO instead of relying on self.initiated_changes, we should
+            # move the call to self.app.restart away from the GET handler.
+            # Maybe we should start a monitoring task when we initiate the
+            # refresh.
+            if change_id in self.initiated_changes:
+                # Clearly if we got here we didn't get restarted by
+                # snapd/systemctl (dry-run mode)
+                self.app.restart()
         return change
 
     async def GET(self, wait: bool = False) -> RefreshStatus:

--- a/subiquity/server/controllers/tests/test_refresh.py
+++ b/subiquity/server/controllers/tests/test_refresh.py
@@ -20,6 +20,7 @@ import requests
 import requests_mock
 from jsonschema.validators import validator_for
 
+from subiquity.common.types import Change, TaskStatus
 from subiquity.server.controllers import refresh as refresh_mod
 from subiquity.server.controllers.refresh import RefreshController, SnapChannelSource
 from subiquity.server.snapd import api as snapdapi
@@ -27,6 +28,7 @@ from subiquity.server.snapd import types as snapdtypes
 from subiquitycore.snapd import AsyncSnapd, SnapdConnection, get_fake_connection
 from subiquitycore.tests import SubiTestCase
 from subiquitycore.tests.mocks import make_app
+from subiquitycore.tests.parameterized import parameterized
 
 
 class TestRefreshController(SubiTestCase):
@@ -142,3 +144,47 @@ class TestRefreshController(SubiTestCase):
                     await self.rc.start_update()
 
             self.assertIn('snap \\"subiquity\\" has \\"update\\"', logs.output[0])
+
+    @parameterized.expand(
+        (
+            # Here it's our own change
+            (7, TaskStatus.DO, [7], False),
+            (7, TaskStatus.DOING, [7], False),
+            (7, TaskStatus.DONE, [7], True),
+            (7, TaskStatus.DONE, [6, 7], True),
+            # And here, it's somebody else's
+            (7, TaskStatus.DO, [], False),
+            (7, TaskStatus.DOING, [], False),
+            (7, TaskStatus.DONE, [], False),
+            (7, TaskStatus.DONE, [1, 2, 3], False),
+        ),
+    )
+    async def test_get_progress(
+        self,
+        cid: str,
+        change_status: TaskStatus,
+        our_change_ids: list[str],
+        expect_server_restart: bool,
+    ):
+        self.app.restart = mock.Mock()
+
+        change = Change(
+            id=cid,
+            kind="refresh-snap",
+            summary='Refresh "Subiquity" snap',
+            status=change_status,
+            tasks=[],
+            ready=False,
+        )
+
+        self.rc.initiated_changes = our_change_ids
+
+        with mock.patch.object(
+            self.app.snapdapi.v2, "changes", {cid: mock.AsyncMock()}
+        ) as m_changes:
+            m_changes[cid].GET = mock.AsyncMock(return_value=change)
+            change = await self.rc.get_progress(cid)
+        if expect_server_restart:
+            self.app.restart.assert_called_once()
+        else:
+            self.app.restart.assert_not_called()

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -1078,6 +1078,8 @@ class SubiquityServer(Application):
         self.hub.broadcast(InstallerChannels.SNAPD_NETWORK_CHANGE)
 
     def restart(self):
+        # FIXME this method can only work if we're running the subiquity snap.
+        # For ubuntu-desktop-bootstrap, this would just cause a server shutdown.
         if not self.snapd:
             return
         cmdline = ["snap", "run", "subiquity.subiquity-server"]


### PR DESCRIPTION
Currently, the GET handler for /refresh/progress can trigger a server restart if the change ID specified corresponds to a DONE change.
    
This is generally a bad practice. First, because the server should be able to restart without the client querying /refresh/progress.  But more importantly, because the GET method is considered a safe method, and clients are allowed to retry safe requests on failure.

Therefore, if a client sends a GET /refresh/progress and this causes the server to restart, the client can decide to retry the request when the server becomes available again.

And this can cause the server to restart in a loop, until the client gives up. This causes various issues like clients receiving `ServerDisconnectedError` exceptions.

Ideally, we would never trigger a server restart in the GET handler. But doing so properly requires major code changes (i.e, currently the server does not monitor the refresh progress, without the client's intervention).

For now, we'll make sure that we only trigger a server restart if the change ID requested actually corresponds to a refresh operation **that was initiated by the current server process**.

Otherwise, if the change ID does not belong to us, we'll simply return the snapd change with status DONE.

LP:#2146422