### PR TITLE
Add auto-proceed option for errors in TPM/FDE autoinstalls

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -40,6 +40,7 @@ PPA
 PPAs
 PReP
 RSA
+Secboot
 SHA
 SSD
 Seagate

--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -623,6 +623,33 @@ Additionally, TPM-backed encryption can be enabled by using the ``hybrid`` layou
           name: hybrid
           encrypted: yes
 
+TPM-backed encryption supports the additional ``auto-proceed`` property, specifying the list of pre-install errors that Subiquity should automatically attempt to proceed past.
+
+.. code-block:: yaml
+
+    autoinstall:
+      storage:
+        layout:
+          name: hybrid
+          encrypted: yes
+          auto-proceed: [running-in-vm]
+
+One can also specify ``auto-proceed`` as a single pre-install error (i.e., ``auto-proceed: running-in-vm``).
+
+The list of currently supported pre-install errors is:
+
+ * ``running-in-vm``
+ * ``insufficient-dma-protection``
+ * ``no-kernel-iommu``
+ * ``addon-drivers-present``
+ * ``sys-prep-applications-present``
+ * ``absolute-present``
+ * ``weak-secure-boot-algorithms-detected``
+ * ``pre-os-secure-boot-auth-by-enrolled-digests``
+ * ``no-hardware-root-of-trust``
+
+See the `upstream definition in Secboot <https://github.com/canonical/secboot/blob/457b03a16d19dadd703c5a33bf8565f16113023c/efi/preinstall/checks_context.go#L162-L172>`__
+
 Sizing-policy
 ^^^^^^^^^^^^^
 

--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -623,6 +623,45 @@ Additionally, TPM-backed encryption can be enabled by using the ``hybrid`` layou
           name: hybrid
           encrypted: yes
 
