### PR TITLE
snapcraft: default user in group lxd

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -177,6 +177,11 @@ parts:
       echo "get passwd/user-default-groups" | \
         debconf-communicate user-setup | \
         cut -d ' ' -f 2- > $CRAFT_PART_INSTALL/users-and-groups
+        # add lxd to the groups for the default user,
+        # but we don't want lxd added to the default groups in user-setup
+        if ! grep -q lxd $CRAFT_PART_INSTALL/users-and-groups; then \
+          sed -i $CRAFT_PART_INSTALL/users-and-groups -e '1s/$/ lxd/'; \
+        fi
     stage:
       - users-and-groups
 

--- a/users-and-groups
+++ b/users-and-groups
@@ -1,1 +1,1 @@
-adm cdrom dip lpadmin plugdev sambashare debian-tor libvirtd users
+adm cdrom dip lpadmin plugdev sambashare debian-tor libvirtd users lxd


### PR DESCRIPTION
Add lxd to the list of groups that the default user should be in. Note that the local users-and-groups file is just a copy convenient for testing, the package user-setup is the source of truth.