### PR TITLE
[resolute] Backport TPM/FDE work for HWROT to resolute

### DIFF
--- a/doc/reference/autoinstall-reference.rst
+++ b/doc/reference/autoinstall-reference.rst
@@ -195,6 +195,8 @@ keyboard
 
 The layout of any attached keyboard. The mapping keys correspond to settings in the :file:`/etc/default/keyboard` configuration file. See the :manpage:`keyboard(5)` manual page for more details.
 
+.. note:: Known issue: for TPM-backed encrypted installations with a passphrase, the disk can only be unlocked using the primary layout.
+
 The mapping contains keys:
 
 layout

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -72,6 +72,7 @@ from subiquity.common.types.storage import (
     AddPartitionV2,
     CalculateEntropyRequest,
     CoreBootEncryptionFeatures,
+    CoreBootEncryptionRequirement,
     CoreBootFixEncryptionSupport,
     Disk,
     EntropyResponse,
@@ -406,6 +407,12 @@ class API:
 
             class core_boot_encryption_features:
                 def GET() -> List[CoreBootEncryptionFeatures]: ...
+
+            class core_boot_encryption_requirements:
+                def GET() -> List[CoreBootEncryptionRequirement]:
+                    """Return the storage-encryption requirements that must be
+                    met for a TPM/FDE install (e.g. "volumes-auth"), as
+                    reported by snapd."""
 
             class core_boot_fix_encryption_support:
                 def POST(data: Payload[CoreBootFixEncryptionSupport]) -> None: ...

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -568,6 +568,10 @@ class CoreBootEncryptionFeatures(enum.Enum):
     PIN_AUTH = "pin-auth"
 
 
+class CoreBootEncryptionRequirement(enum.Enum):
+    VOLUMES_AUTH = "volumes-auth"
+
+
 @attr.s(auto_attribs=True)
 class CoreBootFixEncryptionSupport:
     action: CoreBootFixActionWithArgs

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -171,6 +171,7 @@ class CoreBootAvailabilityErrorKind(enum.Enum):
     PRE_OS_SECURE_BOOT_AUTH_BY_ENROLLED_DIGESTS = (
         "pre-os-secure-boot-auth-by-enrolled-digests"
     )
+    NO_HARDWARE_ROOT_OF_TRUST = "no-hardware-root-of-trust"
 
 
 # Shared enum used by the snapd API

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -1155,6 +1155,12 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         )
         if self._volumes_auth is not None:
             kwargs["volumes_auth"] = self._volumes_auth
