### PR TITLE
Fix some typos in docs, user-facing content but also comments

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -401,8 +401,8 @@ installation. It was helpful to me when working on this to categorize
      least in part because a snap update may resolve them, so the user
      needs to be able to get to that screen before being bothered about them.
    * When the filesystem screen is not interactive, these errors
-     errors are handled as if an immediate error occured when the
-     filesystem config is needed.
+     are handled as if an immediate error occurred when the filesystem config
+     is needed.
  * **API** errors are when an exception occurs while handling an API
    call from the client.
    * These are always bugs and perhaps could be handled as immediate
@@ -544,11 +544,11 @@ see these results).
 
 When adding a new feature to subiquity, I have found it easiest to design the
 UI first and then "work inwards" to design the controller and the model.
-Subiquity is mostly a UI, after all, so starting there does made sense.  I also
+Subiquity is mostly a UI, after all, so starting there does make sense.  I also
 try not to worry about how hard a UI would be to implement!
 
 The model is sometimes quite trivial, because it's basically defined by the
-curtin config, and sometimes much less so (e.g. the fileystem model).
+curtin config, and sometimes much less so (e.g. the filesystem model).
 
 Once the view code and the model exist, the controller "just" sits between
 them. Again, often this is simple, but sometimes it is not.

--- a/doc/explanation/cloudinit-autoinstall-interaction.rst
+++ b/doc/explanation/cloudinit-autoinstall-interaction.rst
@@ -28,7 +28,7 @@ being installed, they must appear under a :ref:`ai-user-data` section under
         # and configure the target system to be installed.
 
         user-data:
-            # cloud-init directives may also be optionally be specified here.
+            # cloud-init directives may also optionally be specified here.
             # These directives also affect the target system to be installed,
             # and are processed on first boot.
 

--- a/doc/howto/autoinstall-validation.rst
+++ b/doc/howto/autoinstall-validation.rst
@@ -3,7 +3,7 @@
 Autoinstall Validation
 =====================================
 
-The following how-to guide demonstrates how to perform pre-validation of a autoinstall config.
+The following how-to guide demonstrates how to perform pre-validation of an autoinstall config.
 
 Autoinstall config is validated against a :doc:`JSON schema <../reference/autoinstall-schema>` during runtime before it is applied. This check ensures existence of required keys and their data types, but does not guarantee total validity of the data provided (see the :ref:`Validator Limitations<validator-limitations>` section for more details).
 
@@ -90,7 +90,7 @@ Validator Limitations
 
 The autoinstall validator currently has the following limitations:
 
-1. The validator makes an assumption about the target installation media that may not necessarily be true about the actual installation media. It assumes that (1) the installation target is ubuntu-server and (2) the only valid install source is :code:`synthesized`. Some cases where this would cause the validator fail otherwise correct autoinstall configurations:
+1. The validator makes an assumption about the target installation media that may not necessarily be true about the actual installation media. It assumes that (1) the installation target is ubuntu-server and (2) the only valid install source is :code:`synthesized`. Some cases where this would cause the validator to fail on otherwise correct autoinstall configurations:
 
    a. Missing both an :code:`identity` and :code:`user-data` section for a Desktop target, where these sections are fully optional.
    b. A :code:`source` section which specifies any :code:`id` other than :code:`synthesized`, where the :code:`id` may really match a valid source on the target ISO.
@@ -166,7 +166,7 @@ Another common mistake is to forget the ``#cloud-config`` header in the cloud-co
             # autoinstall directives
 
 
-Again, this is not indicative of a real runtime error that would appear. Instead, this case would result in having the installer presenting a fully interactive install where a partially or fully automated installation was desired instead.
+Again, this is not indicative of a real runtime error that would appear. Instead, this case would result in the installer presenting a fully interactive install where a partially or fully automated installation was desired instead.
 
 Common Mistake #3
 ^^^^^^^^^^^^^^^^^

--- a/doc/howto/report-bugs.rst
+++ b/doc/howto/report-bugs.rst
@@ -27,6 +27,6 @@ To create a Launchpad bug report based on the contents of a crash report, use th
 
     apport-cli /path/to/report.crash
 
