### PR TITLE
Add experimental support for TPM/FDE in a gap

### DIFF
--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -137,6 +137,11 @@ def make_server_args_parser():
         action="store_false",
         default=True,
     )
+    parser.add_argument(
+        "--experimental-use-gap-tpm-fde",
+        action="store_true",
+        help="[EXPERIMENTAL] Enable TPM-backed FDE for use-gap guided scenarios",
+    )
 
     parser.add_argument("--storage-version", action="store", type=int)
     parser.add_argument("--use-os-prober", action="store_true", default=False)

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -311,6 +311,7 @@ class GuidedDisallowedCapabilityReason(enum.Enum):
     CORE_BOOT_ENCRYPTION_UNAVAILABLE = enum.auto()
     NOT_UEFI = enum.auto()
     THIRD_PARTY_DRIVERS = enum.auto()
+    INCOMPATIBLE_LOCATION = enum.auto()
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -30,11 +30,35 @@ class ProbeStatus(enum.Enum):
     DONE = enum.auto()
 
 
+class Bootloader(enum.Enum):
+    GRUB = "GRUB"
+
+    @classmethod
+    def from_snapd(cls, value: str):
+        # Typically, snapd uses "grub" as the bootloader.
+        # But it also supports:
+        # * "android-boot"
+        # * "lk"
+        # * "u-boot"
+        # * "piboot"
+        # https://github.com/canonical/snapd/blob/b247de9fd0682c56d463d2ab2e906a6dfa234296/gadget/gadget.go#L111-L115
+        return cls(value.upper())
+
+
 class FirmwareType(enum.Enum):
     NONE = "NONE"  # a system where the bootloader is external, e.g. s390x
     BIOS = "BIOS"  # BIOS, where the bootloader gets dd-ed to the start of a device
     UEFI = "UEFI"  # UEFI, ESPs and /boot/efi and all that (amd64 and arm64)
     PREP = "PREP"  # ppc64el, which puts grub on a PReP partition
+
+    def _bootloader(self) -> Bootloader | None:
+        """Returns the bootloader typically used on a platform with this
+        firmware type.
+        In the future, this function might be moved outside of FirmwareType,
+        thus the leading underscore in the name."""
+        if self == self.NONE:
+            return None
+        return Bootloader.GRUB
 
 
 @attr.s(auto_attribs=True)

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -2326,15 +2326,22 @@ class StorageController(SubiquityController, StorageManipulator):
         guided_recovery_key: Union[bool, RecoveryKey] = False
 
         if name == "hybrid":
-            if "mode" in layout:
-                raise AutoinstallError("cannot use 'mode' with hybrid layout")
             capability = self.get_core_boot_autoinstall_capability(
                 encrypted=layout.get("encrypted", None)
             )
-
-            match = layout.get("match", {"size": "largest"})
-            disk = self.get_bootable_matching_disk(match)
-            mode = "reformat_disk"
+            # Default to reformat_disk for backward compatibility:
+            # mode was previously forbidden for hybrid, so all existing
+            # autoinstall configs implicitly relied on reformat_disk.
+            mode = layout.get("mode", "reformat_disk")
+            try:
+                self.validate_layout_mode(mode)
+            except ValueError as e:
+                raise AutoinstallError(str(e)) from None
+            if mode == "use_gap" and not self.opts.experimental_use_gap_tpm_fde:
+                raise AutoinstallError(
+                    "use_gap mode with hybrid (TPM/FDE) layout requires "
+                    "the --experimental-use-gap-tpm-fde flag"
+                )
         else:
             # this check is conceptually unnecessary but results in a
             # much cleaner error message...

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -178,6 +178,10 @@ class StorageNotFoundError(StorageRecoverableError):
     title = _("Storage entity not found")
 
 
+class IncompatibleLocationError(Exception):
+    pass
+
+
 @attr.s(auto_attribs=True)
 class CapabilityInfo:
     allowed: List[GuidedCapability] = attr.Factory(list)
@@ -270,7 +274,7 @@ class VariationInfo:
 
         disk = gap.device
 
-        if disk.ptable != volume.schema:
+        if disk.ptable is not None and disk.ptable != volume.schema:
             return False
 
         try:
