### PR TITLE
Add core boot encryption requirements

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -71,7 +71,7 @@ from subiquity.common.types import (
 from subiquity.common.types.storage import (
     AddPartitionV2,
     CalculateEntropyRequest,
-    CoreBootEncryptionFeatures,
+    CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
     CoreBootFixEncryptionSupport,
     Disk,
@@ -406,7 +406,7 @@ class API:
                 def GET() -> str: ...
 
             class core_boot_encryption_features:
-                def GET() -> List[CoreBootEncryptionFeatures]: ...
+                def GET() -> List[CoreBootEncryptionFeature]: ...
 
             class core_boot_encryption_requirements:
                 def GET() -> List[CoreBootEncryptionRequirement]:

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -72,6 +72,7 @@ from subiquity.common.types.storage import (
     AddPartitionV2,
     CalculateEntropyRequest,
     CoreBootEncryptionFeatures,
+    CoreBootEncryptionRequirement,
     CoreBootFixEncryptionSupport,
     Disk,
     EntropyResponse,
@@ -406,6 +407,12 @@ class API:
 
             class core_boot_encryption_features:
                 def GET() -> List[CoreBootEncryptionFeatures]: ...
+
+            class core_boot_encryption_requirements:
+                def GET() -> List[CoreBootEncryptionRequirement]:
+                    """Return the storage-encryption requirements that must be
+                    met for a TPM/FDE install (e.g. "volumes-auth"), as
+                    reported by snapd."""
 
             class core_boot_fix_encryption_support:
                 def POST(data: Payload[CoreBootFixEncryptionSupport]) -> None: ...

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -568,6 +568,10 @@ class CoreBootEncryptionFeatures(enum.Enum):
     PIN_AUTH = "pin-auth"
 
 
+class CoreBootEncryptionRequirement(enum.Enum):
+    VOLUMES_AUTH = "volumes-auth"
+
+
 @attr.s(auto_attribs=True)
 class CoreBootFixEncryptionSupport:
     action: CoreBootFixActionWithArgs

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -563,11 +563,14 @@ class EntropyResponse:
     failure_reasons: Optional[List[str]] = None
 
 
-class CoreBootEncryptionFeatures(enum.Enum):
+# Each value describes a single feature offered for a core-boot (TPM/FDE)
+# install.
+class CoreBootEncryptionFeature(enum.Enum):
     PASSPHRASE_AUTH = "passphrase-auth"
     PIN_AUTH = "pin-auth"
 
 
+# Requirements that must be met for storage encryption to be supported.
 class CoreBootEncryptionRequirement(enum.Enum):
     VOLUMES_AUTH = "volumes-auth"
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -56,6 +56,7 @@ from subiquity.common.types.storage import (
     Bootloader,
     CalculateEntropyRequest,
     CoreBootEncryptionFeatures,
+    CoreBootEncryptionRequirement,
     CoreBootEncryptionSupportError,
     CoreBootFixAction,
     CoreBootFixEncryptionSupport,
@@ -1922,6 +1923,38 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 return []
 
             return [CoreBootEncryptionFeatures(feature.value) for feature in features]
+
+        raise StorageInvalidUsageError("no suitable variation for core boot")
+
+    async def v2_core_boot_encryption_requirements_GET(
+        self,
+    ) -> List[CoreBootEncryptionRequirement]:
+        """Return a list of requirements that must be met for storage
+        encryption to be supported when installing with TPM/FDE. If multiple
+        variations support TPM/FDE, only the first one is accounted for.
+        Although it sounds like an arbitrary choice, it is consistent with the
+        implementation of set_info_for_capability, which is used when doing a
+        POST to /storage/v2/guided (the user does not choose which variation
+        to use)."""
+        # Typically, this endpoint is used by the desktop installer before any
+        # POST /storage/* is done. This means we can't "guess" what the user
+        # wants to do, not even if they really want to do TPM/FDE.
+        for variation in self._variation_info.values():
+            try:
+                requirements: list[snapdtypes.EncryptionRequirement] = (
+                    variation.system.storage_encryption.requirements
+                )
+            except AttributeError:
+                continue
+
+            if requirements is None:
+                # Snapd is not reporting any requirement.
+                return []
+
+            return [
+                CoreBootEncryptionRequirement(requirement.value)
+                for requirement in requirements
+            ]
 
         raise StorageInvalidUsageError("no suitable variation for core boot")
 

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -55,7 +55,7 @@ from subiquity.common.types.storage import (
     AddPartitionV2,
     Bootloader,
     CalculateEntropyRequest,
-    CoreBootEncryptionFeatures,
+    CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
     CoreBootEncryptionSupportError,
     CoreBootFixAction,
@@ -1900,7 +1900,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
 
     async def v2_core_boot_encryption_features_GET(
         self,
-    ) -> List[CoreBootEncryptionFeatures]:
+    ) -> List[CoreBootEncryptionFeature]:
         """Return a list of encryption features (i.e., pin, passphrase)
         supported when installing with TPM/FDE. If multiple variations support
         TPM/FDE, only the first one is accounted for. Although it sounds like
@@ -1922,7 +1922,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 # Snapd is not offering pin/passphrase.
                 return []
 
-            return [CoreBootEncryptionFeatures(feature.value) for feature in features]
+            return [CoreBootEncryptionFeature(feature.value) for feature in features]
 
         raise StorageInvalidUsageError("no suitable variation for core boot")
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -33,7 +33,7 @@ from subiquity.common.types.storage import (
     AddPartitionV2,
     Bootloader,
     CalculateEntropyRequest,
-    CoreBootEncryptionFeatures,
+    CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
     CoreBootFixAction,
     CoreBootFixActionWithArgs,
@@ -1097,24 +1097,24 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
                     snapdtypes.EncryptionFeature.PASSPHRASE_AUTH,
                 ],
                 [
-                    CoreBootEncryptionFeatures.PIN_AUTH,
-                    CoreBootEncryptionFeatures.PASSPHRASE_AUTH,
+                    CoreBootEncryptionFeature.PIN_AUTH,
+                    CoreBootEncryptionFeature.PASSPHRASE_AUTH,
                 ],
             ),
             (
                 [snapdtypes.EncryptionFeature.PIN_AUTH],
-                [CoreBootEncryptionFeatures.PIN_AUTH],
+                [CoreBootEncryptionFeature.PIN_AUTH],
             ),
             (
                 [snapdtypes.EncryptionFeature.PASSPHRASE_AUTH],
-                [CoreBootEncryptionFeatures.PASSPHRASE_AUTH],
+                [CoreBootEncryptionFeature.PASSPHRASE_AUTH],
             ),
         )
     )
     async def test_v2_core_boot_encryption_features_GET(
         self,
         snapd_features: list[snapdtypes.EncryptionFeature],
-        expected: list[CoreBootEncryptionFeatures],
+        expected: list[CoreBootEncryptionFeature],
     ):
         self.fsc.model = make_model()
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -34,6 +34,7 @@ from subiquity.common.types.storage import (
     Bootloader,
     CalculateEntropyRequest,
     CoreBootEncryptionFeatures,
+    CoreBootEncryptionRequirement,
     CoreBootFixAction,
     CoreBootFixActionWithArgs,
     CoreBootFixEncryptionSupport,
@@ -1176,6 +1177,67 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
             StorageInvalidUsageError, "no suitable variation for core boot"
         ):
             await self.fsc.v2_core_boot_encryption_features_GET()
+
+    @parameterized.expand(
+        (
+            (
+                [snapdtypes.EncryptionRequirement.VOLUMES_AUTH],
+                [CoreBootEncryptionRequirement.VOLUMES_AUTH],
+            ),
+            (
+                # No requirement
+                None,
+                [],
+            ),
+        )
+    )
+    async def test_v2_core_boot_encryption_requirements_GET(
+        self,
+        snapd_requirements: list[snapdtypes.EncryptionRequirement],
+        expected: list[CoreBootEncryptionRequirement],
+    ):
+        self.fsc.model = make_model()
+
+        self.fsc._variation_info = {
+            "mimimal-enhanced-secureboot": VariationInfo(
+                name="minimal-enhanced-secureboot",
+                label="enhanced-secureboot-desktop",
+                system=snapdtypes.SystemDetails(
+                    model=snapdtypes.Model(architecture="amd64", snaps=[]),
+                    label="enhanced-secureboot-desktop",
+                    storage_encryption=snapdtypes.StorageEncryption(
+                        support=snapdtypes.StorageEncryptionSupport.AVAILABLE,
+                        storage_safety=snapdtypes.StorageSafety.PREFER_ENCRYPTED,
+                        requirements=snapd_requirements,
+                    ),
+                ),
+            ),
+        }
+
+        self.assertEqual(
+            expected, await self.fsc.v2_core_boot_encryption_requirements_GET()
+        )
+
+    async def test_v2_core_boot_encryption_requirements_GET__no_suitable_variation(
+        self,
+    ):
+        self.fsc.model = make_model()
+
+        self.fsc._variation_info = {}
+
+        with self.assertRaisesRegex(
+            StorageInvalidUsageError, "no suitable variation for core boot"
+        ):
+            await self.fsc.v2_core_boot_encryption_requirements_GET()
+
+        self.fsc._variation_info = {
+            "minimal": VariationInfo(name="minimal", label=None, system=None),
+        }
+
+        with self.assertRaisesRegex(
+            StorageInvalidUsageError, "no suitable variation for core boot"
+        ):
+            await self.fsc.v2_core_boot_encryption_requirements_GET()
 
     # Just to make sure we don't reboot/shutdown if other assertions fail.
     @mock.patch(

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -198,11 +198,9 @@ class EncryptionType(enum.Enum):
     DEVICE_SETUP_HOOK = "device-setup-hook"
 
 
-class EncryptionFeature(enum.Enum):
-    PASSPHRASE_AUTH = "passphrase-auth"
-    PIN_AUTH = "pin-auth"
-
-
+# Alias the snapd-side enums to the Subiquity API storage types so the two layers
+# cannot drift apart instead of duplicating the definitions here.
+EncryptionFeature = storagetypes.CoreBootEncryptionFeature
 EncryptionRequirement = storagetypes.CoreBootEncryptionRequirement
 
 AvailabilityAction = storagetypes.CoreBootFixAction

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -203,6 +203,8 @@ class EncryptionFeature(enum.Enum):
     PIN_AUTH = "pin-auth"
 
 
+EncryptionRequirement = storagetypes.CoreBootEncryptionRequirement
+
 AvailabilityAction = storagetypes.CoreBootFixAction
 AvailabilityActionArgs = storagetypes.CoreBootFixActionArgs
 AvailabilityErrorKind = storagetypes.CoreBootAvailabilityErrorKind
@@ -225,6 +227,8 @@ class StorageEncryption:
     # Introduced in snapd 2.68, but can be None if snapd does not want to offer
     # pin/passphrase.
     features: Optional[List[EncryptionFeature]] = None
+    # Introduced in snapd 2.76, but can be None if snapd has no requirement.
+    requirements: Optional[List[EncryptionRequirement]] = None
 
     # Since snapd 2.71 <-- to be confirmed once released.
     availability_check_errors: Optional[List[AvailabilityCheckError]] = None


### PR DESCRIPTION
This introduces a new endpoint that mimics snapd's `encryption.requirements`. The only difference is that while snapd's `requirements` field will not be present if empty, Subiquity will return an empty list instead.

I've used the opportunity to rename `CoreBootEncryptionFeatures` to `CoreBootEncryptionFeature` since it's an enumeration, not a flag class, list or anything that calls for plural.

@d-loose fyi