### PR TITLE
Introduce storage requirements system, including ext4 /boot requirement for SecureBoot

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -40,6 +40,7 @@ subiquity/common/storage/boot.py
 subiquity/common/storage/__init__.py
 subiquity/common/storage/labels.py
 subiquity/common/storage/manipulator.py
+subiquity/common/storage/requirements.py
 subiquity/common/storage/tests/__init__.py
 subiquity/common/storage/tests/test_actions.py
 subiquity/common/storage/tests/test_labels.py

--- a/subiquity/client/controllers/storage.py
+++ b/subiquity/client/controllers/storage.py
@@ -285,6 +285,7 @@ class StorageController(SubiquityTuiController, StorageManipulator):
         self.model = StorageModel(
             status.bootloader,
             root="/",
+            dry_run=self.app.opts.dry_run,
             opt_supports_nvme_tcp_booting=self.supports_nvme_tcp_booting,
         )
         self.model.load_server_data(status)

--- a/subiquity/common/storage/requirements.py
+++ b/subiquity/common/storage/requirements.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING
 
 import attrs
 
+from subiquitycore.lsb_release import lsb_release
+
 if TYPE_CHECKING:
     # Avoid circular import: models/storage.py imports Requirements
     # from this module at the top level.
@@ -95,6 +97,14 @@ def _is_boot_ext4(model) -> bool:
     return mount.fstype == "ext4"
 
 
+def _needs_ext4_boot(model) -> bool:
+    """UEFI systems with signed GRUB require ext4 for /boot on 26.10+."""
+    if not model.is_root_mounted() or not model.uses_signed_grub():
+        return False
+    release = lsb_release(dry_run=model.dry_run)["release"]
+    return tuple(int(p) for p in release.split(".")) >= (26, 10)
+
+
 class Requirements:
     """Well-known install-readiness checks for storage setup.
 
@@ -124,7 +134,7 @@ class Requirements:
         guidance_message_kind=GuidanceMessageKind.USE_EXT4_BOOT,
         severity=RequirementSeverity.BLOCKING,
         check=_is_boot_ext4,
-        applies_to=lambda m: m.is_root_mounted() and m.uses_signed_grub(),
+        applies_to=_needs_ext4_boot,
     )
 
     @staticmethod

--- a/subiquity/common/storage/requirements.py
+++ b/subiquity/common/storage/requirements.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import enum
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import attrs
+
+if TYPE_CHECKING:
+    # Avoid circular import: models/storage.py imports Requirements
+    # from this module at the top level.
+    from subiquity.models.storage import StorageModel
+
+
+class RequirementSeverity(enum.Enum):
+    """How seriously a violated requirement should be treated."""
+
+    BLOCKING = "blocking"
+    WARNING = "warning"
+
+
+@attrs.define
+class StorageRequirement:
+    """A single install-readiness check with a user-facing guidance message.
+
+    Attributes
+    ----------
+    guidance_message:
+        Translatable string shown to the user when the requirement is violated.
+    severity:
+        Whether a violation blocks installation or is merely advisory.
+    check:
+        Callable that returns True when the requirement is satisfied.
+    applies_to:
+        Callable that returns True when this requirement is relevant for
+        the current system configuration.  Defaults to always applicable.
+    """
+
+    guidance_message: str
+    severity: RequirementSeverity
+    check: Callable[["StorageModel"], bool]
+    applies_to: Callable[["StorageModel"], bool] = lambda m: True
+
+    def is_applicable(self, model) -> bool:
+        """Return True if this requirement applies to the given model."""
+        return self.applies_to(model)
+
+    def is_satisfied(self, model) -> bool:
+        """Return True if this requirement's condition is met."""
+        return self.check(model)
+
+    def is_violated(self, model) -> bool:
+        """Return True when this requirement applies but is not satisfied."""
+        return self.is_applicable(model) and not self.is_satisfied(model)
+
+
+class Requirements:
+    """Well-known install-readiness checks for storage setup.
+
+    Each class attribute is a named ``StorageRequirement`` instance.
+    Use ``Requirements.all()`` to iterate over every registered requirement.
+    """
+
+    ROOT_MOUNTED = StorageRequirement(
+        guidance_message=_("Mount a filesystem at /"),
+        severity=RequirementSeverity.BLOCKING,
+        check=lambda m: m.is_root_mounted(),
+    )
+    REMOTE_BOOT_LOCAL = StorageRequirement(
+        guidance_message=_("Mount a local filesystem at /boot"),
+        severity=RequirementSeverity.BLOCKING,
+        check=lambda m: m.is_boot_mounted() and not m.is_bootfs_on_remote_storage(),
+        applies_to=lambda m: m.is_root_mounted()
+        and m.is_rootfs_on_remote_storage()
+        and not m.supports_nvme_tcp_booting,
+    )
+    BOOTLOADER_NEEDED = StorageRequirement(
+        guidance_message=_("Select a boot disk"),
+        severity=RequirementSeverity.BLOCKING,
+        check=lambda m: not m.needs_bootloader_partition(),
+    )
+
+    @staticmethod
+    def all() -> list[StorageRequirement]:
+        """Return every registered requirement in evaluation order."""
+        return [
+            Requirements.ROOT_MOUNTED,
+            Requirements.REMOTE_BOOT_LOCAL,
+            Requirements.BOOTLOADER_NEEDED,
+        ]

--- a/subiquity/common/storage/requirements.py
+++ b/subiquity/common/storage/requirements.py
@@ -66,6 +66,17 @@ class StorageRequirement:
         return self.is_applicable(model) and not self.is_satisfied(model)
 
 
