### PR TITLE
Decouple format UI form from partition UI form

### DIFF
--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -44,9 +44,10 @@ from subiquitycore.view import BaseView
 
 from .delete import ConfirmDeleteStretchy, ConfirmReformatStretchy
 from .disk_info import DiskInfoStretchy
+from .format import FormatEntireStretchy
 from .helpers import summarize_device
 from .lvm import VolGroupStretchy
-from .partition import FormatEntireStretchy, PartitionStretchy
+from .partition import PartitionStretchy
 from .raid import RaidStretchy
 
 log = logging.getLogger("subiquity.ui.views.filesystem.filesystem")

--- a/subiquity/ui/views/filesystem/format.py
+++ b/subiquity/ui/views/filesystem/format.py
@@ -1,0 +1,255 @@
+# Copyright 2026 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from urwid import Text, connect_signal
+
+from subiquity.common.filesystem import boot, labels
+from subiquity.models.filesystem import Disk
+from subiquity.ui.mount import (
+    MountField,
+    common_mountpoints,
+    suitable_mountpoints_for_existing_fs,
+)
+from subiquitycore.ui.container import Pile
+from subiquitycore.ui.form import BooleanField, Form, FormField
+from subiquitycore.ui.selector import Selector
+from subiquitycore.ui.stretchy import Stretchy
+
+log = logging.getLogger("subiquity.ui.views.filesystem.format")
+
+
+class FSTypeField(FormField):
+    takes_default_style = False
+
+    def _make_widget(self, form):
+        # This will need to do something different for editing an
+        # existing partition that is already formatted.
+        options = [
+            ("ext4", True),
+            ("xfs", True),
+            ("btrfs", True),
+            ("---", False),
+            ("swap", True),
+        ]
+        if form.existing_fs_type is None:
+            options = options + [
+                ("---", False),
+                (_("Leave unformatted"), True, None),
+            ]
+        else:
+            label = _("Leave formatted as {fstype}").format(
+                fstype=form.existing_fs_type
+            )
+            options = [
+                (label, True, None),
+                ("---", False),
+            ] + options
+        sel = Selector(opts=options)
+        sel.value = None
+        return sel
+
+
+class FormatForm(Form):
+    """Form for formatting (and optionally mounting) a device without partitioning."""
+
+    def __init__(
+        self,
+        model,
+        initial,
+        device,
+        remote_storage: bool,
+    ):
+        self.model = model
+        self.device = device
+        self.existing_fs_type = None
+        self.remote_storage: bool = remote_storage
+        if device:
+            ofstype = device.original_fstype()
+            if ofstype:
+                self.existing_fs_type = ofstype
+        initial_path = initial.get("mount")
+        self.mountpoints = {
+            m.path: m.device.volume
+            for m in self.model.all_mounts()
+            if m.path != initial_path
+        }
+        super().__init__(initial)
+        connect_signal(self.fstype.widget, "select", self.select_fstype)
+        self.form_pile = None
+        self.select_fstype(None, self.fstype.widget.value)
+
+    fstype = FSTypeField(_("Format:"))
+    mount = MountField(_("Mount:"))
+    use_swap = BooleanField(
+        _("Use as swap"), help=_("Use this swap partition in the installed system.")
+    )
+
+    def select_fstype(self, sender, fstype):
+        show_use = False
+        if fstype is None and self.existing_fs_type is not None:
+            self.mount.widget.disable_unsuitable_mountpoints_for_existing_fs()
+            self.mount.value = self.mount.value
+        else:
+            self.mount.widget.enable_common_mountpoints()
+            self.mount.value = self.mount.value
+        if self.remote_storage:
+            self.mount.widget.disable_boot_boot_efi_mountpoints()
+            self.mount.value = self.mount.value
+        if fstype is None:
+            if self.existing_fs_type == "swap":
+                show_use = True
+        if self.form_pile is not None:
+            for i, (w, o) in enumerate(self.form_pile.contents):
+                if w is self.mount._table and show_use:
+                    self.form_pile.contents[i] = (self.use_swap._table, o)
+                elif w is self.use_swap._table and not show_use:
+                    self.form_pile.contents[i] = (self.mount._table, o)
+        if not boot.is_esp(self.device):
+            fstype_for_check = fstype
+            if fstype_for_check is None:
+                fstype_for_check = self.existing_fs_type
+            self.mount.enabled = self.model.is_mounted_filesystem(fstype_for_check)
+        self.fstype.value = fstype
+        self.mount.showing_extra = False
+        self.mount.validate()
+
+    def clean_mount(self, val):
+        if self.model.is_mounted_filesystem(self.fstype):
+            return val
+        else:
+            return None
+
+    def validate_mount(self):
+        mount = self.mount.value
+        if mount is None:
+            return
+        # /usr/include/linux/limits.h:PATH_MAX
+        if len(mount) > 4095:
+            return _("Path exceeds PATH_MAX")
+        dev = self.mountpoints.get(mount)
+        if dev is not None:
+            return _("{device} is already mounted at {path}.").format(
+                device=labels.label(dev).title(), path=mount
+            )
+        if self.existing_fs_type is not None:
+            if self.fstype.value is None:
+                if mount in common_mountpoints:
+                    if mount not in suitable_mountpoints_for_existing_fs:
+                        self.mount.show_extra(
+                            (
+                                "info_error",
+                                _(
+                                    "Mounting an existing filesystem at "
+                                    "{mountpoint} is usually a bad idea, "
+                                    "proceed only with caution."
+                                ).format(mountpoint=mount),
+                            )
+                        )
+        if self.remote_storage and mount in ("/boot", "/boot/efi"):
+            self.mount.show_extra(
+                (
+                    "info_error",
+                    _(
+                        f"The filesystem for {mount} should be stored on local"
+                        " storage. Storing it on remote storage will likely"
+                        " prevent the system from booting."
+                    ),
+                )
+            )
+
+    def as_rows(self):
+        r = super().as_rows()
+        if self.existing_fs_type == "swap":
+            exclude = self.mount._table
+        else:
+            exclude = self.use_swap._table
+        i = r.index(exclude)
+        del r[i - 1 : i + 1]
+        return r
+
+
+def initial_data_for_fs(fs):
+    r = {}
+    if fs is not None:
+        if fs.preserve:
+            r["fstype"] = None
+            if fs.fstype == "swap":
+                r["use_swap"] = fs.mount() is not None
+        else:
+            r["fstype"] = fs.fstype
+        if fs._m.is_mounted_filesystem(fs.fstype):
+            mount = fs.mount()
+            if mount is not None:
+                r["mount"] = mount.path
+            else:
+                r["mount"] = None
+    return r
+
+
+class FormatEntireStretchy(Stretchy):
+    def __init__(self, parent, device):
+        self.device = device
+        self.model = parent.model
+        self.controller = parent.controller
+        self.parent = parent
+
+        initial = {}
+        fs = device.fs()
+        if fs is not None:
+            initial.update(initial_data_for_fs(fs))
+        elif not isinstance(device, Disk):
+            initial["fstype"] = "ext4"
+        self.form = FormatForm(
+            self.model,
+            initial,
+            device,
+            remote_storage=device.on_remote_storage(),
+        )
+
+        connect_signal(self.form, "submit", self.done)
+        connect_signal(self.form, "cancel", self.cancel)
+
+        rows = []
+        if isinstance(device, Disk):
+            rows = [
+                Text(
+                    _(
+                        "Formatting and mounting a disk directly is unusual. "
+                        "You probably want to add a partition instead."
+                    )
+                ),
+                Text(""),
+            ]
+        rows.extend(self.form.as_rows())
+        self.form.form_pile = Pile(rows)
+        widgets = [
+            self.form.form_pile,
+            Text(""),
+            self.form.buttons,
+        ]
+
+        title = _("Format and/or mount {device}").format(device=labels.label(device))
+
+        super().__init__(title, widgets, 0, 0)
+
+    def cancel(self, button=None):
+        self.parent.remove_overlay()
+
+    def done(self, form):
+        log.debug("Format Entire Result: {}".format(form.as_data()))
+        self.controller.add_format_handler(self.device, form.as_data())
+        self.parent.refresh_model_inputs()
+        self.parent.remove_overlay()

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -30,62 +30,30 @@ from subiquity.common.filesystem import boot, gaps, labels
 from subiquity.models.filesystem import (
     HUMAN_UNITS,
     LVM_CHUNK_SIZE,
-    Disk,
     LVM_VolGroup,
     align_up,
     dehumanize_size,
     humanize_size,
 )