+TPM-backed encryption supports the additional ``accepted-errors`` property, which lists the pre-install errors that the user accepts. For each accepted error, Subiquity automatically executes the corresponding ``proceed`` action that snapd offers for it, allowing the unattended installation to continue.
+
+.. note::
+
+   The ``accepted-errors`` property is the autoinstall equivalent of selecting **Solution: Ignore** for each listed error in the desktop installer UI.
+
+.. code-block:: yaml
+
+    autoinstall:
+      storage:
+        layout:
+          name: hybrid
+          encrypted: yes
+          accepted-errors: [running-in-vm]
+
+One can also specify ``accepted-errors`` as a single pre-install error (i.e., ``accepted-errors: running-in-vm``).
+
+The list of currently supported pre-install errors is:
+
+ * ``running-in-vm``
+ * ``insufficient-dma-protection``
+ * ``no-kernel-iommu``
+ * ``addon-drivers-present``
+ * ``sys-prep-applications-present``
+ * ``absolute-present``
+ * ``weak-secure-boot-algorithms-detected``
+ * ``pre-os-secure-boot-auth-by-enrolled-digests``
+ * ``no-hardware-root-of-trust``
+
+See the `upstream definition in Secboot <https://github.com/canonical/secboot/blob/457b03a16d19dadd703c5a33bf8565f16113023c/efi/preinstall/checks_context.go#L162-L172>`__
+
+.. note::
+
+   Listing an error kind means you accept the associated risk. Several errors kinds such as ``weak-secure-boot-algorithms-detected`` indicate a reduced security posture; only list them when you understand the implications for the installed system.
+
+.. note::
+
+   Only errors for which snapd offers a ``proceed`` action can be honored. Other errors (those that require a different action such as ``reboot``, ``enable-tpm-via-firmware`` or ``clear-tpm``) are **not** handled and will still cause the installation to fail, even if listed under ``accepted-errors``.
+
 Sizing-policy
 ^^^^^^^^^^^^^
 

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -55,10 +55,12 @@ from subiquity.common.types.storage import (
     AddPartitionV2,
     Bootloader,
     CalculateEntropyRequest,
+    CoreBootAvailabilityErrorKind,
     CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
     CoreBootEncryptionSupportError,
     CoreBootFixAction,
+    CoreBootFixActionArgs,
     CoreBootFixActionWithArgs,
     CoreBootFixEncryptionSupport,
     Disk,
@@ -371,6 +373,10 @@ class StorageController(SubiquityController, StorageManipulator):
 
         # If needed, this can be moved outside of the storage/filesystem stuff.
         self._probe_firmware_task = SingleInstanceTask(self._probe_firmware)
+
+        # What error kinds we allow to automatically proceed with for
+        # unattended installs.
+        self.autoproceed: set[CoreBootAvailabilityErrorKind] = set()
 
     def is_core_boot_classic(self):
         return self._info.is_core_boot_classic()
@@ -2192,7 +2198,9 @@ class StorageController(SubiquityController, StorageManipulator):
             return False
         return True
 
-    def ensure_core_boot_autoinstall_capability_compatible(self, capability) -> None:
+    async def ensure_core_boot_autoinstall_capability_compatible(
+        self, capability, *, autoproceed: set[CoreBootAvailabilityErrorKind] = set()
+    ) -> None:
         for allowed in self.find_allowed_capabilities(core_boot_classic=True):
             if capability.is_compatible_with(allowed):
                 return
@@ -2205,25 +2213,41 @@ class StorageController(SubiquityController, StorageManipulator):
             raise RuntimeError(f"invalid capability {capability.name}")
 
         # Now let's generate an autoinstall error that includes usable info
-        first_error = None
+        error = None
         try:
             disallowed_errors = self._find_disallowed_errors(capability)
         except ValueError:
             pass
         else:
             try:
-                first_error = next(iter(disallowed_errors)).kind.value
+                # We pick the first one ...
+                error = next(iter(disallowed_errors))
             except StopIteration:
                 pass
             else:
+                # Let's check if we have auto-proceed for this error
+                actions = {action.type for action in error.actions}
+                if error.kind in autoproceed and CoreBootFixAction.PROCEED in actions:
+                    # We do, let's proceed and retry
+                    action_proceed = CoreBootFixActionWithArgs(
+                        type=CoreBootFixAction.PROCEED,
+                        args=CoreBootFixActionArgs(
+                            error_kinds=[error.kind],
+                        ),
+                    )
+                    await self.execute_fix_action(action_proceed)
+                    await self.ensure_core_boot_autoinstall_capability_compatible(
+                        capability, autoproceed=autoproceed
+                    )
+                    return
                 raise AutoinstallError(
                     _(
-                        f"hybrid layout ({encryption_text}) is not available: {first_error}"
+                        f"hybrid layout ({encryption_text}) is not available: {error.kind.value}"
                     )
                 )
         raise AutoinstallError(f"hybrid layout ({encryption_text}) is not available")
 
-    def get_core_boot_autoinstall_capability(
+    async def get_core_boot_autoinstall_capability(
         self, *, encrypted: bool | None
     ) -> GuidedCapability:
         core_boot_caps = set(self.find_allowed_capabilities(core_boot_classic=True))
@@ -2249,7 +2273,11 @@ class StorageController(SubiquityController, StorageManipulator):
 
         # this check is conceptually unnecessary but results in a
         # much cleaner error message...
-        self.ensure_core_boot_autoinstall_capability_compatible(capability)
+
+        await self.ensure_core_boot_autoinstall_capability_compatible(
+            capability,
+            autoproceed=self.autoproceed,
+        )
         return capability
 
     async def run_autoinstall_guided(self, layout):
@@ -2261,7 +2289,22 @@ class StorageController(SubiquityController, StorageManipulator):
         if name == "hybrid":
             if "mode" in layout:
                 raise AutoinstallError("cannot use 'mode' with hybrid layout")
-            capability = self.get_core_boot_autoinstall_capability(
+
+            if "auto-proceed" in layout:
+                autoproceed = layout["auto-proceed"]
+                if isinstance(autoproceed, str):
+                    autoproceed = [autoproceed]
+                kinds = set()
+                for kind in autoproceed:
+                    try:
+                        kinds.add(CoreBootAvailabilityErrorKind(kind))
+                    except ValueError:
+                        raise AutoinstallError(
+                            f"invalid error kind {kind!r} in 'auto-proceed'"
+                        ) from None
+                self.autoproceed = kinds
+
+            capability = await self.get_core_boot_autoinstall_capability(
                 encrypted=layout.get("encrypted", None)
             )
 

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -59,6 +59,7 @@ from subiquity.common.types.storage import (
     CoreBootEncryptionRequirement,
     CoreBootEncryptionSupportError,
     CoreBootFixAction,
+    CoreBootFixActionWithArgs,
     CoreBootFixEncryptionSupport,
     Disk,
     EntropyResponse,
@@ -1964,8 +1965,8 @@ class StorageController(SubiquityController, StorageManipulator):
 
         raise StorageInvalidUsageError("no suitable variation for core boot")
 
-    async def v2_core_boot_fix_encryption_support_POST(
-        self, data: CoreBootFixEncryptionSupport
+    async def execute_fix_action(
+        self, action: CoreBootFixActionWithArgs, system_label: str | None
     ) -> None:
         async def shutdown_action(action):
             if self.app.opts.dry_run:
@@ -1993,8 +1994,8 @@ class StorageController(SubiquityController, StorageManipulator):
             ),
         }
 
-        if data.action.type in local_actions:
-            action = local_actions[data.action.type]
+        if action.type in local_actions:
+            action = local_actions[action.type]
             await action.coroutine_function(*action.args)
             return
 
@@ -2002,7 +2003,7 @@ class StorageController(SubiquityController, StorageManipulator):
         # self._info.label here if the system label is not specified. This is
         # because in the normal flow, fix-encryption-support is called *before*
         # choosing a variation.
-        label_filter = data.system_label if data.system_label is not None else False
+        label_filter = system_label if system_label is not None else False
         try:
             variation = next(
                 self.find_variations(core_boot_classic=True, label=label_filter)
@@ -2013,8 +2014,8 @@ class StorageController(SubiquityController, StorageManipulator):
         system = await self.app.snapdapi.v2.systems[variation.label].POST(
             snapdtypes.SystemActionRequest(
                 action=snapdtypes.SystemAction.FIX_ENCRYPTION_SUPPORT,
-                fix_action=data.action.type,
-                args=data.action.args,
+                fix_action=action.type,
+                args=action.args,
             ),
             return_type=snapdtypes.SystemDetails,
         )
@@ -2037,6 +2038,11 @@ class StorageController(SubiquityController, StorageManipulator):
         )
         self._maybe_disable_encryption(info)
         self._variation_info[variation.name] = info
+
+    async def v2_core_boot_fix_encryption_support_POST(
+        self, data: CoreBootFixEncryptionSupport
+    ) -> None:
+        await self.execute_fix_action(data.action, data.system_label)
 
     async def dry_run_wait_probe_POST(self) -> None:
         if not self.app.opts.dry_run:

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -60,10 +60,12 @@ from subiquity.common.types.storage import (
     AddPartitionV2,
     Bootloader,
     CalculateEntropyRequest,
+    CoreBootAvailabilityErrorKind,
     CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
     CoreBootEncryptionSupportError,
     CoreBootFixAction,
+    CoreBootFixActionArgs,
     CoreBootFixActionWithArgs,
     CoreBootFixEncryptionSupport,
     Disk,
@@ -415,6 +417,10 @@ class StorageController(SubiquityController, StorageManipulator):
 
         # If needed, this can be moved outside of the storage/filesystem stuff.
         self._probe_firmware_task = SingleInstanceTask(self._probe_firmware)
+
+        # Pre-install error kinds that the user accepts (and that we should
+        # automatically proceed past for unattended installs).
+        self.accepted_errors: set[CoreBootAvailabilityErrorKind] = set()
 
     def is_core_boot_classic(self):
         return self._info.is_core_boot_classic()
@@ -2160,7 +2166,9 @@ class StorageController(SubiquityController, StorageManipulator):
             return False
         return True
 
-    def ensure_core_boot_autoinstall_capability_compatible(self, capability) -> None:
+    async def ensure_core_boot_autoinstall_capability_compatible(
+        self, capability, *, accepted_errors: set[CoreBootAvailabilityErrorKind] = set()
+    ) -> None:
         for allowed in self.find_allowed_capabilities(core_boot_classic=True):
             if capability.is_compatible_with(allowed):
                 return
@@ -2173,25 +2181,44 @@ class StorageController(SubiquityController, StorageManipulator):
             raise RuntimeError(f"invalid capability {capability.name}")
 
         # Now let's generate an autoinstall error that includes usable info
-        first_error = None
+        error = None
         try:
             disallowed_errors = self._find_disallowed_errors(capability)
         except ValueError:
             pass
         else:
             try:
-                first_error = next(iter(disallowed_errors)).kind.value
+                # We pick the first one ...
+                error = next(iter(disallowed_errors))
             except StopIteration:
                 pass
             else:
+                # Let's check if the user accepts this error
+                actions = {action.type for action in error.actions}
+                if (
+                    error.kind in accepted_errors
+                    and CoreBootFixAction.PROCEED in actions
+                ):
+                    # We do, let's proceed and retry
+                    action_proceed = CoreBootFixActionWithArgs(
+                        type=CoreBootFixAction.PROCEED,
+                        args=CoreBootFixActionArgs(
+                            error_kinds=[error.kind],
+                        ),
+                    )
+                    await self.execute_fix_action(action_proceed)
+                    await self.ensure_core_boot_autoinstall_capability_compatible(
+                        capability, accepted_errors=accepted_errors
+                    )
+                    return
                 raise AutoinstallError(
                     _(
-                        f"hybrid layout ({encryption_text}) is not available: {first_error}"
+                        f"hybrid layout ({encryption_text}) is not available: {error.kind.value}"
                     )
                 )
         raise AutoinstallError(f"hybrid layout ({encryption_text}) is not available")
 
-    def get_core_boot_autoinstall_capability(
+    async def get_core_boot_autoinstall_capability(
         self, *, encrypted: bool | None
     ) -> GuidedCapability:
         core_boot_caps = set(self.find_allowed_capabilities(core_boot_classic=True))
@@ -2217,7 +2244,11 @@ class StorageController(SubiquityController, StorageManipulator):
 
         # this check is conceptually unnecessary but results in a
         # much cleaner error message...
-        self.ensure_core_boot_autoinstall_capability_compatible(capability)
+
+        await self.ensure_core_boot_autoinstall_capability_compatible(
+            capability,
+            accepted_errors=self.accepted_errors,
+        )
         return capability
 
     async def run_autoinstall_guided(self, layout):
@@ -2227,7 +2258,21 @@ class StorageController(SubiquityController, StorageManipulator):
         guided_recovery_key: Union[bool, RecoveryKey] = False
 
         if name == "hybrid":
-            capability = self.get_core_boot_autoinstall_capability(
+            if "accepted-errors" in layout:
+                accepted_errors = layout["accepted-errors"]
+                if isinstance(accepted_errors, str):
+                    accepted_errors = [accepted_errors]
+                kinds = set()
+                for kind in accepted_errors:
+                    try:
+                        kinds.add(CoreBootAvailabilityErrorKind(kind))
+                    except ValueError:
+                        raise AutoinstallError(
+                            f"invalid error kind {kind!r} in 'accepted-errors'"
+                        ) from None
+                self.accepted_errors = kinds
+
+            capability = await self.get_core_boot_autoinstall_capability(
                 encrypted=layout.get("encrypted", None)
             )
             # Default to reformat_disk for backward compatibility:

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -64,6 +64,7 @@ from subiquity.common.types.storage import (
     CoreBootEncryptionRequirement,
     CoreBootEncryptionSupportError,
     CoreBootFixAction,
+    CoreBootFixActionWithArgs,
     CoreBootFixEncryptionSupport,
     Disk,
     EntropyResponse,
@@ -1932,8 +1933,8 @@ class StorageController(SubiquityController, StorageManipulator):
 
         raise StorageInvalidUsageError("no suitable variation for core boot")
 
-    async def v2_core_boot_fix_encryption_support_POST(
-        self, data: CoreBootFixEncryptionSupport
+    async def execute_fix_action(
+        self, action: CoreBootFixActionWithArgs, system_label: str | None
     ) -> None:
         async def shutdown_action(action):
             if self.app.opts.dry_run:
@@ -1961,8 +1962,8 @@ class StorageController(SubiquityController, StorageManipulator):
             ),
         }
 
-        if data.action.type in local_actions:
-            action = local_actions[data.action.type]
+        if action.type in local_actions:
+            action = local_actions[action.type]
             await action.coroutine_function(*action.args)
             return
 
@@ -1970,7 +1971,7 @@ class StorageController(SubiquityController, StorageManipulator):
         # self._info.label here if the system label is not specified. This is
         # because in the normal flow, fix-encryption-support is called *before*
         # choosing a variation.
-        label_filter = data.system_label if data.system_label is not None else False
+        label_filter = system_label if system_label is not None else False
         try:
             variation = next(
                 self.find_variations(core_boot_classic=True, label=label_filter)
@@ -1981,8 +1982,8 @@ class StorageController(SubiquityController, StorageManipulator):
         system = await self.app.snapdapi.v2.systems[variation.label].POST(
             snapdtypes.SystemActionRequest(
                 action=snapdtypes.SystemAction.FIX_ENCRYPTION_SUPPORT,
-                fix_action=data.action.type,
-                args=data.action.args,
+                fix_action=action.type,
+                args=action.args,
             ),
             return_type=snapdtypes.SystemDetails,
         )
@@ -2005,6 +2006,11 @@ class StorageController(SubiquityController, StorageManipulator):
         )
         self._maybe_disable_encryption(info)
         self._variation_info[variation.name] = info
+
+    async def v2_core_boot_fix_encryption_support_POST(
+        self, data: CoreBootFixEncryptionSupport
+    ) -> None:
+        await self.execute_fix_action(data.action, data.system_label)
 
     async def dry_run_wait_probe_POST(self) -> None:
         if not self.app.opts.dry_run:

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import copy
+import re
 import subprocess
 import uuid
 from pathlib import Path
@@ -33,10 +34,14 @@ from subiquity.common.types.storage import (
     AddPartitionV2,
     Bootloader,
     CalculateEntropyRequest,
+    CoreBootAvailabilityErrorKind,
     CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
+    CoreBootEncryptionSupportError,
     CoreBootFixAction,
+    CoreBootFixActionArgs,
     CoreBootFixActionWithArgs,
+    CoreBootFixActionWithCategoryAndArgs,
     CoreBootFixEncryptionSupport,
     EntropyResponse,
     Gap,
@@ -445,7 +450,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
             (None, set(), AutoinstallError),
         )
     )
-    def test_get_core_boot_autoinstall_capability(
+    async def test_get_core_boot_autoinstall_capability(
         self, encrypted: bool, allowed_caps: set[GuidedCapability], expected
     ):
         with mock.patch.object(
@@ -460,10 +465,104 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
             with ctx:
                 self.assertEqual(
                     expected,
-                    self.ctrler.get_core_boot_autoinstall_capability(
+                    await self.ctrler.get_core_boot_autoinstall_capability(
                         encrypted=encrypted
                     ),
                 )
+
+    @staticmethod
+    def _make_core_boot_error(
+        kind=CoreBootAvailabilityErrorKind.RUNNING_IN_VM,
+        action_types=(CoreBootFixAction.PROCEED,),
+    ):
+        return CoreBootEncryptionSupportError(
+            kind=kind,
+            message="msg",
+            actions=[
+                CoreBootFixActionWithCategoryAndArgs(type=t, for_user=False, args=None)
+                for t in action_types
+            ],
+        )
+
+    @parameterized.expand(
+        (
+            # No auto-proceed
+            (CoreBootAvailabilityErrorKind.RUNNING_IN_VM, True, set(), False),
+            # We should autoproceed
+            (
+                CoreBootAvailabilityErrorKind.RUNNING_IN_VM,
+                True,
+                {CoreBootAvailabilityErrorKind.RUNNING_IN_VM},
+                True,
+            ),
+            # In the unlikely event that running-in-vm would not offer an Action.PROCEED
+            (
+                CoreBootAvailabilityErrorKind.RUNNING_IN_VM,
+                False,
+                {CoreBootAvailabilityErrorKind.RUNNING_IN_VM},
+                False,
+            ),
+            # No error found
+            (
+                None,
+                True,
+                {CoreBootAvailabilityErrorKind.RUNNING_IN_VM},
+                False,
+            ),
+        )
+    )
+    async def test_ensure_core_boot_autoinstall_capability_compatible(
+        self,
+        error_kind: CoreBootAvailabilityErrorKind | None,
+        has_proceed_action: bool,
+        autoproceed: set[CoreBootAvailabilityErrorKind],
+        expect_success: bool,
+    ):
+        errors = []
+        if error_kind is not None:
+            action_types = [] if not has_proceed_action else [CoreBootFixAction.PROCEED]
+            errors.append(
+                self._make_core_boot_error(kind=error_kind, action_types=action_types)
+            )
+            not_avail_regex = f"not available: {re.escape(error_kind.value)}$"
+        else:
+            not_avail_regex = "not available$"
+        # First call to find_allowed_capabilities: no compatible cap, reach the
+        # disallowed-error path. Recursive second call (if any): a compatible
+        # cap is found, terminate the recursion.
+        p_find_allowed = mock.patch.object(
+            self.ctrler,
+            "find_allowed_capabilities",
+            side_effect=[
+                iter([]),
+                iter([GuidedCapability.CORE_BOOT_ENCRYPTED]),
+            ],
+        )
+        p_find_disallowed = mock.patch.object(
+            self.ctrler,
+            "_find_disallowed_errors",
+            return_value=errors,
+        )
+        p_fix_action = mock.patch.object(self.ctrler, "execute_fix_action")
+
+        with p_find_allowed, p_find_disallowed, p_fix_action as m_fix_action:
+            coro = self.ctrler.ensure_core_boot_autoinstall_capability_compatible(
+                GuidedCapability.CORE_BOOT_ENCRYPTED,
+                autoproceed=autoproceed,
+            )
+
+            if expect_success:
+                await coro
+                m_fix_action.assert_awaited_once_with(
+                    CoreBootFixActionWithArgs(
+                        type=CoreBootFixAction.PROCEED,
+                        args=CoreBootFixActionArgs(error_kinds=[error_kind]),
+                    )
+                )
+            else:
+                with self.assertRaisesRegex(AutoinstallError, not_avail_regex):
+                    await coro
+                m_fix_action.assert_not_awaited()
 
     async def test_probe_restricted(self):
         await self.ctrler._probe_once(context=None, restricted=True)

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -1288,15 +1288,14 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
     )
     @mock.patch("subiquity.server.controllers.storage.shutdown.initiate_reboot")
     @mock.patch("subiquity.server.casper.disable_media_eject_prompt", mock.Mock())
-    async def test_v2_core_boot_fix_encryption_support__reboot(self, m_initiate_reboot):
+    async def test_execute_fix_action__reboot(self, m_initiate_reboot):
         self.ctrler.model = make_model()
 
         # If dry_run is True, we won't call the initiate method.
         self.app.opts.dry_run = False
-        await self.ctrler.v2_core_boot_fix_encryption_support_POST(
-            CoreBootFixEncryptionSupport(
-                action=CoreBootFixActionWithArgs(type=CoreBootFixAction.REBOOT),
-            ),
+        await self.ctrler.execute_fix_action(
+            CoreBootFixActionWithArgs(type=CoreBootFixAction.REBOOT),
+            system_label=None,
         )
 
         m_initiate_reboot.assert_called_once()
@@ -1310,19 +1309,14 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         "subiquity.server.controllers.storage.shutdown.initiate_reboot_to_fw_settings"
     )
     @mock.patch("subiquity.server.casper.disable_media_eject_prompt", mock.Mock())
-    async def test_v2_core_boot_fix_encryption_support__reboot_to_fw(
-        self, m_initiate_reboot_to_fw
-    ):
+    async def test_execute_fix_action__reboot_to_fw(self, m_initiate_reboot_to_fw):
         self.ctrler.model = make_model()
 
         # If dry_run is True, we won't call the initiate method.
         self.app.opts.dry_run = False
-        await self.ctrler.v2_core_boot_fix_encryption_support_POST(
-            CoreBootFixEncryptionSupport(
-                action=CoreBootFixActionWithArgs(
-                    type=CoreBootFixAction.REBOOT_TO_FW_SETTINGS
-                ),
-            ),
+        await self.ctrler.execute_fix_action(
+            CoreBootFixActionWithArgs(type=CoreBootFixAction.REBOOT_TO_FW_SETTINGS),
+            system_label=None,
         )
 
         m_initiate_reboot_to_fw.assert_called_once()
@@ -1334,20 +1328,30 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
     )
     @mock.patch("subiquity.server.controllers.storage.shutdown.initiate_poweroff")
     @mock.patch("subiquity.server.casper.disable_media_eject_prompt", mock.Mock())
-    async def test_v2_core_boot_fix_encryption_support__poweroff(
-        self, m_initiate_poweroff
-    ):
+    async def test_execute_fix_action__poweroff(self, m_initiate_poweroff):
         self.ctrler.model = make_model()
 
         # If dry_run is True, we won't call the initiate method.
         self.app.opts.dry_run = False
-        await self.ctrler.v2_core_boot_fix_encryption_support_POST(
-            CoreBootFixEncryptionSupport(
-                action=CoreBootFixActionWithArgs(type=CoreBootFixAction.SHUTDOWN),
-            ),
+        await self.ctrler.execute_fix_action(
+            CoreBootFixActionWithArgs(type=CoreBootFixAction.SHUTDOWN),
+            system_label=None,
         )
 
         m_initiate_poweroff.assert_called_once()
+
+    async def test_v2_core_boot_fix_encryption_support(self):
+        action_with_args = mock.Mock()
+        with mock.patch.object(self.ctrler, "execute_fix_action") as m_fix_action:
+            await self.ctrler.v2_core_boot_fix_encryption_support_POST(
+                CoreBootFixEncryptionSupport(
+                    action=action_with_args,
+                    system_label="enhanced-secureboot-desktop",
+                ),
+            )
+        m_fix_action.assert_called_once_with(
+            action_with_args, "enhanced-secureboot-desktop"
+        )
 
     @parameterized.expand(((True,), (False,)))
     async def test__pre_shutdown_install_started(self, zfsutils_linux_installed: bool):

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -16,6 +16,7 @@
 import asyncio
 import contextlib
 import copy
+import re
 import subprocess
 import uuid
 from pathlib import Path
@@ -34,10 +35,14 @@ from subiquity.common.storage.actions import DeviceAction
 from subiquity.common.types.storage import (
     AddPartitionV2,
     CalculateEntropyRequest,
+    CoreBootAvailabilityErrorKind,
     CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
+    CoreBootEncryptionSupportError,
     CoreBootFixAction,
+    CoreBootFixActionArgs,
     CoreBootFixActionWithArgs,
+    CoreBootFixActionWithCategoryAndArgs,
     CoreBootFixEncryptionSupport,
     EntropyResponse,
     FirmwareType,
@@ -537,7 +542,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
             (None, set(), AutoinstallError),
         )
     )
-    def test_get_core_boot_autoinstall_capability(
+    async def test_get_core_boot_autoinstall_capability(
         self, encrypted: bool, allowed_caps: set[GuidedCapability], expected
     ):
         with mock.patch.object(
@@ -552,10 +557,104 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
             with ctx:
                 self.assertEqual(
                     expected,
-                    self.ctrler.get_core_boot_autoinstall_capability(
+                    await self.ctrler.get_core_boot_autoinstall_capability(
                         encrypted=encrypted
                     ),
                 )
+
+    @staticmethod
+    def _make_core_boot_error(
+        kind=CoreBootAvailabilityErrorKind.RUNNING_IN_VM,
+        action_types=(CoreBootFixAction.PROCEED,),
+    ):
+        return CoreBootEncryptionSupportError(
+            kind=kind,
+            message="msg",
+            actions=[
+                CoreBootFixActionWithCategoryAndArgs(type=t, for_user=False, args=None)
+                for t in action_types
+            ],
+        )
+
+    @parameterized.expand(
+        (
+            # No accepted-errors
+            (CoreBootAvailabilityErrorKind.RUNNING_IN_VM, True, set(), False),
+            # We should proceed past the accepted error
+            (
+                CoreBootAvailabilityErrorKind.RUNNING_IN_VM,
+                True,
+                {CoreBootAvailabilityErrorKind.RUNNING_IN_VM},
+                True,
+            ),
+            # In the unlikely event that running-in-vm would not offer an Action.PROCEED
+            (
+                CoreBootAvailabilityErrorKind.RUNNING_IN_VM,
+                False,
+                {CoreBootAvailabilityErrorKind.RUNNING_IN_VM},
+                False,
+            ),
+            # No error found
+            (
+                None,
+                True,
+                {CoreBootAvailabilityErrorKind.RUNNING_IN_VM},
+                False,
+            ),
+        )
+    )
+    async def test_ensure_core_boot_autoinstall_capability_compatible(
+        self,
+        error_kind: CoreBootAvailabilityErrorKind | None,
+        has_proceed_action: bool,
+        accepted_errors: set[CoreBootAvailabilityErrorKind],
+        expect_success: bool,
+    ):
+        errors = []
+        if error_kind is not None:
+            action_types = [] if not has_proceed_action else [CoreBootFixAction.PROCEED]
+            errors.append(
+                self._make_core_boot_error(kind=error_kind, action_types=action_types)
+            )
+            not_avail_regex = f"not available: {re.escape(error_kind.value)}$"
+        else:
+            not_avail_regex = "not available$"
+        # First call to find_allowed_capabilities: no compatible cap, reach the
+        # disallowed-error path. Recursive second call (if any): a compatible
+        # cap is found, terminate the recursion.
+        p_find_allowed = mock.patch.object(
+            self.ctrler,
+            "find_allowed_capabilities",
+            side_effect=[
+                iter([]),
+                iter([GuidedCapability.CORE_BOOT_ENCRYPTED]),
+            ],
+        )
+        p_find_disallowed = mock.patch.object(
+            self.ctrler,
+            "_find_disallowed_errors",
+            return_value=errors,
+        )
+        p_fix_action = mock.patch.object(self.ctrler, "execute_fix_action")
+
+        with p_find_allowed, p_find_disallowed, p_fix_action as m_fix_action:
+            coro = self.ctrler.ensure_core_boot_autoinstall_capability_compatible(
+                GuidedCapability.CORE_BOOT_ENCRYPTED,
+                accepted_errors=accepted_errors,
+            )
+
+            if expect_success:
+                await coro
+                m_fix_action.assert_awaited_once_with(
+                    CoreBootFixActionWithArgs(
+                        type=CoreBootFixAction.PROCEED,
+                        args=CoreBootFixActionArgs(error_kinds=[error_kind]),
+                    )
+                )
+            else:
+                with self.assertRaisesRegex(AutoinstallError, not_avail_regex):
+                    await coro
+                m_fix_action.assert_not_awaited()
 
     async def test_probe_restricted(self):
         await self.ctrler._probe_once(context=None, restricted=True)

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -1376,15 +1376,14 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
     )
     @mock.patch("subiquity.server.controllers.storage.shutdown.initiate_reboot")
     @mock.patch("subiquity.server.casper.disable_media_eject_prompt", mock.Mock())
-    async def test_v2_core_boot_fix_encryption_support__reboot(self, m_initiate_reboot):
+    async def test_execute_fix_action__reboot(self, m_initiate_reboot):
         self.ctrler.model = make_model()
 
         # If dry_run is True, we won't call the initiate method.
         self.app.opts.dry_run = False
-        await self.ctrler.v2_core_boot_fix_encryption_support_POST(
-            CoreBootFixEncryptionSupport(
-                action=CoreBootFixActionWithArgs(type=CoreBootFixAction.REBOOT),
-            ),
+        await self.ctrler.execute_fix_action(
+            CoreBootFixActionWithArgs(type=CoreBootFixAction.REBOOT),
+            system_label=None,
         )
 
         m_initiate_reboot.assert_called_once()
@@ -1398,19 +1397,14 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         "subiquity.server.controllers.storage.shutdown.initiate_reboot_to_fw_settings"
     )
     @mock.patch("subiquity.server.casper.disable_media_eject_prompt", mock.Mock())
-    async def test_v2_core_boot_fix_encryption_support__reboot_to_fw(
-        self, m_initiate_reboot_to_fw
-    ):
+    async def test_execute_fix_action__reboot_to_fw(self, m_initiate_reboot_to_fw):
         self.ctrler.model = make_model()
 
         # If dry_run is True, we won't call the initiate method.
         self.app.opts.dry_run = False
-        await self.ctrler.v2_core_boot_fix_encryption_support_POST(
-            CoreBootFixEncryptionSupport(
-                action=CoreBootFixActionWithArgs(
-                    type=CoreBootFixAction.REBOOT_TO_FW_SETTINGS
-                ),
-            ),
+        await self.ctrler.execute_fix_action(
+            CoreBootFixActionWithArgs(type=CoreBootFixAction.REBOOT_TO_FW_SETTINGS),
+            system_label=None,
         )
 
         m_initiate_reboot_to_fw.assert_called_once()
@@ -1422,20 +1416,30 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
     )
     @mock.patch("subiquity.server.controllers.storage.shutdown.initiate_poweroff")
     @mock.patch("subiquity.server.casper.disable_media_eject_prompt", mock.Mock())
-    async def test_v2_core_boot_fix_encryption_support__poweroff(
-        self, m_initiate_poweroff
-    ):
+    async def test_execute_fix_action__poweroff(self, m_initiate_poweroff):
         self.ctrler.model = make_model()
 
         # If dry_run is True, we won't call the initiate method.
         self.app.opts.dry_run = False
-        await self.ctrler.v2_core_boot_fix_encryption_support_POST(
-            CoreBootFixEncryptionSupport(
-                action=CoreBootFixActionWithArgs(type=CoreBootFixAction.SHUTDOWN),
-            ),
+        await self.ctrler.execute_fix_action(
+            CoreBootFixActionWithArgs(type=CoreBootFixAction.SHUTDOWN),
+            system_label=None,
         )
 
         m_initiate_poweroff.assert_called_once()
+
+    async def test_v2_core_boot_fix_encryption_support(self):
+        action_with_args = mock.Mock()
+        with mock.patch.object(self.ctrler, "execute_fix_action") as m_fix_action:
+            await self.ctrler.v2_core_boot_fix_encryption_support_POST(
+                CoreBootFixEncryptionSupport(
+                    action=action_with_args,
+                    system_label="enhanced-secureboot-desktop",
+                ),
+            )
+        m_fix_action.assert_called_once_with(
+            action_with_args, "enhanced-secureboot-desktop"
+        )
 
     @parameterized.expand(((True,), (False,)))
     async def test__pre_shutdown_install_started(self, zfsutils_linux_installed: bool):


### PR DESCRIPTION
A limitation of TPM/FDE unattended installations was the inability for the user to "interact" with pre-install check errors. Such errors block the installation even in scenarios where a trivial `Action.PROCEED` would normally fix the situation. Notably, this is an issue in VMs because the pre-install check returns a `"running-in-vm"` error. Therefore, we were unable to run automated TPM/FDE installations on VMs.

This patch brings the ability to automatically execute an `Action.PROCEED` for selective error kinds.

To do this, we introduce an `accepted-errors` autoinstall directive (available for the hybrid layout with encryption). The directive can be used to enumerate the different error kinds that should automatically be addressed with an `Action.PROCEED`, should snapd offer it as a solution.

One can specify `accepted-errors` as a list of error kinds, or as a single error kind.

The following configuration allows to perform a TPM/FDE unattended installation on a VM:
```yaml
storage:
  layout:
    name: hybrid
    encryption: yes
    accepted-errors: [running-in-vm]
    ## If only one is specified, no need for a list
    ## So the following is equivalent.
    # accepted-errors: running-in-vm
```