### PR TITLE
Fix mount field not automatically updated when fstype is selected

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1568,7 +1568,7 @@ class FilesystemModel:
     }
 
     @staticmethod
-    def is_mounted_filesystem(fstype):
+    def is_mounted_filesystem(fstype: str | None):
         if fstype in [None, "swap"]:
             return False
         else:

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -248,7 +248,7 @@ class PartitionForm(Form):
             return dehumanize_size(val)
 
     def clean_mount(self, val):
-        if self.model.is_mounted_filesystem(self.fstype):
+        if self.model.is_mounted_filesystem(self.fstype.value):
             return val
         else:
             return None

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -203,13 +203,16 @@ class PartitionForm(Form):
         show_use = False
         if fstype is None and self.existing_fs_type is not None:
             self.mount.widget.disable_unsuitable_mountpoints_for_existing_fs()
-            self.mount.value = self.mount.value
         else:
             self.mount.widget.enable_common_mountpoints()
-            self.mount.value = self.mount.value
         if self.remote_storage:
             self.mount.widget.disable_boot_boot_efi_mountpoints()
-            self.mount.value = self.mount.value
+        self.fstype.value = fstype
+        # The right side of the following expression is a getter that leans on
+        # clean_mount(), whose return value depends on self.fstype.value. It is
+        # important that fstype.value is set before, or we would be operating
+        # based on its previous value.
+        self.mount.value = self.mount.value
         if fstype is None:
             if self.existing_fs_type == "swap":
                 show_use = True
@@ -224,7 +227,6 @@ class PartitionForm(Form):
             if fstype_for_check is None:
                 fstype_for_check = self.existing_fs_type
             self.mount.enabled = self.model.is_mounted_filesystem(fstype_for_check)
-        self.fstype.value = fstype
         self.mount.showing_extra = False
         self.mount.validate()
 


### PR DESCRIPTION
As reported in #2369, the `clean_mount` function was essentially useless because it was passing the bound form field to `is_mounted_filesystem` instead of its value.

After fixing this bug though, it became clear that after changing a filesystem type, the mount field was updated using the old fstype value, not the new one. This made the UI worse.

The second patch in this PR ensures that when we refresh the mount field, we use the new fstype value, not the old one. 

See the different screen captures:

Original behavior

[Screencast From 2026-06-02 14-04-12.webm](https://github.com/user-attachments/assets/cc0cd69c-4939-4467-8ee0-2a70c0be6911)

Intermediate behavior (worse)

[Screencast From 2026-06-02 14-10-28.webm](https://github.com/user-attachments/assets/8c2e7024-daa0-4468-b37b-46b3f3fc0066)

Final behavior

[Screencast From 2026-06-02 14-05-18.webm](https://github.com/user-attachments/assets/9985bb6a-b586-4f0d-9185-9fb39b777ef9)