-from subiquity.ui.mount import (
-    MountField,
-    common_mountpoints,
-    suitable_mountpoints_for_existing_fs,
+from subiquity.ui.mount import MountField
+from subiquity.ui.views.filesystem.format import (
+    FormatForm,
+    FSTypeField,
+    initial_data_for_fs,
 )
 from subiquitycore.ui.container import Pile
 from subiquitycore.ui.form import (
     BooleanField,
-    Form,
     FormField,
     WantsToKnowFormField,
     simple_field,
 )
 from subiquitycore.ui.interactive import StringEditor
-from subiquitycore.ui.selector import Option, Selector
+from subiquitycore.ui.selector import Option
 from subiquitycore.ui.stretchy import Stretchy
 from subiquitycore.ui.utils import rewrap
 
 log = logging.getLogger("subiquity.ui.views.filesystem.partition")
-
-
-class FSTypeField(FormField):
-    takes_default_style = False
-
-    def _make_widget(self, form):
-        # This will need to do something different for editing an
-        # existing partition that is already formatted.
-        options = [
-            ("ext4", True),
-            ("xfs", True),
-            ("btrfs", True),
-            ("---", False),
-            ("swap", True),
-        ]
-        if form.existing_fs_type is None:
-            options = options + [
-                ("---", False),
-                (_("Leave unformatted"), True, None),
-            ]
-        else:
-            label = _("Leave formatted as {fstype}").format(
-                fstype=form.existing_fs_type
-            )
-            options = [
-                (label, True, None),
-                ("---", False),
-            ] + options
-        sel = Selector(opts=options)
-        sel.value = None
-        return sel
 
 
 class SizeWidget(StringEditor):
@@ -161,7 +129,12 @@ class LVNameEditor(StringEditor, WantsToKnowFormField):
 LVNameField = simple_field(LVNameEditor)
 
 
-class PartitionForm(Form):
+class PartitionForm(FormatForm):
+    """Form for adding or editing a partition (or LVM logical volume).
+
+    Extends FormatForm with name and size fields.
+    """
+
     def __init__(
         self,
         model,
@@ -172,62 +145,18 @@ class PartitionForm(Form):
         alignment,
         remote_storage: bool,
     ):
-        self.model = model
-        self.device = device
-        self.existing_fs_type = None
-        self.remote_storage: bool = remote_storage
-        if device:
-            ofstype = device.original_fstype()
-            if ofstype:
-                self.existing_fs_type = ofstype
-        initial_path = initial.get("mount")
-        self.mountpoints = {
-            m.path: m.device.volume
-            for m in self.model.all_mounts()
-            if m.path != initial_path
-        }
         self.max_size = max_size
+        self.lvm_names = lvm_names
+        self.alignment = alignment
         if max_size is not None:
             self.size_str = humanize_size(max_size)
             self.size.caption = _("Size (max {size}):").format(size=self.size_str)
-        self.lvm_names = lvm_names
-        self.alignment = alignment
-        super().__init__(initial)
+        super().__init__(model, initial, device, remote_storage)
         if max_size is None:
             self.remove_field("size")
-        connect_signal(self.fstype.widget, "select", self.select_fstype)
-        self.form_pile = None
-        self.select_fstype(None, self.fstype.widget.value)
 
-    def select_fstype(self, sender, fstype):
-        show_use = False
-        if fstype is None and self.existing_fs_type is not None:
-            self.mount.widget.disable_unsuitable_mountpoints_for_existing_fs()
-            self.mount.value = self.mount.value
-        else:
-            self.mount.widget.enable_common_mountpoints()
-            self.mount.value = self.mount.value
-        if self.remote_storage:
-            self.mount.widget.disable_boot_boot_efi_mountpoints()
-            self.mount.value = self.mount.value
-        if fstype is None:
-            if self.existing_fs_type == "swap":
-                show_use = True
-        if self.form_pile is not None:
-            for i, (w, o) in enumerate(self.form_pile.contents):
-                if w is self.mount._table and show_use:
-                    self.form_pile.contents[i] = (self.use_swap._table, o)
-                elif w is self.use_swap._table and not show_use:
-                    self.form_pile.contents[i] = (self.mount._table, o)
-        if not boot.is_esp(self.device):
-            fstype_for_check = fstype
-            if fstype_for_check is None:
-                fstype_for_check = self.existing_fs_type
-            self.mount.enabled = self.model.is_mounted_filesystem(fstype_for_check)
-        self.fstype.value = fstype
-        self.mount.showing_extra = False
-        self.mount.validate()
-
+    # Fields are re-declared here (in display order) because MetaForm only
+    # collects fields defined directly on each class, not inherited ones.
     name = LVNameField(_("Name: "))
     size = SizeField()
     fstype = FSTypeField(_("Format:"))
@@ -246,12 +175,6 @@ class PartitionForm(Form):
             return self.max_size
         else:
             return dehumanize_size(val)
-
-    def clean_mount(self, val):
-        if self.model.is_mounted_filesystem(self.fstype):
-            return val
-        else:
-            return None
 
     def validate_name(self):
         if self.lvm_names is None:
@@ -284,54 +207,6 @@ class PartitionForm(Form):
             return _("There is already a logical volume named {name}.").format(
                 name=self.name.value
             )
-
-    def validate_mount(self):
-        mount = self.mount.value
-        if mount is None:
-            return
-        # /usr/include/linux/limits.h:PATH_MAX
-        if len(mount) > 4095:
-            return _("Path exceeds PATH_MAX")
-        dev = self.mountpoints.get(mount)
-        if dev is not None:
-            return _("{device} is already mounted at {path}.").format(
-                device=labels.label(dev).title(), path=mount
-            )
-        if self.existing_fs_type is not None:
-            if self.fstype.value is None:
-                if mount in common_mountpoints:
-                    if mount not in suitable_mountpoints_for_existing_fs:
-                        self.mount.show_extra(
-                            (
-                                "info_error",
-                                _(
-                                    "Mounting an existing filesystem at "
-                                    "{mountpoint} is usually a bad idea, "
-                                    "proceed only with caution."
-                                ).format(mountpoint=mount),
-                            )
-                        )
-        if self.remote_storage and mount in ("/boot", "/boot/efi"):
-            self.mount.show_extra(
-                (
-                    "info_error",
-                    _(
-                        f"The filesystem for {mount} should be stored on local"
-                        " storage. Storing it on remote storage will likely"
-                        " prevent the system from booting."
-                    ),
-                )
-            )
-
-    def as_rows(self):
-        r = super().as_rows()
-        if self.existing_fs_type == "swap":
-            exclude = self.mount._table
-        else:
-            exclude = self.use_swap._table
-        i = r.index(exclude)
-        del r[i - 1 : i + 1]
-        return r
 
 
 bios_grub_partition_description = _(
@@ -411,24 +286,6 @@ been selected as a boot device, Grub will be installed onto this
 partition.
 """
 )
-
-
-def initial_data_for_fs(fs):
-    r = {}
-    if fs is not None:
-        if fs.preserve:
-            r["fstype"] = None
-            if fs.fstype == "swap":
-                r["use_swap"] = fs.mount() is not None
-        else:
-            r["fstype"] = fs.fstype
-        if fs._m.is_mounted_filesystem(fs.fstype):
-            mount = fs.mount()
-            if mount is not None:
-                r["mount"] = mount.path
-            else:
-                r["mount"] = None
-    return r
 
 
 class PartitionStretchy(Stretchy):
@@ -633,68 +490,5 @@ class PartitionStretchy(Stretchy):
         else:
             handler = self.controller.partition_disk_handler
         handler(self.disk, spec, partition=self.partition, gap=self.gap)
-        self.parent.refresh_model_inputs()
-        self.parent.remove_overlay()
-
-
-class FormatEntireStretchy(Stretchy):
-    def __init__(self, parent, device):
-        self.device = device
-        self.model = parent.model
-        self.controller = parent.controller
-        self.parent = parent
-
-        initial = {}
-        fs = device.fs()
-        if fs is not None:
-            initial.update(initial_data_for_fs(fs))
-        elif not isinstance(device, Disk):
-            initial["fstype"] = "ext4"
-        # We're reusing the form meant for partitions but specify a maxsize of
-        # zero to hide the size field.
-        self.form = PartitionForm(
-            self.model,
-            0,
-            initial,
-            None,
-            device,
-            alignment=0,
-            remote_storage=device.on_remote_storage(),
-        )
-        self.form.remove_field("size")
-        self.form.remove_field("name")
-
-        connect_signal(self.form, "submit", self.done)
-        connect_signal(self.form, "cancel", self.cancel)
-
-        rows = []
-        if isinstance(device, Disk):
-            rows = [
-                Text(
-                    _(
-                        "Formatting and mounting a disk directly is unusual. "
-                        "You probably want to add a partition instead."
-                    )
-                ),
-                Text(""),
-            ]
-        rows.extend(self.form.as_rows())
-        self.form.form_pile = Pile(rows)
-        widgets = [
-            self.form.form_pile,
-            Text(""),
-            self.form.buttons,
-        ]
-
-        title = _("Format and/or mount {device}").format(device=labels.label(device))
-
-        super().__init__(title, widgets, 0, 0)
-
-    def cancel(self, button=None):
-        self.parent.remove_overlay()
-
-    def done(self, form):
-        log.debug("Format Entire Result: {}".format(form.as_data()))
-        self.controller.add_format_handler(self.device, form.as_data())
         self.parent.refresh_model_inputs()
         self.parent.remove_overlay()

--- a/subiquity/ui/views/filesystem/tests/test_format.py
+++ b/subiquity/ui/views/filesystem/tests/test_format.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest import mock
+
+import urwid
+
+from subiquity.client.controllers.filesystem import FilesystemController
+from subiquity.models.tests.test_filesystem import make_model_and_disk
+from subiquity.ui.mount import common_mountpoints, suitable_mountpoints_for_existing_fs
+from subiquity.ui.views.filesystem.format import (
+    FormatEntireStretchy,
+    FormatForm,
+)
+from subiquitycore.tests.parameterized import parameterized
+from subiquitycore.view import BaseView
+
+
+def make_format_entire_view(model, disk):
+    controller = mock.create_autospec(spec=FilesystemController)
+    base_view = BaseView(urwid.Text(""))
+    base_view.model = model
+    base_view.controller = controller
+    base_view.refresh_model_inputs = lambda: None
+    stretchy = FormatEntireStretchy(base_view, disk)
+    base_view.show_stretchy_overlay(stretchy)
+    return base_view, stretchy
+
+
+class TestFormatEntireStretchy(unittest.TestCase):
+    def test_format_entire_unusual_filesystem(self):
+        model, disk = make_model_and_disk()
+        fs = model.add_filesystem(disk, "ntfs")
+        fs.preserve = True
+        model._orig_config = model._render_actions()
+        view, stretchy = make_format_entire_view(model, disk)
+        self.assertEqual(stretchy.form.fstype.value, None)
+
+
+class TestFormatForm(unittest.TestCase):
+    def _make_mount_form(
+        self,
+        mount_value,
+        *,
+        mountpoints=None,
+        existing_fs_type=None,
+        fstype_value="ext4",
+        remote_storage=False,
+    ):
+        form = mock.MagicMock(spec=FormatForm)
+        form.mount.value = mount_value
+        form.mountpoints = mountpoints if mountpoints is not None else {}
+        form.existing_fs_type = existing_fs_type
+        form.fstype.value = fstype_value
+        form.remote_storage = remote_storage
+        return form
+
+    def _make_clean_mount_form(self, is_mounted):
+        form = mock.MagicMock()
+        form.model.is_mounted_filesystem.return_value = is_mounted
+        return form
+
+    def test_validate_mount__none(self):
+        # None mount value means "leave unmounted"; always accepted.
+        form = self._make_mount_form(None)
+        self.assertIsNone(FormatForm.validate_mount(form))
+
+    def test_validate_mount__error_path_too_long(self):
+        form = self._make_mount_form("a" * 4096)
+        self.assertIsNotNone(FormatForm.validate_mount(form))
+
+    def test_validate_mount__error_already_mounted(self):
+        form = self._make_mount_form(
+            "/home", mountpoints={"/home": mock.sentinel.device}
+        )
+        with mock.patch(
+            "subiquity.ui.views.filesystem.format.labels.label",
+            return_value="sda",
+        ):
+            self.assertIsNotNone(FormatForm.validate_mount(form))
+
+    def test_validate_mount__valid(self):
+        form = self._make_mount_form("/home")
+        self.assertIsNone(FormatForm.validate_mount(form))
+
+    def test_validate_mount__warning_existing_fs_unsuitable_mountpoint(self):
+        # Mounting an existing filesystem at a "bad" common mountpoint shows a
+        # warning but is not an error.
+        unsuitable = next(
+            m
+            for m in common_mountpoints
+            if m not in suitable_mountpoints_for_existing_fs
+        )
+        form = self._make_mount_form(
+            unsuitable,
+            existing_fs_type="ext4",
+            fstype_value=None,
+        )
+        self.assertIsNone(FormatForm.validate_mount(form))
+        form.mount.show_extra.assert_called_once()
+
+    def test_validate_mount__no_warning_existing_fs_suitable_mountpoint(self):
+        # Mounting an existing filesystem at a suitable mountpoint shows no warning.
+        form = self._make_mount_form(
+            "/home",
+            existing_fs_type="ext4",
+            fstype_value=None,
+        )
+        self.assertIsNone(FormatForm.validate_mount(form))
+        form.mount.show_extra.assert_not_called()
+
+    @parameterized.expand([["boot", "/boot"], ["boot_efi", "/boot/efi"]])
+    def test_validate_mount__warning_remote_storage(self, _name, mount):
+        form = self._make_mount_form(mount, remote_storage=True)
+        self.assertIsNone(FormatForm.validate_mount(form))
+        form.mount.show_extra.assert_called_once()
+
+    def test_clean_mount__mounted_filesystem_returns_path(self):
+        form = self._make_clean_mount_form(is_mounted=True)
+        self.assertEqual("/home", FormatForm.clean_mount(form, "/home"))
+
+    def test_clean_mount__unmounted_filesystem_returns_none(self):
+        form = self._make_clean_mount_form(is_mounted=False)
+        self.assertIsNone(FormatForm.clean_mount(form, "/home"))

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -7,9 +7,7 @@ from subiquity.client.controllers.filesystem import FilesystemController
 from subiquity.common.filesystem import gaps
 from subiquity.models.filesystem import MiB, dehumanize_size
 from subiquity.models.tests.test_filesystem import make_model_and_disk
-from subiquity.ui.mount import common_mountpoints, suitable_mountpoints_for_existing_fs
 from subiquity.ui.views.filesystem.partition import (
-    FormatEntireStretchy,
     PartitionForm,
     PartitionStretchy,
 )
@@ -29,17 +27,6 @@ def make_partition_view(model, disk, **kw):
     return base_view, stretchy
 
 
-def make_format_entire_view(model, disk):
-    controller = mock.create_autospec(spec=FilesystemController)
-    base_view = BaseView(urwid.Text(""))
-    base_view.model = model
-    base_view.controller = controller
-    base_view.refresh_model_inputs = lambda: None
-    stretchy = FormatEntireStretchy(base_view, disk)
-    base_view.show_stretchy_overlay(stretchy)
-    return base_view, stretchy
-
-
 class PartitionViewTests(unittest.TestCase):
     def test_initial_focus(self):
         model, disk = make_model_and_disk()
@@ -51,6 +38,29 @@ class PartitionViewTests(unittest.TestCase):
                 return
         else:
             self.fail("Size widget not focus")
+
+    def test_create_partition_unaligned_size(self):
+        # In LP: #2013201, the user would type in 1.1G and the partition
+        # created would not be aligned to a MiB boundary.
+        unaligned_data = {
+            "size": "1.1G",  # Corresponds to 1181116006.4 bytes (not an int)
+            "fstype": "ext4",
+        }
+        valid_data = {
+            "mount": "/",
+            "size": 1127 * MiB,  # ~1.10058 GiB
+            "use_swap": False,
+            "fstype": "ext4",
+        }
+        model, disk = make_model_and_disk()
+        gap = gaps.Gap(device=disk, offset=1 << 20, size=99 << 30)
+        view, stretchy = make_partition_view(model, disk, gap=gap)
+        view_helpers.enter_data(stretchy.form, unaligned_data)
+        stretchy.form.size.widget.lost_focus()
+        view_helpers.click(stretchy.form.done_btn.base_widget)
+        view.controller.partition_disk_handler.assert_called_once_with(
+            stretchy.disk, valid_data, partition=None, gap=gap
+        )
 
     def test_create_partition(self):
         valid_data = {
@@ -240,37 +250,6 @@ class PartitionViewTests(unittest.TestCase):
             stretchy.disk, expected_data, partition=stretchy.partition, gap=None
         )
 
-    def test_format_entire_unusual_filesystem(self):
-        model, disk = make_model_and_disk()
-        fs = model.add_filesystem(disk, "ntfs")
-        fs.preserve = True
-        model._orig_config = model._render_actions()
-        view, stretchy = make_format_entire_view(model, disk)
-        self.assertEqual(stretchy.form.fstype.value, None)
-
-    def test_create_partition_unaligned_size(self):
-        # In LP: #2013201, the user would type in 1.1G and the partition
-        # created would not be aligned to a MiB boundary.
-        unaligned_data = {
-            "size": "1.1G",  # Corresponds to 1181116006.4 bytes (not an int)
-            "fstype": "ext4",
-        }
-        valid_data = {
-            "mount": "/",
-            "size": 1127 * MiB,  # ~1.10058 GiB
-            "use_swap": False,
-            "fstype": "ext4",
-        }
-        model, disk = make_model_and_disk()
-        gap = gaps.Gap(device=disk, offset=1 << 20, size=99 << 30)
-        view, stretchy = make_partition_view(model, disk, gap=gap)
-        view_helpers.enter_data(stretchy.form, unaligned_data)
-        stretchy.form.size.widget.lost_focus()
-        view_helpers.click(stretchy.form.done_btn.base_widget)
-        view.controller.partition_disk_handler.assert_called_once_with(
-            stretchy.disk, valid_data, partition=None, gap=gap
-        )
-
 
 class TestPartitionForm(unittest.TestCase):
     def _make_name_form(self, lvm_names, name_value):
@@ -279,32 +258,10 @@ class TestPartitionForm(unittest.TestCase):
         form.name.value = name_value
         return form
 
-    def _make_mount_form(
-        self,
-        mount_value,
-        *,
-        mountpoints=None,
-        existing_fs_type=None,
-        fstype_value="ext4",
-        remote_storage=False,
-    ):
-        form = mock.MagicMock(spec=PartitionForm)
-        form.mount.value = mount_value
-        form.mountpoints = mountpoints if mountpoints is not None else {}
-        form.existing_fs_type = existing_fs_type
-        form.fstype.value = fstype_value
-        form.remote_storage = remote_storage
-        return form
-
     def _make_size_form(self, size_str, max_size):
         form = mock.MagicMock(spec=PartitionForm)
         form.size_str = size_str
         form.max_size = max_size
-        return form
-
-    def _make_clean_mount_form(self, is_mounted):
-        form = mock.MagicMock()
-        form.model.is_mounted_filesystem.return_value = is_mounted
         return form
 
     def test_validate_name__no_lvm(self):
@@ -342,61 +299,6 @@ class TestPartitionForm(unittest.TestCase):
         form = self._make_name_form({"other-lv"}, "my-lv")
         self.assertIsNone(PartitionForm.validate_name(form))
 
-    def test_validate_mount__none(self):
-        # None mount value means "leave unmounted"; always accepted.
-        form = self._make_mount_form(None)
-        self.assertIsNone(PartitionForm.validate_mount(form))
-
-    def test_validate_mount__error_path_too_long(self):
-        form = self._make_mount_form("a" * 4096)
-        self.assertIsNotNone(PartitionForm.validate_mount(form))
-
-    def test_validate_mount__error_already_mounted(self):
-        form = self._make_mount_form(
-            "/home", mountpoints={"/home": mock.sentinel.device}
-        )
-        with mock.patch(
-            "subiquity.ui.views.filesystem.partition.labels.label",
-            return_value="sda",
-        ):
-            self.assertIsNotNone(PartitionForm.validate_mount(form))
-
-    def test_validate_mount__valid(self):
-        form = self._make_mount_form("/home")
-        self.assertIsNone(PartitionForm.validate_mount(form))
-
-    def test_validate_mount__warning_existing_fs_unsuitable_mountpoint(self):
-        # Mounting an existing filesystem at a "bad" common mountpoint shows a
-        # warning but is not an error.
-        unsuitable = next(
-            m
-            for m in common_mountpoints
-            if m not in suitable_mountpoints_for_existing_fs
-        )
-        form = self._make_mount_form(
-            unsuitable,
-            existing_fs_type="ext4",
-            fstype_value=None,
-        )
-        self.assertIsNone(PartitionForm.validate_mount(form))
-        form.mount.show_extra.assert_called_once()
-
-    def test_validate_mount__no_warning_existing_fs_suitable_mountpoint(self):
-        # Mounting an existing filesystem at a suitable mountpoint shows no warning.
-        form = self._make_mount_form(
-            "/home",
-            existing_fs_type="ext4",
-            fstype_value=None,
-        )
-        self.assertIsNone(PartitionForm.validate_mount(form))
-        form.mount.show_extra.assert_not_called()
-
-    @parameterized.expand([["boot", "/boot"], ["boot_efi", "/boot/efi"]])
-    def test_validate_mount__warning_remote_storage(self, _name, mount):
-        form = self._make_mount_form(mount, remote_storage=True)
-        self.assertIsNone(PartitionForm.validate_mount(form))
-        form.mount.show_extra.assert_called_once()
-
     @parameterized.expand(
         [
             ["empty", ""],
@@ -419,11 +321,3 @@ class TestPartitionForm(unittest.TestCase):
         result = PartitionForm.clean_size(form, val)
         expected = dehumanize_size(val if val[-1].isalpha() else val + "G")
         self.assertEqual(expected, result)
-
-    def test_clean_mount__mounted_filesystem_returns_path(self):
-        form = self._make_clean_mount_form(is_mounted=True)
-        self.assertEqual("/home", PartitionForm.clean_mount(form, "/home"))
-
-    def test_clean_mount__unmounted_filesystem_returns_none(self):
-        form = self._make_clean_mount_form(is_mounted=False)
-        self.assertIsNone(PartitionForm.clean_mount(form, "/home"))

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -7,11 +7,14 @@ from subiquity.client.controllers.filesystem import FilesystemController
 from subiquity.common.filesystem import gaps
 from subiquity.models.filesystem import MiB, dehumanize_size
 from subiquity.models.tests.test_filesystem import make_model_and_disk
+from subiquity.ui.mount import common_mountpoints, suitable_mountpoints_for_existing_fs
 from subiquity.ui.views.filesystem.partition import (
     FormatEntireStretchy,
+    PartitionForm,
     PartitionStretchy,
 )
 from subiquitycore.testing import view_helpers
+from subiquitycore.tests.parameterized import parameterized
 from subiquitycore.view import BaseView
 
 
@@ -267,3 +270,160 @@ class PartitionViewTests(unittest.TestCase):
         view.controller.partition_disk_handler.assert_called_once_with(
             stretchy.disk, valid_data, partition=None, gap=gap
         )
+
+
+class TestPartitionForm(unittest.TestCase):
+    def _make_name_form(self, lvm_names, name_value):
+        form = mock.MagicMock(spec=PartitionForm)
+        form.lvm_names = lvm_names
+        form.name.value = name_value
+        return form
+
+    def _make_mount_form(
+        self,
+        mount_value,
+        *,
+        mountpoints=None,
+        existing_fs_type=None,
+        fstype_value="ext4",
+        remote_storage=False,
+    ):
+        form = mock.MagicMock(spec=PartitionForm)
+        form.mount.value = mount_value
+        form.mountpoints = mountpoints if mountpoints is not None else {}
+        form.existing_fs_type = existing_fs_type
+        form.fstype.value = fstype_value
+        form.remote_storage = remote_storage
+        return form
+
+    def _make_size_form(self, size_str, max_size):
+        form = mock.MagicMock(spec=PartitionForm)
+        form.size_str = size_str
+        form.max_size = max_size
+        return form
+
+    def _make_clean_mount_form(self, is_mounted):
+        form = mock.MagicMock()
+        form.model.is_mounted_filesystem.return_value = is_mounted
+        return form
+
+    def test_validate_name__no_lvm(self):
+        # When lvm_names is None the partition is not an LV; any name is accepted.
+        form = self._make_name_form(None, "")
+        self.assertIsNone(PartitionForm.validate_name(form))
+
+    @parameterized.expand(
+        [
+            ["empty", set(), ""],
+            ["starts_with_hyphen", set(), "-bad"],
+            ["reserved_dot", set(), "."],
+            ["reserved_dotdot", set(), ".."],
+            ["reserved_snapshot", set(), "snapshot"],
+            ["reserved_pvmove", set(), "pvmove"],
+            ["reserved_substring_cdata", set(), "lv_cdata"],
+            ["reserved_substring_cmeta", set(), "lv_cmeta"],
+            ["reserved_substring_corig", set(), "lv_corig"],
+            ["reserved_substring_mlog", set(), "lv_mlog"],
+            ["reserved_substring_mimage", set(), "lv_mimage"],
+            ["reserved_substring_pmspare", set(), "lv_pmspare"],
+            ["reserved_substring_rimage", set(), "lv_rimage"],
+            ["reserved_substring_rmeta", set(), "lv_rmeta"],
+            ["reserved_substring_tdata", set(), "lv_tdata"],
+            ["reserved_substring_tmeta", set(), "lv_tmeta"],
+            ["reserved_substring_vorigin", set(), "lv_vorigin"],
+            ["duplicate", {"existing-lv"}, "existing-lv"],
+        ]
+    )
+    def test_validate_name__invalid(self, _name, lvm_names, name_value):
+        form = self._make_name_form(lvm_names, name_value)
+        self.assertIsNotNone(PartitionForm.validate_name(form))
+
+    def test_validate_name__valid(self):
+        form = self._make_name_form({"other-lv"}, "my-lv")
+        self.assertIsNone(PartitionForm.validate_name(form))
+
+    def test_validate_mount__none(self):
+        # None mount value means "leave unmounted"; always accepted.
+        form = self._make_mount_form(None)
+        self.assertIsNone(PartitionForm.validate_mount(form))
+
+    def test_validate_mount__error_path_too_long(self):
+        form = self._make_mount_form("a" * 4096)
+        self.assertIsNotNone(PartitionForm.validate_mount(form))
+
+    def test_validate_mount__error_already_mounted(self):
+        form = self._make_mount_form(
+            "/home", mountpoints={"/home": mock.sentinel.device}
+        )
+        with mock.patch(
+            "subiquity.ui.views.filesystem.partition.labels.label",
+            return_value="sda",
+        ):
+            self.assertIsNotNone(PartitionForm.validate_mount(form))
+
+    def test_validate_mount__valid(self):
+        form = self._make_mount_form("/home")
+        self.assertIsNone(PartitionForm.validate_mount(form))
+
+    def test_validate_mount__warning_existing_fs_unsuitable_mountpoint(self):
+        # Mounting an existing filesystem at a "bad" common mountpoint shows a
+        # warning but is not an error.
+        unsuitable = next(
+            m
+            for m in common_mountpoints
+            if m not in suitable_mountpoints_for_existing_fs
+        )
+        form = self._make_mount_form(
+            unsuitable,
+            existing_fs_type="ext4",
+            fstype_value=None,
+        )
+        self.assertIsNone(PartitionForm.validate_mount(form))
+        form.mount.show_extra.assert_called_once()
+
+    def test_validate_mount__no_warning_existing_fs_suitable_mountpoint(self):
+        # Mounting an existing filesystem at a suitable mountpoint shows no warning.
+        form = self._make_mount_form(
+            "/home",
+            existing_fs_type="ext4",
+            fstype_value=None,
+        )
+        self.assertIsNone(PartitionForm.validate_mount(form))
+        form.mount.show_extra.assert_not_called()
+
+    @parameterized.expand([["boot", "/boot"], ["boot_efi", "/boot/efi"]])
+    def test_validate_mount__warning_remote_storage(self, _name, mount):
+        form = self._make_mount_form(mount, remote_storage=True)
+        self.assertIsNone(PartitionForm.validate_mount(form))
+        form.mount.show_extra.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ["empty", ""],
+            ["equal_to_size_str", "1.00G"],
+        ]
+    )
+    def test_clean_size__returns_max(self, _name, val):
+        max_size = 1 << 30
+        form = self._make_size_form("1.00G", max_size)
+        self.assertEqual(max_size, PartitionForm.clean_size(form, val))
+
+    @parameterized.expand(
+        [
+            ["with_suffix", "512M"],
+            ["no_suffix_uses_size_str_unit", "512"],
+        ]
+    )
+    def test_clean_size__returns_parsed(self, _name, val):
+        form = self._make_size_form("1.00G", 1 << 30)
+        result = PartitionForm.clean_size(form, val)
+        expected = dehumanize_size(val if val[-1].isalpha() else val + "G")
+        self.assertEqual(expected, result)
+
+    def test_clean_mount__mounted_filesystem_returns_path(self):
+        form = self._make_clean_mount_form(is_mounted=True)
+        self.assertEqual("/home", PartitionForm.clean_mount(form, "/home"))
+
+    def test_clean_mount__unmounted_filesystem_returns_none(self):
+        form = self._make_clean_mount_form(is_mounted=False)
+        self.assertIsNone(PartitionForm.clean_mount(form, "/home"))


### PR DESCRIPTION
When we need to format something without partitioning, we used to lean on the partition form. But the partition form has fields that are no use when formatting only. Instead of passing non sensible values to the initializer and removing fields on the fly, let's have a separate form for formatting only.