### PR TITLE
Backport noble - storage - group partition actions together when rendering

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -26,8 +26,10 @@ import secrets
 import tempfile
 from abc import ABC, abstractmethod
 from typing import (
+    Any,
     Callable,
     Dict,
+    Iterator,
     List,
     Literal,
     Optional,
@@ -1981,13 +1983,18 @@ class FilesystemModel:
         return objs
 
     def _render_actions(self, mode: ActionRenderMode = ActionRenderMode.DEFAULT):
-        # The curtin storage config has the constraint that an action must be
-        # preceded by all the things that it depends on.  We handle this by
-        # repeatedly iterating over all actions and checking if we can emit
-        # each action by checking if all of the actions it depends on have been
-        # emitted.  Eventually this will either emit all actions or stop making
-        # progress -- which means there is a cycle in the definitions,
-        # something the UI should have prevented <wink>.
+        # The curtin storage config has the following constraints:
+        #  * an action must be preceded by all the things that it depends on.
+        #    We handle this by repeatedly iterating over all actions and checking
+        #    if we can emit each action by checking if all of the actions it
+        #    depends on have been emitted.  Eventually this will either emit
+        #    all actions or stop making progress -- which means there is a
+        #    cycle in the definitions, something the UI should have prevented
+        #    <wink>.
+        #  * All {type: partition} actions for a given device must be grouped
+        #    together to avoid adding a partition to a device that is already
+        #    in use (i.e., typically because of a {type: mount} action).
+        #    See LP: #2146873
         r = []
         emitted_ids = set()
 
@@ -2037,6 +2044,27 @@ class FilesystemModel:
                             return False
             return True
 
+        def grouped_partition_actions(
+            actions: list[dict[str, Any]],
+        ) -> Iterator[dict[str, Any]]:
+            # While this function could work with model objects instead of
+            # rendered actions, it is currently executed after actions are
+            # emitted to avoid forgetting any partition.
+            # If we were to execute it before, we would not consider partitions
+            # actions automatically added as dependencies in "can_emit".
+            device_to_partitions = collections.defaultdict(list)
+
+            for action in actions:
+                if action["type"] == "partition":
+                    device_to_partitions[action["device"]].append(action)
+
+            for action in actions:
+                if action["type"] == "partition":
+                    if device_to_partitions[action["device"]][0] is action:
+                        yield from device_to_partitions[action["device"]]
+                else:
+                    yield action
+
         mountpoints = {m.path: m.id for m in self.all_mountlikes()}
         log.debug("mountpoints %s", mountpoints)
 
@@ -2075,7 +2103,7 @@ class FilesystemModel:
                     act["volume"] = device["id"]
             r = devices + r
 
-        return r
+        return list(grouped_partition_actions(r))
 
     def render(self, mode: ActionRenderMode = ActionRenderMode.DEFAULT):
         if self.dd_target is not None:

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -38,6 +38,7 @@ from subiquity.models.filesystem import (
     RecoveryKeyHandler,
     ZPool,
     align_down,
+    asdict,
     dehumanize_size,
     get_canmount,
     get_raid_size,
@@ -1155,6 +1156,40 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertTrue(disk1p1.id in rendered_ids)
         self.assertTrue(disk2.id in rendered_ids)
         self.assertTrue(disk2p1.id in rendered_ids)
+
+    def test_render_groups_partitions_together(self):
+        """Ensure that rendered partition actions for a given disk are grouped
+        together, even when the actions were not created back to back"""
+        model = make_model(Bootloader.NONE)
+
+        d1 = make_disk(model)
+        d1p1 = make_partition(model, d1)
+        d1p1fs = model.add_filesystem(d1p1, "ext4")
+        model.add_mount(d1p1fs, "/")
+        d1p2 = make_partition(model, d1)
+        d1p2fs = model.add_filesystem(d1p2, "ext4")
+        model.add_mount(d1p2fs, "/home")
+        d1p3 = make_partition(model, d1)
+        d1p3fs = model.add_filesystem(d1p3, "ext4")
+        model.add_mount(d1p3fs, "/boot")
+
+        d2 = make_disk(model)
+        d2p1 = make_partition(model, d2)
+        model.add_filesystem(d2p1, "ext4")
+        d2p2 = make_partition(model, d2)
+
+        rendered_actions = model._render_actions()
+
+        d1p1_idx = rendered_actions.index(asdict(d1p1, for_api=False))
+        d1p2_idx = rendered_actions.index(asdict(d1p2, for_api=False))
+        d1p3_idx = rendered_actions.index(asdict(d1p3, for_api=False))
+
+        d2p1_idx = rendered_actions.index(asdict(d2p1, for_api=False))
+        d2p2_idx = rendered_actions.index(asdict(d2p2, for_api=False))
+
+        self.assertEqual(1 + d1p1_idx, d1p2_idx)
+        self.assertEqual(1 + d1p2_idx, d1p3_idx)
+        self.assertEqual(1 + d2p1_idx, d2p2_idx)
 
 
 class TestPartitionNumbering(unittest.TestCase):


### PR DESCRIPTION
Backport for noble of the following: https://github.com/canonical/subiquity/pull/2363

LP:#2146873

(cherry picked from commit 78c75dd382ec9eda8b72ed16565d861fbb8ded30)