+        # This is required to have the proper keyboard layout on first boot
+        # before typing the passphrase.
+        # Only supported since 2.76 but ignored on older versions.
+        kwargs["keyboard_config"] = snapdtypes.KeyboardConfig.from_subiquity_kb_model(
+            self.app.base_model.keyboard
+        )
         result = await snapdapi.post_and_wait(
             self.app.snapdapi,
             self.app.snapdapi.v2.systems[label].POST,

--- a/subiquity/server/controllers/filesystem.py
+++ b/subiquity/server/controllers/filesystem.py
@@ -56,6 +56,7 @@ from subiquity.common.types.storage import (
     Bootloader,
     CalculateEntropyRequest,
     CoreBootEncryptionFeatures,
+    CoreBootEncryptionRequirement,
     CoreBootEncryptionSupportError,
     CoreBootFixAction,
     CoreBootFixEncryptionSupport,
@@ -1922,6 +1923,38 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
                 return []
 
             return [CoreBootEncryptionFeatures(feature.value) for feature in features]
+
+        raise StorageInvalidUsageError("no suitable variation for core boot")
+
+    async def v2_core_boot_encryption_requirements_GET(
+        self,
+    ) -> List[CoreBootEncryptionRequirement]:
+        """Return a list of requirements that must be met for storage
+        encryption to be supported when installing with TPM/FDE. If multiple
+        variations support TPM/FDE, only the first one is accounted for.
+        Although it sounds like an arbitrary choice, it is consistent with the
+        implementation of set_info_for_capability, which is used when doing a
+        POST to /storage/v2/guided (the user does not choose which variation
+        to use)."""
+        # Typically, this endpoint is used by the desktop installer before any
+        # POST /storage/* is done. This means we can't "guess" what the user
+        # wants to do, not even if they really want to do TPM/FDE.
+        for variation in self._variation_info.values():
+            try:
+                requirements: list[snapdtypes.EncryptionRequirement] = (
+                    variation.system.storage_encryption.requirements
+                )
+            except AttributeError:
+                continue
+
+            if requirements is None:
+                # Snapd is not reporting any requirement.
+                return []
+
+            return [
+                CoreBootEncryptionRequirement(requirement.value)
+                for requirement in requirements
+            ]
 
         raise StorageInvalidUsageError("no suitable variation for core boot")
 

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -34,6 +34,7 @@ from subiquity.common.types.storage import (
     Bootloader,
     CalculateEntropyRequest,
     CoreBootEncryptionFeatures,
+    CoreBootEncryptionRequirement,
     CoreBootFixAction,
     CoreBootFixActionWithArgs,
     CoreBootFixEncryptionSupport,
@@ -1176,6 +1177,67 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
             StorageInvalidUsageError, msg="no suitable variation for core boot"
         ):
             await self.fsc.v2_core_boot_encryption_features_GET()
+
+    @parameterized.expand(
+        (
+            (
+                [snapdtypes.EncryptionRequirement.VOLUMES_AUTH],
+                [CoreBootEncryptionRequirement.VOLUMES_AUTH],
+            ),
+            (
+                # No requirement
+                None,
+                [],
+            ),
+        )
+    )
+    async def test_v2_core_boot_encryption_requirements_GET(
+        self,
+        snapd_requirements: list[snapdtypes.EncryptionRequirement],
+        expected: list[CoreBootEncryptionRequirement],
+    ):
+        self.fsc.model = make_model()
+
+        self.fsc._variation_info = {
+            "mimimal-enhanced-secureboot": VariationInfo(
+                name="minimal-enhanced-secureboot",
+                label="enhanced-secureboot-desktop",
+                system=snapdtypes.SystemDetails(
+                    model=snapdtypes.Model(architecture="amd64", snaps=[]),
+                    label="enhanced-secureboot-desktop",
+                    storage_encryption=snapdtypes.StorageEncryption(
+                        support=snapdtypes.StorageEncryptionSupport.AVAILABLE,
+                        storage_safety=snapdtypes.StorageSafety.PREFER_ENCRYPTED,
+                        requirements=snapd_requirements,
+                    ),
+                ),
+            ),
+        }
+
+        self.assertEqual(
+            expected, await self.fsc.v2_core_boot_encryption_requirements_GET()
+        )
+
+    async def test_v2_core_boot_encryption_requirements_GET__no_suitable_variation(
+        self,
+    ):
+        self.fsc.model = make_model()
+
+        self.fsc._variation_info = {}
+
+        with self.assertRaisesRegex(
+            StorageInvalidUsageError, "no suitable variation for core boot"
+        ):
+            await self.fsc.v2_core_boot_encryption_requirements_GET()
+
+        self.fsc._variation_info = {
+            "minimal": VariationInfo(name="minimal", label=None, system=None),
+        }
+
+        with self.assertRaisesRegex(
+            StorageInvalidUsageError, "no suitable variation for core boot"
+        ):
+            await self.fsc.v2_core_boot_encryption_requirements_GET()
 
     # Just to make sure we don't reboot/shutdown if other assertions fail.
     @mock.patch(

--- a/subiquity/server/controllers/tests/test_filesystem.py
+++ b/subiquity/server/controllers/tests/test_filesystem.py
@@ -485,6 +485,42 @@ class TestSubiquityControllerFilesystem(IsolatedAsyncioTestCase):
         self.assertIsNone(self.fsc.queued_probe_data)
         load.assert_not_called()
 
+    async def test_setup_encryption__passes_keyboard_config(self):
+        self.fsc._info = mock.Mock()
+        self.fsc._info.label = "prefer-encrypted"
+        self.fsc._info.system.volumes = {"vol-key": mock.Mock()}
+        self.fsc._on_volume = mock.Mock()
+        self.fsc._volumes_auth = None
+
+        kb = self.app.base_model.keyboard
+        kb.setting.layout = "fr"
+        kb.setting.variant = "azerty"
+        kb.setting.toggle = "alt_shift_toggle"
+
+        with mock.patch.object(
+            snapdapi,
+            "post_and_wait",
+            return_value=mock.Mock(encrypted_devices={}),
+        ) as m_post:
+            await self.fsc.setup_encryption()
+
+        # post_and_wait is called as:
+        #   post_and_wait(client, meth, request, ann=...)
+        # so:
+        #   args[0] is the snapdapi client
+        #   args[1] is the systems[label].POST bound method
+        #   args[2] is the SystemActionRequest
+        req = m_post.call_args.args[2]
+        self.assertEqual(
+            snapdtypes.KeyboardConfig(
+                model="pc105",
+                layout="fr",
+                variant="azerty",
+                options=["grp:alt_shift_toggle"],
+            ),
+            req.keyboard_config,
+        )
+
     fw_lenovo = {
         "bios-vendor": "LENOVO",
         "bios-version": "R10ET39W (1.24 )",
@@ -3168,6 +3204,9 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
     async def test_from_sample_data(self):
         # calling this a unit test is definitely questionable. but it
         # runs much more quickly than the integration test!
+        self.app.base_model.keyboard.setting.layout = "us"
+        self.app.base_model.keyboard.setting.variant = ""
+        self.app.base_model.keyboard.setting.toggle = None
         self.fsc.model = model = make_model(Bootloader.UEFI)
         disk = make_disk(model)
         self.app.base_model.source.current.type = "fsimage"

--- a/subiquity/server/snapd/test/test_types.py
+++ b/subiquity/server/snapd/test/test_types.py
@@ -14,11 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import TestCase
+from unittest.mock import Mock
 
 import attr
 import attrs
 
-from subiquity.server.snapd.types import snapdtype
+from subiquity.server.snapd.types import KeyboardConfig, snapdtype
 from subiquitycore.tests.parameterized import parameterized
 
 
@@ -38,3 +39,52 @@ class TestMetadataMerge(TestCase):
 
         [field] = attrs.fields(MetadataMerge)
         self.assertEqual(expected, field.metadata)
+
+
+class TestKeyboardConfig(TestCase):
+    @parameterized.expand(
+        (
+            # default us layout
+            ("us", "", None, "us", "", []),
+            # with toggle
+            ("us", "", "alt_shift_toggle", "us", "", ["grp:alt_shift_toggle"]),
+            # with variant
+            ("us", "dvorak", None, "us", "dvorak", []),
+            # with toggle and variant
+            (
+                "fr",
+                "azerty",
+                "alt_shift_toggle",
+                "fr",
+                "azerty",
+                ["grp:alt_shift_toggle"],
+            ),
+            # with multi layout
+            (
+                "us,cz",
+                ",bksl",
+                "alt_shift_toggle",
+                "us",
+                "",
+                ["grp:alt_shift_toggle"],
+            ),
+        )
+    )
+    def test_from_subiquity_kb_model(
+        self,
+        layout,
+        variant,
+        toggle,
+        expected_layout,
+        expected_variant,
+        expected_options,
+    ):
+        kb = Mock()
+        kb.setting.layout = layout
+        kb.setting.variant = variant
+        kb.setting.toggle = toggle
+        config = KeyboardConfig.from_subiquity_kb_model(kb)
+        self.assertEqual(config.model, "pc105")
+        self.assertEqual(config.layout, expected_layout)
+        self.assertEqual(config.variant, expected_variant)
+        self.assertEqual(config.options, expected_options)

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -343,6 +343,29 @@ class VolumesAuth:
 
 
 @snapdtype
+class KeyboardConfig:
+    model: str
+    layout: str
+    variant: str
+    options: List[str]
+
+    @classmethod
+    def from_subiquity_kb_model(cls, model) -> "KeyboardConfig":
+        # KeyboardSetting.layout/variant can hold comma-separated multi-layout
+        # values, but snapd's KeyboardConfig only accepts a single layout/variant
+        # (its Validate() rejects commas). snapd's KernelCommandLineFragment only
+        # uses the first layout anyway, so we send only the primary one.
+        layout = model.setting.layout.split(",")[0]
+        variant = model.setting.variant.split(",")[0]
+        return cls(
+            model="pc105",
+            layout=layout,
+            variant=variant,
+            options=[] if not model.setting.toggle else [f"grp:{model.setting.toggle}"],
+        )
+
+
+@snapdtype
 class SystemActionRequest:
     action: Optional[SystemAction] = None
 
@@ -353,6 +376,7 @@ class SystemActionRequest:
     # When optional_install=None it is equivalent to OptionalInstall(all=True)
     optional_install: Optional[OptionalInstall] = None
     volumes_auth: Optional[VolumesAuth] = None
+    keyboard_config: Optional[KeyboardConfig] = None  # New in snapd 2.76
     # -- for step=PRESEED
     target_root: Optional[str] = None
 

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -203,6 +203,8 @@ class EncryptionFeature(enum.Enum):
     PIN_AUTH = "pin-auth"
 
 
+EncryptionRequirement = storagetypes.CoreBootEncryptionRequirement
+
 AvailabilityAction = storagetypes.CoreBootFixAction
 AvailabilityActionArgs = storagetypes.CoreBootFixActionArgs
 AvailabilityErrorKind = storagetypes.CoreBootAvailabilityErrorKind
@@ -225,6 +227,8 @@ class StorageEncryption:
     # Introduced in snapd 2.68, but can be None if snapd does not want to offer
     # pin/passphrase.
     features: Optional[List[EncryptionFeature]] = None
+    # Introduced in snapd 2.76, but can be None if snapd has no requirement.
+    requirements: Optional[List[EncryptionRequirement]] = None
 
     # Since snapd 2.71 <-- to be confirmed once released.
     availability_check_errors: Optional[List[AvailabilityCheckError]] = None


### PR DESCRIPTION
This is a backport to 26.04 of the three following PRs:
* #2390 
* #2391 
* #2394 

I've excluded bits of #2394 that are not strictly necessary (a type rename + type aliasing)