### PR TITLE
storage: fix on-remote-storage not working with ZFS and zpools

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1359,6 +1359,9 @@ class Filesystem:
         else:
             return False
 
+    def on_remote_storage(self) -> bool:
+        return self.volume.on_remote_storage()
+
 
 @fsobj("mount")
 class Mount:
@@ -1385,6 +1388,9 @@ class Mount:
             # /boot/efi
             return False
         return True
+
+    def on_remote_storage(self) -> bool:
+        return self.device.on_remote_storage()
 
 
 def get_canmount(properties: Optional[dict], default: bool) -> bool:
@@ -1457,6 +1463,9 @@ class ZPool:
         self._m._actions.append(zfs)
         return zfs
 
+    def on_remote_storage(self) -> bool:
+        return any(vdev.on_remote_storage() for vdev in self.vdevs)
+
 
 @fsobj("zfs")
 class ZFS:
@@ -1479,6 +1488,9 @@ class ZFS:
             return self.properties.get("mountpoint", self.volume)
         else:
             return None
+
+    def on_remote_storage(self) -> bool:
+        return self.pool.on_remote_storage()
 
 
 ConstructedDevice = Union[Raid, LVM_VolGroup, ZPool]
@@ -2453,13 +2465,13 @@ class FilesystemModel:
         return self._mount_for_path("/") is not None
 
     def is_rootfs_on_remote_storage(self) -> bool:
-        return self._mount_for_path("/").device.volume.on_remote_storage()
+        return self._mount_for_path("/").on_remote_storage()
 
     def is_boot_mounted(self) -> bool:
         return self._mount_for_path("/boot") is not None
 
     def is_bootfs_on_remote_storage(self) -> bool:
-        return self._mount_for_path("/boot").device.volume.on_remote_storage()
+        return self._mount_for_path("/boot").on_remote_storage()
 
     def _can_install_remote(self) -> bool:
         """Tells whether installing with the rootfs on remote storage would be

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -2076,6 +2076,106 @@ class TestOnRemoteStorage(SubiTestCase):
         with mock.patch.object(vg, "on_remote_storage", return_value=True):
             self.assertTrue(lv.on_remote_storage())
 
+    def test_filesystem(self):
+        m, d = make_model_and_disk()
+        p = make_partition(model=m, device=d)
+        fs = make_filesystem(model=m, partition=p)
+
+        with mock.patch.object(p, "on_remote_storage", return_value=False):
+            self.assertFalse(fs.on_remote_storage())
+        with mock.patch.object(p, "on_remote_storage", return_value=True):
+            self.assertTrue(fs.on_remote_storage())
+
+    def test_mount(self):
+        m, d = make_model_and_disk()
+        p = make_partition(model=m, device=d)
+        fs = make_filesystem(model=m, partition=p)
+        mount = make_mount(model=m, fs=fs, path="/")
+
+        with mock.patch.object(fs, "on_remote_storage", return_value=False):
+            self.assertFalse(mount.on_remote_storage())
+        with mock.patch.object(fs, "on_remote_storage", return_value=True):
+            self.assertTrue(mount.on_remote_storage())
+
+    def test_zpool(self):
+        m = make_model()
+        d0 = make_disk(fs_model=m)
+        d1 = make_disk(fs_model=m)
+
+        pool = make_zpool(model=m, device=d0)
+
+        d0_local = mock.patch.object(d0, "on_remote_storage", return_value=False)
+        d0_remote = mock.patch.object(d0, "on_remote_storage", return_value=True)
+
+        with d0_local:
+            self.assertFalse(pool.on_remote_storage())
+        with d0_remote:
+            self.assertTrue(pool.on_remote_storage())
+
+        # With multiple vdevs — any remote makes pool remote.
+        pool.vdevs.append(d1)
+
+        d0_local = mock.patch.object(d0, "on_remote_storage", return_value=False)
+        d1_local = mock.patch.object(d1, "on_remote_storage", return_value=False)
+        d0_remote = mock.patch.object(d0, "on_remote_storage", return_value=True)
+        d1_remote = mock.patch.object(d1, "on_remote_storage", return_value=True)
+
+        with d0_local, d1_local:
+            self.assertFalse(pool.on_remote_storage())
+        with d0_local, d1_remote:
+            self.assertTrue(pool.on_remote_storage())
+        with d0_remote, d1_local:
+            self.assertTrue(pool.on_remote_storage())
+        with d0_remote, d1_remote:
+            self.assertTrue(pool.on_remote_storage())
+
+    def test_zfs(self):
+        m = make_model()
+        d = make_disk(fs_model=m)
+        pool = make_zpool(model=m, device=d, pool="pool0")
+        zfs = make_zfs(model=m, pool=pool, volume="pool0/test")
+
+        with mock.patch.object(pool, "on_remote_storage", return_value=False):
+            self.assertFalse(zfs.on_remote_storage())
+        with mock.patch.object(pool, "on_remote_storage", return_value=True):
+            self.assertTrue(zfs.on_remote_storage())
+
+    def test_is_rootfs_on_remote_storage_with_zfs(self):
+        m = make_model()
+        ctrler = make_nvme_controller(
+            model=m,
+            transport="tcp",
+            tcp_addr="172.16.82.78",
+            tcp_port=4420,
+        )
+        d = make_disk(fs_model=m, name="nvme0n1", nvme_controller=ctrler)
+        pool = make_zpool(model=m, device=d, pool="pool0")
+        make_zfs(
+            model=m,
+            pool=pool,
+            volume="pool0/root",
+            properties={"mountpoint": "/", "canmount": "on"},
+        )
+        self.assertTrue(m.is_rootfs_on_remote_storage())
+
+    def test_is_bootfs_on_remote_storage_with_zfs(self):
+        m = make_model()
+        ctrler = make_nvme_controller(
+            model=m,
+            transport="tcp",
+            tcp_addr="172.16.82.78",
+            tcp_port=4420,
+        )
+        d = make_disk(fs_model=m, name="nvme0n1", nvme_controller=ctrler)
+        pool = make_zpool(model=m, device=d, pool="pool0")
+        make_zfs(
+            model=m,
+            pool=pool,
+            volume="pool0/boot",
+            properties={"mountpoint": "/boot", "canmount": "on"},
+        )
+        self.assertTrue(m.is_bootfs_on_remote_storage())
+
 
 class TestDiskForMatch(SubiTestCase):
     match_sort_criteria = (["smallest"], ["largest"])


### PR DESCRIPTION
`_mount_for_path` can sometimes return something that isn't a `Mount` object. When that happens, accessing `.device.volume` fails.

Typically, this happens with zpools and zfs datasets.

Instead of enumerating all the different scenarios, I'm adding a `on_remote_storage` method to all the potential fsobj.