-To run ``apport-cli`` in the installer environment, switch to a shell. This way, ``apport`` can not open a browser to for you to complete the report. Instead, it provides a URL for completing the report, which you can do on another computer.
+To run ``apport-cli`` in the installer environment, switch to a shell. This inhibits ``apport`` from opening a browser for you to complete the report. Instead, it provides a URL for completing the report, which you can do on another computer.
 
 .. note:: Issues for the Subiquity autoinstaller are `tracked in Launchpad <https://bugs.launchpad.net/subiquity>`_.

--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -1095,7 +1095,7 @@ install
 ^^^^^^^
 
 * **type:** boolean or string (special value ``auto``)
-* **default:**: ``auto``
+* **default:** ``auto``
 
 Whether to install the available OEM meta-packages. The special value ``auto`` -- which is the default -- enables the installation on Ubuntu Desktop but not on Ubuntu Server. This option has no effect on core boot classic.
 

--- a/doc/tutorial/screen-by-screen.rst
+++ b/doc/tutorial/screen-by-screen.rst
@@ -62,7 +62,7 @@ Zdev (s390x only)
 
 This screen is only shown on the s390x architecture and allows z-specific configuration of devices.
 
-The list of devices can be long. Use the :kbd:`Home`, :kbd:`End`, :kbd:`PgUp` and :kbd:`PgDn` keys navigate through the list quickly.
+The list of devices can be long. Use the :kbd:`Home`, :kbd:`End`, :kbd:`PgUp` and :kbd:`PgDn` keys to navigate through the list quickly.
 
 Network
 -------

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -355,7 +355,7 @@ class API:
                 default behavior expands partition to fill disk if size not
                 supplied or -1.
                 Other partition fields are ignored.
-                adding a partion when there is not yet a boot partition can
+                adding a partition when there is not yet a boot partition can
                 result in the boot partition being added automatically - see
                 add_boot_partition for more control over this.
                 format=None means an unformatted partition

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1985,7 +1985,7 @@ class FilesystemModel:
         Perhaps surprisingly the order of the returned actions matters.
         The devices are presented in the filesystem view in the reverse
         of the order they appear in _actions, which means that e.g. a
-        RAID appears higher up the list than the disks is is composed
+        RAID appears higher up the list than the disks it is composed
         of. This is quite important as it makes "unpeeling" existing
         compound structures easy, you just delete the top device until
         you only have disks left.

--- a/subiquity/server/apt.py
+++ b/subiquity/server/apt.py
@@ -201,7 +201,7 @@ class AptConfigurer:
         try:
             shutil.chown(partial_dir, user="_apt")
         except (PermissionError, LookupError) as exc:
-            log.warning("could to set owner of file %s: %r", partial_dir, exc)
+            log.warning("could not set owner of file %s: %r", partial_dir, exc)
 
         apt_cmd = [
             "apt-get",

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -851,7 +851,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
     def start_guided_erase_install(
         self, target: GuidedStorageTargetEraseInstall, disk: ModelDisk
     ) -> gaps.Gap:
-        """Remove the targetted partition and return the resulting gap. If
+        """Remove the targeted partition and return the resulting gap. If
         there was free space before or after the partition being removed, it
         will be included in the returned gap. Therefore gap.offset and gap.size
         will not necessarily match partition.offset and partition.size."""
@@ -1712,7 +1712,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 # these two scenarios:
                 # 1. No intention to change the partition name:
                 #     {"partition": {"number": 1, ...}
-                # 2. Attemping to reset the partition name:
+                # 2. Attempting to reset the partition name:
                 #     {"partition": {"number": 1, "name": null, ...}
                 log.warning(
                     "cannot tell if the user wants to keep the current"

--- a/subiquity/server/controllers/oem.py
+++ b/subiquity/server/controllers/oem.py
@@ -216,7 +216,7 @@ class OEMController(SubiquityController):
             if kernel_model.explicitly_requested:
                 msg = _(
                     """\
-A specific kernel flavor was requested but it cannot be satistified when \
+A specific kernel flavor was requested but it cannot be satisfied when \
 installing on certified hardware or other hardware covered by HWE kernels.
 You should either disable the installation of OEM meta-packages using the \
 following autoinstall snippet or let the installer decide which kernel to

--- a/subiquity/server/controllers/tests/test_kernel.py
+++ b/subiquity/server/controllers/tests/test_kernel.py
@@ -154,7 +154,7 @@ class TestMetapackageSelection(SubiTestCase):
     async def test_bridge_options(self, scenario):
         # This test "knows" a bit too much about which conditions the
         # bridge kernel code uses to check for the various
-        # reasons. But its better than no tests.
+        # reasons. But it's better than no tests.
         source_model = self.app.base_model.source = SourceModel()
         source_model.catalog.kernel.default = "linux-default"
         source_model.catalog.kernel.bridge = "linux-bridge"

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -538,7 +538,7 @@ class SubiquityServer(Application):
         # Some common errors have apport reports written closer to where the
         # exception was originally thrown. We write a generic "unknown error"
         # report for cases where it wasn't written already, except in cases
-        # where we want to explicitly supress report generation (e.g., bad
+        # where we want to explicitly suppress report generation (e.g., bad
         # autoinstall cases).
 
         report: Optional[ErrorReport] = None

--- a/subiquity/server/ubuntu_advantage.py
+++ b/subiquity/server/ubuntu_advantage.py
@@ -147,7 +147,7 @@ class MockedUAInterfaceStrategy(UAInterfaceStrategy):
         }
 
     async def magic_wait_v1(self, magic_token: str) -> dict:
