### PR TITLE
storage: make questionable classmethod a staticmethod instead

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1567,8 +1567,8 @@ class FilesystemModel:
         ),
     }
 
-    @classmethod
-    def is_mounted_filesystem(self, fstype):
+    @staticmethod
+    def is_mounted_filesystem(fstype):
         if fstype in [None, "swap"]:
             return False
         else:


### PR DESCRIPTION
In commit 51cf1afc91f1720785e1966744003b2adba6d5b0, we introduced FilesystemModel.is_mounted_filesystem to replace the old FilesystemModel.get_fs_by_name method.

That said, we preserved the `@classmethod` decorator even though:
 * the first parameter is called `self`, not `cls`
 * we do not use `self` (or `cls`).

I think we originally wanted to drop the `@classmethod` decorator but forgot to do so. Either way, the method itself does not use any of the class' attributes. It essentially belongs to the class for name-spacing so let's make it a `@staticmethod` instead.