### PR TITLE
snapcraft: use fixed console-setup from PPA to fix keyboard detection

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,6 +8,15 @@ source-code: https://github.com/canonical/subiquity
 issues: https://bugs.launchpad.net/subiquity/+filebug
 contact: https://bugs.launchpad.net/subiquity/+filebug
 
+# The version of console-setup currently in noble has an incomplete pc105.tree
+# file.
+# Let's pull version 1.226ubuntu1.1 that we're currrently SRUing. Once the
+# package makes it to -updates, we can drop this PPA.
+# See LP: #2152901
+package-repositories:
+  - type: apt
+    ppa: subiquity/core24
+
 apps:
   subiquity:
     command: usr/bin/subiquity-cmd $SNAP/usr/bin/python3.12 -m subiquity


### PR DESCRIPTION
The keyboard detection mechanism is based on the pc105.tree file, that we extract from console-setup.

Unfortunately, console-setup 1.226ubuntu1 (in the -release pocket in noble) has an incomplete pc105.tree file, which results in a broken keyboard detection mechanism when Subiquity is built as a core24 snap.

We're SRUing 1.226ubuntu1.1, but the package hasn't reached -updates yet.

In the meantime, the package has been copied to the ~subiquity/ubuntu/core24 PPA. Let's use it to fix the keyboard detection mechanism.

As soon as the fixed console-setup version makes it to noble-updates, we can drop the use of this PPA.

We will need to apply this change to `ubuntu/resolute` as well if we're not in time for 26.04.1.

LP:#2152901