-        """Simulate a timeout respnose from u.pro.attach.magic.wait.v1
+        """Simulate a timeout response from u.pro.attach.magic.wait.v1
         endpoint."""
         # Simulate a normal timeout
         await asyncio.sleep(600 / self.scale_factor)
@@ -165,7 +165,7 @@ class MockedUAInterfaceStrategy(UAInterfaceStrategy):
         }
 
     async def magic_revoke_v1(self, magic_token: str) -> dict:
-        """Simulate a success respnose from u.pro.attach.magic.revoke.v1
+        """Simulate a success response from u.pro.attach.magic.revoke.v1
         endpoint."""
         await asyncio.sleep(1 / self.scale_factor)
         return {

--- a/subiquity/ui/views/filesystem/compound.py
+++ b/subiquity/ui/views/filesystem/compound.py
@@ -199,7 +199,7 @@ class CompoundDiskForm(Form):
                     # An empty disk can always have a boot partition added.
                     potential_boot_disks.add(d)
                 elif d.preserve:
-                    # As can a disk that still has it's original
+                    # As can a disk that still has its original
                     # partition table (it can be reformatted, or it
                     # might already have a bootloader partition we can
                     # reuse)

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -397,7 +397,7 @@ unconfigured_prep_partition_description = _(
     """\
 Required bootloader partition
 
-This is the PReP partion which is required on POWER. If this disk is
+This is the PReP partition which is required on POWER. If this disk is
 selected as a boot device, Grub will be installed onto this partition.
 """
 )
@@ -406,7 +406,7 @@ configured_prep_partition_description = _(
     """\
 Required bootloader partition
 
-This is the PReP partion which is required on POWER. As this disk has
+This is the PReP partition which is required on POWER. As this disk has
 been selected as a boot device, Grub will be installed onto this
 partition.
 """

--- a/subiquity/ui/views/ubuntu_pro.py
+++ b/subiquity/ui/views/ubuntu_pro.py
@@ -590,7 +590,7 @@ class UbuntuProView(BaseView):
 
     def on_contract_selected(self, contract_token: str) -> None:
         """Function to call when the contract selection has finished
-        succesfully."""
+        successfully."""
         checking_token_overlay = CheckingContractToken(self)
         self.show_overlay(
             checking_token_overlay, width=checking_token_overlay.width, min_width=None
@@ -603,7 +603,7 @@ class UbuntuProView(BaseView):
 
             log.error(
                 "contract-token obtained using contract-selection"
-                " counld not be validated: %r",
+                " could not be validated: %r",
                 status,
             )
             self._w = self.upgrade_mode_screen()


### PR DESCRIPTION
https://github.com/canonical/curtin/pull/48 contains part of the doc fixes needed for the CI. But it looks like maybe something else is needed.