### PR TITLE
workflow: use workshop as method of running CI.

### DIFF
--- a/.github/workflows/ci-lxd.yaml
+++ b/.github/workflows/ci-lxd.yaml
@@ -1,0 +1,44 @@
+name: CI-lxd
+
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu-daily:noble
+          - ubuntu-daily:resolute
+    steps:
+    - uses: actions/checkout@v4
+    - name: run
+      run: |
+        sudo ./scripts/github-ci-lxd-setup.sh
+        sudo ./scripts/test-in-lxd.sh ${{ matrix.image }} "make check"
+
+  lint:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu-daily:noble     # match the core snap we're running against
+          - ubuntu-daily:resolute  # latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: lint
+      run: |
+        sudo ./scripts/github-ci-lxd-setup.sh
+        sudo ./scripts/test-in-lxd.sh ${{ matrix.image }} "make lint"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,31 +18,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - ubuntu-daily:noble
-          - ubuntu-daily:resolute
+        series:
+          - noble     # match core snap
+          - resolute  # latest
+        make-target:
+          - lint
+          - check
     steps:
     - uses: actions/checkout@v4
+    - uses: canonical/launch-workshop@v1
+      with:
+        workshop: subiquity-${{ matrix.series }}
     - name: run
-      run: |
-        sudo ./scripts/github-ci-lxd-setup.sh
-        sudo ./scripts/test-in-lxd.sh ${{ matrix.image }} "make check"
-
-  lint:
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - ubuntu-daily:noble     # match the core snap we're running against
-          - ubuntu-daily:resolute  # latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: lint
-      run: |
-        sudo ./scripts/github-ci-lxd-setup.sh
-        sudo ./scripts/test-in-lxd.sh ${{ matrix.image }} "make lint"
-
+      run: workshop exec subiquity-${{ matrix.series }} -- sudo make ${{ matrix.make-target }}
   format-black:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
* Move to using workshop as the primary method of running containers for CI.  This simplifies the story of reproducing the CI environment locally.
* Unify lint + tests there.
* Move aside existing direct LXD tests for now, to be removed in following PR.
* sudo is still needed to run integration tests due to not having a tty, so we can fake it with the read of /dev/console.  (Anticipated integration tests improvements using pyte should resolve that.)