@@ -300,6 +304,15 @@ class VariationInfo:
         else:
             gap_size = gap.size
         r = self.capability_info.copy()
+        if self.is_core_boot_classic():
+            if not self.is_core_boot_use_gap_compatible(gap):
+                r.disallow_all(
+                    reason=GuidedDisallowedCapabilityReason.INCOMPATIBLE_LOCATION,
+                )
+        # For TPM/FDE, is_core_boot_use_gap_compatible already checks if the
+        # gap is big enough to fit all required partitions as defined by
+        # gadget.yaml. However, the calculation for install_min is different so
+        # let's also check for it.
         if gap_size < install_min:
             r.disallow_all(
                 reason=GuidedDisallowedCapabilityReason.TOO_SMALL,
@@ -954,7 +967,13 @@ class StorageController(SubiquityController, StorageManipulator):
                 raise StorageConstraintViolationError(
                     "Not using enhanced_secureboot: disabled on commandline"
                 )
-            assert isinstance(choice.target, GuidedStorageTargetReformat)
+            allowed_guided_types: tuple[type, ...] = (GuidedStorageTargetReformat,)
+            if self.app.opts.experimental_use_gap_tpm_fde:
+                allowed_guided_types = (
+                    GuidedStorageTargetReformat,
+                    GuidedStorageTargetUseGap,
+                )
+            assert isinstance(choice.target, allowed_guided_types)
             self.use_tpm = choice.capability.is_tpm_backed()
             await self.guided_core_boot(disk, choice)
             return
@@ -1098,27 +1117,54 @@ class StorageController(SubiquityController, StorageManipulator):
         self._on_volume = snapdtypes.OnVolume.from_volume(volume)
         self._volumes_auth = snapdtypes.VolumesAuth.from_choice(choice)
 
-        preserved_parts = set()
-
-        if self._on_volume.schema != disk.ptable:
-            disk.ptable = self._on_volume.schema
+        if isinstance(choice.target, GuidedStorageTargetUseGap):
+            # In theory we could set parts_by_offset_size for existing
+            # partitions outside the gap. But with the current implementation,
+            # this is unnecessary.
             parts_by_offset_size = {}
+
+            for part_or_gap in gaps.parts_and_gaps(disk):
+                if not isinstance(part_or_gap, gaps.Gap):
+                    continue
+                gap = part_or_gap
+                # Maybe we want to be more forgiving here and accept if the
+                # requested gap is contained inside an actual gap.
+                if (
+                    gap.offset == choice.target.gap.offset
+                    and gap.size == choice.target.gap.size
+                ):
+                    break
+            else:
+                raise RuntimeError("cannot find matching gap")
+
+            if not self._info.is_core_boot_use_gap_compatible(gap):
+                raise IncompatibleLocationError
+        elif isinstance(choice.target, GuidedStorageTargetReformat):
+            preserved_parts = set()
+
+            if self._on_volume.schema != disk.ptable:
+                parts_by_offset_size = {}
+                disk.ptable = self._on_volume.schema
+            else:
+                parts_by_offset_size = {
+                    (part.offset, part.size): part for part in disk.partitions()
+                }
+
+                for _struct, offset, size in self._on_volume.offsets_and_sizes():
+                    if (offset, size) in parts_by_offset_size:
+                        preserved_parts.add(parts_by_offset_size[(offset, size)])
+
+                for part in list(disk.partitions()):
+                    if part not in preserved_parts:
+                        self.delete_partition(part)
+                        del parts_by_offset_size[(part.offset, part.size)]
+
+            if not preserved_parts:
+                self.reformat(disk, self._on_volume.schema)
         else:
-            parts_by_offset_size = {
-                (part.offset, part.size): part for part in disk.partitions()
-            }
-
-            for _struct, offset, size in self._on_volume.offsets_and_sizes():
-                if (offset, size) in parts_by_offset_size:
-                    preserved_parts.add(parts_by_offset_size[(offset, size)])
-
-            for part in list(disk.partitions()):
-                if part not in preserved_parts:
-                    self.delete_partition(part)
-                    del parts_by_offset_size[(part.offset, part.size)]
-
-        if not preserved_parts:
-            self.reformat(disk, self._on_volume.schema)
+            raise RuntimeError(
+                "only reformat (and experimental use-gap) are supported for TPM/FDE"
+            )
 
         for structure, offset, size in self._on_volume.offsets_and_sizes():
             if (offset, size) in parts_by_offset_size:
@@ -2361,18 +2407,21 @@ class StorageController(SubiquityController, StorageManipulator):
             f"autoinstall: running guided {capability} install in "
             f"mode {mode} using {target}"
         )
