### PR TITLE
storage: don't specify alignment data when formatting a raw device

### DIFF
--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -651,13 +651,15 @@ class FormatEntireStretchy(Stretchy):
             initial.update(initial_data_for_fs(fs))
         elif not isinstance(device, Disk):
             initial["fstype"] = "ext4"
+        # We're reusing the form meant for partitions but specify a maxsize of
+        # zero to hide the size field.
         self.form = PartitionForm(
             self.model,
             0,
             initial,
             None,
             device,
-            alignment=device.alignment_data().part_align,
+            alignment=0,
             remote_storage=device.on_remote_storage(),
         )
         self.form.remove_field("size")


### PR DESCRIPTION
When formatting a disk on the TUI, we use the same form as we use for creating a partition but with removed fields (e.g., size). For partitions, a maximum size and alignement info are needed, so they are mandatory in PartitionForm's initializer.

When formatting a disk though, the alignment info is unused. We still have to pass a value because it is mandatory in PartitionForm but there is no need to give a sound value.

Previously, we would still pass the alignment info that corresponds to a GPT. This makes the code confusing.

Let's specify the alignment info as a zero value instead.