### PR TITLE
fix assign_omitted_offsets exiting early on multi-disk systems

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1873,11 +1873,18 @@ class FilesystemModel:
                 prev_end = part.offset + part.size
 
             if not logical_parts:
-                return
+                continue
 
-            extended_part = next(
+            extended_parts = list(
                 filter(lambda x: x.flag == "extended", disk.partitions())
             )
+            if not extended_parts:
+                log.warning(
+                    "Disk %s has logical partitions but no extended partition",
+                    disk.path,
+                )
+                continue
+            extended_part = extended_parts[0]
 
             prev_end = extended_part.offset
             for part in logical_parts:

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -2269,3 +2269,46 @@ class TestDiskForMatch(SubiTestCase):
         ]
         self.assertEqual(vdb, m.disk_for_match([vda, vdb], match))
         self.assertEqual([vdb], m.disks_for_match([vda, vdb], match))
+
+
+class TestAssignOmittedOffsets(SubiTestCase):
+    def test_multi_disk_offsets_assigned(self):
+        """assign_omitted_offsets must process all disks, not just the first."""
+        m = make_model(storage_version=2)
+        d1 = make_disk(m, path="/dev/nvme0n1", ptable="gpt")
+        d2 = make_disk(m, path="/dev/nvme1n1", ptable="gpt")
+
+        p1 = make_partition(m, d1, size=50 * (2**30))
+        p2 = make_partition(m, d2, size=50 * (2**30))
+
+        # Clear offsets to simulate what _actions_from_config produces
+        # when the autoinstall config omits them.
+        p1.offset = None
+        p2.offset = None
+
+        m.assign_omitted_offsets()
+
+        self.assertIsNotNone(p1.offset)
+        self.assertIsNotNone(p2.offset)
+
+    def test_single_disk_no_logical(self):
+        """A single GPT disk with no logical parts gets offsets assigned."""
+        m = make_model(storage_version=2)
+        d = make_disk(m, ptable="gpt")
+        p = make_partition(m, d, size=10 * (2**30))
+        p.offset = None
+
+        m.assign_omitted_offsets()
+
+        self.assertIsNotNone(p.offset)
+
+    def test_storage_version_1_is_noop(self):
+        """assign_omitted_offsets does nothing for storage version 1."""
+        m = make_model(storage_version=1)
+        d = make_disk(m, ptable="gpt")
+        p = make_partition(m, d, size=10 * (2**30))
+        p.offset = None
+
+        m.assign_omitted_offsets()
+
+        self.assertIsNone(p.offset)


### PR DESCRIPTION
## Summary

`assign_omitted_offsets()` uses `return` instead of `continue` when a disk has
no logical partitions (line 1876 of `subiquity/models/filesystem.py`). Since the
function iterates over all disks in a `for disk in self._all(type="disk"):` loop,
this causes it to exit entirely after processing the first disk, leaving
partitions on subsequent disks with `offset=None`.

Later, `partitions_by_offset()` calls `sorted(..., key=lambda p: p.offset)`,
which crashes with:

```
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```

Any storage v2 autoinstall config with two or more GPT disks triggers this
because GPT disks never have MBR logical partitions.

LP:#2146858

## Changes

- **`return` -> `continue`** so the loop processes all disks
- Replace bare `next(filter(...))` for extended partition lookup with a guarded
  `list(filter(...))` to avoid `StopIteration` if the data is inconsistent
- Add `TestAssignOmittedOffsets` test class (this function was previously
  untested)

## Related

- LP:#2093314 crashes at the same site (`partitions_by_offset`) but the root
  cause identified there is partitions with a literal offset of 0 on USB media.
  This is a separate code path where offsets are never assigned at all.