### PR TITLE
snapd: add support for hardware-root-of-trust error kind

### DIFF
--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -171,6 +171,7 @@ class CoreBootAvailabilityErrorKind(enum.Enum):
     PRE_OS_SECURE_BOOT_AUTH_BY_ENROLLED_DIGESTS = (
         "pre-os-secure-boot-auth-by-enrolled-digests"
     )
+    NO_HARDWARE_ROOT_OF_TRUST = "no-hardware-root-of-trust"
 
 
 # Shared enum used by the snapd API


### PR DESCRIPTION
secboot has introduced the new `"no-hardware-root-of-trust"` error kind for preinstall check. Let's make sure Subiquity knows about it.
Caught by our snapd-sync.yaml CI job
```
'ErrorKindNoHardwareRootOfTrust' => 'no-hardware-root-of-trust' is not present in Subiquity, consider adding.
```