### PR TITLE
refresh: store change IDs in a set

### DIFF
--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -64,13 +64,13 @@ class RefreshController(SubiquityController):
         self.app.hub.subscribe(
             InstallerChannels.SNAPD_NETWORK_CHANGE, self.snapd_network_changed
         )
-        # List of snapd change IDs for refresh operations that we initiated.
-        # We use a list because refresh operations can fail and be restarted.
-        # This was introduced to avoid accidentally restarting the server when
-        # a client queries progress using a change_id that is not ours (or in
-        # practice, belongs to a server process that was running before the
-        # refresh.  See LP: #2146422.
-        self.initiated_changes: list[str] = []
+        # Snapd change IDs for refresh operations that we initiated.
+        # We store multiple because refresh operations can fail and be
+        # restarted.  This was introduced to avoid accidentally restarting the
+        # server when a client queries progress using a change_id that is not
+        # ours (or in practice, belongs to a server process that was running
+        # before the refresh.  See LP: #2146422.
+        self.initiated_changes: set[str] = []
 
     def load_autoinstall_data(self, data):
         if data is not None:
@@ -226,7 +226,7 @@ class RefreshController(SubiquityController):
                 "v2/snaps/%s returned %s", self.snap_name, http_err.response.text
             )
             raise
-        self.initiated_changes.append(change_id)
+        self.initiated_changes.add(change_id)
         context.description = "change id: {}".format(change_id)
         return change_id
 

--- a/subiquity/server/controllers/tests/test_refresh.py
+++ b/subiquity/server/controllers/tests/test_refresh.py
@@ -148,15 +148,15 @@ class TestRefreshController(SubiTestCase):
     @parameterized.expand(
         (
             # Here it's our own change
-            (7, TaskStatus.DO, [7], False),
-            (7, TaskStatus.DOING, [7], False),
-            (7, TaskStatus.DONE, [7], True),
-            (7, TaskStatus.DONE, [6, 7], True),
+            ("7", TaskStatus.DO, ["7"], False),
+            ("7", TaskStatus.DOING, ["7"], False),
+            ("7", TaskStatus.DONE, ["7"], True),
+            ("7", TaskStatus.DONE, ["6", "7"], True),
             # And here, it's somebody else's
-            (7, TaskStatus.DO, [], False),
-            (7, TaskStatus.DOING, [], False),
-            (7, TaskStatus.DONE, [], False),
-            (7, TaskStatus.DONE, [1, 2, 3], False),
+            ("7", TaskStatus.DO, [], False),
+            ("7", TaskStatus.DOING, [], False),
+            ("7", TaskStatus.DONE, [], False),
+            ("7", TaskStatus.DONE, ["1", "2", "3"], False),
         ),
     )
     async def test_get_progress(

--- a/subiquity/server/controllers/tests/test_refresh.py
+++ b/subiquity/server/controllers/tests/test_refresh.py
@@ -177,7 +177,7 @@ class TestRefreshController(SubiTestCase):
             ready=False,
         )
 
-        self.rc.initiated_changes = our_change_ids
+        self.rc.initiated_changes = set(our_change_ids)
 
         with mock.patch.object(
             self.app.snapdapi.v2, "changes", {cid: mock.AsyncMock()}


### PR DESCRIPTION
These two fixes were suggested by copilot as part of #2348  but we needed to act fast before the 26.04 release. This is essentially a follow on PR that addresses the suggestions.