### PR TITLE
noble backport: reimplement [old] cloudinit's rand_user_password

### DIFF
--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -24,7 +24,6 @@ from typing import Any, List, Optional
 import jsonschema
 import yaml
 from aiohttp import web
-from cloudinit.config.cc_set_passwords import rand_user_password
 from jsonschema.exceptions import ValidationError
 from systemd import journal
 
@@ -32,6 +31,7 @@ from subiquity.cloudinit import (
     CloudInitSchemaValidationError,
     cloud_init_status_wait,
     get_host_combined_cloud_config,
+    rand_user_password,
     validate_cloud_init_schema,
 )
 from subiquity.common.api.server import bind, controller_for_request

--- a/subiquity/tests/test_cloudinit.py
+++ b/subiquity/tests/test_cloudinit.py
@@ -19,10 +19,13 @@ from unittest import skipIf
 from unittest.mock import Mock, patch
 
 from subiquity.cloudinit import (
+    CLOUD_INIT_PW_SET,
     CloudInitSchemaValidationError,
     cloud_init_status_wait,
     cloud_init_version,
     get_schema_failure_keys,
+    rand_str,
+    rand_user_password,
     read_json_extended_status,
     read_legacy_status,
     supports_format_json,
@@ -215,3 +218,33 @@ class TestCloudInitSchemaValidation(SubiTestCase):
         sources = await get_schema_failure_keys()
         log_mock.warning.assert_called()
         self.assertEqual([], sources)
+
+
+class TestCloudInitRandomStrings(SubiTestCase):
+    def test_passwd_constraints(self):
+        # password is 20 characters by default
+        password = rand_user_password()
+        self.assertEqual(len(password), 20)
+
+        # password is requested length
+        password = rand_user_password(pwlen=32)
+        self.assertEqual(len(password), 32)
+
+        # passwords contain valid chars
+        # sample passwords
+        for _i in range(100):
+            password = rand_user_password()
+            self.assertTrue(all(char in CLOUD_INIT_PW_SET for char in password))
+
+    def test_rand_string_generation(self):
+        # random string is 32 characters by default
+        password = rand_str()
+        self.assertEqual(len(password), 32)
+
+        # password is requested length
+        password = rand_str(strlen=20)
+        self.assertEqual(len(password), 20)
+
+        # password characters sampled from provided set
+        choices = ["a"]
+        self.assertEqual("a" * 32, rand_str(select_from=choices))


### PR DESCRIPTION
An SRU of cloud-init to core22 enforced stricter rules for password creation in `rand_user_password`.

https://github.com/canonical/cloud-init/commit/879945f56103d937a7fee84bfe7662dc2a5be708

In resolute and devel, Subiquity is not affected by these stricter rules because we're not staging cloud-init anymore. Instead, we copied the `rand_user_password` implementation from cloud-init to Subiquity.

As mentioned in https://github.com/canonical/subiquity/pull/2384, the implementation of `rand_user_password` in Subiquity is no longer in sync with cloud-init. Nevertheless, the behavior we want for the password in Subiquity is that of the previous cloud-init implementation. And it makes no sense to have a different behavior in main and noble.

LP:#2118989