-        await self.guided(
-            GuidedChoiceV2(
-                target=target,
-                capability=capability,
-                password=password,
-                recovery_key=guided_recovery_key,
-                sizing_policy=sizing_policy,
-                reset_partition=reset_partition,
-                reset_partition_size=reset_partition_size,
-            ),
-            reset_partition_only=layout.get("reset-partition-only", False),
-        )
+        try:
+            await self.guided(
+                GuidedChoiceV2(
+                    target=target,
+                    capability=capability,
+                    password=password,
+                    recovery_key=guided_recovery_key,
+                    sizing_policy=sizing_policy,
+                    reset_partition=reset_partition,
+                    reset_partition_size=reset_partition_size,
+                ),
+                reset_partition_only=layout.get("reset-partition-only", False),
+            )
+        except IncompatibleLocationError as e:
+            raise AutoinstallError(_("cannot install at this location")) from e
 
     def validate_layout_mode(self, mode):
         if mode not in ("reformat_disk", "use_gap"):

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -57,6 +57,7 @@ from subiquity.common.storage.requirements import (
 from subiquity.common.storage.spec import FileSystemSpec, PartitionSpec, VolGroupSpec
 from subiquity.common.types.storage import (
     AddPartitionV2,
+    Bootloader,
     CalculateEntropyRequest,
     CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
@@ -260,6 +261,34 @@ class VariationInfo:
 
     def is_valid(self) -> bool:
         return bool(self.capability_info.allowed)
+
+    def is_core_boot_use_gap_compatible(self, gap: gaps.Gap) -> bool:
+        [volume] = self.system.volumes.values()
+
+        if not isinstance(gap.device, ModelDisk):
+            return False
+
+        disk = gap.device
+
+        if disk.ptable != volume.schema:
+            return False
+
+        try:
+            if disk._m.firmware_type._bootloader() != Bootloader.from_snapd(
+                volume.bootloader
+            ):
+                return False
+        except ValueError:
+            # A bootloader that is not supported by Subiquity.
+            return False
+
+        # Now we check that all partitions defined in the gadget fit in the
+        # gap.
+        for struct, offset, size in volume.offsets_and_sizes():
+            if not (gap.offset <= offset <= offset + size <= gap.offset + gap.size):
+                return False
+
+        return True
 
     def capability_info_for_gap(
         self,

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -1531,7 +1531,10 @@ class StorageController(SubiquityController, StorageManipulator):
                 continue
 
             capability_info = CapabilityInfo()
-            for variation in self.find_variations(core_boot_classic=False):
+            core_boot_classic = (
+                None if self.opts.experimental_use_gap_tpm_fde else False
+            )
+            for variation in self.find_variations(core_boot_classic=core_boot_classic):
                 capability_info.combine(
                     variation.capability_info_for_gap(gap, install_min)
                 )

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -509,7 +509,7 @@ class StorageController(SubiquityController, StorageManipulator):
             ]
             return info
 
-        offsets_and_sizes = list(self._offsets_and_sizes_for_volume(volume))
+        offsets_and_sizes = list(volume.offsets_and_sizes())
         _structure, last_offset, last_size = offsets_and_sizes[-1]
         info.min_size = last_offset + last_size
 
@@ -1059,17 +1059,6 @@ class StorageController(SubiquityController, StorageManipulator):
             disks.append(disk)
         return [d for d in disks]
 
-    def _offsets_and_sizes_for_volume(self, volume: snapdtypes.Volume):
-        offset = self.model._partition_alignment_data["gpt"].min_start_offset
-        assert volume.structure is not None
-        for structure in volume.structure:
-            if structure.role == snapdtypes.Role.MBR:
-                continue
-            if structure.offset is not None:
-                offset = structure.offset
-            yield (structure, offset, structure.size)
-            offset = offset + structure.size
-
     async def guided_core_boot(self, disk: ModelDisk, choice: GuidedChoiceV2):
         if self._info.needs_systems_mount:
             await SystemsDirMounter(self.app, self._info.name).mount()
@@ -1090,9 +1079,7 @@ class StorageController(SubiquityController, StorageManipulator):
                 (part.offset, part.size): part for part in disk.partitions()
             }
 
-            for _struct, offset, size in self._offsets_and_sizes_for_volume(
-                self._on_volume
-            ):
+            for _struct, offset, size in self._on_volume.offsets_and_sizes():
                 if (offset, size) in parts_by_offset_size:
                     preserved_parts.add(parts_by_offset_size[(offset, size)])
 
@@ -1104,9 +1091,7 @@ class StorageController(SubiquityController, StorageManipulator):
         if not preserved_parts:
             self.reformat(disk, self._on_volume.schema)
 
-        for structure, offset, size in self._offsets_and_sizes_for_volume(
-            self._on_volume
-        ):
+        for structure, offset, size in self._on_volume.offsets_and_sizes():
             if (offset, size) in parts_by_offset_size:
                 part = parts_by_offset_size[(offset, size)]
             else:

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -1070,7 +1070,7 @@ class StorageController(SubiquityController, StorageManipulator):
             yield (structure, offset, structure.size)
             offset = offset + structure.size
 
-    async def guided_core_boot(self, disk: Disk, choice: GuidedChoiceV2):
+    async def guided_core_boot(self, disk: ModelDisk, choice: GuidedChoiceV2):
         if self._info.needs_systems_mount:
             await SystemsDirMounter(self.app, self._info.name).mount()
         # Formatting for a core boot classic system relies on some curtin

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -2386,6 +2386,35 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
                 offset=1 << 20,
             )
 
