### PR TITLE
storage: add the option to remove a ZFS storage pool

### DIFF
--- a/subiquity/common/filesystem/manipulator.py
+++ b/subiquity/common/filesystem/manipulator.py
@@ -32,6 +32,7 @@ from subiquity.models.filesystem import (
     LVM_VolGroup,
     Partition,
     Raid,
+    ZPool,
     align_up,
 )
 from subiquitycore.utils import write_named_tempfile
@@ -187,6 +188,13 @@ class FilesystemManipulator:
         self.model.remove_volgroup(vg)
 
     delete_lvm_volgroup = delete_volgroup
+
+    def delete_zpool(self, zpool: ZPool):
+        for zfs in list(zpool._zfses):
+            self.model._remove(zfs)
+        for d in zpool.vdevs:
+            d.wipe = "superblock"
+        self.model.remove_zpool(zpool)
 
     def create_logical_volume(self, vg: LVM_VolGroup, spec: LogicalVolumeSpec):
         lv = self.model.add_logical_volume(vg=vg, name=spec["name"], size=spec["size"])

--- a/subiquity/common/filesystem/tests/test_manipulator.py
+++ b/subiquity/common/filesystem/tests/test_manipulator.py
@@ -83,6 +83,22 @@ class TestFilesystemManipulator(unittest.TestCase):
         dm_crypts = [a for a in manipulator.model._actions if a.type == "dm_crypt"]
         self.assertEqual(dm_crypts, [])
 
+    def test_delete_zpool(self):
+        manipulator, disk = make_manipulator_and_disk()
+        zpool = manipulator.model.add_zpool(device=disk, pool="pool0", mountpoint="/")
+        manipulator.delete_zpool(zpool)
+        self.assertNotIn(zpool, manipulator.model._actions)
+        self.assertEqual(disk.wipe, "superblock")
+
+    def test_delete_zpool_with_zfses(self):
+        manipulator, disk = make_manipulator_and_disk()
+        zpool = manipulator.model.add_zpool(device=disk, pool="pool0", mountpoint="/")
+        zfs = zpool.create_zfs(volume="pool0/ROOT")
+        manipulator.delete_zpool(zpool)
+        self.assertNotIn(zpool, manipulator.model._actions)
+        self.assertNotIn(zfs, manipulator.model._actions)
+        self.assertEqual(disk.wipe, "superblock")
+
     def test_wipe_existing_fs(self):
         # LP: #1983036 - edit a partition to wipe it and mount it, but not
         # actually change the fs type already there

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -2533,6 +2533,11 @@ class FilesystemModel:
         self._actions.append(zpool)
         return zpool
 
+    def remove_zpool(self, zpool: ZPool):
+        if len(zpool._zfses):
+            raise Exception("can only remove empty ZPOOL")
+        self._remove(zpool)
+
     def uses_zfs(self):
         return self._one(type="zpool") is not None
 

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1870,6 +1870,21 @@ class TestZPool(SubiTestCase):
         self.assertEqual("/SRV/srv", zfs_zp2.volume)
         self.assertEqual("/srv", zfs_zp2.path)
 
+    def test_remove_zpool(self):
+        m = make_model()
+        d = make_disk(m)
+        zp = make_zpool(model=m, device=d, mountpoint="/", pool="p1")
+        m.remove_zpool(zp)
+        self.assertNotIn(zp, m._actions)
+
+    def test_remove_zpool_with_zfses_fails(self):
+        m = make_model()
+        d = make_disk(m)
+        zp = make_zpool(model=m, device=d, mountpoint="/", pool="p1")
+        make_zfs(model=m, pool=zp, volume="pool1/ROOT")
+        with self.assertRaisesRegex(Exception, "empty ZPOOL"):
+            m.remove_zpool(zp)
+
 
 class TestRootfs(SubiTestCase):
     def test_mount_rootfs(self):


### PR DESCRIPTION
When a ZPool data structure exists, attempting to do a GuidedTargetReformat was leading to the following exception:
```python
  File "subiquity/server/controllers/filesystem.py", line 816, in start_guided_reformat
    self.reformat(disk, ptable=target.ptable, wipe="superblock-recursive")
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "subiquity/common/filesystem/manipulator.py", line 287, in reformat
    self.delete_partition(
    ~~~~~~~~~~~~~~~~~~~~~^
        p, override_preserve=True, allow_renumbering=False, allow_moving=False
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "subiquity/common/filesystem/manipulator.py", line 138, in delete_partition
    self.clear(part)
    ~~~~~~~~~~^^^^^^
  File "subiquity/common/filesystem/manipulator.py", line 279, in clear
    self.delete(subobj)
    ~~~~~~~~~~~^^^^^^^^
  File "subiquity/common/filesystem/manipulator.py", line 270, in delete
    getattr(self, "delete_" + obj.type)(obj)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'FilesystemController' object has no attribute 'delete_zpool'. Did you mean: 'create_zpool'?
```
Although it does not prevent existing ZFS installs from being overwritten (because probert zfs does not work), it is possible to run into this scenario using the /storage/v2/guided API.

Fixed by implementing the delete_zpool function, mimicking the delete_volgroup from LVM.
```
$ ./curl.sh  /storage/v2/guided --json '{"target": {"disk_id": "disk-sda", "$type": "GuidedStorageTargetReformat"}, "capability": "ZFS"}' 
{"status": "DONE", "error_report": null, "configured": {"target": {"disk_id": "disk-sda", "ptable": null, "allowed": [], "disallowed": [], "$type": "GuidedStorageTargetReformat"}, "capability": "ZFS", "password": null, "pin": null, "recovery_key": null, "sizing_policy": "SCALED", "reset_partition": false, "reset_partition_size": null}, "targets": [{"disk_id": "disk-sda", "ptable": null, "allowed": ["DIRECT", "LVM", "LVM_LUKS", "ZFS", "ZFS_LUKS_KEYSTORE"], "disallowed": [], "$type": "GuidedStorageTargetReformat"}, {"allowed": ["MANUAL"], "disallowed": [], "$type": "GuidedStorageTargetManual"}]}
$ ./curl.sh  /storage/v2/guided --json '{"target": {"disk_id": "disk-sda", "$type": "GuidedStorageTargetReformat"}, "capability": "ZFS"}' 
{"status": "DONE", "error_report": null, "configured": {"target": {"disk_id": "disk-sda", "ptable": null, "allowed": [], "disallowed": [], "$type": "GuidedStorageTargetReformat"}, "capability": "ZFS", "password": null, "pin": null, "recovery_key": null, "sizing_policy": "SCALED", "reset_partition": false, "reset_partition_size": null}, "targets": [{"disk_id": "disk-sda", "ptable": null, "allowed": ["DIRECT", "LVM", "LVM_LUKS", "ZFS", "ZFS_LUKS_KEYSTORE"], "disallowed": [], "$type": "GuidedStorageTargetReformat"}, {"allowed": ["MANUAL"], "disallowed": [], "$type": "GuidedStorageTargetManual"}]}
```

LP:#2057673