### PR TITLE
storage: pick capability in dry-run storage v2 UI

### DIFF
--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -50,6 +50,7 @@ from subiquitycore.ui.form import (
     SubFormField,
 )
 from subiquitycore.ui.selector import Option
+from subiquitycore.ui.stretchy import Stretchy
 from subiquitycore.ui.table import TablePile, TableRow
 from subiquitycore.ui.utils import Color, rewrap, screen
 from subiquitycore.view import BaseView
@@ -327,6 +328,28 @@ installation will not be possible.
 )
 
 
+class CapabilitySelectionStretchy(Stretchy):
+    def __init__(
+        self, parent: "GuidedDiskSelectionViewV2Debug", *, target, allowed_capabilities
+    ) -> None:
+        self.parent = parent
+        self.target = target
+
+        buttons = []
+        for cap in allowed_capabilities:
+            label = cap.name.replace("_", " ").title()
+            buttons.append(
+                forward_btn(label=label, on_press=self.proceed, user_arg=cap)
+            )
+
+        return super().__init__("Capability", buttons, 0, 0)
+
+    def proceed(self, sender, cap: GuidedCapability):
+        self.parent.controller.guided_choice(
+            GuidedChoiceV2(target=self.target, capability=cap)
+        )
+
+
 class GuidedDiskSelectionViewV2Debug(BaseView):
     title = "Guided storage configuration for storage version 2 (only for debugging)"
 
@@ -337,9 +360,7 @@ some storage-version=2 bugs that may have occurred using the desktop installer.
 Considerations:
  * The view is incomplete, has no translations, might crash in some scenarios, use \
 it at your own risk...
- * The allowed / disallowed capabilities are basically ignored. Selecting \
-a scenario will use the DIRECT capability (except for manual partitioning where \
-it will use MANUAL)
+ * Parameters of allowed capabilities (e.g., passphrase for LVM+LUKS) are not supported.
  * For target resize, the recommended size will be used (no slider is implemented).
  """
 
@@ -429,9 +450,11 @@ it will use MANUAL)
             if isinstance(target, GuidedStorageTargetResize):
                 # Feel free to add a slider or something to configure the size...
                 target.new_size = target.recommended
-            # Feel free to implement something more than DIRECT
-            self.controller.guided_choice(
-                GuidedChoiceV2(target=target, capability=GuidedCapability.DIRECT)
+            # The overlay will call the controller or close itself
+            self.show_stretchy_overlay(
+                CapabilitySelectionStretchy(
+                    parent=self, target=target, allowed_capabilities=target.allowed
+                )
             )
 
 


### PR DESCRIPTION
In the debug storage v2 UI, we can now select the guided capability we want. The limitation is that the parameters are not yet supported. Therefore:
 * LVM+LUKS is essentially LVM (because we don't specify a passphrase - and Subiquity does not complain about it)
 * ZFS with keystore is essentially ZFS (because we don't specify a passphrase)

That said, it is still useful since it makes it possible to exercice guided ZFS and TPM backed FDE (with some limitations).

```diff
diff --git a/Makefile b/Makefile
index d546c7b1..10cc21d4 100644
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTHONPATH=$(shell pwd):$(shell pwd)/probert:$(shell pwd)/curtin
 PROBERTDIR=./probert
 PROBERT_REPO=https://github.com/canonical/probert
 DRYRUN?=--dry-run --bootloader uefi --machine-config examples/machines/simple.json \
-       --source-catalog examples/sources/install.yaml \
+       --source-catalog examples/sources/desktop.yaml --dry-run-config examples/dry-run-configs/tpm.yaml \
        --postinst-hooks-dir examples/postinst.d/
 UNITTESTARGS?=
 COVERAGEARGS:=--cov=subiquity --cov=subiquitycore --cov=console_conf
```


```bash
make dryrun-debug-sv2
```

<img width="1010" height="647" alt="Screenshot From 2026-06-23 20-56-08" src="https://github.com/user-attachments/assets/39d2ec93-4d71-4672-93d6-204d29973d9c" />
<img width="1010" height="647" alt="Screenshot From 2026-06-23 20-56-12" src="https://github.com/user-attachments/assets/6b08e0f9-e7d0-49ae-b869-6e2cbd962b60" />


