### PR TITLE
Drop workarounds for core versions < core24

### DIFF
--- a/subiquity/common/filesystem/spec.py
+++ b/subiquity/common/filesystem/spec.py
@@ -17,17 +17,7 @@
 replaced by `attr.s` structures or similar."""
 
 
-import typing
-from typing import Any, TypedDict
-
-try:
-    from typing import Required
-except ImportError:
-    # For compability with Python < 3.11.
-    # TODO Keep only what is in the try block when switching to core24.
-    class Required(typing.Generic[typing.TypeVar("T")]):
-        pass
-
+from typing import Any, Required, TypedDict
 
 from subiquity.models.filesystem import (
     Disk,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -2061,10 +2061,6 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 # self._probe_once_task.wait as if _probe_once_task
                 # gets cancelled, we should be cancelled too.
                 await asyncio.wait_for(self._probe_once_task.task, probert_timeout)
-            except asyncio.CancelledError:
-                # asyncio.CancelledError is a subclass of Exception in
-                # Python 3.6 (sadface)
-                raise
             except Exception as exc:
                 block_discover_log.exception(
                     "block probing failed restricted=%s", restricted

--- a/subiquity/server/controllers/network.py
+++ b/subiquity/server/controllers/network.py
@@ -205,10 +205,6 @@ class NetworkController(BaseNetworkController, SubiquityController):
     async def _apply_config(self, *, context=None, silent=False):
         try:
             await super()._apply_config(context=context, silent=silent)
-        except asyncio.CancelledError:
-            # asyncio.CancelledError is a subclass of Exception in
-            # Python 3.6 (sadface)
-            raise
         except Exception:
             log.exception("_apply_config failed")
             self.model.has_network = False

--- a/subiquity/server/ubuntu_advantage.py
+++ b/subiquity/server/ubuntu_advantage.py
@@ -328,10 +328,7 @@ class UAInterface:
         """
         info = await self.get_subscription_status(token)
 
-        # Sometimes, a time zone offset of 0 is replaced by the letter Z. This
-        # is specified in RFC 3339 but not supported by fromisoformat before
-        # Python 3.11. See https://bugs.python.org/issue35829
-        expiration = dt.fromisoformat(info["expires"].replace("Z", "+00:00"))
+        expiration = dt.fromisoformat(info["expires"])
         if expiration <= dt.now(datetime.timezone.utc):
             raise ExpiredTokenError(token, expires=info["expires"])
 

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -186,9 +186,6 @@ class Server(Client):
                 self.proc.kill()
             except ProcessLookupError:
                 pass
-            # https://github.com/python/cpython/issues/88050
-            # fixed in python 3.11
-            self.proc._transport.close()
 
 
 class TestAPI(SubiTestCase):

--- a/subiquity/ui/views/ssh.py
+++ b/subiquity/ui/views/ssh.py
@@ -395,12 +395,7 @@ class SSHView(BaseView):
                 make_action_menu_row(
                     [
                         Text("["),
-                        # LP: #2055702 wrap="ellipsis" looks better but it
-                        # produces crashes on non UTF-8 and/or serial
-                        # terminals,
-                        # We can move back to wrap="ellipsis" when we switch to
-                        # core24 or if the fix gets SRUd to jammy.
-                        Text(key, wrap="clip"),
+                        Text(key, wrap="ellipsis"),
                         menu,
                         Text("]"),
                     ],


### PR DESCRIPTION
We have been using core24 in the main branch for a year and a half. There is no need to keep workarounds for core22 or older.