+def _is_boot_ext4(model) -> bool:
+    """Return True when /boot (or / if no separate boot) uses the ext4
+    filesystem.  Only meaningful on GRUB-based architectures where ext4
+    is the validated boot filesystem.  Other filesystems that GRUB
+    supports (ext2, ext3, FAT, ISO9660, ...) are not validated here."""
+    mount = model._mount_for_path("/boot", parent_ok=True)
+    if mount is None:
+        return False
+    return mount.fstype == "ext4"
+
+
 class Requirements:
     """Well-known install-readiness checks for storage setup.
 
@@ -91,6 +102,12 @@ class Requirements:
         severity=RequirementSeverity.BLOCKING,
         check=lambda m: not m.needs_bootloader_partition(),
     )
+    BOOT_FILESYSTEM = StorageRequirement(
+        guidance_message=_("Use the ext4 filesystem for /boot"),
+        severity=RequirementSeverity.BLOCKING,
+        check=_is_boot_ext4,
+        applies_to=lambda m: m.is_root_mounted() and m.uses_signed_grub(),
+    )
 
     @staticmethod
     def all() -> list[StorageRequirement]:
@@ -99,4 +116,5 @@ class Requirements:
             Requirements.ROOT_MOUNTED,
             Requirements.REMOTE_BOOT_LOCAL,
             Requirements.BOOTLOADER_NEEDED,
+            Requirements.BOOT_FILESYSTEM,
         ]

--- a/subiquity/common/storage/requirements.py
+++ b/subiquity/common/storage/requirements.py
@@ -31,14 +31,32 @@ class RequirementSeverity(enum.Enum):
     WARNING = "warning"
 
 
+class GuidanceMessageKind(enum.Enum):
+    """User-facing guidance messages shown when a storage requirement is
+    violated.
+
+    Use the member (e.g. ``GuidanceMessageKind.MOUNT_ROOT``) in APIs and wire
+    protocols — the member's **key** is the stable identifier.  The
+    ``.value`` is a locale-dependent translated string and **must not**
+    be sent over the API or stored in configuration.
+    """
+
+    MOUNT_ROOT = _("Mount a filesystem at /")
+    MOUNT_LOCAL_BOOT = _("Mount a local filesystem at /boot")
+    SELECT_BOOT_DISK = _("Select a boot disk")
+    USE_EXT4_BOOT = _("Use the ext4 filesystem for /boot")
+
+
 @attrs.define
 class StorageRequirement:
     """A single install-readiness check with a user-facing guidance message.
 
     Attributes
     ----------
-    guidance_message:
-        Translatable string shown to the user when the requirement is violated.
+    guidance_message_kind:
+        Enum member identifying the kind of guidance message to show the user
+        when the requirement is violated.  The enum's ``.value`` is a
+        locale-dependent translated string.
     severity:
         Whether a violation blocks installation or is merely advisory.
     check:
@@ -48,7 +66,7 @@ class StorageRequirement:
         the current system configuration.  Defaults to always applicable.
     """
 
-    guidance_message: str
+    guidance_message_kind: GuidanceMessageKind
     severity: RequirementSeverity
     check: Callable[["StorageModel"], bool]
     applies_to: Callable[["StorageModel"], bool] = lambda m: True
@@ -85,12 +103,12 @@ class Requirements:
     """
 
     ROOT_MOUNTED = StorageRequirement(
-        guidance_message=_("Mount a filesystem at /"),
+        guidance_message_kind=GuidanceMessageKind.MOUNT_ROOT,
         severity=RequirementSeverity.BLOCKING,
         check=lambda m: m.is_root_mounted(),
     )
     REMOTE_BOOT_LOCAL = StorageRequirement(
-        guidance_message=_("Mount a local filesystem at /boot"),
+        guidance_message_kind=GuidanceMessageKind.MOUNT_LOCAL_BOOT,
         severity=RequirementSeverity.BLOCKING,
         check=lambda m: m.is_boot_mounted() and not m.is_bootfs_on_remote_storage(),
         applies_to=lambda m: m.is_root_mounted()
@@ -98,12 +116,12 @@ class Requirements:
         and not m.supports_nvme_tcp_booting,
     )
     BOOTLOADER_NEEDED = StorageRequirement(
-        guidance_message=_("Select a boot disk"),
+        guidance_message_kind=GuidanceMessageKind.SELECT_BOOT_DISK,
         severity=RequirementSeverity.BLOCKING,
         check=lambda m: not m.needs_bootloader_partition(),
     )
     BOOT_FILESYSTEM = StorageRequirement(
-        guidance_message=_("Use the ext4 filesystem for /boot"),
+        guidance_message_kind=GuidanceMessageKind.USE_EXT4_BOOT,
         severity=RequirementSeverity.BLOCKING,
         check=_is_boot_ext4,
         applies_to=lambda m: m.is_root_mounted() and m.uses_signed_grub(),

--- a/subiquity/common/storage/tests/test_requirements.py
+++ b/subiquity/common/storage/tests/test_requirements.py
@@ -20,7 +20,13 @@ from subiquity.common.storage.requirements import (
     RequirementSeverity,
     StorageRequirement,
 )
-from subiquity.models.tests.test_storage import make_model
+from subiquity.models.tests.test_storage import (
+    make_filesystem,
+    make_model,
+    make_model_and_disk,
+    make_mount,
+    make_partition,
+)
 from subiquitycore.tests.parameterized import parameterized
 
 
@@ -89,6 +95,7 @@ class TestRequirements(unittest.TestCase):
                 Requirements.ROOT_MOUNTED,
                 Requirements.REMOTE_BOOT_LOCAL,
                 Requirements.BOOTLOADER_NEEDED,
+                Requirements.BOOT_FILESYSTEM,
             ],
         )
 
@@ -175,3 +182,51 @@ class TestRequirements(unittest.TestCase):
             self.assertTrue(Requirements.BOOTLOADER_NEEDED.is_satisfied(model))
         with mock.patch.object(model, "needs_bootloader_partition", return_value=True):
             self.assertFalse(Requirements.BOOTLOADER_NEEDED.is_satisfied(model))
+
+    @parameterized.expand(
+        (
+            (False, False, False),
+            (False, True, False),
+            (True, False, False),
+            (True, True, True),
+        )
+    )
+    def test_BOOT_FILESYSTEM_applies_to(
+        self,
+        root_mounted: bool,
+        uses_signed_grub: bool,
+        expected: bool,
+    ):
+        model = make_model()
+        with (
+            mock.patch.object(model, "is_root_mounted", return_value=root_mounted),
+            mock.patch.object(model, "uses_signed_grub", return_value=uses_signed_grub),
+        ):
+            self.assertEqual(
+                expected, Requirements.BOOT_FILESYSTEM.is_applicable(model)
+            )
+
+    @parameterized.expand(
+        (
+            ("ext4", "ext4", True),
+            ("xfs", "ext4", False),
+            (None, "ext4", True),
+            (None, "xfs", False),
+        )
+    )
+    def test_BOOT_FILESYSTEM_check(
+        self,
+        boot_fstype: str | None,
+        root_fstype: str,
+        expected: bool,
+    ):
+        model, disk = make_model_and_disk()
+        p1 = make_partition(model, disk)
+        rootfs = make_filesystem(model, p1, fstype=root_fstype)
+        make_mount(model, rootfs, "/")
+        if boot_fstype is not None:
+            p2 = make_partition(model, disk)
+            boot_fs = make_filesystem(model, p2, fstype=boot_fstype)
+            make_mount(model, boot_fs, "/boot")
+
+        self.assertEqual(expected, Requirements.BOOT_FILESYSTEM.is_satisfied(model))

