### PR TITLE
storage: rename Bootloader -> FirmwareType

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PYTHONSRC=$(NAME)
 PYTHONPATH=$(shell pwd):$(shell pwd)/probert:$(shell pwd)/curtin
 PROBERTDIR=./probert
 PROBERT_REPO=https://github.com/canonical/probert
-DRYRUN?=--dry-run --bootloader uefi --machine-config examples/machines/simple.json \
+DRYRUN?=--dry-run --firmware-type uefi --machine-config examples/machines/simple.json \
 	--source-catalog examples/sources/install.yaml \
 	--postinst-hooks-dir examples/postinst.d/
 UNITTESTARGS?=

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -135,7 +135,7 @@ for answers in examples/answers/*.yaml; do
         --answers "$answers" \
         "${opts[@]}" \
         --machine-config "$config" \
-        --bootloader uefi \
+        --firmware-type uefi \
         --snaps-from-examples \
         --source-catalog $catalog
     validate install
@@ -155,7 +155,7 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --dry-run \
     --output-base "$tmpdir" \
     --machine-config examples/machines/existing-partitions.json \
-    --bootloader bios \
+    --firmware-type bios \
     --autoinstall examples/autoinstall/most-options.yaml \
     --dry-run-config examples/dry-run-configs/apt-local-mirror.yaml \
     --kernel-cmdline autoinstall \
@@ -211,7 +211,7 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --machine-config examples/machines/simple.json \
     --autoinstall examples/autoinstall/hybrid.yaml \
     --dry-run-config examples/dry-run-configs/tpm.yaml \
-    --bootloader uefi \
+    --firmware-type uefi \
     --kernel-cmdline autoinstall \
     --source-catalog examples/sources/tpm.yaml
 validate
@@ -226,7 +226,7 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --machine-config examples/machines/simple.json \
     --autoinstall examples/autoinstall/hybrid.yaml \
     --dry-run-config examples/dry-run-configs/tpm.yaml \
-    --bootloader uefi \
+    --firmware-type uefi \
     --snaps-from-examples \
     --kernel-cmdline autoinstall \
     --source-catalog examples/sources/tpm.yaml
@@ -243,7 +243,7 @@ LANG=C.UTF-8 timeout --foreground 60 \
     --output-base "$tmpdir" \
     --machine-config examples/machines/simple.json \
     --autoinstall examples/autoinstall/core-installer.yaml \
-    --bootloader uefi \
+    --firmware-type uefi \
     --snaps-from-examples \
     --kernel-cmdline autoinstall \
     --source-catalog examples/sources/core-installer.yaml

--- a/subiquity/client/controllers/storage.py
+++ b/subiquity/client/controllers/storage.py
@@ -31,7 +31,7 @@ from subiquity.common.types.storage import (
 )
 from subiquity.models.storage import (
     ActionRenderMode,
-    Bootloader,
+    FirmwareType,
     StorageModel,
     raidlevels_by_value,
 )
@@ -283,13 +283,13 @@ class StorageController(SubiquityTuiController, StorageManipulator):
         # Technically, we don't know if NVMe/TCP support was detected or
         # specified on CLI ; but that's okay.
         self.model = StorageModel(
-            status.bootloader,
+            status.firmware_type,
             root="/",
             dry_run=self.app.opts.dry_run,
             opt_supports_nvme_tcp_booting=self.supports_nvme_tcp_booting,
         )
         self.model.load_server_data(status)
-        if self.model.bootloader == Bootloader.PREP:
+        if self.model.firmware_type == FirmwareType.PREP:
             self.supports_resilient_boot = False
         else:
             release = lsb_release(dry_run=self.app.opts.dry_run)["release"]

--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -71,10 +71,12 @@ def make_server_args_parser():
         type=argparse.FileType(),
         help="Don't Probe. Use probe data file",
     )
+    # --bootloader is deprecated and will be removed soon.
     parser.add_argument(
+        "--firmware-type",
         "--bootloader",
         choices=["none", "bios", "prep", "uefi"],
-        help="Override style of bootloader to use",
+        help="Override firmware type to use",
     )
     parser.add_argument(
         "--autoinstall",
@@ -198,8 +200,8 @@ def main():
         if opts.snaps_from_examples is None:
             opts.snaps_from_examples = True
         logdir = opts.output_base
-        if opts.bootloader is None:
-            opts.bootloader = "uefi"
+        if opts.firmware_type is None:
+            opts.firmware_type = "uefi"
         # Set for system_scripts support in dry run
         if not os.environ.get("SNAP"):
             os.environ["SNAP"] = str(pathlib.Path(__file__).parents[2])

--- a/subiquity/common/storage/actions.py
+++ b/subiquity/common/storage/actions.py
@@ -20,8 +20,8 @@ from gettext import pgettext
 from subiquity.common.storage import boot, gaps, labels
 from subiquity.common.types.storage import GapUsable
 from subiquity.models.storage import (
-    Bootloader,
     Disk,
+    FirmwareType,
     LVM_LogicalVolume,
     LVM_VolGroup,
     Partition,
@@ -86,7 +86,7 @@ def _disk_actions(disk):
         DeviceAction.FORMAT,
         DeviceAction.REMOVE,
     ]
-    if disk._m.bootloader != Bootloader.NONE:
+    if disk._m.firmware_type != FirmwareType.NONE:
         actions.append(DeviceAction.TOGGLE_BOOT)
     return actions
 
@@ -115,7 +115,7 @@ def _raid_actions(raid):
             DeviceAction.DELETE,
             DeviceAction.REFORMAT,
         ]
-        if raid._m.bootloader == Bootloader.UEFI:
+        if raid._m.firmware_type == FirmwareType.UEFI:
             if raid.container and raid.container.metadata == "imsm":
                 actions.append(DeviceAction.TOGGLE_BOOT)
         return actions

--- a/subiquity/common/storage/boot.py
+++ b/subiquity/common/storage/boot.py
@@ -22,7 +22,7 @@ from typing import Any, Optional
 import attr
 
 from subiquity.common.storage import gaps, sizes
-from subiquity.models.storage import Bootloader, Disk, Partition, Raid, align_up
+from subiquity.models.storage import Disk, FirmwareType, Partition, Raid, align_up
 
 log = logging.getLogger("subiquity.common.storage.boot")
 
@@ -35,19 +35,19 @@ def is_boot_device(device):
 
 @is_boot_device.register(Disk)
 def _is_boot_device_disk(disk):
-    bl = disk._m.bootloader
-    if bl == Bootloader.NONE:
+    fwt = disk._m.firmware_type
+    if fwt == FirmwareType.NONE:
         return False
-    elif bl == Bootloader.BIOS:
+    elif fwt == FirmwareType.BIOS:
         return disk.grub_device
-    elif bl in [Bootloader.PREP, Bootloader.UEFI]:
+    elif fwt in [FirmwareType.PREP, FirmwareType.UEFI]:
         return any(p.grub_device for p in disk._partitions)
 
 
 @is_boot_device.register(Raid)
 def _is_boot_device_raid(raid):
-    bl = raid._m.bootloader
-    if bl != Bootloader.UEFI:
+    fwt = raid._m.firmware_type
+    if fwt != FirmwareType.UEFI:
         return False
     if not raid.container or raid.container.metadata != "imsm":
         return False
@@ -321,19 +321,19 @@ def get_boot_device_plan_prep(device, resize_partition):
 
 
 def get_boot_device_plan(device, resize_partition=None):
-    bl = device._m.bootloader
-    if bl == Bootloader.BIOS:
+    fwt = device._m.firmware_type
+    if fwt == FirmwareType.BIOS:
         # we don't attempt resize_partition with BIOS,
         # a move might help but a resize alone won't
         # and we don't move preserved partitions.
         return get_boot_device_plan_bios(device)
-    if bl == Bootloader.UEFI:
+    if fwt == FirmwareType.UEFI:
         return get_boot_device_plan_uefi(device, resize_partition)
-    if bl == Bootloader.PREP:
+    if fwt == FirmwareType.PREP:
         return get_boot_device_plan_prep(device, resize_partition)
-    if bl == Bootloader.NONE:
+    if fwt == FirmwareType.NONE:
         return NoOpBootPlan()
-    raise Exception(f"unexpected bootloader {bl} here")
+    raise Exception(f"unexpected firmware type {fwt} here")
 
 
 @functools.singledispatch
@@ -362,8 +362,8 @@ def _can_be_boot_device_disk(disk, *, resize_partition=None, with_reformatting=F
 def _can_be_boot_device_raid(raid, *, resize_partition=None, with_reformatting=False):
     if raid.on_remote_storage():
         return False
-    bl = raid._m.bootloader
-    if bl != Bootloader.UEFI:
+    fwt = raid._m.firmware_type
+    if fwt != FirmwareType.UEFI:
         return False
     if not raid.container or raid.container.metadata != "imsm":
         return False
@@ -410,11 +410,11 @@ def all_boot_devices(model):
 
 
 def is_bootloader_partition(partition):
-    if partition._m.bootloader == Bootloader.BIOS:
+    if partition._m.firmware_type == FirmwareType.BIOS:
         return partition.flag == "bios_grub"
-    elif partition._m.bootloader == Bootloader.UEFI:
+    elif partition._m.firmware_type == FirmwareType.UEFI:
         return is_esp(partition)
-    elif partition._m.bootloader == Bootloader.PREP:
+    elif partition._m.firmware_type == FirmwareType.PREP:
         return partition.flag == "prep"
     else:
         return False

--- a/subiquity/common/storage/manipulator.py
+++ b/subiquity/common/storage/manipulator.py
@@ -26,7 +26,7 @@ from subiquity.common.storage.spec import (
     RaidSpec,
     VolGroupSpec,
 )
-from subiquity.common.types.storage import Bootloader
+from subiquity.common.types.storage import FirmwareType
 from subiquity.models.storage import (
     LVM_LogicalVolume,
     LVM_VolGroup,
@@ -430,20 +430,20 @@ class StorageManipulator:
         self.model.add_mount(part.fs(), "/boot/efi")
 
     def remove_boot_disk(self, boot_disk):
-        if self.model.bootloader == Bootloader.BIOS:
+        if self.model.firmware_type == FirmwareType.BIOS:
             boot_disk.grub_device = False
         partitions = [
             p for p in boot_disk.partitions() if boot.is_bootloader_partition(p)
         ]
         remount = False
         if boot_disk.preserve:
-            if self.model.bootloader == Bootloader.BIOS:
+            if self.model.firmware_type == FirmwareType.BIOS:
                 return
             for p in partitions:
                 p.grub_device = False
-                if self.model.bootloader == Bootloader.PREP:
+                if self.model.firmware_type == FirmwareType.PREP:
                     p.wipe = None
-                elif self.model.bootloader == Bootloader.UEFI:
+                elif self.model.firmware_type == FirmwareType.UEFI:
                     if p.fs():
                         if p.fs().mount():
                             self.delete_mount(p.fs().mount())
@@ -464,7 +464,7 @@ class StorageManipulator:
             if full:
                 largest_part = max(boot_disk.partitions(), key=lambda p: p.size)
                 largest_part.size += tot_size
-        if self.model.bootloader == Bootloader.UEFI and remount:
+        if self.model.firmware_type == FirmwareType.UEFI and remount:
             part = self.model._one(type="partition", grub_device=True)
             if part:
                 self._mount_esp(part)

--- a/subiquity/common/storage/tests/test_actions.py
+++ b/subiquity/common/storage/tests/test_actions.py
@@ -17,7 +17,7 @@ import unittest
 
 from subiquity.common.storage import gaps
 from subiquity.common.storage.actions import DeviceAction
-from subiquity.models.storage import Bootloader
+from subiquity.models.storage import FirmwareType
 from subiquity.models.tests.test_storage import (
     make_disk,
     make_lv,
@@ -129,11 +129,11 @@ class TestActions(unittest.TestCase):
         self.assertActionNotSupported(disk, DeviceAction.DELETE)
 
     def test_disk_action_TOGGLE_BOOT_NONE(self):
-        model, disk = make_model_and_disk(Bootloader.NONE)
+        model, disk = make_model_and_disk(FirmwareType.NONE)
         self.assertActionNotSupported(disk, DeviceAction.TOGGLE_BOOT)
 
     def test_disk_action_TOGGLE_BOOT_BIOS(self):
-        model = make_model(Bootloader.BIOS)
+        model = make_model(FirmwareType.BIOS)
         # Disks with msdos partition tables can always be the BIOS boot disk.
         dos_disk = make_disk(model, ptable="msdos", preserve=True)
         self.assertActionPossible(dos_disk, DeviceAction.TOGGLE_BOOT)
@@ -187,11 +187,11 @@ class TestActions(unittest.TestCase):
         )
         self.assertActionNotPossible(gpt_disk4, DeviceAction.TOGGLE_BOOT)
 
-    def _test_TOGGLE_BOOT_boot_partition(self, bl, flag):
+    def _test_TOGGLE_BOOT_boot_partition(self, fwt, flag):
         # The logic for when TOGGLE_BOOT is enabled for both UEFI and PREP
         # bootloaders turns out to be the same, modulo the special flag that
         # has to be present on a partition.
-        model = make_model(bl)
+        model = make_model(fwt)
         # A disk with a new partition table can always be the UEFI/PREP boot
         # disk.
         new_disk = make_disk(model, preserve=False)
@@ -214,10 +214,10 @@ class TestActions(unittest.TestCase):
         self.assertActionPossible(old_disk, DeviceAction.TOGGLE_BOOT)
 
     def test_disk_action_TOGGLE_BOOT_UEFI(self):
-        self._test_TOGGLE_BOOT_boot_partition(Bootloader.UEFI, "boot")
+        self._test_TOGGLE_BOOT_boot_partition(FirmwareType.UEFI, "boot")
 
     def test_disk_action_TOGGLE_BOOT_PREP(self):
-        self._test_TOGGLE_BOOT_boot_partition(Bootloader.PREP, "prep")
+        self._test_TOGGLE_BOOT_boot_partition(FirmwareType.PREP, "prep")
 
     def test_partition_action_INFO(self):
         model, part = make_model_and_partition()
@@ -261,11 +261,11 @@ class TestActions(unittest.TestCase):
         model.add_volgroup("vg1", {part2})
         self.assertActionNotPossible(part2, DeviceAction.DELETE)
 
-        part = make_partition(make_model(Bootloader.BIOS), flag="bios_grub")
+        part = make_partition(make_model(FirmwareType.BIOS), flag="bios_grub")
         self.assertActionNotPossible(part, DeviceAction.DELETE)
-        part = make_partition(make_model(Bootloader.UEFI), flag="boot")
+        part = make_partition(make_model(FirmwareType.UEFI), flag="boot")
         self.assertActionNotPossible(part, DeviceAction.DELETE)
-        part = make_partition(make_model(Bootloader.PREP), flag="prep")
+        part = make_partition(make_model(FirmwareType.PREP), flag="prep")
         self.assertActionNotPossible(part, DeviceAction.DELETE)
 
         # You cannot delete a partition from a disk that has

--- a/subiquity/common/storage/tests/test_manipulator.py
+++ b/subiquity/common/storage/tests/test_manipulator.py
@@ -22,7 +22,7 @@ import attr
 from subiquity.common.storage import boot, gaps, sizes
 from subiquity.common.storage.actions import DeviceAction
 from subiquity.common.storage.manipulator import StorageManipulator
-from subiquity.models.storage import Bootloader, MiB, Partition
+from subiquity.models.storage import FirmwareType, MiB, Partition
 from subiquity.models.tests.test_storage import (
     make_disk,
     make_filesystem,
@@ -32,16 +32,16 @@ from subiquity.models.tests.test_storage import (
 from subiquitycore.tests.parameterized import parameterized
 
 
-def make_manipulator(bootloader=None, storage_version=1):
+def make_manipulator(firmware_type=None, storage_version=1):
     manipulator = StorageManipulator()
-    manipulator.model = make_model(bootloader)
+    manipulator.model = make_model(firmware_type)
     manipulator.model.storage_version = storage_version
     manipulator.supports_resilient_boot = True
     return manipulator
 
 
-def make_manipulator_and_disk(bootloader=None):
-    manipulator = make_manipulator(bootloader)
+def make_manipulator_and_disk(firmware_type=None):
+    manipulator = make_manipulator(firmware_type)
     return manipulator, make_disk(manipulator.model)
 
 
@@ -122,15 +122,15 @@ class TestStorageManipulator(unittest.TestCase):
     def test_can_only_add_boot_once(self):
         # This is really testing model code but it's much easier to test with a
         # manipulator around.
-        for bl in Bootloader:
-            manipulator, disk = make_manipulator_and_disk(bl)
+        for fwt in FirmwareType:
+            manipulator, disk = make_manipulator_and_disk(fwt)
             if DeviceAction.TOGGLE_BOOT not in DeviceAction.supported(disk):
                 continue
             manipulator.add_boot_disk(disk)
             self.assertFalse(
                 DeviceAction.TOGGLE_BOOT.can(disk)[0],
                 "add_boot_disk(disk) did not make _can_TOGGLE_BOOT false "
-                "with bootloader {}".format(bl),
+                "with firmware type {}".format(fwt),
             )
 
     def assertIsMountedAtBootEFI(self, device):
@@ -143,15 +143,15 @@ class TestStorageManipulator(unittest.TestCase):
             self.assertIs(device.fs().mount(), None)
 
     def add_existing_boot_partition(self, manipulator, disk):
-        if manipulator.model.bootloader == Bootloader.BIOS:
+        if manipulator.model.firmware_type == FirmwareType.BIOS:
             part = manipulator.model.add_partition(
                 disk, size=1 << 20, offset=0, flag="bios_grub"
             )
-        elif manipulator.model.bootloader == Bootloader.UEFI:
+        elif manipulator.model.firmware_type == FirmwareType.UEFI:
             part = manipulator.model.add_partition(
                 disk, size=512 << 20, offset=0, flag="boot"
             )
-        elif manipulator.model.bootloader == Bootloader.PREP:
+        elif manipulator.model.firmware_type == FirmwareType.PREP:
             part = manipulator.model.add_partition(
                 disk, size=8 << 20, offset=0, flag="prep"
             )
@@ -159,16 +159,16 @@ class TestStorageManipulator(unittest.TestCase):
         return part
 
     def assertIsBootDisk(self, manipulator, disk):
-        if manipulator.model.bootloader == Bootloader.BIOS:
+        if manipulator.model.firmware_type == FirmwareType.BIOS:
             self.assertTrue(disk.grub_device)
             if disk.ptable == "gpt":
                 self.assertEqual(disk.partitions()[0].flag, "bios_grub")
-        elif manipulator.model.bootloader == Bootloader.UEFI:
+        elif manipulator.model.firmware_type == FirmwareType.UEFI:
             for part in disk.partitions():
                 if part.flag == "boot" and part.grub_device:
                     return
             self.fail("{} is not a boot disk".format(disk))
-        elif manipulator.model.bootloader == Bootloader.PREP:
+        elif manipulator.model.firmware_type == FirmwareType.PREP:
             for part in disk.partitions():
                 if part.flag == "prep" and part.grub_device:
                     self.assertEqual(part.wipe, "zero")
@@ -176,22 +176,22 @@ class TestStorageManipulator(unittest.TestCase):
             self.fail("{} is not a boot disk".format(disk))
 
     def assertIsNotBootDisk(self, manipulator, disk):
-        if manipulator.model.bootloader == Bootloader.BIOS:
+        if manipulator.model.firmware_type == FirmwareType.BIOS:
             self.assertFalse(disk.grub_device)
-        elif manipulator.model.bootloader == Bootloader.UEFI:
+        elif manipulator.model.firmware_type == FirmwareType.UEFI:
             for part in disk.partitions():
                 if part.flag == "boot" and part.grub_device:
                     self.fail("{} is a boot disk".format(disk))
-        elif manipulator.model.bootloader == Bootloader.PREP:
+        elif manipulator.model.firmware_type == FirmwareType.PREP:
             for part in disk.partitions():
                 if part.flag == "prep" and part.grub_device:
                     self.fail("{} is a boot disk".format(disk))
 
     def test_boot_disk_resilient(self):
-        for bl in Bootloader:
-            if bl == Bootloader.NONE:
+        for fwt in FirmwareType:
+            if fwt == FirmwareType.NONE:
                 continue
-            manipulator = make_manipulator(bl)
+            manipulator = make_manipulator(fwt)
             manipulator.supports_resilient_boot = True
 
             disk1 = make_disk(manipulator.model, preserve=False)
@@ -203,14 +203,14 @@ class TestStorageManipulator(unittest.TestCase):
 
             manipulator.add_boot_disk(disk1)
             self.assertIsBootDisk(manipulator, disk1)
-            if bl == Bootloader.UEFI:
+            if fwt == FirmwareType.UEFI:
                 self.assertIsMountedAtBootEFI(disk1.partitions()[0])
 
             size_before = disk2p1.size
             manipulator.add_boot_disk(disk2)
             self.assertIsBootDisk(manipulator, disk1)
             self.assertIsBootDisk(manipulator, disk2)
-            if bl == Bootloader.UEFI:
+            if fwt == FirmwareType.UEFI:
                 self.assertIsMountedAtBootEFI(disk1.partitions()[0])
                 self.assertNotMounted(disk2.partitions()[0])
             self.assertEqual(len(disk2.partitions()), 2)
@@ -220,7 +220,7 @@ class TestStorageManipulator(unittest.TestCase):
             manipulator.remove_boot_disk(disk1)
             self.assertIsNotBootDisk(manipulator, disk1)
             self.assertIsBootDisk(manipulator, disk2)
-            if bl == Bootloader.UEFI:
+            if fwt == FirmwareType.UEFI:
                 self.assertIsMountedAtBootEFI(disk2.partitions()[0])
             self.assertEqual(len(disk1.partitions()), 0)
 
@@ -230,10 +230,10 @@ class TestStorageManipulator(unittest.TestCase):
             self.assertEqual(disk2p1.size, size_before)
 
     def test_boot_disk_no_resilient(self):
-        for bl in Bootloader:
-            if bl == Bootloader.NONE:
+        for fwt in FirmwareType:
+            if fwt == FirmwareType.NONE:
                 continue
-            manipulator = make_manipulator(bl)
+            manipulator = make_manipulator(fwt)
             manipulator.supports_resilient_boot = False
 
             disk1 = make_disk(manipulator.model, preserve=False)
@@ -245,24 +245,24 @@ class TestStorageManipulator(unittest.TestCase):
 
             manipulator.add_boot_disk(disk1)
             self.assertIsBootDisk(manipulator, disk1)
-            if bl == Bootloader.UEFI:
+            if fwt == FirmwareType.UEFI:
                 self.assertIsMountedAtBootEFI(disk1.partitions()[0])
 
             size_before = disk2p1.size
             manipulator.add_boot_disk(disk2)
             self.assertIsNotBootDisk(manipulator, disk1)
             self.assertIsBootDisk(manipulator, disk2)
-            if bl == Bootloader.UEFI:
+            if fwt == FirmwareType.UEFI:
                 self.assertIsMountedAtBootEFI(disk2.partitions()[0])
             self.assertEqual(len(disk2.partitions()), 2)
             self.assertEqual(disk2.partitions()[1], disk2p1)
             self.assertEqual(disk2.partitions()[0].size + disk2p1.size, size_before)
 
     def test_boot_disk_existing(self):
-        for bl in Bootloader:
-            if bl == Bootloader.NONE:
+        for fwt in FirmwareType:
+            if fwt == FirmwareType.NONE:
                 continue
-            manipulator = make_manipulator(bl)
+            manipulator = make_manipulator(fwt)
 
             disk1 = make_disk(manipulator.model, preserve=True)
             part = self.add_existing_boot_partition(manipulator, disk1)
@@ -270,18 +270,18 @@ class TestStorageManipulator(unittest.TestCase):
             wipe_before = part.wipe
             manipulator.add_boot_disk(disk1)
             self.assertIsBootDisk(manipulator, disk1)
-            if bl == Bootloader.UEFI:
+            if fwt == FirmwareType.UEFI:
                 self.assertIsMountedAtBootEFI(part)
 
             manipulator.remove_boot_disk(disk1)
             self.assertIsNotBootDisk(manipulator, disk1)
             self.assertEqual(len(disk1.partitions()), 1)
             self.assertEqual(part.wipe, wipe_before)
-            if bl == Bootloader.UEFI:
+            if fwt == FirmwareType.UEFI:
                 self.assertNotMounted(part)
 
     def test_mounting_partition_makes_boot_disk(self):
-        manipulator = make_manipulator(Bootloader.UEFI)
+        manipulator = make_manipulator(FirmwareType.UEFI)
         disk1 = make_disk(manipulator.model, preserve=True)
         disk1p1 = manipulator.model.add_partition(
             disk1, size=512 << 20, offset=0, flag="boot"
@@ -298,10 +298,10 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertEqual(efi_mnt.device.volume, disk1p1)
 
     def test_add_boot_has_valid_offset(self):
-        for bl in Bootloader:
-            if bl == Bootloader.NONE:
+        for fwt in FirmwareType:
+            if fwt == FirmwareType.NONE:
                 continue
-            manipulator = make_manipulator(bl)
+            manipulator = make_manipulator(fwt)
 
             disk1 = make_disk(manipulator.model, preserve=True)
             manipulator.add_boot_disk(disk1)
@@ -349,7 +349,7 @@ class TestStorageManipulator(unittest.TestCase):
 
     @parameterized.expand([(1,), (2,)])
     def test_add_boot_BIOS_empty(self, version):
-        manipulator = make_manipulator(Bootloader.BIOS, version)
+        manipulator = make_manipulator(FirmwareType.BIOS, version)
         disk = make_disk(manipulator.model, preserve=True)
         with self.assertPartitionOperations(
             disk,
@@ -364,7 +364,7 @@ class TestStorageManipulator(unittest.TestCase):
 
     @parameterized.expand([(1,), (2,)])
     def test_add_boot_BIOS_full(self, version):
-        manipulator = make_manipulator(Bootloader.BIOS, version)
+        manipulator = make_manipulator(FirmwareType.BIOS, version)
         disk = make_disk(manipulator.model, preserve=True)
         part = make_partition(manipulator.model, disk, size=gaps.largest_gap_size(disk))
 
@@ -386,7 +386,7 @@ class TestStorageManipulator(unittest.TestCase):
 
     @parameterized.expand([(1,), (2,)])
     def test_add_boot_BIOS_half_full(self, version):
-        manipulator = make_manipulator(Bootloader.BIOS, version)
+        manipulator = make_manipulator(FirmwareType.BIOS, version)
         disk = make_disk(manipulator.model, preserve=True)
         part = make_partition(
             manipulator.model, disk, size=gaps.largest_gap_size(disk) // 2
@@ -404,7 +404,7 @@ class TestStorageManipulator(unittest.TestCase):
 
     @parameterized.expand([(1,), (2,)])
     def test_add_boot_BIOS_full_resizes_larger(self, version):
-        manipulator = make_manipulator(Bootloader.BIOS)
+        manipulator = make_manipulator(FirmwareType.BIOS)
         # 2002MiB so that the space available for partitioning (2000MiB)
         # divided by 4 is an whole number of megabytes.
         disk = make_disk(manipulator.model, preserve=True, size=2002 * MiB)
@@ -432,14 +432,14 @@ class TestStorageManipulator(unittest.TestCase):
 
     @parameterized.expand([(1,), (2,)])
     def test_no_add_boot_BIOS_preserved_full(self, version):
-        manipulator = make_manipulator(Bootloader.BIOS, version)
+        manipulator = make_manipulator(FirmwareType.BIOS, version)
         disk = make_disk(manipulator.model, preserve=True)
         full_size = gaps.largest_gap_size(disk)
         make_partition(manipulator.model, disk, size=full_size, preserve=True)
         self.assertFalse(boot.can_be_boot_device(disk))
 
     def test_no_add_boot_BIOS_preserved_v1(self):
-        manipulator = make_manipulator(Bootloader.BIOS, 1)
+        manipulator = make_manipulator(FirmwareType.BIOS, 1)
         disk = make_disk(manipulator.model, preserve=True)
         half_size = gaps.largest_gap_size(disk) // 2
         make_partition(
@@ -448,7 +448,7 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertFalse(boot.can_be_boot_device(disk))
 
     def test_add_boot_BIOS_preserved_v2(self):
-        manipulator = make_manipulator(Bootloader.BIOS, 2)
+        manipulator = make_manipulator(FirmwareType.BIOS, 2)
         disk = make_disk(manipulator.model, preserve=True)
         half_size = gaps.largest_gap_size(disk) // 2
         part = make_partition(
@@ -466,7 +466,7 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertIsBootDisk(manipulator, disk)
 
     def test_add_boot_BIOS_new_and_preserved_v2(self):
-        manipulator = make_manipulator(Bootloader.BIOS, 2)
+        manipulator = make_manipulator(FirmwareType.BIOS, 2)
         # 2002MiB so that the space available for partitioning (2000MiB)
         # divided by 4 is an whole number of megabytes.
         disk = make_disk(manipulator.model, preserve=True, size=2002 * MiB)
@@ -493,7 +493,7 @@ class TestStorageManipulator(unittest.TestCase):
 
     @parameterized.expand([(1,), (2,)])
     def test_no_add_boot_BIOS_preserved_at_start(self, version):
-        manipulator = make_manipulator(Bootloader.BIOS, version)
+        manipulator = make_manipulator(FirmwareType.BIOS, version)
         disk = make_disk(manipulator.model, preserve=True)
         half_size = gaps.largest_gap_size(disk) // 2
         make_partition(manipulator.model, disk, size=half_size, preserve=True)
@@ -503,13 +503,13 @@ class TestStorageManipulator(unittest.TestCase):
     def test_no_add_boot_BIOS_gpt_teeny_disk(self, version):
         # Showed up in VM testing - the ISO created cloud-localds shows up as a
         # potential install target, and weird things happen.
-        manipulator = make_manipulator(Bootloader.BIOS, version)
+        manipulator = make_manipulator(FirmwareType.BIOS, version)
         disk = make_disk(manipulator.model, ptable="gpt", size=1 << 20)
         self.assertFalse(boot.can_be_boot_device(disk))
 
     @parameterized.expand([(1,), (2,)])
     def test_add_boot_BIOS_msdos(self, version):
-        manipulator = make_manipulator(Bootloader.BIOS, version)
+        manipulator = make_manipulator(FirmwareType.BIOS, version)
         disk = make_disk(manipulator.model, preserve=True, ptable="msdos")
         part = make_partition(
             manipulator.model, disk, size=gaps.largest_gap_size(disk), preserve=True
@@ -522,24 +522,24 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertIsBootDisk(manipulator, disk)
 
     def boot_size_for_disk(self, disk):
-        bl = disk._m.bootloader
-        if bl == Bootloader.UEFI:
+        fwt = disk._m.firmware_type
+        if fwt == FirmwareType.UEFI:
             return sizes.get_efi_size(disk.size)
-        elif bl == Bootloader.PREP:
+        elif fwt == FirmwareType.PREP:
             return sizes.PREP_GRUB_SIZE_BYTES
         else:
-            self.fail("unexpected bootloader %r" % (bl,))
+            self.fail("unexpected firmware type %r" % (fwt,))
 
     ADD_BOOT_PARAMS = [
-        (Bootloader.UEFI, 1),
-        (Bootloader.PREP, 1),
-        (Bootloader.UEFI, 2),
-        (Bootloader.PREP, 2),
+        (FirmwareType.UEFI, 1),
+        (FirmwareType.PREP, 1),
+        (FirmwareType.UEFI, 2),
+        (FirmwareType.PREP, 2),
     ]
 
     @parameterized.expand(ADD_BOOT_PARAMS)
-    def test_add_boot_empty(self, bl, version):
-        manipulator = make_manipulator(bl, version)
+    def test_add_boot_empty(self, fwt, version):
+        manipulator = make_manipulator(fwt, version)
         disk = make_disk(manipulator.model, preserve=True)
         with self.assertPartitionOperations(
             disk,
@@ -552,8 +552,8 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertIsBootDisk(manipulator, disk)
 
     @parameterized.expand(ADD_BOOT_PARAMS)
-    def test_add_boot_full(self, bl, version):
-        manipulator = make_manipulator(bl, version)
+    def test_add_boot_full(self, fwt, version):
+        manipulator = make_manipulator(fwt, version)
         disk = make_disk(manipulator.model, preserve=True)
         part = make_partition(manipulator.model, disk, size=gaps.largest_gap_size(disk))
         size = self.boot_size_for_disk(disk)
@@ -566,8 +566,8 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertIsBootDisk(manipulator, disk)
 
     @parameterized.expand(ADD_BOOT_PARAMS)
-    def test_add_boot_half_full(self, bl, version):
-        manipulator = make_manipulator(bl, version)
+    def test_add_boot_half_full(self, fwt, version):
+        manipulator = make_manipulator(fwt, version)
         disk = make_disk(manipulator.model, preserve=True)
         part = make_partition(
             manipulator.model, disk, size=gaps.largest_gap_size(disk) // 2
@@ -582,8 +582,8 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertIsBootDisk(manipulator, disk)
 
     @parameterized.expand(ADD_BOOT_PARAMS)
-    def test_add_boot_full_resizes_larger(self, bl, version):
-        manipulator = make_manipulator(bl, version)
+    def test_add_boot_full_resizes_larger(self, fwt, version):
+        manipulator = make_manipulator(fwt, version)
         # 2002MiB so that the space available for partitioning (2000MiB)
         # divided by 4 is an whole number of megabytes.
         disk = make_disk(manipulator.model, preserve=True, size=2002 * MiB)
@@ -604,16 +604,16 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertIsBootDisk(manipulator, disk)
 
     @parameterized.expand(ADD_BOOT_PARAMS)
-    def test_no_add_boot_full_preserved_partition(self, bl, version):
-        manipulator = make_manipulator(bl, version)
+    def test_no_add_boot_full_preserved_partition(self, fwt, version):
+        manipulator = make_manipulator(fwt, version)
         disk = make_disk(manipulator.model, preserve=True)
         full_size = gaps.largest_gap_size(disk)
         make_partition(manipulator.model, disk, size=full_size, preserve=True)
         self.assertFalse(boot.can_be_boot_device(disk))
 
     @parameterized.expand(ADD_BOOT_PARAMS)
-    def test_add_boot_half_preserved_partition(self, bl, version):
-        manipulator = make_manipulator(bl, version)
+    def test_add_boot_half_preserved_partition(self, fwt, version):
+        manipulator = make_manipulator(fwt, version)
         disk = make_disk(manipulator.model, preserve=True)
         half_size = gaps.largest_gap_size(disk) // 2
         part = make_partition(manipulator.model, disk, size=half_size, preserve=True)
@@ -629,11 +629,11 @@ class TestStorageManipulator(unittest.TestCase):
                 manipulator.add_boot_disk(disk)
             self.assertIsBootDisk(manipulator, disk)
 
-    @parameterized.expand([(Bootloader.UEFI,), (Bootloader.PREP,)])
-    def test_add_boot_half_preserved_half_new_partition(self, bl):
+    @parameterized.expand([(FirmwareType.UEFI,), (FirmwareType.PREP,)])
+    def test_add_boot_half_preserved_half_new_partition(self, fwt):
         # This test is v2 only because you can only get into this
         # situation in a v2 world.
-        manipulator = make_manipulator(bl, 2)
+        manipulator = make_manipulator(fwt, 2)
         disk = make_disk(manipulator.model, preserve=True)
         half_size = gaps.largest_gap_size(disk) // 2
         old_part = make_partition(manipulator.model, disk, size=half_size)
@@ -650,10 +650,10 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertIsBootDisk(manipulator, disk)
 
     @parameterized.expand(ADD_BOOT_PARAMS)
-    def test_add_boot_existing_boot_partition(self, bl, version):
-        manipulator = make_manipulator(bl, version)
+    def test_add_boot_existing_boot_partition(self, fwt, version):
+        manipulator = make_manipulator(fwt, version)
         disk = make_disk(manipulator.model, preserve=True, size=2002 * MiB)
-        if bl == Bootloader.UEFI:
+        if fwt == FirmwareType.UEFI:
             flag = "boot"
         else:
             flag = "prep"
@@ -671,7 +671,7 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertIsBootDisk(manipulator, disk)
 
     def test_logical_no_esp_in_gap(self):
-        manipulator = make_manipulator(Bootloader.UEFI, storage_version=2)
+        manipulator = make_manipulator(FirmwareType.UEFI, storage_version=2)
         m = manipulator.model
         d1 = make_disk(m, preserve=True, ptable="msdos")
         size = gaps.largest_gap_size(d1)
@@ -682,7 +682,7 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertFalse(boot.can_be_boot_device(d1))
 
     def test_logical_no_esp_by_resize(self):
-        manipulator = make_manipulator(Bootloader.UEFI, storage_version=2)
+        manipulator = make_manipulator(FirmwareType.UEFI, storage_version=2)
         m = manipulator.model
         d1 = make_disk(m, preserve=True, ptable="msdos")
         size = gaps.largest_gap_size(d1)
@@ -692,7 +692,7 @@ class TestStorageManipulator(unittest.TestCase):
         self.assertFalse(boot.can_be_boot_device(d1, resize_partition=p5))
 
     def test_logical_no_esp_in_new_part(self):
-        manipulator = make_manipulator(Bootloader.UEFI, storage_version=2)
+        manipulator = make_manipulator(FirmwareType.UEFI, storage_version=2)
         m = manipulator.model
         d1 = make_disk(m, preserve=True, ptable="msdos")
         size = gaps.largest_gap_size(d1)
@@ -701,9 +701,9 @@ class TestStorageManipulator(unittest.TestCase):
         make_partition(m, d1, flag="logical", size=size)
         self.assertFalse(boot.can_be_boot_device(d1))
 
-    @parameterized.expand([[Bootloader.UEFI], [Bootloader.PREP]])
-    def test_too_many_primaries(self, bl):
-        manipulator = make_manipulator(bl, storage_version=2)
+    @parameterized.expand([[FirmwareType.UEFI], [FirmwareType.PREP]])
+    def test_too_many_primaries(self, fwt):
+        manipulator = make_manipulator(fwt, storage_version=2)
         m = manipulator.model
         d1 = make_disk(m, preserve=True, ptable="msdos", size=100 << 30)
         tenth = 10 << 30

--- a/subiquity/common/types/storage.py
+++ b/subiquity/common/types/storage.py
@@ -30,9 +30,9 @@ class ProbeStatus(enum.Enum):
     DONE = enum.auto()
 
 
-class Bootloader(enum.Enum):
+class FirmwareType(enum.Enum):
     NONE = "NONE"  # a system where the bootloader is external, e.g. s390x
-    BIOS = "BIOS"  # BIOS, where the bootloader dd-ed to the start of a device
+    BIOS = "BIOS"  # BIOS, where the bootloader gets dd-ed to the start of a device
     UEFI = "UEFI"  # UEFI, ESPs and /boot/efi and all that (amd64 and arm64)
     PREP = "PREP"  # ppc64el, which puts grub on a PReP partition
 
@@ -362,7 +362,9 @@ class GuidedDisallowedCapability:
 class StorageResponse:
     status: ProbeStatus
     error_report: Optional[ErrorReportRef] = None
-    bootloader: Optional[Bootloader] = None
+    firmware_type: Optional[FirmwareType] = None
+    # Deprecated, for backward compatibility
+    bootloader: Optional[FirmwareType] = None
     orig_config: Optional[list] = None
     config: Optional[list] = None
     dasd: Optional[dict] = None

--- a/subiquity/models/storage.py
+++ b/subiquity/models/storage.py
@@ -56,7 +56,7 @@ from subiquity.common.storage.requirements import (
     RequirementSeverity,
 )
 from subiquity.common.types.storage import (
-    Bootloader,
+    FirmwareType,
     OsProber,
     RecoveryKey,
     StorageResponse,
@@ -1591,30 +1591,30 @@ class StorageModel:
         else:
             return True
 
-    def _probe_bootloader(self):
+    def _probe_firmware_type(self) -> FirmwareType:
         # This will at some point change to return a list so that we can
         # configure BIOS _and_ UEFI on amd64 systems.
         if os.path.exists("/sys/firmware/efi"):
-            return Bootloader.UEFI
+            return FirmwareType.UEFI
         elif platform.machine().startswith("ppc64"):
-            return Bootloader.PREP
+            return FirmwareType.PREP
         elif platform.machine() == "s390x":
-            return Bootloader.NONE
+            return FirmwareType.NONE
         else:
-            return Bootloader.BIOS
+            return FirmwareType.BIOS
 
     def __init__(
         self,
-        bootloader=None,
+        firmware_type=None,
         *,
         root: str,
         dry_run: bool,
         opt_supports_nvme_tcp_booting: bool | None = None,
         detected_supports_nvme_tcp_booting: bool | None = None,
     ):
-        if bootloader is None:
-            bootloader = self._probe_bootloader()
-        self.bootloader = bootloader
+        if firmware_type is None:
+            firmware_type = self._probe_firmware_type()
+        self.firmware_type = firmware_type
         self.dry_run = dry_run
         self.root = root
         self.opt_supports_nvme_tcp_booting: bool | None = opt_supports_nvme_tcp_booting
@@ -1651,7 +1651,7 @@ class StorageModel:
         # expressed in terms of curtin actions, which are not what we want to
         # use on the V2 storage API.
         orig_model = StorageModel(
-            self.bootloader,
+            self.firmware_type,
             root=self.root,
             dry_run=self.dry_run,
             opt_supports_nvme_tcp_booting=self.opt_supports_nvme_tcp_booting,
@@ -2447,32 +2447,32 @@ class StorageModel:
     def needs_bootloader_partition(self):
         """true if no disk have a boot partition, and one is needed"""
         # s390x has no such thing
-        if self.bootloader == Bootloader.NONE:
+        if self.firmware_type == FirmwareType.NONE:
             return False
-        elif self.bootloader == Bootloader.BIOS:
+        elif self.firmware_type == FirmwareType.BIOS:
             return self._one(type="disk", grub_device=True) is None
-        elif self.bootloader == Bootloader.UEFI:
+        elif self.firmware_type == FirmwareType.UEFI:
             for esp in self._all(type="partition", grub_device=True):
                 if esp.fs() and esp.fs().mount():
                     if esp.fs().mount().path == "/boot/efi":
                         return False
             return True
-        elif self.bootloader == Bootloader.PREP:
+        elif self.firmware_type == FirmwareType.PREP:
             return self._one(type="partition", grub_device=True) is None
         else:
-            raise AssertionError("unknown bootloader type {}".format(self.bootloader))
+            raise AssertionError("unknown firmware type {}".format(self.firmware_type))
 
     def uses_grub(self) -> bool:
         """Return True when the system's bootloader is GRUB-based.
 
-        Only s390x systems (``Bootloader.NONE``) do not use GRUB; all
+        Only s390x systems (``FirmwareType.NONE``) do not use GRUB; all
         other boot methods (BIOS, UEFI, PREP) rely on GRUB.
 
         Curtin also has a ``uses_grub(machine)`` function in
         curtin/commands/curthooks.py, which determines GRUB usage from
         the machine architecture instead.  Consider consolidating.
         """
-        return self.bootloader != Bootloader.NONE
+        return self.firmware_type != FirmwareType.NONE
 
     def uses_signed_grub(self) -> bool:
         """Return True when the system uses signed GRUB.
@@ -2489,7 +2489,7 @@ class StorageModel:
         package currently exists (for example, riscv64 on 26.04). This makes
         the installation layout more future-proof if signed packages become
         available."""
-        return self.uses_grub() and self.bootloader == Bootloader.UEFI
+        return self.uses_grub() and self.firmware_type == FirmwareType.UEFI
 
     def _mount_for_path(self, path: str | pathlib.Path, *, parent_ok=False):
         """Return the mount-like at *path*, or None.

--- a/subiquity/models/tests/test_storage.py
+++ b/subiquity/models/tests/test_storage.py
@@ -33,9 +33,9 @@ from subiquity.models.storage import (
     LVM_CHUNK_SIZE,
     ZFS,
     ActionRenderMode,
-    Bootloader,
     Disk,
     Filesystem,
+    FirmwareType,
     NotFinalPartitionError,
     NVMeController,
     Partition,
@@ -147,7 +147,7 @@ class FakeStorageInfo:
 
 
 def make_model(
-    bootloader=None,
+    firmware_type=None,
     storage_version=None,
     *,
     dry_run=False,
@@ -158,8 +158,8 @@ def make_model(
         dry_run=dry_run,
         opt_supports_nvme_tcp_booting=supports_nvme_tcp_booting,
     )
-    if bootloader is not None:
-        model.bootloader = bootloader
+    if firmware_type is not None:
+        model.firmware_type = firmware_type
     if storage_version is not None:
         model.storage_version = storage_version
     model._probe_data = {}
@@ -183,8 +183,8 @@ def make_disk(storage_model=None, **kw):
     return disk
 
 
-def make_model_and_disk(bootloader=None, storage_version=None, **kw):
-    model = make_model(bootloader, storage_version)
+def make_model_and_disk(firmware_type=None, storage_version=None, **kw):
+    model = make_model(firmware_type, storage_version)
     return model, make_disk(model, **kw)
 
 
@@ -228,8 +228,8 @@ def make_mount(model, fs: Filesystem, path):
     return model.add_mount(fs, path)
 
 
-def make_model_and_partition(bootloader=None):
-    model, disk = make_model_and_disk(bootloader)
+def make_model_and_partition(firmware_type=None):
+    model, disk = make_model_and_disk(firmware_type)
     return model, make_partition(model, disk)
 
 
@@ -246,8 +246,8 @@ def make_raid(model, disks=None, **kw):
     return r
 
 
-def make_model_and_raid(bootloader=None):
-    model = make_model(bootloader)
+def make_model_and_raid(firmware_type=None):
+    model = make_model(firmware_type)
     return model, make_raid(model)
 
 
@@ -260,8 +260,8 @@ def make_vg(model, pvs=None):
     return model.add_volgroup(name, pvs)
 
 
-def make_model_and_vg(bootloader=None):
-    model = make_model(bootloader)
+def make_model_and_vg(firmware_type=None):
+    model = make_model(firmware_type)
     return model, make_vg(model)
 
 
@@ -273,8 +273,8 @@ def make_lv(model, vg=None, size=None):
     return model.add_logical_volume(vg, name, size)
 
 
-def make_model_and_lv(bootloader=None, lv_size=None):
-    model = make_model(bootloader)
+def make_model_and_lv(firmware_type=None, lv_size=None):
+    model = make_model(firmware_type)
     return model, make_lv(model, size=lv_size)
 
 
@@ -362,13 +362,13 @@ class TestStorageModel(unittest.TestCase):
         self._test_ok_for_xxx(model, make_partition, "ok_for_raid", False)
         self._test_ok_for_xxx(model, make_partition, "ok_for_lvm_vg", False)
 
-        part = make_partition(make_model(Bootloader.BIOS), flag="bios_grub")
+        part = make_partition(make_model(FirmwareType.BIOS), flag="bios_grub")
         self.assertFalse(part.ok_for_raid)
         self.assertFalse(part.ok_for_lvm_vg)
-        part = make_partition(make_model(Bootloader.UEFI), flag="boot")
+        part = make_partition(make_model(FirmwareType.UEFI), flag="boot")
         self.assertFalse(part.ok_for_raid)
         self.assertFalse(part.ok_for_lvm_vg)
-        part = make_partition(make_model(Bootloader.PREP), flag="prep")
+        part = make_partition(make_model(FirmwareType.PREP), flag="prep")
         self.assertFalse(part.ok_for_raid)
         self.assertFalse(part.ok_for_lvm_vg)
 
@@ -446,26 +446,26 @@ class TestStorageModel(unittest.TestCase):
 
     @parameterized.expand(
         (
-            (Bootloader.NONE, None, None, False, True),
-            (Bootloader.BIOS, "ext4", None, True, True),
-            (Bootloader.BIOS, "btrfs", None, True, True),
-            (Bootloader.UEFI, "ext4", None, True, True),
-            (Bootloader.UEFI, "xfs", None, True, False),
-            (Bootloader.PREP, "ext4", None, True, True),
-            (Bootloader.PREP, "zfs", None, True, True),
-            (Bootloader.BIOS, None, "ext4", False, True),
-            (Bootloader.BIOS, None, "btrfs", False, True),
+            (FirmwareType.NONE, None, None, False, True),
+            (FirmwareType.BIOS, "ext4", None, True, True),
+            (FirmwareType.BIOS, "btrfs", None, True, True),
+            (FirmwareType.UEFI, "ext4", None, True, True),
+            (FirmwareType.UEFI, "xfs", None, True, False),
+            (FirmwareType.PREP, "ext4", None, True, True),
+            (FirmwareType.PREP, "zfs", None, True, True),
+            (FirmwareType.BIOS, None, "ext4", False, True),
+            (FirmwareType.BIOS, None, "btrfs", False, True),
         )
     )
     def test_boot_filesystem_requirement(
         self,
-        bootloader: Bootloader,
+        firmware_type: FirmwareType,
         boot_fstype: str | None,
         root_fstype: str | None,
         has_separate_boot: bool,
         expected: bool,
     ):
-        model, disk = make_model_and_disk(bootloader)
+        model, disk = make_model_and_disk(firmware_type)
 
         with (
             mock.patch.object(model, "needs_bootloader_partition", return_value=False),
@@ -497,7 +497,7 @@ class TestStorageModel(unittest.TestCase):
         )
     )
     def test_boot_filesystem_release_requirement(self, release, expected):
-        model, disk = make_model_and_disk(Bootloader.UEFI)
+        model, disk = make_model_and_disk(FirmwareType.UEFI)
         part = make_partition(model, disk)
         fs = make_filesystem(model, part, fstype="xfs")
         make_mount(model, fs, "/")
@@ -907,7 +907,7 @@ class TestAutoInstallConfig(unittest.TestCase):
             )
 
     def test_extended_partition_remaining_size(self):
-        model = make_model(bootloader=Bootloader.BIOS, storage_version=2)
+        model = make_model(firmware_type=FirmwareType.BIOS, storage_version=2)
         make_disk(model, serial="aaaa", size=dehumanize_size("100M"))
 
         fake_up_blockdata(model)
@@ -956,7 +956,7 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertEqual(extended.size, 120832 * 512)
 
     def test_logical_partition_remaining_size(self):
-        model = make_model(bootloader=Bootloader.BIOS, storage_version=2)
+        model = make_model(firmware_type=FirmwareType.BIOS, storage_version=2)
         make_disk(model, serial="aaaa", size=dehumanize_size("100M"))
 
         fake_up_blockdata(model)
@@ -1009,7 +1009,7 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertEqual(logical.size, extended.size - ebr_space)
 
     def test_partition_remaining_size_in_extended_and_logical(self):
-        model = make_model(bootloader=Bootloader.BIOS, storage_version=2)
+        model = make_model(firmware_type=FirmwareType.BIOS, storage_version=2)
         make_disk(model, serial="aaaa", size=dehumanize_size("100M"))
         fake_up_blockdata(model)
         model.apply_autoinstall_config(
@@ -1073,7 +1073,7 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertEqual(p6.size, 96256 * 512)
 
     def test_partition_remaining_size_in_extended_and_logical_multiple(self):
-        model = make_model(bootloader=Bootloader.BIOS, storage_version=2)
+        model = make_model(firmware_type=FirmwareType.BIOS, storage_version=2)
         make_disk(model, serial="aaaa", size=dehumanize_size("20G"))
         fake_up_blockdata(model)
         model.apply_autoinstall_config(
@@ -1243,7 +1243,7 @@ class TestAutoInstallConfig(unittest.TestCase):
 
 class TestRenderActions(unittest.TestCase):
     def test_render_does_not_include_unreferenced(self):
-        model = make_model(Bootloader.NONE)
+        model = make_model(FirmwareType.NONE)
         disk1 = make_disk(model, preserve=True)
         disk2 = make_disk(model, preserve=True)
         disk1p1 = make_partition(model, disk1, preserve=True)
@@ -1257,7 +1257,7 @@ class TestRenderActions(unittest.TestCase):
         self.assertTrue(disk2p1.id not in rendered_ids)
 
     def test_render_for_api_does_include_unreferenced(self):
-        model = make_model(Bootloader.NONE)
+        model = make_model(FirmwareType.NONE)
         disk1 = make_disk(model, preserve=True)
         disk2 = make_disk(model, preserve=True)
         disk1p1 = make_partition(model, disk1, preserve=True)
@@ -1273,7 +1273,7 @@ class TestRenderActions(unittest.TestCase):
         self.assertTrue(disk2p1.id in rendered_ids)
 
     def test_render_devices_skips_format_mount(self):
-        model = make_model(Bootloader.NONE)
+        model = make_model(FirmwareType.NONE)
         disk1 = make_disk(model, preserve=True)
         disk1p1 = make_partition(model, disk1, preserve=True)
         fs = model.add_filesystem(disk1p1, "ext4")
@@ -1287,7 +1287,7 @@ class TestRenderActions(unittest.TestCase):
         self.assertTrue(mnt.id not in rendered_ids)
 
     def test_render_format_mount(self):
-        model = make_model(Bootloader.NONE)
+        model = make_model(FirmwareType.NONE)
         disk1 = make_disk(model, preserve=True)
         disk1p1 = make_partition(model, disk1, preserve=True)
         disk1p1.path = "/dev/vda1"
@@ -1304,7 +1304,7 @@ class TestRenderActions(unittest.TestCase):
         self.assertEqual(rendered_by_id[vol_id]["path"], "/dev/vda1")
 
     def test_render_includes_all_partitions(self):
-        model = make_model(Bootloader.NONE)
+        model = make_model(FirmwareType.NONE)
         disk1 = make_disk(model, preserve=True)
         disk1p1 = make_partition(
             model, disk1, preserve=True, offset=1 << 20, size=512 << 20
@@ -1320,7 +1320,7 @@ class TestRenderActions(unittest.TestCase):
         self.assertTrue(disk1p2.id in rendered_ids)
 
     def test_render_numbers_existing_partitions(self):
-        model = make_model(Bootloader.NONE)
+        model = make_model(FirmwareType.NONE)
         disk1 = make_disk(model, preserve=True)
         disk1p1 = make_partition(model, disk1, preserve=True)
         fs = model.add_filesystem(disk1p1, "ext4")
@@ -1332,7 +1332,7 @@ class TestRenderActions(unittest.TestCase):
             self.assertEqual(action["number"], 1)
 
     def test_render_includes_unmounted_new_partition(self):
-        model = make_model(Bootloader.NONE)
+        model = make_model(FirmwareType.NONE)
         disk1 = make_disk(model, preserve=True)
         disk2 = make_disk(model)
         disk1p1 = make_partition(model, disk1, preserve=True)
@@ -1348,7 +1348,7 @@ class TestRenderActions(unittest.TestCase):
     def test_render_groups_partitions_together(self):
         """Ensure that rendered partition actions for a given disk are grouped
         together, even when the actions were not created back to back"""
-        model = make_model(Bootloader.NONE)
+        model = make_model(FirmwareType.NONE)
 
         d1 = make_disk(model)
         d1p1 = make_partition(model, d1)
@@ -1544,7 +1544,7 @@ class TestSwap(unittest.TestCase):
         ]
     )
     def test_should_add_swapfile_nomount(self, fs):
-        m, d1 = make_model_and_disk(Bootloader.BIOS)
+        m, d1 = make_model_and_disk(FirmwareType.BIOS)
         d1p1 = make_partition(m, d1)
         m.add_filesystem(d1p1, fs)
         self.assertTrue(m.should_add_swapfile())
@@ -1558,7 +1558,7 @@ class TestSwap(unittest.TestCase):
         ]
     )
     def test_should_add_swapfile(self, fs, kern_maj_ver, expected):
-        m, d1 = make_model_and_disk(Bootloader.BIOS)
+        m, d1 = make_model_and_disk(FirmwareType.BIOS)
         d1p1 = make_partition(m, d1)
         m.add_mount(m.add_filesystem(d1p1, fs), "/")
         with mock.patch(
@@ -1568,7 +1568,7 @@ class TestSwap(unittest.TestCase):
             self.assertEqual(expected, m.should_add_swapfile())
 
     def test_should_add_swapfile_has_swappart(self):
-        m, d1 = make_model_and_disk(Bootloader.BIOS)
+        m, d1 = make_model_and_disk(FirmwareType.BIOS)
         d1p1 = make_partition(m, d1)
         d1p2 = make_partition(m, d1)
         m.add_mount(m.add_filesystem(d1p1, "ext4"), "/")

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -57,7 +57,6 @@ from subiquity.common.storage.requirements import (
 from subiquity.common.storage.spec import FileSystemSpec, PartitionSpec, VolGroupSpec
 from subiquity.common.types.storage import (
     AddPartitionV2,
-    Bootloader,
     CalculateEntropyRequest,
     CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
@@ -66,6 +65,7 @@ from subiquity.common.types.storage import (
     CoreBootFixEncryptionSupport,
     Disk,
     EntropyResponse,
+    FirmwareType,
     GuidedCapability,
     GuidedChoiceV2,
     GuidedDisallowedCapability,
@@ -338,9 +338,9 @@ class StorageController(SubiquityController, StorageManipulator):
         self.ai_data: Optional[dict[str, Any]] = {}
         super().__init__(app)
         self.model.target = app.base_model.target
-        if self.opts.dry_run and self.opts.bootloader:
-            name = self.opts.bootloader.upper()
-            self.model.bootloader = getattr(Bootloader, name)
+        if self.opts.dry_run and self.opts.firmware_type:
+            name = self.opts.firmware_type.upper()
+            self.model.firmware_type = getattr(FirmwareType, name)
         self.model.storage_version = self.opts.storage_version
         self._monitor: Optional[pyudev.Monitor] = None
         self._errors: dict[bool, tuple[Exception, ErrorReport]] = {}
@@ -543,7 +543,7 @@ class StorageController(SubiquityController, StorageManipulator):
         return info
 
     def _maybe_disable_encryption(self, info: VariationInfo) -> None:
-        if self.model.bootloader != Bootloader.UEFI:
+        if self.model.firmware_type != FirmwareType.UEFI:
             log.debug("Disabling core boot based install options on non-UEFI system")
             info.capability_info.disallow_if(
                 lambda cap: cap.is_core_boot(),
@@ -1003,7 +1003,9 @@ class StorageController(SubiquityController, StorageManipulator):
     def _done_response(self):
         return StorageResponse(
             status=ProbeStatus.DONE,
-            bootloader=self.model.bootloader,
+            firmware_type=self.model.firmware_type,
+            # Temporary, for backward compatibility
+            bootloader=self.model.firmware_type,
             error_report=self.full_probe_error(),
             orig_config=self.model._orig_config,
             config=self.model._render_actions(mode=ActionRenderMode.FOR_API),
@@ -2392,7 +2394,7 @@ class StorageController(SubiquityController, StorageManipulator):
         self.model.grub = self.ai_data.get("grub")
 
     def start(self):
-        if self.model.bootloader == Bootloader.PREP:
+        if self.model.firmware_type == FirmwareType.PREP:
             self.supports_resilient_boot = False
         else:
             release = lsb_release(dry_run=self.app.opts.dry_run)["release"]

--- a/subiquity/server/controllers/tests/test_identity.py
+++ b/subiquity/server/controllers/tests/test_identity.py
@@ -116,7 +116,7 @@ class TestControllerUserCreationFlows(SubiTestCase):
     # See subiquity/models/tests/test_subiquity.py for details.
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = False
+        self.app.opts.bootloader = "uefi"
         self.app.controllers.Storage = StorageController(self.app)
         self.ic = IdentityController(self.app)
         self.ic.model.user = None

--- a/subiquity/server/controllers/tests/test_identity.py
+++ b/subiquity/server/controllers/tests/test_identity.py
@@ -116,7 +116,7 @@ class TestControllerUserCreationFlows(SubiTestCase):
     # See subiquity/models/tests/test_subiquity.py for details.
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = "uefi"
+        self.app.opts.firmware_type = "uefi"
         self.app.controllers.Storage = StorageController(self.app)
         self.ic = IdentityController(self.app)
         self.ic.model.user = None

--- a/subiquity/server/controllers/tests/test_integrity.py
+++ b/subiquity/server/controllers/tests/test_integrity.py
@@ -28,7 +28,7 @@ from subiquitycore.tests.mocks import make_app
 class TestMd5Check(SubiTestCase):
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = "UEFI"
+        self.app.opts.bootloader = "uefi"
         self.ic = IntegrityController(app=self.app)
         self.ic.model = IntegrityModel()
 

--- a/subiquity/server/controllers/tests/test_integrity.py
+++ b/subiquity/server/controllers/tests/test_integrity.py
@@ -28,7 +28,7 @@ from subiquitycore.tests.mocks import make_app
 class TestMd5Check(SubiTestCase):
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = "uefi"
+        self.app.opts.firmware_type = "uefi"
         self.ic = IntegrityController(app=self.app)
         self.ic.model = IntegrityModel()
 

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -32,7 +32,6 @@ from subiquity.common.storage import boot, gaps, labels
 from subiquity.common.storage.actions import DeviceAction
 from subiquity.common.types.storage import (
     AddPartitionV2,
-    Bootloader,
     CalculateEntropyRequest,
     CoreBootEncryptionFeature,
     CoreBootEncryptionRequirement,
@@ -40,6 +39,7 @@ from subiquity.common.types.storage import (
     CoreBootFixActionWithArgs,
     CoreBootFixEncryptionSupport,
     EntropyResponse,
+    FirmwareType,
     Gap,
     GapUsable,
     GuidedCapability,
@@ -96,9 +96,9 @@ from subiquitycore.tests.parameterized import parameterized
 from subiquitycore.tests.util import random_string
 from subiquitycore.utils import matching_dicts
 
-bootloaders = [(bl,) for bl in list(Bootloader)]
-bootloaders_and_ptables = [
-    (bl, pt) for bl in list(Bootloader) for pt in ("gpt", "msdos", "vtoc")
+firmware_types = [(fwt,) for fwt in list(FirmwareType)]
+firmware_types_and_ptables = [
+    (fwt, pt) for fwt in list(FirmwareType) for pt in ("gpt", "msdos", "vtoc")
 ]
 
 
@@ -169,7 +169,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = "UEFI"
+        self.app.opts.firmware_type = "UEFI"
         self.app.command_runner = mock.AsyncMock()
         self.app.prober = mock.AsyncMock()
         self.app.prober.get_storage = mock.AsyncMock()
@@ -591,7 +591,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         self.assertEqual(expect_log, found_log)
 
     async def test_layout_no_grub_or_swap(self):
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         self.ctrler.run_autoinstall_guided = mock.AsyncMock()
 
         self.ctrler.ai_data = {
@@ -605,7 +605,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
 
     @parameterized.expand(((True,), (False,)))
     async def test_layout_plus_grub(self, reorder_uefi):
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         self.ctrler.run_autoinstall_guided = mock.AsyncMock()
 
         self.ctrler.ai_data = {
@@ -630,7 +630,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
 
     @parameterized.expand(((0,), ("1G",)))
     async def test_layout_plus_swap(self, swapsize):
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         self.ctrler.run_autoinstall_guided = mock.AsyncMock()
 
         self.ctrler.ai_data = {"layout": {"name": "direct"}, "swap": {"size": swapsize}}
@@ -640,7 +640,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         self.assertEqual(swapsize, curtin_cfg["swap"]["size"])
 
     async def test_apply_autoinstall_config_rejects_non_ext4_boot(self):
-        model, disk = make_model_and_disk(Bootloader.UEFI)
+        model, disk = make_model_and_disk(FirmwareType.UEFI)
 
         part = make_partition(model, disk)
         fs = make_filesystem(model, part, fstype="xfs")
@@ -1432,7 +1432,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         # 'ubuntu-desktop'. The variations of those two sources are different.
         # Upon switching to the new source, we forgot to discard the old
         # variations. This lead to a crash further in the install.
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         make_disk(model)
         self.app.base_model.source.current.type = "fsimage"
         self.app.base_model.source.current.variations = {
@@ -1520,7 +1520,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
             self.assertIn("cannot load assertions for label", logs.output[0])
 
     def test_start_guided_reformat__no_in_use(self):
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         disk = make_disk(model)
 
         p1 = make_partition(model, disk, size=10 << 30)
@@ -1564,7 +1564,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         partitions that should have been removed. Because we were iterating
         over device._partitions and calling delete_partition in the body, we
         failed to iterate over some of the partitions."""
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         disk = make_disk(model)
 
         p1 = make_partition(model, disk, size=10 << 30)
@@ -1595,7 +1595,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         self.assertEqual(expected_del_calls, m_del_part.mock_calls)
 
     def test_start_guided_erase_install__no_free_space(self):
-        self.ctrler.model = model = make_model(Bootloader.UEFI, storage_version=2)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI, storage_version=2)
         disk = make_disk(model)
 
         p1 = make_partition(model, disk, size=10 << 30)
@@ -1609,7 +1609,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         self.assertEqual(p1.size, gap.size)
 
     def test_start_guided_erase_install__free_space_after(self):
-        self.ctrler.model = model = make_model(Bootloader.UEFI, storage_version=2)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI, storage_version=2)
         disk = make_disk(model)
 
         part = make_partition(model, disk, size=10 << 30)
@@ -1624,7 +1624,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         self.assertEqual(part.size + trailing_gap.size, gap.size)
 
     def test_start_guided_erase_install__free_space_before(self):
-        self.ctrler.model = model = make_model(Bootloader.UEFI, storage_version=2)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI, storage_version=2)
         disk = make_disk(model)
 
         part = make_partition(model, disk, size=-1, offset=20 << 30)
@@ -1639,7 +1639,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         self.assertEqual(part.size + leading_gap.size, gap.size)
 
     def test_start_guided_erase_install__free_space_before_and_after(self):
-        self.ctrler.model = model = make_model(Bootloader.UEFI, storage_version=2)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI, storage_version=2)
         disk = make_disk(model)
 
         part = make_partition(model, disk, size=10 << 30, offset=20 << 30)
@@ -1772,7 +1772,7 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
 class TestRunAutoinstallGuided(IsolatedAsyncioTestCase):
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = None
+        self.app.opts.firmware_type = None
         self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
         self.ctrler = StorageController(self.app)
         self.model = self.ctrler.model = make_model()
@@ -1844,17 +1844,17 @@ class TestRunAutoinstallGuided(IsolatedAsyncioTestCase):
 
 class TestGuided(IsolatedAsyncioTestCase):
     boot_expectations = [
-        (Bootloader.UEFI, "gpt", "/boot/efi"),
-        (Bootloader.UEFI, "msdos", "/boot/efi"),
-        (Bootloader.BIOS, "gpt", None),
+        (FirmwareType.UEFI, "gpt", "/boot/efi"),
+        (FirmwareType.UEFI, "msdos", "/boot/efi"),
+        (FirmwareType.BIOS, "gpt", None),
         # BIOS + msdos is different
-        (Bootloader.PREP, "gpt", None),
-        (Bootloader.PREP, "msdos", None),
+        (FirmwareType.PREP, "gpt", None),
+        (FirmwareType.PREP, "msdos", None),
     ]
 
-    async def _guided_setup(self, bootloader, ptable, storage_version=None):
+    async def _guided_setup(self, firmware_type, ptable, storage_version=None):
         self.app = make_app()
-        self.app.opts.bootloader = bootloader.value
+        self.app.opts.firmware_type = firmware_type.value
         self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
         self.controller = StorageController(self.app)
         self.controller.supports_resilient_boot = True
@@ -1867,13 +1867,13 @@ class TestGuided(IsolatedAsyncioTestCase):
         }
         self.app.controllers.Source.get_handler.return_value = TrivialSourceHandler("")
         await self.controller._examine_systems_task.wait()
-        self.model = make_model(bootloader, storage_version)
+        self.model = make_model(firmware_type, storage_version)
         self.controller.model = self.model
         self.d1 = make_disk(self.model, ptable=ptable)
 
     @parameterized.expand(boot_expectations)
-    async def test_guided_direct(self, bootloader, ptable, p1mnt):
-        await self._guided_setup(bootloader, ptable)
+    async def test_guided_direct(self, firmware_type, ptable, p1mnt):
+        await self._guided_setup(firmware_type, ptable)
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
         )
@@ -1888,7 +1888,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertIsNone(gaps.largest_gap(self.d1))
 
     async def test_guided_reset_partition(self):
-        await self._guided_setup(Bootloader.UEFI, "gpt")
+        await self._guided_setup(FirmwareType.UEFI, "gpt")
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
         )
@@ -1904,7 +1904,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertEqual("/", d1p3.mount)
 
     async def test_fixed_reset_partition(self):
-        await self._guided_setup(Bootloader.UEFI, "gpt")
+        await self._guided_setup(FirmwareType.UEFI, "gpt")
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
         )
@@ -1924,7 +1924,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertEqual("/", d1p3.mount)
 
     async def test_guided_reset_partition_only(self):
-        await self._guided_setup(Bootloader.UEFI, "gpt")
+        await self._guided_setup(FirmwareType.UEFI, "gpt")
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
         )
@@ -1952,7 +1952,7 @@ class TestGuided(IsolatedAsyncioTestCase):
     async def test_rest_partition_size(
         self, ai_data, reset_partition, reset_partition_size
     ):
-        await self._guided_setup(Bootloader.UEFI, "gpt")
+        await self._guided_setup(FirmwareType.UEFI, "gpt")
         self.controller.guided = mock.AsyncMock()
         layout = ai_data | {"name": "direct"}
         await self.controller.run_autoinstall_guided(layout)
@@ -1961,7 +1961,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertEqual(guided_choice.reset_partition_size, reset_partition_size)
 
     async def test_guided_direct_BIOS_MSDOS(self):
-        await self._guided_setup(Bootloader.BIOS, "msdos")
+        await self._guided_setup(FirmwareType.BIOS, "msdos")
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, ptable="msdos", allowed=default_capabilities
         )
@@ -1974,8 +1974,8 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertIsNone(gaps.largest_gap(self.d1))
 
     @parameterized.expand(boot_expectations)
-    async def test_guided_lvm(self, bootloader, ptable, p1mnt):
-        await self._guided_setup(bootloader, ptable)
+    async def test_guided_lvm(self, firmware_type, ptable, p1mnt):
+        await self._guided_setup(firmware_type, ptable)
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
         )
@@ -1995,7 +1995,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertIsNone(gaps.largest_gap(self.d1))
 
     async def test_guided_lvm_BIOS_MSDOS(self):
-        await self._guided_setup(Bootloader.BIOS, "msdos")
+        await self._guided_setup(FirmwareType.BIOS, "msdos")
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, ptable="msdos", allowed=default_capabilities
         )
@@ -2013,8 +2013,8 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertIsNone(gaps.largest_gap(self.d1))
 
     @parameterized.expand(boot_expectations)
-    async def test_guided_zfs(self, bootloader, ptable, p1mnt):
-        await self._guided_setup(bootloader, ptable)
+    async def test_guided_zfs(self, firmware_type, ptable, p1mnt):
+        await self._guided_setup(firmware_type, ptable)
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
         )
@@ -2049,8 +2049,8 @@ class TestGuided(IsolatedAsyncioTestCase):
         [userdata_root] = self.model._all(type="zfs", path="/root")
 
     @parameterized.expand(boot_expectations)
-    async def test_guided_zfs_luks_keystore(self, bootloader, ptable, p1mnt):
-        await self._guided_setup(bootloader, ptable)
+    async def test_guided_zfs_luks_keystore(self, firmware_type, ptable, p1mnt):
+        await self._guided_setup(firmware_type, ptable)
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
         )
@@ -2092,7 +2092,7 @@ class TestGuided(IsolatedAsyncioTestCase):
         self.assertEqual("zfs", zfs_boot.type)
 
     async def test_guided_zfs_BIOS_MSDOS(self):
-        await self._guided_setup(Bootloader.BIOS, "msdos")
+        await self._guided_setup(FirmwareType.BIOS, "msdos")
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, ptable="msdos", allowed=default_capabilities
         )
@@ -2121,7 +2121,7 @@ class TestGuided(IsolatedAsyncioTestCase):
     async def test_guided_zfs_swap_size_lp_2034939(self, suggested):
         suggested.return_value = (1 << 30) + 1
         # crash due to add_partition for swap with unaligned size
-        await self._guided_setup(Bootloader.UEFI, "gpt")
+        await self._guided_setup(FirmwareType.UEFI, "gpt")
         target = GuidedStorageTargetReformat(
             disk_id=self.d1.id, allowed=default_capabilities
         )
@@ -2130,12 +2130,12 @@ class TestGuided(IsolatedAsyncioTestCase):
         )
         # just checking that this doesn't throw
 
-    async def _guided_side_by_side(self, bl, ptable):
-        await self._guided_setup(bl, ptable, storage_version=2)
+    async def _guided_side_by_side(self, fwt, ptable):
+        await self._guided_setup(fwt, ptable, storage_version=2)
         self.controller.add_boot_disk(self.d1)
         for p in self.d1._partitions:
             p.preserve = True
-            if bl == Bootloader.UEFI:
+            if fwt == FirmwareType.UEFI:
                 # let it pass the is_esp check
                 p._info = FakeStorageInfo(size=p.size)
                 p._info.raw["ID_PART_ENTRY_TYPE"] = str(0xEF)
@@ -2167,13 +2167,13 @@ class TestGuided(IsolatedAsyncioTestCase):
 
     @parameterized.expand(
         [
-            (bl, pt, flag)
-            for bl in list(Bootloader)
+            (fwt, pt, flag)
+            for fwt in list(FirmwareType)
             for pt, flag in (("msdos", "logical"), ("gpt", None))
         ]
     )
-    async def test_guided_direct_side_by_side(self, bl, pt, flag):
-        await self._guided_side_by_side(bl, pt)
+    async def test_guided_direct_side_by_side(self, fwt, pt, flag):
+        await self._guided_side_by_side(fwt, pt)
         parts_before = self.d1._partitions.copy()
         gap = gaps.largest_gap(self.d1)
         target = GuidedStorageTargetUseGap(
@@ -2190,13 +2190,13 @@ class TestGuided(IsolatedAsyncioTestCase):
 
     @parameterized.expand(
         [
-            (bl, pt, flag)
-            for bl in list(Bootloader)
+            (fwt, pt, flag)
+            for fwt in list(FirmwareType)
             for pt, flag in (("msdos", "logical"), ("gpt", None))
         ]
     )
-    async def test_guided_lvm_side_by_side(self, bl, pt, flag):
-        await self._guided_side_by_side(bl, pt)
+    async def test_guided_lvm_side_by_side(self, fwt, pt, flag):
+        await self._guided_side_by_side(fwt, pt)
         parts_before = self.d1._partitions.copy()
         gap = gaps.largest_gap(self.d1)
         target = GuidedStorageTargetUseGap(
@@ -2217,7 +2217,7 @@ class TestGuided(IsolatedAsyncioTestCase):
 class TestLayout(IsolatedAsyncioTestCase):
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = None
+        self.app.opts.firmware_type = None
         self.ctrler = StorageController(app=self.app)
 
     @parameterized.expand([("reformat_disk",), ("use_gap",)])
@@ -2262,14 +2262,14 @@ class TestLayout(IsolatedAsyncioTestCase):
 
 
 class TestGuidedV2(IsolatedAsyncioTestCase):
-    async def _setup(self, bootloader, ptable, fix_bios=True, **kw):
+    async def _setup(self, firmware_type, ptable, fix_bios=True, **kw):
         self.app = make_app()
-        self.app.opts.bootloader = bootloader.value
+        self.app.opts.firmware_type = firmware_type.value
         self.app.snapdinfo = mock.Mock(spec=SnapdInfo)
         self.ctrler = StorageController(app=self.app)
         self.ctrler.calculate_suggested_install_min = mock.Mock()
         self.ctrler.calculate_suggested_install_min.return_value = 10 << 30
-        self.ctrler.model = self.model = make_model(bootloader)
+        self.ctrler.model = self.model = make_model(firmware_type)
         self.ctrler._examine_systems_task.start_sync()
         self.app.dr_cfg = DRConfig()
         self.app.base_model.source.current.type = "fsimage"
@@ -2287,7 +2287,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         }
         self.ctrler._probe_task.task = mock.Mock()
         self.ctrler._examine_systems_task.task = mock.Mock()
-        if bootloader == Bootloader.BIOS and ptable != "msdos" and fix_bios:
+        if firmware_type == FirmwareType.BIOS and ptable != "msdos" and fix_bios:
             make_partition(
                 self.model,
                 self.disk,
@@ -2297,10 +2297,10 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
                 offset=1 << 20,
             )
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_blank_disk(self, bootloader, ptable):
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_blank_disk(self, firmware_type, ptable):
         # blank disks should not report a UseGap case
-        await self._setup(bootloader, ptable, fix_bios=False)
+        await self._setup(firmware_type, ptable, fix_bios=False)
         expected = [
             GuidedStorageTargetReformat(
                 disk_id=self.disk.id, allowed=default_capabilities
@@ -2311,16 +2311,16 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertEqual(expected, resp.targets)
         self.assertEqual(ProbeStatus.DONE, resp.status)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_probing(self, bootloader, ptable):
-        await self._setup(bootloader, ptable, fix_bios=False)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_probing(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable, fix_bios=False)
         self.ctrler._probe_task.task = None
         resp = await self.ctrler.v2_guided_GET()
         self.assertEqual([], resp.targets)
         self.assertEqual(ProbeStatus.PROBING, resp.status)
 
     async def test_manual(self):
-        await self._setup(Bootloader.UEFI, "gpt")
+        await self._setup(FirmwareType.UEFI, "gpt")
         guided_get_resp = await self.ctrler.v2_guided_GET()
         [reformat, manual] = guided_get_resp.targets
         self.assertEqual(manual, GuidedStorageTargetManual())
@@ -2330,9 +2330,9 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         guided_get_resp = await self.ctrler.v2_guided_GET()
         self.assertEqual([reformat, manual], guided_get_resp.targets)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_small_blank_disk_1GiB(self, bootloader, ptable):
-        await self._setup(bootloader, ptable, size=1 << 30)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_small_blank_disk_1GiB(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable, size=1 << 30)
         resp = await self.ctrler.v2_guided_GET()
         expected = [
             GuidedStorageTargetReformat(
@@ -2344,9 +2344,9 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         ]
         self.assertEqual(expected, resp.targets)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_small_blank_disk_1MiB(self, bootloader, ptable):
-        await self._setup(bootloader, ptable, size=1 << 20)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_small_blank_disk_1MiB(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable, size=1 << 20)
         resp = await self.ctrler.v2_guided_GET()
 
         reformat = GuidedStorageTargetReformat(
@@ -2356,8 +2356,8 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         )
         manual = GuidedStorageTargetManual()
 
-        # depending on bootloader/ptable combo, GuidedStorageTargetReformat may
-        # show up but it will all be disallowed.
+        # depending on firmware-type/ptable combo, GuidedStorageTargetReformat
+        # may show up but it will all be disallowed.
         for target in resp.targets:
             if isinstance(target, GuidedStorageTargetManual):
                 self.assertEqual(target, manual)
@@ -2366,9 +2366,9 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             else:
                 raise Exception(f"unexpected target {target}")
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_used_half_disk(self, bootloader, ptable):
-        await self._setup(bootloader, ptable, size=100 << 30)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_used_half_disk(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable, size=100 << 30)
         p = make_partition(self.model, self.disk, preserve=True, size=50 << 30)
         gap_offset = p.size + p.offset
         self.fs_probe[p._path()] = {"ESTIMATED_MIN_SIZE": 1 << 20}
@@ -2392,10 +2392,10 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertTrue(isinstance(resize, GuidedStorageTargetResize))
         self.assertEqual(1, len(resp.targets))
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_used_half_disk_mounted(self, bootloader, ptable):
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_used_half_disk_mounted(self, firmware_type, ptable):
         # When a partition is already mounted, it can't be resized.
-        await self._setup(bootloader, ptable, size=100 << 30)
+        await self._setup(firmware_type, ptable, size=100 << 30)
         p = make_partition(
             self.model, self.disk, preserve=True, size=50 << 30, is_in_use=True
         )
@@ -2411,9 +2411,9 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         )
         self.assertEqual(1, len(resp.targets))
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_used_full_disk(self, bootloader, ptable):
-        await self._setup(bootloader, ptable)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_used_full_disk(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable)
         p = make_partition(
             self.model, self.disk, preserve=True, size=gaps.largest_gap_size(self.disk)
         )
@@ -2433,9 +2433,9 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertTrue(isinstance(resize, GuidedStorageTargetResize))
         self.assertEqual(1, len(resp.targets))
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_weighted_split(self, bootloader, ptable):
-        await self._setup(bootloader, ptable, size=250 << 30)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_weighted_split(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable, size=250 << 30)
         # add an extra, filler, partition so that there is no use_gap result
         make_partition(self.model, self.disk, preserve=True, size=9 << 30)
         p = make_partition(self.model, self.disk, preserve=True, size=240 << 30)
@@ -2451,7 +2451,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             reformat,
         )
 
-        if ptable != "vtoc" or bootloader == Bootloader.NONE:
+        if ptable != "vtoc" or firmware_type == FirmwareType.NONE:
             # VTOC has primary_part_limit=3
             resize = possible.pop(0)
             expected = GuidedStorageTargetResize(
@@ -2466,9 +2466,9 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             self.assertEqual(expected, resize)
         self.assertEqual(1, len(possible))
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_half_disk_reformat(self, bootloader, ptable):
-        await self._setup(bootloader, ptable, size=100 << 30)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_half_disk_reformat(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable, size=100 << 30)
         p = make_partition(self.model, self.disk, preserve=True, size=50 << 30)
         self.fs_probe[p._path()] = {"ESTIMATED_MIN_SIZE": 1 << 20}
 
@@ -2492,9 +2492,9 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertFalse(resp.need_boot)
         self.assertEqual(1, len(guided_get_resp.targets))
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_half_disk_use_gap(self, bootloader, ptable):
-        await self._setup(bootloader, ptable, size=100 << 30)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_half_disk_use_gap(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable, size=100 << 30)
         p = make_partition(self.model, self.disk, preserve=True, size=50 << 30)
         self.fs_probe[p._path()] = {"ESTIMATED_MIN_SIZE": 1 << 20}
 
@@ -2527,9 +2527,9 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertFalse(resp.need_boot)
         self.assertEqual(1, len(guided_get_resp.targets))
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_half_disk_resize(self, bootloader, ptable):
-        await self._setup(bootloader, ptable, size=100 << 30)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_half_disk_resize(self, firmware_type, ptable):
+        await self._setup(firmware_type, ptable, size=100 << 30)
         p = make_partition(self.model, self.disk, preserve=True, size=50 << 30)
         self.fs_probe[p._path()] = {"ESTIMATED_MIN_SIZE": 1 << 20}
 
@@ -2579,7 +2579,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
     )
     async def test_lvm_20G_bad_offset(self, disk_size):
         disk_size = disk_size << 30
-        await self._setup(Bootloader.BIOS, "gpt", size=disk_size)
+        await self._setup(FirmwareType.BIOS, "gpt", size=disk_size)
 
         guided_get_resp = await self.ctrler.v2_guided_GET()
 
@@ -2605,8 +2605,8 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             disk_size - (1 << 20), parts[-1].offset + parts[-1].size, disk_size
         )
 
-    async def _sizing_setup(self, bootloader, ptable, disk_size, policy):
-        await self._setup(bootloader, ptable, size=disk_size)
+    async def _sizing_setup(self, firmware_type, ptable, disk_size, policy):
+        await self._setup(firmware_type, ptable, size=disk_size)
 
         resp = await self.ctrler.v2_guided_GET()
         reformat = [
@@ -2628,32 +2628,32 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         size = dehumanize_size(lvm_partition["size"])
         return size, part_size
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_scaled_disk(self, bootloader, ptable):
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_scaled_disk(self, firmware_type, ptable):
         size, part_size = await self._sizing_setup(
-            bootloader, ptable, 50 << 30, SizingPolicy.SCALED
+            firmware_type, ptable, 50 << 30, SizingPolicy.SCALED
         )
         # expected to be about half, differing by boot and ptable types
         self.assertLess(20 << 30, size)
         self.assertLess(size, 30 << 30)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_unscaled_disk(self, bootloader, ptable):
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_unscaled_disk(self, firmware_type, ptable):
         size, part_size = await self._sizing_setup(
-            bootloader, ptable, 50 << 30, SizingPolicy.ALL
+            firmware_type, ptable, 50 << 30, SizingPolicy.ALL
         )
         # there is some subtle differences in sizing depending on
-        # ptable/bootloader and how the rounding goes
+        # ptable/firmware_type and how the rounding goes
         self.assertLess(part_size - (5 << 20), size)
         self.assertLess(size, part_size)
         # but we should using most of the disk, minus boot partition(s)
         self.assertLess(45 << 30, size)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_in_use(self, bootloader, ptable):
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_in_use(self, firmware_type, ptable):
         # Disks with "in use" partitions allow a reformat if there is
         # enough space on the rest of the disk.
-        await self._setup(bootloader, ptable, fix_bios=True)
+        await self._setup(firmware_type, ptable, fix_bios=True)
         make_partition(
             self.model, self.disk, preserve=True, size=4 << 30, is_in_use=True
         )
@@ -2667,12 +2667,12 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertEqual(expected, resp.targets)
         self.assertEqual(ProbeStatus.DONE, resp.status)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_in_use_full(self, bootloader, ptable):
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_in_use_full(self, firmware_type, ptable):
         # Disks with "in use" partitions allow a reformat (but not
         # usegap) if there is enough space on the rest of the disk,
         # even if the disk is full of other partitions.
-        await self._setup(bootloader, ptable, fix_bios=True)
+        await self._setup(firmware_type, ptable, fix_bios=True)
         make_partition(
             self.model, self.disk, preserve=True, size=4 << 30, is_in_use=True
         )
@@ -2689,11 +2689,11 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertEqual(expected, resp.targets)
         self.assertEqual(ProbeStatus.DONE, resp.status)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_in_use_too_small(self, bootloader, ptable):
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_in_use_too_small(self, firmware_type, ptable):
         # Disks with "in use" partitions do not allow a reformat if
         # there is not enough space on the rest of the disk.
-        await self._setup(bootloader, ptable, fix_bios=True, size=25 << 30)
+        await self._setup(firmware_type, ptable, fix_bios=True, size=25 << 30)
         make_partition(
             self.model, self.disk, preserve=True, size=23 << 30, is_in_use=True
         )
@@ -2711,12 +2711,12 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         ]
         self.assertEqual(expected, resp.targets)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_in_use_reformat_and_gap(self, bootloader, ptable):
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_in_use_reformat_and_gap(self, firmware_type, ptable):
         # Disks with "in use" partitions allow both a reformat and a
         # usegap if there is an in use partition, another partition
         # and a big enough gap.
-        await self._setup(bootloader, ptable, fix_bios=True)
+        await self._setup(firmware_type, ptable, fix_bios=True)
         make_partition(
             self.model, self.disk, preserve=True, size=4 << 30, is_in_use=True
         )
@@ -2733,7 +2733,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
             GuidedStorageTargetManual(),
         ]
         # VTOC does not have enough room for an ESP + 3 partitions, presumably.
-        if ptable != "vtoc" or bootloader == Bootloader.NONE:
+        if ptable != "vtoc" or firmware_type == FirmwareType.NONE:
             expected.insert(
                 1,
                 GuidedStorageTargetUseGap(
@@ -2765,7 +2765,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         create_boot_part: bool,
         expected_scenario: bool,
     ):
-        await self._setup(Bootloader.NONE, "gpt", fix_bios=True)
+        await self._setup(FirmwareType.NONE, "gpt", fix_bios=True)
         install_min = self.ctrler.calculate_suggested_install_min()
 
         for _ in range(existing_primaries):
@@ -2790,7 +2790,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertEqual(expected_scenario, scenarios != [])
 
     async def test_available_erase_install_scenarios(self):
-        await self._setup(Bootloader.NONE, "gpt", fix_bios=True)
+        await self._setup(FirmwareType.NONE, "gpt", fix_bios=True)
         install_min = self.ctrler.calculate_suggested_install_min()
 
         p1 = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
@@ -2827,7 +2827,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertEqual(p2.number, scenario2.partition_number)
 
     async def test_available_erase_install_scenarios__no_os(self):
-        await self._setup(Bootloader.NONE, "gpt", fix_bios=True)
+        await self._setup(FirmwareType.NONE, "gpt", fix_bios=True)
         install_min = self.ctrler.calculate_suggested_install_min()
 
         make_partition(self.model, self.disk, preserve=True, size=4 << 20)
@@ -2836,7 +2836,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertFalse(self.ctrler.available_erase_install_scenarios(install_min))
 
     async def test_available_erase_install_scenarios__full_primaries(self):
-        await self._setup(Bootloader.UEFI, "dos", fix_bios=True)
+        await self._setup(FirmwareType.UEFI, "dos", fix_bios=True)
         install_min = self.ctrler.calculate_suggested_install_min()
 
         p1 = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
@@ -2862,7 +2862,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertFalse(self.ctrler.available_erase_install_scenarios(install_min))
 
     async def test_available_erase_install_scenarios__with_logical_partitions(self):
-        await self._setup(Bootloader.UEFI, "dos", fix_bios=True)
+        await self._setup(FirmwareType.UEFI, "dos", fix_bios=True)
         install_min = self.ctrler.calculate_suggested_install_min()
 
         model, disk = self.model, self.disk
@@ -2909,14 +2909,14 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
         self.assertEqual(3, len(sorted_scenarios))
 
     async def test_resize_has_enough_room_for_partitions__one_primary(self):
-        await self._setup(Bootloader.NONE, "gpt", fix_bios=True)
+        await self._setup(FirmwareType.NONE, "gpt", fix_bios=True)
 
         p = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
 
         self.assertTrue(self.ctrler.resize_has_enough_room_for_partitions(self.disk, p))
 
     async def test_resize_has_enough_room_for_partitions__full_primaries(self):
-        await self._setup(Bootloader.NONE, "dos", fix_bios=True)
+        await self._setup(FirmwareType.NONE, "dos", fix_bios=True)
 
         p1 = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
         p2 = make_partition(self.model, self.disk, preserve=True, size=4 << 20)
@@ -2938,7 +2938,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
 
     @mock.patch("subiquity.server.controllers.storage.boot.get_boot_device_plan")
     async def test_resize_has_enough_room_for_partitions__one_more(self, p_boot_plan):
-        await self._setup(Bootloader.NONE, "dos", fix_bios=True)
+        await self._setup(FirmwareType.NONE, "dos", fix_bios=True)
 
         model = self.model
         disk = self.disk
@@ -2962,7 +2962,7 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
 
     @mock.patch("subiquity.server.controllers.storage.boot.get_boot_device_plan")
     async def test_resize_has_enough_room_for_partitions__logical(self, p_boot_plan):
-        await self._setup(Bootloader.NONE, "dos", fix_bios=True)
+        await self._setup(FirmwareType.NONE, "dos", fix_bios=True)
 
         model = self.model
         disk = self.disk
@@ -2998,29 +2998,29 @@ class TestGuidedV2(IsolatedAsyncioTestCase):
 
 
 class TestManualBoot(IsolatedAsyncioTestCase):
-    def _setup(self, bootloader, ptable, **kw):
+    def _setup(self, firmware_type, ptable, **kw):
         self.app = make_app()
-        self.app.opts.bootloader = bootloader.value
+        self.app.opts.firmware_type = firmware_type.value
         self.ctrler = StorageController(app=self.app)
         self.ctrler.calculate_suggested_install_min = mock.Mock()
         self.ctrler.calculate_suggested_install_min.return_value = 10 << 30
-        self.ctrler.model = self.model = make_model(bootloader)
+        self.ctrler.model = self.model = make_model(firmware_type)
         self.model.storage_version = 2
         self.ctrler._probe_task.task = mock.Mock()
         self.ctrler._probe_firmware_task.task = mock.Mock()
         self.ctrler._examine_systems_task.task = mock.Mock()
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_get_boot_disks_only(self, bootloader, ptable):
-        self._setup(bootloader, ptable)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_get_boot_disks_only(self, firmware_type, ptable):
+        self._setup(firmware_type, ptable)
         make_disk(self.model)
         resp = await self.ctrler.v2_GET()
         [d] = resp.disks
         self.assertTrue(d.can_be_boot_device)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_get_boot_disks_all(self, bootloader, ptable):
-        self._setup(bootloader, ptable)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_get_boot_disks_all(self, firmware_type, ptable):
+        self._setup(firmware_type, ptable)
         make_disk(self.model)
         make_disk(self.model)
         resp = await self.ctrler.v2_GET()
@@ -3028,9 +3028,9 @@ class TestManualBoot(IsolatedAsyncioTestCase):
         self.assertTrue(d1.can_be_boot_device)
         self.assertTrue(d2.can_be_boot_device)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_get_boot_disks_some(self, bootloader, ptable):
-        self._setup(bootloader, ptable)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_get_boot_disks_some(self, firmware_type, ptable):
+        self._setup(firmware_type, ptable)
         ctrler = make_nvme_controller(
             model=self.model, transport="tcp", tcp_addr="172.16.82.78", tcp_port=4420
         )
@@ -3039,7 +3039,7 @@ class TestManualBoot(IsolatedAsyncioTestCase):
         d2 = make_disk(self.model)
         make_disk(self.model, nvme_controller=ctrler)
         make_partition(self.model, d1, size=gaps.largest_gap_size(d1), preserve=True)
-        if bootloader == Bootloader.NONE:
+        if firmware_type == FirmwareType.NONE:
             # NONE will always pass the boot check, even on a full disk
             # .. well unless if it is a "remote" disk.
             bootable = set([d1.id, d2.id])
@@ -3049,9 +3049,9 @@ class TestManualBoot(IsolatedAsyncioTestCase):
         for d in resp.disks:
             self.assertEqual(d.id in bootable, d.can_be_boot_device)
 
-    @parameterized.expand(bootloaders_and_ptables)
-    async def test_get_boot_disks_no_remote(self, bootloader, ptable):
-        self._setup(bootloader, ptable)
+    @parameterized.expand(firmware_types_and_ptables)
+    async def test_get_boot_disks_no_remote(self, firmware_type, ptable):
+        self._setup(firmware_type, ptable)
         d = make_disk(self.model)
         with mock.patch.object(d, "on_remote_storage", return_value=False):
             resp = await self.ctrler.v2_GET()
@@ -3065,7 +3065,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
     def setUp(self):
         self.app = make_app()
         self.app.command_runner = mock.AsyncMock()
-        self.app.opts.bootloader = "UEFI"
+        self.app.opts.firmware_type = "UEFI"
         self.app.opts.block_probing_timeout = None
         self.app.prober = mock.Mock()
         self.app.prober.get_storage = mock.AsyncMock()
@@ -3084,7 +3084,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.app.base_model.source.search_drivers = False
         self.ctrler = StorageController(app=self.app)
         self.ctrler._configured = True
-        self.ctrler.model = make_model(Bootloader.UEFI)
+        self.ctrler.model = make_model(FirmwareType.UEFI)
         self.capability = GuidedCapability.CORE_BOOT_ENCRYPTED
 
         @contextlib.asynccontextmanager
@@ -3278,7 +3278,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.app.base_model.keyboard.setting.layout = "us"
         self.app.base_model.keyboard.setting.variant = ""
         self.app.base_model.keyboard.setting.toggle = None
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         disk = make_disk(model)
         self.app.base_model.source.current.type = "fsimage"
         self.app.base_model.source.current.variations = {
@@ -3348,7 +3348,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
     async def test_from_sample_data_autoinstall(self):
         # calling this a unit test is definitely questionable. but it
         # runs much more quickly than the integration test!
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         disk = make_disk(model)
         self.app.base_model.source.current.variations = {
             "default": CatalogEntryVariation(
@@ -3376,7 +3376,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.assertEqual(partition_count, len(disk.partitions()))
 
     async def test_from_sample_data_defective(self):
-        self.ctrler.model = model = make_model(Bootloader.UEFI)
+        self.ctrler.model = model = make_model(FirmwareType.UEFI)
         make_disk(model)
         self.app.base_model.source.current.type = "fsimage"
         self.app.base_model.source.current.variations = {
@@ -3400,11 +3400,11 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
 
 class TestMatchingDisks(IsolatedAsyncioTestCase):
     def setUp(self):
-        bootloader = Bootloader.UEFI
+        firmware_type = FirmwareType.UEFI
         self.app = make_app()
-        self.app.opts.bootloader = bootloader.value
+        self.app.opts.firmware_type = firmware_type.value
         self.ctrler = StorageController(app=self.app)
-        self.ctrler.model = make_model(bootloader)
+        self.ctrler.model = make_model(firmware_type)
 
     def test_no_match_raises_AutoinstallError(self):
         with self.assertRaises(AutoinstallError):
@@ -3441,7 +3441,7 @@ class TestMatchingDisks(IsolatedAsyncioTestCase):
 class TestResetPartitionLookAhead(IsolatedAsyncioTestCase):
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = None
+        self.app.opts.firmware_type = None
         self.ctrler = StorageController(app=self.app)
 
     @parameterized.expand(
@@ -3524,7 +3524,7 @@ class TestGuidedChoiceValidation(IsolatedAsyncioTestCase):
 class TestCalculateEntropy(IsolatedAsyncioTestCase):
     def setUp(self):
         self.app = make_app()
-        self.app.opts.bootloader = None
+        self.app.opts.firmware_type = None
         self.ctrler = StorageController(app=self.app)
         self.ctrler._info = mock.Mock()
         self.ctrler._info.needs_systems_mount = False

--- a/subiquity/server/controllers/zdev.py
+++ b/subiquity/server/controllers/zdev.py
@@ -24,7 +24,7 @@ import attrs
 
 from subiquity.common.apidef import API
 from subiquity.common.types import ZdevInfo
-from subiquity.common.types.storage import Bootloader
+from subiquity.common.types.storage import FirmwareType
 from subiquity.server.controller import SubiquityController
 from subiquitycore.async_helpers import schedule_task
 from subiquitycore.context import with_context
@@ -680,7 +680,7 @@ class ZdevController(SubiquityController):
             await self.chzdev(action, zdevinfos[ai_action.id])
 
     def interactive(self):
-        if self.app.base_model.storage.bootloader != Bootloader.NONE:
+        if self.app.base_model.storage.firmware_type != FirmwareType.NONE:
             return False
         return super().interactive()
 

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -149,7 +149,7 @@ class Server(Client):
             return
 
     async def spawn(
-        self, output_base, socket, machine_config, bootloader="uefi", extra_args=None
+        self, output_base, socket, machine_config, firmware_type="uefi", extra_args=None
     ):
         env = os.environ.copy()
         env["SUBIQUITY_REPLAY_TIMESCALE"] = "100"
@@ -158,8 +158,8 @@ class Server(Client):
             "-m",
             "subiquity.cmd.server",
             "--dry-run",
-            "--bootloader",
-            bootloader,
+            "--firmware-type",
+            firmware_type,
             "--socket",
             socket,
             "--output-base",
@@ -586,7 +586,7 @@ class TestCore(TestAPI):
             attrs = data["storage"]["blockdev"]["/dev/sda"]["attrs"]
             attrs["size"] = str(25 << 30)
         kw = dict(
-            bootloader="uefi",
+            firmware_type="uefi",
             extra_args=[
                 "--storage-version",
                 "2",
@@ -623,7 +623,7 @@ class TestCore(TestAPI):
             attrs = data["storage"]["blockdev"]["/dev/sda"]["attrs"]
             attrs["size"] = str(25 << 30)
         kw = dict(
-            bootloader="uefi",
+            firmware_type="uefi",
             extra_args=[
                 "--storage-version",
                 "2",
@@ -651,7 +651,7 @@ class TestCore(TestAPI):
             attrs = data["storage"]["blockdev"]["/dev/sda"]["attrs"]
             attrs["size"] = str(25 << 30)
         kw = dict(
-            bootloader="bios",
+            firmware_type="bios",
             extra_args=[
                 "--storage-version",
                 "2",

--- a/subiquity/ui/views/storage/tests/test_storage.py
+++ b/subiquity/ui/views/storage/tests/test_storage.py
@@ -4,7 +4,7 @@ from unittest import mock
 import urwid
 
 from subiquity.client.controllers.storage import StorageController
-from subiquity.models.storage import Bootloader, Disk, StorageModel
+from subiquity.models.storage import Disk, FirmwareType, StorageModel
 from subiquity.models.tests.test_storage import FakeStorageInfo, make_model
 from subiquity.ui.views.storage.storage import StorageView
 from subiquitycore.testing import view_helpers
@@ -14,7 +14,7 @@ class StorageViewTests(unittest.TestCase):
     def make_view(self, model, devices=[]):
         controller = mock.create_autospec(spec=StorageController)
         controller.ui = mock.Mock()
-        model.bootloader = Bootloader.NONE
+        model.firmware_type = FirmwareType.NONE
         model.all_devices = mock.Mock(return_value=devices)
         return StorageView(model, controller)
 


### PR DESCRIPTION
UEFI, BIOS and PREP use to be referred to bootloaders in Subiquity. That said, examples of what typically is referred to as a bootloader are Grub and U-Boot.

The integration with snapd makes this wording inconsistency worse.

This patch now changes the wording from "bootloader" to "firmware-type" when it comes to UEFI, BIOS or PREP.

I am not 100% sold on the name yet, feedback would be appreciated.

For now, the `--bootloader` cmdline argument has been kept for backward compatibility purpose bug I'm planning to get rid of it.

As for the API, `bootloader` is now an alias of `firmware_type` too. We can keep this one around longer if needed.