### PR TITLE
snapd: pass keyboard layout to snapd

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -197,6 +197,8 @@ The layout (or layouts) of any attached keyboard. The mapping keys correspond to
 
 Multiple layouts may be configured using comma-separated values, as documented in :manpage:`keyboard(5)`.
 
+.. note:: Known issue: for TPM-backed encrypted installations with a passphrase, the disk can only be unlocked using the primary layout.
+
 The mapping contains keys:
 
 layout

--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -193,7 +193,9 @@ keyboard
 * **default:** US English keyboard
 * **can be interactive:** true
 
-The layout of any attached keyboard. The mapping keys correspond to settings in the :file:`/etc/default/keyboard` configuration file. See the :manpage:`keyboard(5)` manual page for more details.
+The layout (or layouts) of any attached keyboard. The mapping keys correspond to settings in the :file:`/etc/default/keyboard` configuration file. See the :manpage:`keyboard(5)` manual page for more details.
+
+Multiple layouts may be configured using comma-separated values, as documented in :manpage:`keyboard(5)`.
 
 The mapping contains keys:
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1155,6 +1155,12 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         )
         if self._volumes_auth is not None:
             kwargs["volumes_auth"] = self._volumes_auth
+        # This is required to have the proper keyboard layout on first boot
+        # before typing the passphrase.
+        # Only supported since 2.76 but ignored on older versions.
+        kwargs["keyboard_config"] = snapdtypes.KeyboardConfig.from_subiquity_kb_model(
+            self.app.base_model.keyboard
+        )
         result = await snapdapi.post_and_wait(
             self.app.snapdapi,
             self.app.snapdapi.v2.systems[label].POST,

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -487,6 +487,42 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.assertIsNone(self.fsc.queued_probe_data)
         load.assert_not_called()
 
+    async def test_setup_encryption__passes_keyboard_config(self):
+        self.fsc._info = mock.Mock()
+        self.fsc._info.label = "prefer-encrypted"
+        self.fsc._info.system.volumes = {"vol-key": mock.Mock()}
+        self.fsc._on_volume = mock.Mock()
+        self.fsc._volumes_auth = None
+
+        kb = self.app.base_model.keyboard
+        kb.setting.layout = "fr"
+        kb.setting.variant = "azerty"
+        kb.setting.toggle = "alt_shift_toggle"
+
+        with mock.patch.object(
+            snapdapi,
+            "post_and_wait",
+            return_value=mock.Mock(encrypted_devices={}),
+        ) as m_post:
+            await self.fsc.setup_encryption()
+
+        # post_and_wait is called as:
+        #   post_and_wait(client, meth, request, ann=...)
+        # so:
+        #   args[0] is the snapdapi client
+        #   args[1] is the systems[label].POST bound method
+        #   args[2] is the SystemActionRequest
+        req = m_post.call_args.args[2]
+        self.assertEqual(
+            snapdtypes.KeyboardConfig(
+                model="pc105",
+                layout="fr",
+                variant="azerty",
+                options=["grp:alt_shift_toggle"],
+            ),
+            req.keyboard_config,
+        )
+
     fw_lenovo = {
         "bios-vendor": "LENOVO",
         "bios-version": "R10ET39W (1.24 )",
@@ -3168,6 +3204,9 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
     async def test_from_sample_data(self):
         # calling this a unit test is definitely questionable. but it
         # runs much more quickly than the integration test!
+        self.app.base_model.keyboard.setting.layout = "us"
+        self.app.base_model.keyboard.setting.variant = ""
+        self.app.base_model.keyboard.setting.toggle = None
         self.fsc.model = model = make_model(Bootloader.UEFI)
         disk = make_disk(model)
         self.app.base_model.source.current.type = "fsimage"

--- a/subiquity/server/snapd/test/test_types.py
+++ b/subiquity/server/snapd/test/test_types.py
@@ -14,11 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import TestCase
+from unittest.mock import Mock
 
 import attr
 import attrs
 
-from subiquity.server.snapd.types import snapdtype
+from subiquity.server.snapd.types import KeyboardConfig, snapdtype
 from subiquitycore.tests.parameterized import parameterized
 
 
@@ -38,3 +39,52 @@ class TestMetadataMerge(TestCase):
 
         [field] = attrs.fields(MetadataMerge)
         self.assertEqual(expected, field.metadata)
+
+
+class TestKeyboardConfig(TestCase):
+    @parameterized.expand(
+        (
+            # default us layout
+            ("us", "", None, "us", "", []),
+            # with toggle
+            ("us", "", "alt_shift_toggle", "us", "", ["grp:alt_shift_toggle"]),
+            # with variant
+            ("us", "dvorak", None, "us", "dvorak", []),
+            # with toggle and variant
+            (
+                "fr",
+                "azerty",
+                "alt_shift_toggle",
+                "fr",
+                "azerty",
+                ["grp:alt_shift_toggle"],
+            ),
+            # with multi layout
+            (
+                "us,cz",
+                ",bksl",
+                "alt_shift_toggle",
+                "us",
+                "",
+                ["grp:alt_shift_toggle"],
+            ),
+        )
+    )
+    def test_from_subiquity_kb_model(
+        self,
+        layout,
+        variant,
+        toggle,
+        expected_layout,
+        expected_variant,
+        expected_options,
+    ):
+        kb = Mock()
+        kb.setting.layout = layout
+        kb.setting.variant = variant
+        kb.setting.toggle = toggle
+        config = KeyboardConfig.from_subiquity_kb_model(kb)
+        self.assertEqual(config.model, "pc105")
+        self.assertEqual(config.layout, expected_layout)
+        self.assertEqual(config.variant, expected_variant)
+        self.assertEqual(config.options, expected_options)

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -341,6 +341,29 @@ class VolumesAuth:
 
 
 @snapdtype
+class KeyboardConfig:
+    model: str
+    layout: str
+    variant: str
+    options: List[str]
+
+    @classmethod
+    def from_subiquity_kb_model(cls, model) -> "KeyboardConfig":
+        # KeyboardSetting.layout/variant can hold comma-separated multi-layout
+        # values, but snapd's KeyboardConfig only accepts a single layout/variant
+        # (its Validate() rejects commas). snapd's KernelCommandLineFragment only
+        # uses the first layout anyway, so we send only the primary one.
+        layout = model.setting.layout.split(",")[0]
+        variant = model.setting.variant.split(",")[0]
+        return cls(
+            model="pc105",
+            layout=layout,
+            variant=variant,
+            options=[] if not model.setting.toggle else [f"grp:{model.setting.toggle}"],
+        )
+
+
+@snapdtype
 class SystemActionRequest:
     action: Optional[SystemAction] = None
 
@@ -351,6 +374,7 @@ class SystemActionRequest:
     # When optional_install=None it is equivalent to OptionalInstall(all=True)
     optional_install: Optional[OptionalInstall] = None
     volumes_auth: Optional[VolumesAuth] = None
+    keyboard_config: Optional[KeyboardConfig] = None  # New in snapd 2.76
     # -- for step=PRESEED
     target_root: Optional[str] = None
 


### PR DESCRIPTION
Since snapd 2.76, setup_encryption expects the keyboard configuration. The purpose is to setup the keyboard correctly on first boot before asking for the passphrase.

In snapd before version 2.76, the keyboard configuration is unsupported and would be ignored.