### PR TITLE
filesystem: add rd.auto=1 to grub for storage with md RAID

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2155,6 +2155,12 @@ class FilesystemModel:
             config["swap"] = {"size": 0}
         if self.grub is not None:
             config["grub"] = self.grub
+        if self.all_raids():
+            config.setdefault("write_files", {})
+            config["write_files"]["grub_md_raid"] = {
+                "path": "etc/default/grub.d/50-curtin-md.cfg",
+                "content": 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX rd.auto=1"\n',
+            }
         return config
 
     def load_probe_data(self, probe_data):

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1326,6 +1326,26 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertTrue(disk2.id in rendered_ids)
         self.assertTrue(disk2p1.id in rendered_ids)
 
+    def test_render_raid_adds_rd_auto_grub_cfg(self):
+        model, raid = make_model_and_raid()
+        fs = model.add_filesystem(raid, "ext4")
+        model.add_mount(fs, "/")
+        rendered = model.render()
+        self.assertIn("write_files", rendered)
+        self.assertIn("grub_md_raid", rendered["write_files"])
+        wf = rendered["write_files"]["grub_md_raid"]
+        self.assertEqual(wf["path"], "etc/default/grub.d/50-curtin-md.cfg")
+        self.assertIn("rd.auto=1", wf["content"])
+
+    def test_render_no_raid_omits_rd_auto_grub_cfg(self):
+        model = make_model(Bootloader.NONE)
+        disk = make_disk(model)
+        part = make_partition(model, disk)
+        fs = model.add_filesystem(part, "ext4")
+        model.add_mount(fs, "/")
+        rendered = model.render()
+        self.assertNotIn("write_files", rendered)
+
 
 class TestPartitionNumbering(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Ubuntu 26.04 switched from initramfs-tools to dracut. Dracut does not auto-assemble md arrays without the rd.auto=1 kernel parameter, causing boot failure when the root filesystem is on md RAID due to MD device UUID not being found (as it is not assembled).

Write a grub.d config snippet via curtin write_files so rd.auto=1 is included in GRUB_CMDLINE_LINUX whenever md RAID arrays are present.