+    async def setup_core_boot_use_gap(self) -> GuidedChoiceV2:
+        await self._setup(FirmwareType.UEFI, "gpt", fix_bios=True, size=100 << 30)
+        make_partition(self.model, self.disk, preserve=True, size=50 << 30)
+        self.ctrler._variation_info["core"] = VariationInfo(
+            name="core",
+            label="system",
+            system=snapdtypes.SystemDetails(
+                label="system",
+                volumes={
+                    "pc": snapdtypes.Volume(
+                        schema="gpt", structure=[], bootloader="grub"
+                    ),
+                },
+                model=mock.Mock(),
+            ),
+            capability_info=CapabilityInfo(
+                allowed=[GuidedCapability.CORE_BOOT_ENCRYPTED]
+            ),
+        )
+        self.ctrler._info = self.ctrler._variation_info["core"]
+
+        target = GuidedStorageTargetUseGap(
+            disk_id=self.disk.id,
+            gap=labels.for_client(gaps.largest_gap(self.disk)),
+        )
+        return GuidedChoiceV2(
+            target=target, capability=GuidedCapability.CORE_BOOT_ENCRYPTED
+        )
+
     @parameterized.expand(firmware_types_and_ptables)
     async def test_blank_disk(self, firmware_type, ptable):
         # blank disks should not report a UseGap case
@@ -3084,6 +3113,19 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         # if we're installing in a logical partition, we have enough room
         self.assertTrue(self.ctrler.resize_has_enough_room_for_partitions(disk, p5))
         self.assertTrue(self.ctrler.resize_has_enough_room_for_partitions(disk, p6))