--- a/subiquity/common/storage/tests/test_requirements.py
+++ b/subiquity/common/storage/tests/test_requirements.py
@@ -202,6 +202,10 @@ class TestRequirements(unittest.TestCase):
         with (
             mock.patch.object(model, "is_root_mounted", return_value=root_mounted),
             mock.patch.object(model, "uses_signed_grub", return_value=uses_signed_grub),
+            mock.patch(
+                "subiquity.common.storage.requirements.lsb_release",
+                return_value={"release": "26.10"},
+            ),
         ):
             self.assertEqual(
                 expected, Requirements.BOOT_FILESYSTEM.is_applicable(model)

--- a/subiquity/common/storage/tests/test_requirements.py
+++ b/subiquity/common/storage/tests/test_requirements.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest import mock
+
+from subiquity.common.storage.requirements import (
+    Requirements,
+    RequirementSeverity,
+    StorageRequirement,
+)
+from subiquity.models.tests.test_storage import make_model
+from subiquitycore.tests.parameterized import parameterized
+
+
+class TestStorageRequirement(unittest.TestCase):
+    def test_init(self):
+        req = StorageRequirement(
+            guidance_message="msg",
+            severity=RequirementSeverity.BLOCKING,
+            check=lambda m: True,
+            applies_to=lambda m: False,
+        )
+        self.assertEqual(req.guidance_message, "msg")
+        self.assertEqual(req.severity, RequirementSeverity.BLOCKING)
+
+    def test_is_applicable(self):
+        req = StorageRequirement(
+            guidance_message="msg",
+            severity=RequirementSeverity.WARNING,
+            check=lambda m: True,
+            applies_to=lambda m: False,
+        )
+        self.assertFalse(req.is_applicable("model"))
+
+    def test_is_satisfied(self):
+        req = StorageRequirement(
+            guidance_message="msg",
+            severity=RequirementSeverity.WARNING,
+            check=lambda m: False,
+        )
+        self.assertFalse(req.is_satisfied("model"))
+
+    def test_is_violated__applicable_not_satisfied(self):
+        req = StorageRequirement(
+            guidance_message="msg",
+            severity=RequirementSeverity.BLOCKING,
+            check=lambda m: False,
+            applies_to=lambda m: True,
+        )
+        self.assertTrue(req.is_violated("model"))
+
+    def test_is_violated__not_applicable(self):
+        req = StorageRequirement(
+            guidance_message="msg",
+            severity=RequirementSeverity.BLOCKING,
+            check=lambda m: False,
+            applies_to=lambda m: False,
+        )
+        self.assertFalse(req.is_violated("model"))
+
+    def test_is_violated__satisfied(self):
+        req = StorageRequirement(
+            guidance_message="msg",
+            severity=RequirementSeverity.BLOCKING,
+            check=lambda m: True,
+            applies_to=lambda m: True,
+        )
+        self.assertFalse(req.is_violated("model"))
+
+
+class TestRequirements(unittest.TestCase):
+    def test_all(self):
+        all_reqs = Requirements.all()
+        self.assertEqual(
+            all_reqs,
+            [
+                Requirements.ROOT_MOUNTED,
+                Requirements.REMOTE_BOOT_LOCAL,
+                Requirements.BOOTLOADER_NEEDED,
+            ],
+        )
+
+    def test_ROOT_MOUNTED_check(self):
+        model = make_model()
+        with mock.patch.object(model, "is_root_mounted", return_value=True):
+            self.assertTrue(Requirements.ROOT_MOUNTED.is_satisfied(model))
+        with mock.patch.object(model, "is_root_mounted", return_value=False):
+            self.assertFalse(Requirements.ROOT_MOUNTED.is_satisfied(model))
+
+    def test_BOOTLOADER_NEEDED_applies_to(self):
+        self.assertTrue(Requirements.BOOTLOADER_NEEDED.is_applicable(make_model()))
+
+    @parameterized.expand(
+        (
+            (True, False, True),
+            (True, True, False),
+            (False, False, False),
+            (False, True, False),
+        )
+    )
+    def test_REMOTE_BOOT_LOCAL_check(
+        self, boot_mounted: bool, bootfs_remote: bool, expected: bool
+    ):
+        model = make_model()
+        with (
+            mock.patch.object(model, "is_boot_mounted", return_value=boot_mounted),
+            mock.patch.object(
+                model,
+                "is_bootfs_on_remote_storage",
+                return_value=bootfs_remote,
+            ),
+        ):
+            self.assertEqual(
+                expected, Requirements.REMOTE_BOOT_LOCAL.is_satisfied(model)
+            )
+
+    # Full truth table: applies only when root_mounted AND rootfs_remote
+    # AND NOT nvme_tcp.  All other combinations should not apply.
+    @parameterized.expand(
+        (
+            (False, False, False, False),
+            (False, False, True, False),
+            (False, True, False, False),
+            (False, True, True, False),
+            (True, False, False, False),
+            (True, False, True, False),
+            (True, True, False, True),
+            (True, True, True, False),
+        )
+    )
+    def test_REMOTE_BOOT_LOCAL_applies_to(
+        self,
+        root_mounted: bool,
+        rootfs_remote: bool,
+        nvme_tcp: bool,
+        expected: bool,
+    ):
+        model = make_model()
+        with (
+            mock.patch.object(model, "is_root_mounted", return_value=root_mounted),
+            mock.patch.object(
+                model,
+                "is_rootfs_on_remote_storage",
+                return_value=rootfs_remote,
+            ),
+            mock.patch.object(
+                type(model),
+                "supports_nvme_tcp_booting",
+                new_callable=mock.PropertyMock,
+                return_value=nvme_tcp,
+            ),
+        ):
+            self.assertEqual(
+                expected, Requirements.REMOTE_BOOT_LOCAL.is_applicable(model)
+            )
+
+    def test_ROOT_MOUNTED_applies_to(self):
+        self.assertTrue(Requirements.ROOT_MOUNTED.is_applicable(make_model()))
+
+    def test_BOOTLOADER_NEEDED_check(self):
+        model = make_model()
+        with mock.patch.object(model, "needs_bootloader_partition", return_value=False):
+            self.assertTrue(Requirements.BOOTLOADER_NEEDED.is_satisfied(model))
+        with mock.patch.object(model, "needs_bootloader_partition", return_value=True):
+            self.assertFalse(Requirements.BOOTLOADER_NEEDED.is_satisfied(model))

--- a/subiquity/common/storage/tests/test_requirements.py
+++ b/subiquity/common/storage/tests/test_requirements.py
@@ -16,6 +16,7 @@ import unittest
 from unittest import mock
 
 from subiquity.common.storage.requirements import (
+    GuidanceMessageKind,
     Requirements,
     RequirementSeverity,
     StorageRequirement,
@@ -33,17 +34,17 @@ from subiquitycore.tests.parameterized import parameterized
 class TestStorageRequirement(unittest.TestCase):
     def test_init(self):
         req = StorageRequirement(
-            guidance_message="msg",
+            guidance_message_kind=GuidanceMessageKind.MOUNT_ROOT,
             severity=RequirementSeverity.BLOCKING,
             check=lambda m: True,
             applies_to=lambda m: False,
         )
-        self.assertEqual(req.guidance_message, "msg")
+        self.assertEqual(req.guidance_message_kind, GuidanceMessageKind.MOUNT_ROOT)
         self.assertEqual(req.severity, RequirementSeverity.BLOCKING)
 
     def test_is_applicable(self):
         req = StorageRequirement(
-            guidance_message="msg",
+            guidance_message_kind=GuidanceMessageKind.MOUNT_ROOT,
             severity=RequirementSeverity.WARNING,
             check=lambda m: True,
             applies_to=lambda m: False,
@@ -52,7 +53,7 @@ class TestStorageRequirement(unittest.TestCase):
 
     def test_is_satisfied(self):
         req = StorageRequirement(
-            guidance_message="msg",
+            guidance_message_kind=GuidanceMessageKind.MOUNT_ROOT,
             severity=RequirementSeverity.WARNING,
             check=lambda m: False,
         )
@@ -60,7 +61,7 @@ class TestStorageRequirement(unittest.TestCase):
 
     def test_is_violated__applicable_not_satisfied(self):
         req = StorageRequirement(
-            guidance_message="msg",
+            guidance_message_kind=GuidanceMessageKind.MOUNT_ROOT,
             severity=RequirementSeverity.BLOCKING,
             check=lambda m: False,
             applies_to=lambda m: True,
@@ -69,7 +70,7 @@ class TestStorageRequirement(unittest.TestCase):
 
     def test_is_violated__not_applicable(self):
         req = StorageRequirement(
-            guidance_message="msg",
+            guidance_message_kind=GuidanceMessageKind.MOUNT_ROOT,
             severity=RequirementSeverity.BLOCKING,
             check=lambda m: False,
             applies_to=lambda m: False,
@@ -78,7 +79,7 @@ class TestStorageRequirement(unittest.TestCase):
 
     def test_is_violated__satisfied(self):
         req = StorageRequirement(
-            guidance_message="msg",
+            guidance_message_kind=GuidanceMessageKind.MOUNT_ROOT,
             severity=RequirementSeverity.BLOCKING,
             check=lambda m: True,
             applies_to=lambda m: True,

--- a/subiquity/models/storage.py
+++ b/subiquity/models/storage.py
@@ -1608,12 +1608,14 @@ class StorageModel:
         bootloader=None,
         *,
         root: str,
+        dry_run: bool,
         opt_supports_nvme_tcp_booting: bool | None = None,
         detected_supports_nvme_tcp_booting: bool | None = None,
     ):
         if bootloader is None:
             bootloader = self._probe_bootloader()
         self.bootloader = bootloader
+        self.dry_run = dry_run
         self.root = root
         self.opt_supports_nvme_tcp_booting: bool | None = opt_supports_nvme_tcp_booting
         self.detected_supports_nvme_tcp_booting: bool | None = (
@@ -1651,6 +1653,7 @@ class StorageModel:
         orig_model = StorageModel(
             self.bootloader,
             root=self.root,
+            dry_run=self.dry_run,
             opt_supports_nvme_tcp_booting=self.opt_supports_nvme_tcp_booting,
             detected_supports_nvme_tcp_booting=self.detected_supports_nvme_tcp_booting,
         )

--- a/subiquity/models/storage.py
+++ b/subiquity/models/storage.py
@@ -2458,11 +2458,21 @@ class StorageModel:
         else:
             raise AssertionError("unknown bootloader type {}".format(self.bootloader))
 
-    def _mount_for_path(self, path):
+    def _mount_for_path(self, path: str | pathlib.Path, *, parent_ok=False):
+        """Return the mount-like at *path*, or None.
+
+        Looks through MountlikeNames (mount, zpool, zfs) for an exact
+        match.  When *parent_ok* is True and no exact match is found,
+        retries with the parent directory, repeating until the root
+        (``/``) is reached.
+        """
+        path = pathlib.Path(path)
         for typename in MountlikeNames:
-            mount = self._one(type=typename, path=path)
+            mount = self._one(type=typename, path=str(path))
             if mount is not None:
                 return mount
+        if parent_ok and path.parent != path:
+            return self._mount_for_path(path.parent, parent_ok=parent_ok)
         return None
 
     def is_root_mounted(self):

--- a/subiquity/models/storage.py
+++ b/subiquity/models/storage.py
@@ -50,6 +50,10 @@ from curtin.swap import can_use_swapfile
 from curtin.util import human2bytes
 from probert.storage import StorageInfo
 
+from subiquity.common.storage.requirements import (
+    Requirements,
+    RequirementSeverity,
+)
 from subiquity.common.types.storage import (
     Bootloader,
     OsProber,
@@ -2486,16 +2490,22 @@ class StorageModel:
         return self.is_boot_mounted() and not self.is_bootfs_on_remote_storage()
 
     def can_install(self) -> bool:
-        if not self.is_root_mounted():
-            return False
-
-        if self.is_rootfs_on_remote_storage() and not self._can_install_remote():
-            return False
-
-        if self.needs_bootloader_partition():
-            return False
-
+        for r in Requirements.all():
+            if r.severity == RequirementSeverity.BLOCKING and r.is_applicable(self):
+                if not r.is_satisfied(self):
+                    return False
         return True
+
+    def guidance_messages(self, *, only_blocking=False) -> list[str]:
+        messages: list[str] = []
+
+        for req in Requirements.all():
+            if only_blocking and req.severity != RequirementSeverity.BLOCKING:
+                continue
+            if req.is_violated(self):
+                messages.append(req.guidance_message)
+
+        return messages
 
     def should_add_swapfile(self):
         mount = self._mount_for_path("/")

--- a/subiquity/models/storage.py
+++ b/subiquity/models/storage.py
@@ -2458,6 +2458,35 @@ class StorageModel:
         else:
             raise AssertionError("unknown bootloader type {}".format(self.bootloader))
 
+    def uses_grub(self) -> bool:
+        """Return True when the system's bootloader is GRUB-based.
+
+        Only s390x systems (``Bootloader.NONE``) do not use GRUB; all
+        other boot methods (BIOS, UEFI, PREP) rely on GRUB.
+
+        Curtin also has a ``uses_grub(machine)`` function in
+        curtin/commands/curthooks.py, which determines GRUB usage from
+        the machine architecture instead.  Consider consolidating.
+        """
+        return self.bootloader != Bootloader.NONE
+
+    def uses_signed_grub(self) -> bool:
+        """Return True when the system uses signed GRUB.
+
+        In curtin, a platform is assumed to use signed GRUB if the following
+        conditions are met:
+         * the system is currently booted using UEFI
+         * a grub-efi-{arch}-signed package exists in the archive (or pool)
+
+        Other platforms (for example BIOS and PREP) use unsigned GRUB.
+
+        Subiquity currently simplifies this policy by assuming that every UEFI
+        system should use signed GRUB, even on architectures where no signed
+        package currently exists (for example, riscv64 on 26.04). This makes
+        the installation layout more future-proof if signed packages become
+        available."""
+        return self.uses_grub() and self.bootloader == Bootloader.UEFI
+
     def _mount_for_path(self, path: str | pathlib.Path, *, parent_ok=False):
         """Return the mount-like at *path*, or None.
 

--- a/subiquity/models/storage.py
+++ b/subiquity/models/storage.py
@@ -51,6 +51,7 @@ from curtin.util import human2bytes
 from probert.storage import StorageInfo
 
 from subiquity.common.storage.requirements import (
+    GuidanceMessageKind,
     Requirements,
     RequirementSeverity,
 )
@@ -2536,15 +2537,15 @@ class StorageModel:
         return True
 
     def guidance_messages(self, *, only_blocking=False) -> list[str]:
-        messages: list[str] = []
+        message_kinds: list[GuidanceMessageKind] = []
 
         for req in Requirements.all():
             if only_blocking and req.severity != RequirementSeverity.BLOCKING:
                 continue
             if req.is_violated(self):
-                messages.append(req.guidance_message)
+                message_kinds.append(req.guidance_message_kind)
 
-        return messages
+        return [message_kind.value for message_kind in message_kinds]
 
     def should_add_swapfile(self):
         mount = self._mount_for_path("/")

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -183,7 +183,9 @@ class SubiquityModel:
         self.debconf_selections = DebconfSelectionsModel()
         self.drivers = DriversModel()
         self.storage = StorageModel(
-            root=root, opt_supports_nvme_tcp_booting=opt_supports_nvme_tcp_booting
+            root=root,
+            dry_run=dry_run,
+            opt_supports_nvme_tcp_booting=opt_supports_nvme_tcp_booting,
         )
         self.identity = IdentityModel()
         self.integrity = IntegrityModel()

--- a/subiquity/models/tests/test_storage.py
+++ b/subiquity/models/tests/test_storage.py
@@ -23,6 +23,11 @@ import attr
 import yaml
 
 from subiquity.common.storage import gaps
+from subiquity.common.storage.requirements import (
+    Requirements,
+    RequirementSeverity,
+    StorageRequirement,
+)
 from subiquity.common.types.storage import RecoveryKey
 from subiquity.models.storage import (
     LVM_CHUNK_SIZE,
@@ -299,6 +304,17 @@ def make_dm_crypt(model, device):
     return model.add_dm_crypt(device)
 
 
+def make_req(*, blocking=True, satisfied=True, applies=True):
+    return StorageRequirement(
+        guidance_message=Mock(),
+        severity=(
+            RequirementSeverity.BLOCKING if blocking else RequirementSeverity.WARNING
+        ),
+        check=lambda m: satisfied,
+        applies_to=lambda m: applies,
+    )
+
+
 class TestStorageModel(unittest.TestCase):
     def _test_ok_for_xxx(self, model, make_new_device, attr, test_partitions=True):
         # Newly formatted devs are ok_for_raid
@@ -393,108 +409,32 @@ class TestStorageModel(unittest.TestCase):
 
     @parameterized.expand(
         (
-            (True, True, True, True),
-            (True, True, False, True),
-            (True, False, False, True),
-            (False, True, True, False),
-            (False, True, False, True),
-            (False, False, False, False),
+            # Zero requirement
+            ([], True),
+            # No violated requirement
+            (
+                [
+                    make_req(satisfied=True),
+                    make_req(satisfied=True),
+                    make_req(satisfied=True, blocking=False),
+                ],
+                True,
+            ),
+            # At least one violated requirement
+            ([make_req(satisfied=True), make_req(satisfied=False)], False),
+            # One violated requirement but it is only a warning.
+            (
+                [make_req(satisfied=True), make_req(satisfied=False, blocking=False)],
+                True,
+            ),
+            # One requirement not satisfied but not applicable to this platform.
+            ([make_req(satisfied=False, applies=False)], True),
         )
     )
-    def test__can_install_remote(
-        self,
-        supports_nvmet_boot: bool,
-        boot_mounted: bool,
-        bootfs_remote: bool,
-        expected: bool,
-    ):
+    def test_can_install(self, requirements, expected):
         model = make_model()
-        p_supports_nvmet_boot = mock.patch(
-            "subiquity.models.storage.StorageModel.supports_nvme_tcp_booting",
-            new_callable=mock.PropertyMock,
-            return_value=supports_nvmet_boot,
-        )
-        p_boot_mounted = mock.patch.object(
-            model, "is_boot_mounted", return_value=boot_mounted
-        )
-        p_bootfs_remote = mock.patch.object(
-            model, "is_bootfs_on_remote_storage", return_value=bootfs_remote
-        )
-
-        with (
-            p_supports_nvmet_boot as m_supports_nvmet_boot,
-            p_boot_mounted as m_boot_mounted,
-            p_bootfs_remote as m_bootfs_remote,
-        ):
-            self.assertEqual(expected, model._can_install_remote())
-
-        m_supports_nvmet_boot.assert_called_once()
-
-        if supports_nvmet_boot:
-            m_boot_mounted.assert_not_called()
-            m_bootfs_remote.assert_not_called()
-        else:
-            m_boot_mounted.assert_called_once()
-            if boot_mounted:
-                m_bootfs_remote.assert_called_once()
-            else:
-                m_bootfs_remote.assert_not_called()
-
-    @parameterized.expand(
-        (
-            (False, False, False, False, False),
-            (True, False, False, False, True),
-            (True, True, False, False, False),
-            (True, True, True, False, True),
-            (True, False, False, True, False),
-        )
-    )
-    def test_can_install(
-        self,
-        root_mounted: bool,
-        rootfs_remote: bool,
-        can_install_remote: bool,
-        needs_bootloader: bool,
-        expected: bool,
-    ):
-        model = make_model()
-        p_root_mounted = mock.patch.object(
-            model, "is_root_mounted", return_value=root_mounted
-        )
-        p_rootfs_remote = mock.patch.object(
-            model, "is_rootfs_on_remote_storage", return_value=rootfs_remote
-        )
-        p_can_install_remote = mock.patch.object(
-            model, "_can_install_remote", return_value=can_install_remote
-        )
-        p_needs_bootloader = mock.patch.object(
-            model, "needs_bootloader_partition", return_value=needs_bootloader
-        )
-
-        with (
-            p_root_mounted as m_root_mounted,
-            p_rootfs_remote as m_rootfs_remote,
-            p_can_install_remote as m_can_install_remote,
-            p_needs_bootloader as m_needs_bootloader,
-        ):
+        with mock.patch.object(Requirements, "all", return_value=requirements):
             self.assertEqual(expected, model.can_install())
-
-        m_root_mounted.assert_called_once()
-
-        if root_mounted:
-            m_rootfs_remote.assert_called_once()
-        else:
-            m_rootfs_remote.assert_not_called()
-
-        if root_mounted and rootfs_remote:
-            m_can_install_remote.assert_called_once()
-        else:
-            m_can_install_remote.assert_not_called()
-
-        if root_mounted and (not rootfs_remote or can_install_remote):
-            m_needs_bootloader.assert_called_once()
-        else:
-            m_needs_bootloader.assert_not_called()
 
     @parameterized.expand(
         (

--- a/subiquity/models/tests/test_storage.py
+++ b/subiquity/models/tests/test_storage.py
@@ -146,9 +146,17 @@ class FakeStorageInfo:
     raw = attr.ib(default=attr.Factory(dict))
 
 
-def make_model(bootloader=None, storage_version=None, supports_nvme_tcp_booting=False):
+def make_model(
+    bootloader=None,
+    storage_version=None,
+    *,
+    dry_run=False,
+    supports_nvme_tcp_booting=False,
+):
     model = StorageModel(
-        root="/tmp", opt_supports_nvme_tcp_booting=supports_nvme_tcp_booting
+        root="/tmp",
+        dry_run=dry_run,
+        opt_supports_nvme_tcp_booting=supports_nvme_tcp_booting,
     )
     if bootloader is not None:
         model.bootloader = bootloader
@@ -459,7 +467,13 @@ class TestStorageModel(unittest.TestCase):
     ):
         model, disk = make_model_and_disk(bootloader)
 
-        with mock.patch.object(model, "needs_bootloader_partition", return_value=False):
+        with (
+            mock.patch.object(model, "needs_bootloader_partition", return_value=False),
+            mock.patch(
+                "subiquity.common.storage.requirements.lsb_release",
+                return_value={"release": "26.10"},
+            ),
+        ):
             if has_separate_boot:
                 part = make_partition(model, disk)
                 fs = make_filesystem(model, part, fstype=boot_fstype)
@@ -472,6 +486,28 @@ class TestStorageModel(unittest.TestCase):
                 fs = make_filesystem(model, part, fstype=root_fstype)
                 make_mount(model, fs, "/")
 
+            self.assertEqual(expected, model.can_install())
+
+    @parameterized.expand(
+        (
+            ("26.04", True),
+            ("26.04.1", True),
+            ("26.10", False),
+            ("27.04", False),
+        )
+    )
+    def test_boot_filesystem_release_requirement(self, release, expected):
+        model, disk = make_model_and_disk(Bootloader.UEFI)
+        part = make_partition(model, disk)
+        fs = make_filesystem(model, part, fstype="xfs")
+        make_mount(model, fs, "/")
+        with (
+            mock.patch.object(model, "needs_bootloader_partition", return_value=False),
+            mock.patch(
+                "subiquity.common.storage.requirements.lsb_release",
+                return_value={"release": release},
+            ),
+        ):
             self.assertEqual(expected, model.can_install())
 
     @parameterized.expand(

--- a/subiquity/models/tests/test_storage.py
+++ b/subiquity/models/tests/test_storage.py
@@ -438,6 +438,44 @@ class TestStorageModel(unittest.TestCase):
 
     @parameterized.expand(
         (
+            (Bootloader.NONE, None, None, False, True),
+            (Bootloader.BIOS, "ext4", None, True, True),
+            (Bootloader.BIOS, "btrfs", None, True, True),
+            (Bootloader.UEFI, "ext4", None, True, True),
+            (Bootloader.UEFI, "xfs", None, True, False),
+            (Bootloader.PREP, "ext4", None, True, True),
+            (Bootloader.PREP, "zfs", None, True, True),
+            (Bootloader.BIOS, None, "ext4", False, True),
+            (Bootloader.BIOS, None, "btrfs", False, True),
+        )
+    )
+    def test_boot_filesystem_requirement(
+        self,
+        bootloader: Bootloader,
+        boot_fstype: str | None,
+        root_fstype: str | None,
+        has_separate_boot: bool,
+        expected: bool,
+    ):
+        model, disk = make_model_and_disk(bootloader)
+
+        with mock.patch.object(model, "needs_bootloader_partition", return_value=False):
+            if has_separate_boot:
+                part = make_partition(model, disk)
+                fs = make_filesystem(model, part, fstype=boot_fstype)
+                make_mount(model, fs, "/boot")
+                part_root = make_partition(model, disk)
+                fs_root = make_filesystem(model, part_root, fstype="ext4")
+                make_mount(model, fs_root, "/")
+            else:
+                part = make_partition(model, disk)
+                fs = make_filesystem(model, part, fstype=root_fstype)
+                make_mount(model, fs, "/")
+
+            self.assertEqual(expected, model.can_install())
+
+    @parameterized.expand(
+        (
             (1, True, False),
             (2, True, False),
             (5, True, True),

--- a/subiquity/models/tests/test_storage.py
+++ b/subiquity/models/tests/test_storage.py
@@ -306,7 +306,7 @@ def make_dm_crypt(model, device):
 
 def make_req(*, blocking=True, satisfied=True, applies=True):
     return StorageRequirement(
-        guidance_message=Mock(),
+        guidance_message_kind=Mock(),
         severity=(
             RequirementSeverity.BLOCKING if blocking else RequirementSeverity.WARNING
         ),

--- a/subiquity/models/tests/test_storage.py
+++ b/subiquity/models/tests/test_storage.py
@@ -1857,6 +1857,70 @@ class TestRootfs(SubiTestCase):
         self.assertFalse(m.is_root_mounted())
 
 
+class TestMountForPath(SubiTestCase):
+    def test_exact_match_parent_ok(self):
+        m, p = make_model_and_partition()
+        fs = make_filesystem(m, p, fstype="ext4")
+        make_mount(m, fs, "/boot")
+        mount = m._mount_for_path("/boot", parent_ok=True)
+        self.assertIsNotNone(mount)
+        self.assertEqual(mount.path, "/boot")
+
+    def test_fallback_to_parent(self):
+        m, p = make_model_and_partition()
+        fs = make_filesystem(m, p, fstype="ext4")
+        make_mount(m, fs, "/")
+        mount = m._mount_for_path("/boot", parent_ok=True)
+        self.assertIsNotNone(mount)
+        self.assertEqual(mount.path, "/")
+
+    def test_fallback_nested(self):
+        m, p = make_model_and_partition()
+        fs = make_filesystem(m, p, fstype="ext4")
+        make_mount(m, fs, "/")
+        mount = m._mount_for_path("/a/b", parent_ok=True)
+        self.assertIsNotNone(mount)
+        self.assertEqual(mount.path, "/")
+
+    def test_no_match_parent_ok(self):
+        m = make_model()
+        mount = m._mount_for_path("/boot", parent_ok=True)
+        self.assertIsNone(mount)
+
+    def test_exact_match_preferred_over_parent(self):
+        m, d = make_model_and_disk()
+        p1 = make_partition(m, d)
+        fs1 = make_filesystem(m, p1, fstype="ext4")
+        make_mount(m, fs1, "/")
+        p2 = make_partition(m, d)
+        fs2 = make_filesystem(m, p2, fstype="xfs")
+        make_mount(m, fs2, "/boot")
+        mount = m._mount_for_path("/boot", parent_ok=True)
+        self.assertIsNotNone(mount)
+        self.assertEqual(mount.path, "/boot")
+        self.assertEqual(mount.fstype, "xfs")
+
+    def test_without_parent_ok_no_fallback(self):
+        m, p = make_model_and_partition()
+        fs = make_filesystem(m, p, fstype="ext4")
+        make_mount(m, fs, "/")
+        mount = m._mount_for_path("/boot")
+        self.assertIsNone(mount)
+
+    def test_root_parent_ok_mounted(self):
+        m, p = make_model_and_partition()
+        fs = make_filesystem(m, p, fstype="ext4")
+        make_mount(m, fs, "/")
+        mount = m._mount_for_path("/", parent_ok=True)
+        self.assertIsNotNone(mount)
+        self.assertEqual(mount.path, "/")
+
+    def test_root_parent_ok_not_mounted(self):
+        m = make_model()
+        mount = m._mount_for_path("/", parent_ok=True)
+        self.assertIsNone(mount)
+
+
 class TestLivePackages(SubiTestCase):
     async def test_defaults(self):
         m = make_model()

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -667,8 +667,11 @@ class StorageController(SubiquityController, StorageManipulator):
         for r in Requirements.all():
             if r.severity == RequirementSeverity.BLOCKING and r.is_violated(self.model):
                 raise AutoinstallError(
-                    _("autoinstall config did not match requirement: {}").format(
-                        r.guidance_message
+                    _(
+                        "autoinstall config did not match requirement {kind}: {msg}"
+                    ).format(
+                        kind=r.guidance_message_kind.name,
+                        msg=r.guidance_message_kind.value,
                     )
                 )
 

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -50,6 +50,10 @@ from subiquity.common.errorreport import ErrorReport, ErrorReportKind
 from subiquity.common.storage import boot, gaps, labels, sizes
 from subiquity.common.storage.actions import DeviceAction
 from subiquity.common.storage.manipulator import StorageManipulator
+from subiquity.common.storage.requirements import (
+    Requirements,
+    RequirementSeverity,
+)
 from subiquity.common.storage.spec import FileSystemSpec, PartitionSpec, VolGroupSpec
 from subiquity.common.types.storage import (
     AddPartitionV2,
@@ -660,12 +664,13 @@ class StorageController(SubiquityController, StorageManipulator):
         await self.convert_autoinstall_config(context=context)
         if self.reset_partition_only:
             return
-        if not self.model.is_root_mounted():
-            raise Exception("autoinstall config did not mount root")
-        if self.model.needs_bootloader_partition():
-            raise Exception(
-                "autoinstall config did not create needed bootloader partition"
-            )
+        for r in Requirements.all():
+            if r.severity == RequirementSeverity.BLOCKING and r.is_violated(self.model):
+                raise AutoinstallError(
+                    _("autoinstall config did not match requirement: {}").format(
+                        r.guidance_message
+                    )
+                )
 
     def update_devices(self, device_map):
         for action in self.model._actions:

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -660,8 +660,12 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
             with mock.patch.object(
                 model, "needs_bootloader_partition", return_value=False
             ):
-                with self.assertRaisesRegex(AutoinstallError, "ext4 filesystem"):
-                    await self.ctrler.apply_autoinstall_config()
+                with mock.patch(
+                    "subiquity.common.storage.requirements.lsb_release",
+                    return_value={"release": "26.10"},
+                ):
+                    with self.assertRaisesRegex(AutoinstallError, "ext4 filesystem"):
+                        await self.ctrler.apply_autoinstall_config()
 
     @mock.patch("subiquity.server.controllers.storage.open", mock.mock_open())
     async def test_probe_once_unlocked_probe_data(self):

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import contextlib
 import copy
 import subprocess
@@ -61,11 +62,13 @@ from subiquity.models.storage import dehumanize_size
 from subiquity.models.tests.test_storage import (
     FakeStorageInfo,
     make_disk,
+    make_filesystem,
     make_model,
     make_model_and_disk,
     make_model_and_lv,
     make_model_and_raid,
     make_model_and_vg,
+    make_mount,
     make_nvme_controller,
     make_partition,
     make_raid,
@@ -635,6 +638,30 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         await self.ctrler.convert_autoinstall_config()
         curtin_cfg = model.render()
         self.assertEqual(swapsize, curtin_cfg["swap"]["size"])
+
+    async def test_apply_autoinstall_config_rejects_non_ext4_boot(self):
+        model, disk = make_model_and_disk(Bootloader.UEFI)
+
+        part = make_partition(model, disk)
+        fs = make_filesystem(model, part, fstype="xfs")
+        make_mount(model, fs, "/")
+
+        self.ctrler.model = model
+        self.ctrler.reset_partition_only = False
+        self.ctrler.ai_data = {"layout": {"name": "direct"}}
+        self.ctrler._start_task = asyncio.Future()
+        self.ctrler._start_task.set_result(None)
+        self.ctrler._probe_task = mock.Mock(wait=mock.AsyncMock())
+        self.ctrler._probe_firmware_task = mock.Mock(wait=mock.AsyncMock())
+        self.ctrler._examine_systems_task = mock.Mock(wait=mock.AsyncMock())
+        self.ctrler._errors = {}
+
+        with mock.patch.object(self.ctrler, "convert_autoinstall_config"):
+            with mock.patch.object(
+                model, "needs_bootloader_partition", return_value=False
+            ):
+                with self.assertRaisesRegex(AutoinstallError, "ext4 filesystem"):
+                    await self.ctrler.apply_autoinstall_config()
 
     @mock.patch("subiquity.server.controllers.storage.open", mock.mock_open())
     async def test_probe_once_unlocked_probe_data(self):

--- a/subiquity/ui/views/storage/storage.py
+++ b/subiquity/ui/views/storage/storage.py
@@ -486,33 +486,19 @@ class StorageView(BaseView):
         self.refresh_model_inputs()
 
     def _guidance(self):
-        todos = []
-        if not self.model.is_root_mounted():
-            todos.append(_("Mount a filesystem at /"))
-        elif (
-            self.model.is_rootfs_on_remote_storage()
-            and not self.model.supports_nvme_tcp_booting
-        ):
-            # We need a /boot partition on local storage
-            if (
-                not self.model.is_boot_mounted()
-                or self.model.is_bootfs_on_remote_storage()
-            ):
-                todos.append(_("Mount a local filesystem at /boot"))
-        if self.model.needs_bootloader_partition():
-            todos.append(_("Select a boot disk"))
-        if not todos:
+        guidance = self.model.guidance_messages(only_blocking=True)
+        if not guidance:
             return None
         rows = [
             TableRow(
                 [
                     Text(_("To continue you need to:")),
-                    Text(todos[0]),
+                    Text(guidance[0]),
                 ]
             ),
         ]
-        for todo in todos[1:]:
-            rows.append(TableRow([Text(""), Text(todo)]))
+        for msg in guidance[1:]:
+            rows.append(TableRow([Text(""), Text(msg)]))
         rows.append(TableRow([Text("")]))
         return TablePile(rows)
 

--- a/subiquity/ui/views/storage/tests/test_storage.py
+++ b/subiquity/ui/views/storage/tests/test_storage.py
@@ -19,7 +19,9 @@ class StorageViewTests(unittest.TestCase):
         return StorageView(model, controller)
 
     def test_simple(self):
-        self.make_view(mock.create_autospec(spec=StorageModel))
+        model = mock.create_autospec(spec=StorageModel)
+        model.guidance_messages.return_value = []
+        self.make_view(model)
 
     def test_one_disk(self):
         model = make_model()


### PR DESCRIPTION
This PR moves the storage requirements / constraints to a file named `subiquity/common/storage/requirements.py`. The goal is to have all requirements there in the end.

Each requirement has:
* a severity - telling whether having this requirement violated is a warning or a blocker for installing.
* a method to check if the requirement should be applied (for instance, some requirements only apply to a given set of architectures)
* a method to check if the requirement is met / satisfied.
* a method to check if the requirement is violated.

For now, we added 3 existing requirements + one new one:

* [existing] a filesystem must be mounted at /
* [existing] a local /boot filesystem must exist for nvme-tcp if the firmware has no support for it
* [existing] a bootloader partition must be present (i.e., either an ESP or a grub spacer) - unless we're doing BIOS + MSDOS or other rare configs
* [new] the filesystem for /boot must be ext4, for platforms that use signed GRUB (i.e., SecureBoot)

Also part of this PR are:

* More complete autoinstall validation for storage configuration (i.e., previously the NVMe/TCP requirement was not checked). Now all requirements defined in requirements.Requirements are evaluated.
* `AutoinstallError` exceptions are now raised when requirements are not met as part of autoinstall.

LP:#2165727