### PR TITLE
snaplist: remove deadcode that uses undefined variable

### DIFF
--- a/subiquity/models/snaplist.py
+++ b/subiquity/models/snaplist.py
@@ -43,9 +43,6 @@ class SnapListModel:
         for info in data["result"]:
             self.update(self._snap_for_name(info["name"]), info)
 
-    def add_partial_snap(self, name):
-        self._snaps_for_name(name)
-
     def update(self, snap, data):
         snap.summary = data["summary"]
         snap.publisher = data["developer"]


### PR DESCRIPTION
In the add_partial_snap method, we lean on a member variable called _snaps_for_name (plural). But the instance variable is actually called _snap_for_name (singular). Running this code would cause an exception but the function is not called anywhere.

Let's remove it.