+
+    async def test_guided_use_gap_core_boot_flag_disabled(self):
+        choice = await self.setup_core_boot_use_gap()
+        self.app.opts.experimental_use_gap_tpm_fde = False
+        with self.assertRaises(AssertionError):
+            await self.ctrler.guided(choice)
+
+    async def test_guided_use_gap_core_boot_flag_enabled(self):
+        choice = await self.setup_core_boot_use_gap()
+        self.app.opts.experimental_use_gap_tpm_fde = True
+        with mock.patch.object(self.ctrler, "guided_core_boot", return_value=None):
+            await self.ctrler.guided(choice)
+            self.ctrler.guided_core_boot.assert_called_once_with(self.disk, choice)
 
 
 class TestManualBoot(IsolatedAsyncioTestCase):

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -1695,7 +1695,9 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
             system=snapdtypes.SystemDetails(
                 label="mock-label",
                 volumes={
-                    "mockVol": snapdtypes.Volume(schema="mock", structure=None),
+                    "mockVol": snapdtypes.Volume(
+                        schema="mock", structure=None, bootloader="grub"
+                    ),
                 },
                 model=snapdtypes.Model(
                     architecture="mock-arch",
@@ -3104,7 +3106,9 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
             system=snapdtypes.SystemDetails(
                 label="system",
                 volumes={
-                    "pc": snapdtypes.Volume(schema="gpt", structure=structures),
+                    "pc": snapdtypes.Volume(
+                        schema="gpt", structure=structures, bootloader="grub"
+                    ),
                 },
                 model=snapdtypes.Model(
                     architecture="amd64",

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -1849,33 +1849,33 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
 
         self.assertEqual(expected_optional_install, actual)
 
-    async def test_run_autoinstall_guided__hybrid_with_mode(self):
-        with self.assertRaisesRegex(
-            AutoinstallError, "cannot use 'mode' with hybrid layout"
-        ):
-            await self.ctrler.run_autoinstall_guided(
-                {"name": "hybrid", "mode": "reformat_disk"}
-            )
-
 
 class TestRunAutoinstallGuided(IsolatedAsyncioTestCase):
     def setUp(self):
         self.app = make_app()
         self.app.opts.firmware_type = None
         self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
+        self.app.snapdapi = snapdapi.make_api_client(AsyncSnapd(get_fake_connection()))
         self.ctrler = StorageController(self.app)
-        self.model = self.ctrler.model = make_model()
+        self.model = self.ctrler.model = make_model(FirmwareType.UEFI)
 
         # This is needed for examine_systems_task
         self.app.base_model.source.current.type = "fsimage"
+        self.app.base_model.source.search_drivers = False
         self.app.base_model.source.current.variations = {
             "default": CatalogEntryVariation(path="", size=1),
+            "core-boot": CatalogEntryVariation(
+                path="", size=1, snapd_system_label="prefer-encrypted"
+            ),
         }
 
     async def asyncSetUp(self):
-        self.ctrler._examine_systems_task.start_sync()
-
-        await self.ctrler._examine_systems_task.wait()
+        with mock.patch(
+            "subiquity.server.snapd.system_getter.SystemsDirMounter.mount",
+            new=mock.AsyncMock(return_value=(mock.Mock(), mock.AsyncMock())),
+        ):
+            self.ctrler._examine_systems_task.start_sync()
+            await self.ctrler._examine_systems_task.wait()
 
     async def test_direct_use_gap__install_media(self):
         """Match directives were previously not honored when using mode: use_gap.
@@ -1929,6 +1929,23 @@ class TestRunAutoinstallGuided(IsolatedAsyncioTestCase):
             reset_partition=mock.ANY,
             reset_partition_size=mock.ANY,
         )
+
+    async def test_hybrid_with_unsupported_mode(self):
+        with self.assertRaisesRegex(
+            AutoinstallError, "Unknown layout mode erase_install"
+        ):
+            await self.ctrler.run_autoinstall_guided(
+                {"name": "hybrid", "mode": "erase_install"}
+            )
+
+    async def test_hybrid_use_gap_not_enabled(self):
+        self.app.opts.experimental_use_gap_tpm_fde = False
+        with self.assertRaisesRegex(
+            AutoinstallError, "requires the --experimental-use-gap-tpm-fde flag"
+        ):
+            await self.ctrler.run_autoinstall_guided(
+                {"name": "hybrid", "mode": "use_gap"}
+            )
 
 
 class TestGuided(IsolatedAsyncioTestCase):
@@ -3527,6 +3544,72 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
             ]
         )
         self.assertEqual(partition_count, len(disk.partitions()))
+
+    async def test_autoinstall_hybrid_use_gap_flag_disabled(self):
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
+        disk = make_disk(model)
+        make_partition(model, disk, preserve=True, size=50 << 30)
+        self.app.base_model.source.current.variations = {
+            "default": CatalogEntryVariation(
+                path="", size=1, snapd_system_label="prefer-encrypted"
+            ),
+        }
+        self.app.dr_cfg.systems_dir_exists = True
+        await self.ctrler._examine_systems_task.start()
+        await self.ctrler._examine_systems_task.wait()
+        self.ctrler.start()
+
+        self.app.opts.experimental_use_gap_tpm_fde = False
+        with self.assertRaises(AutoinstallError):
+            await self.ctrler.run_autoinstall_guided(
+                {
+                    "name": "hybrid",
+                    "mode": "use_gap",
+                }
+            )
+
+    @parameterized.expand(
+        (
+            (True, True),
+            (False, False),
+        )
+    )
+    async def test_autoinstall_hybrid_use_gap(
+        self, flag_enabled: bool, expect_ok: bool
+    ):
+        self.ctrler.model = model = make_model(FirmwareType.UEFI, storage_version=2)
+        disk = make_disk(model, size=100 << 30)
+        make_partition(model, disk, preserve=True, offset=50 << 30)
+        self.app.base_model.source.current.variations = {
+            "default": CatalogEntryVariation(
+                path="", size=1, snapd_system_label="prefer-encrypted"
+            ),
+        }
+        self.app.dr_cfg.systems_dir_exists = True
+        await self.ctrler._examine_systems_task.start()
+        await self.ctrler._examine_systems_task.wait()
+        self.ctrler.start()
+
+        self.app.opts.experimental_use_gap_tpm_fde = flag_enabled
+
+        with mock.patch.object(self.ctrler, "guided") as m_guided:
+            if expect_ok:
+                m_guided_assertion = m_guided.assert_called_once
+                context = contextlib.nullcontext()
+            else:
+                m_guided_assertion = m_guided.assert_not_called
+                context = self.assertRaisesRegex(
+                    AutoinstallError, "requires the --experimental-use-gap-tpm-fde flag"
+                )
+
+            with context:
+                await self.ctrler.run_autoinstall_guided(
+                    {
+                        "name": "hybrid",
+                        "mode": "use_gap",
+                    }
+                )
+            m_guided_assertion()
 
     async def test_from_sample_data_defective(self):
         self.ctrler.model = model = make_model(FirmwareType.UEFI)

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -2907,6 +2907,26 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
 
         self.assertEqual(expected_scenario, scenarios != [])
 
+    @parameterized.expand(
+        (
+            (True, True),
+            (False, False),
+        )
+    )
+    async def test_available_use_gap_scenarios__core_boot(
+        self, flag_enabled: bool, expected_core_boot_encrypted: bool
+    ):
+        await self.setup_core_boot_use_gap()
+        install_min = self.ctrler.calculate_suggested_install_min()
+        self.app.opts.experimental_use_gap_tpm_fde = flag_enabled
+        scenarios = self.ctrler.available_use_gap_scenarios(install_min)
+        self.assertEqual(
+            expected_core_boot_encrypted,
+            any(
+                GuidedCapability.CORE_BOOT_ENCRYPTED in s[1].allowed for s in scenarios
+            ),
+        )
+
     async def test_available_erase_install_scenarios(self):
         await self._setup(FirmwareType.NONE, "gpt", fix_bios=True)
         install_min = self.ctrler.calculate_suggested_install_min()

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -381,6 +381,93 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
                     GuidedCapability.CORE_BOOT_ENCRYPTED
                 )
 
+    # ------------------------------------------------------------------
+    # VariationInfo.is_core_boot_use_gap_compatible
+    # ------------------------------------------------------------------
+    # For a "gpt" volume, offsets_and_sizes() starts at the gpt
+    # min_start_offset (GPT_OVERHEAD // 2 == 1 MiB). With two non-MBR
+    # structures mimicking a real gadget (a 100 MiB system-boot and a
+    # 1 GiB system-data), the resulting spans are
+    # [1 MiB, 101 MiB] and [101 MiB, 1125 MiB], so the gap must cover
+    # [1 MiB, 1125 MiB] (1124 MiB) for the check to pass.
+    def _make_info_for_gap_compat(self, schema="gpt", structures=None) -> VariationInfo:
+        if structures is None:
+            structures = [
+                snapdtypes.VolumeStructure(size=100 << 20),
+                snapdtypes.VolumeStructure(size=1024 << 20),
+            ]
+        volume = snapdtypes.Volume(
+            schema=schema, structure=structures, bootloader="grub"
+        )
+        system = snapdtypes.SystemDetails(
+            label="enhanced-secureboot-desktop",
+            model=snapdtypes.Model(architecture="amd64", snaps=[]),
+            volumes={"pc": volume},
+        )
+        return VariationInfo(
+            name="test",
+            label="enhanced-secureboot-desktop",
+            system=system,
+        )
+
+    def test_is_core_boot_use_gap_compatible__not_disk(self):
+        info = self._make_info_for_gap_compat()
+        gap = gaps.Gap(device=mock.Mock(), offset=0, size=1200 << 20)
+        self.assertFalse(info.is_core_boot_use_gap_compatible(gap))
+
+    def test_is_core_boot_use_gap_compatible__ptable_mismatch(self):
+        info = self._make_info_for_gap_compat(schema="gpt")
+        disk = make_disk(make_model(), ptable="msdos")
+        gap = gaps.Gap(device=disk, offset=0, size=1200 << 20)
+        self.assertFalse(info.is_core_boot_use_gap_compatible(gap))
+
+    def test_is_core_boot_use_gap_compatible__exact_fit(self):
+        info = self._make_info_for_gap_compat()
+        disk = make_disk(make_model(), ptable="gpt")
+        gap = gaps.Gap(device=disk, offset=1 << 20, size=1124 << 20)
+        self.assertTrue(info.is_core_boot_use_gap_compatible(gap))
+
+    def test_is_core_boot_use_gap_compatible__larger_gap(self):
+        info = self._make_info_for_gap_compat()
+        disk = make_disk(make_model(), ptable="gpt")
+        gap = gaps.Gap(device=disk, offset=0, size=1200 << 20)
+        self.assertTrue(info.is_core_boot_use_gap_compatible(gap))
+
+    def test_is_core_boot_use_gap_compatible__gap_starts_late(self):
+        info = self._make_info_for_gap_compat()
+        disk = make_disk(make_model(), ptable="gpt")
+        gap = gaps.Gap(device=disk, offset=50 << 20, size=1124 << 20)
+        self.assertFalse(info.is_core_boot_use_gap_compatible(gap))
+
+    def test_is_core_boot_use_gap_compatible__gap_ends_early(self):
+        info = self._make_info_for_gap_compat()
+        disk = make_disk(make_model(), ptable="gpt")
+        gap = gaps.Gap(device=disk, offset=1 << 20, size=50 << 20)
+        self.assertFalse(info.is_core_boot_use_gap_compatible(gap))
+
+    def test_is_core_boot_use_gap_compatible__mbr_skipped(self):
+        # An MBR-role structure is ignored by offsets_and_sizes(), so
+        # placing it outside the gap must not affect compatibility.
+        structures = [
+            snapdtypes.VolumeStructure(size=1 << 20, role=snapdtypes.Role.MBR),
+            snapdtypes.VolumeStructure(size=100 << 20),
+            snapdtypes.VolumeStructure(size=1024 << 20),
+        ]
+        info = self._make_info_for_gap_compat(structures=structures)
+        disk = make_disk(make_model(), ptable="gpt")
+        gap = gaps.Gap(device=disk, offset=1 << 20, size=1124 << 20)
+        self.assertTrue(info.is_core_boot_use_gap_compatible(gap))
+
+    def test_is_core_boot_use_gap_compatible__explicit_offset_outside_gap(self):
+        structures = [
+            snapdtypes.VolumeStructure(size=100 << 20),
+            snapdtypes.VolumeStructure(offset=2000 << 20, size=1024 << 20),
+        ]
+        info = self._make_info_for_gap_compat(structures=structures)
+        disk = make_disk(make_model(), ptable="gpt")
+        gap = gaps.Gap(device=disk, offset=1 << 20, size=1124 << 20)
+        self.assertFalse(info.is_core_boot_use_gap_compatible(gap))
+
     @parameterized.expand(
         (
             (

--- a/subiquity/server/snapd/types.py
+++ b/subiquity/server/snapd/types.py
@@ -14,12 +14,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import enum
-from typing import Dict, List, Optional, Self
+from typing import Dict, Iterator, List, Optional, Self
 
 import attr
 
 from subiquity.common.serialize import NonExhaustive, named_field
 from subiquity.common.types import storage as storagetypes
+from subiquity.models.storage import StorageModel
 
 RFC3339 = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -154,6 +155,17 @@ class Volume:
     bootloader: str = ""
     id: str = ""
     structure: Optional[List[VolumeStructure]] = None
+
+    def offsets_and_sizes(self) -> Iterator[tuple[VolumeStructure, int, int]]:
+        offset = StorageModel._partition_alignment_data[self.schema].min_start_offset
+        assert self.structure is not None
+        for structure in self.structure:
+            if structure.role == Role.MBR:
+                continue
+            if structure.offset is not None:
+                offset = structure.offset
+            yield (structure, offset, structure.size)
+            offset = offset + structure.size
 
 
 @snapdtype

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -617,6 +617,59 @@ class TestCore(TestAPI):
             self.assertDictSubset(dict(mount="/"), p4)
 
     @timeout()
+    async def test_guided_v2_use_gap_tpm_fde_api(self):
+        cfg = self.machineConfig("examples/machines/win10-along-ubuntu.json")
+        with cfg.edit() as data:
+            # Let's create a large gap at the beginning of the disk
+            pt = data["storage"]["blockdev"]["/dev/sda"]["partitiontable"]
+            for part_number, has_filesystem in (
+                (1, True),
+                (2, False),
+                (3, True),
+                (4, True),
+            ):
+                part_path = f"/dev/sda{part_number}"
+                [node] = match(pt["partitions"], node=part_path)
+                pt["partitions"].remove(node)
+                del data["storage"]["blockdev"][part_path]
+                if has_filesystem:
+                    del data["storage"]["filesystem"][part_path]
+        kw = {
+            "firmware_type": "uefi",
+            "extra_args": [
+                "--storage-version",
+                "2",
+                "--source-catalog",
+                "examples/sources/desktop.yaml",
+                "--dry-run-config",
+                "examples/dry-run-configs/tpm.yaml",
+                "--experimental-use-gap-tpm-fde",
+            ],
+        }
+        async with start_server(cfg, **kw) as inst:
+            await inst.post("/source", source_id="ubuntu-desktop")
+            resp = await inst.get("/storage/v2/guided", wait=True)
+            [use_gap] = match(resp["targets"], _type="GuidedStorageTargetUseGap")
+            self.assertIn("CORE_BOOT_PREFER_ENCRYPTED", use_gap["allowed"])
+            data = {
+                "target": use_gap,
+                "capability": "CORE_BOOT_ENCRYPTED",
+            }
+            await inst.post("/storage/v2/guided", data)
+            v2resp = await inst.get("/storage/v2")
+            [d] = v2resp["disks"]
+            # FIXME The current model has a ~13GiB gap between p1 and p2.
+            #       Presumably this will be removed later.
+            [p1, g1, p2, p3, p4, p5] = d["partitions"]
+            esp = dict(offset=1 << 20, mount="/boot/efi")
+            self.assertDictSubset(esp, p1)
+            self.assertDictSubset(dict(mount="/boot"), p2)
+            self.assertDictSubset(dict(mount=None), p3)
+            self.assertDictSubset(dict(mount="/"), p4)
+            # This is the partition we didn't remove.
+            self.assertDictSubset(dict(mount=None), p5)
+
+    @timeout()
     async def test_basic_core_boot_cmdline_disable(self):
         cfg = self.machineConfig("examples/machines/simple.json")
         with cfg.edit() as data:


### PR DESCRIPTION
Add experimental support for TPM/FDE installs in a gap.

When the `--experimental-use-gap-tpm-fde` option is passed to Subiquity server, Subiquity can start advertising TPM/FDE scenarios in a gap.

This only works if installing in the gap would still result in an install compliant with the requirements from snapd/the gadget.

@d-loose fyi