### PR TITLE
Move core-boot install bits outside of storage.py

### DIFF
--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -810,7 +810,7 @@ class InstallController(SubiquityController):
             await installer.finish_install(
                 context=context, kernel_components=self.kernel_components()
             )
-            await installer.snapd_target_preseed(Path(self.model.target))
+            await installer.target_preseed(Path(self.model.target))
         if self.supports_apt():
             # Don't run ubuntu-drivers install for TPM/FDE.
             # The list of offered drivers is already used to extrapolate a list

--- a/subiquity/server/controllers/install.py
+++ b/subiquity/server/controllers/install.py
@@ -48,6 +48,7 @@ from subiquity.server.controllers.storage import VariationInfo
 from subiquity.server.curtin import run_curtin_command
 from subiquity.server.mounter import Mounter, Mountpoint
 from subiquity.server.runner import get_redacted_command_runner
+from subiquity.server.snapd.core_boot_installer import CoreBootInstaller
 from subiquity.server.types import InstallerChannels
 from subiquitycore.async_helpers import run_in_thread
 from subiquitycore.context import with_context
@@ -389,7 +390,13 @@ class InstallController(SubiquityController):
                 ),
             )
             if storage_controller.use_tpm:
-                await storage_controller.setup_encryption(context=context)
+                installer = CoreBootInstaller(
+                    self.app, storage_controller.core_boot_data
+                )
+                await installer.setup_encryption(
+                    context=context,
+                    apply_encrypted_devices=storage_controller.apply_encrypted_devices,
+                )
             await run_curtin_step(
                 name="formatting",
                 stages=["partitioning"],
@@ -791,17 +798,19 @@ class InstallController(SubiquityController):
 
         storage_controller = self.app.controllers.Storage
         if storage_controller.use_snapd_install_api():
+            installer = CoreBootInstaller(self.app, storage_controller.core_boot_data)
             if storage_controller.use_tpm:
                 # This will generate a recovery key which will initially expire
                 # after a very short duration (e.g., 5 minutes).
                 # We need to reach the finish_install step within that timeframe,
                 # otherwise the key will be considered expired. So let's keep
                 # the two calls next to one another.
-                await storage_controller.fetch_core_boot_recovery_key()
-            await storage_controller.finish_install(
+                key = await installer.fetch_core_boot_recovery_key()
+                storage_controller.model.set_core_boot_recovery_key(key)
+            await installer.finish_install(
                 context=context, kernel_components=self.kernel_components()
             )
-            await storage_controller.snapd_target_preseed(Path(self.model.target))
+            await installer.snapd_target_preseed(Path(self.model.target))
         if self.supports_apt():
             # Don't run ubuntu-drivers install for TPM/FDE.
             # The list of offered drivers is already used to extrapolate a list

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -110,9 +110,8 @@ from subiquity.server import casper, shutdown
 from subiquity.server.autoinstall import AutoinstallError
 from subiquity.server.controller import SubiquityController
 from subiquity.server.controllers.source import SEARCH_DRIVERS_AUTOINSTALL_DEFAULT
-from subiquity.server.mounter import Mounter
-from subiquity.server.snapd import api as snapdapi
 from subiquity.server.snapd import types as snapdtypes
+from subiquity.server.snapd.core_boot_installer import CoreBootInstallData
 from subiquity.server.snapd.system_getter import SystemGetter, SystemsDirMounter
 from subiquity.server.types import InstallerChannels
 from subiquitycore.async_helpers import (
@@ -402,8 +401,7 @@ class StorageController(SubiquityController, StorageManipulator):
         self._variation_info: Dict[str, VariationInfo] = {}
         self._info: Optional[VariationInfo] = None
         self._system_getter = SystemGetter(self.app)
-        self._on_volume: Optional[snapdtypes.OnVolume] = None
-        self._volumes_auth: Optional[snapdtypes.VolumesAuth] = None
+        self.core_boot_data: Optional[CoreBootInstallData] = None
         self._role_to_device: Dict[Union[str, snapdtypes.Role], _Device] = {}
         self._device_to_structure: Dict[_Device, snapdtypes.OnVolume] = {}
         self._pyudev_context: Optional[pyudev.Context] = None
@@ -421,7 +419,7 @@ class StorageController(SubiquityController, StorageManipulator):
         return self._info.is_core_boot_classic()
 
     def use_snapd_install_api(self):
-        return self._on_volume is not None
+        return self.core_boot_data is not None
 
     def load_autoinstall_data(self, data):
         # Log disabled to prevent LUKS password leak
@@ -1114,8 +1112,12 @@ class StorageController(SubiquityController, StorageManipulator):
         # features that are only available with v2 partitioning.
         self.model.storage_version = 2
         [volume] = self._info.system.volumes.values()
-        self._on_volume = snapdtypes.OnVolume.from_volume(volume)
-        self._volumes_auth = snapdtypes.VolumesAuth.from_choice(choice)
+        on_volume = snapdtypes.OnVolume.from_volume(volume)
+        self.core_boot_data = CoreBootInstallData(
+            info=self._info,
+            on_volume=on_volume,
+            volumes_auth=snapdtypes.VolumesAuth.from_choice(choice),
+        )
 
         if isinstance(choice.target, GuidedStorageTargetUseGap):
             # In theory we could set parts_by_offset_size for existing
@@ -1142,15 +1144,15 @@ class StorageController(SubiquityController, StorageManipulator):
         elif isinstance(choice.target, GuidedStorageTargetReformat):
             preserved_parts = set()
 
-            if self._on_volume.schema != disk.ptable:
+            if on_volume.schema != disk.ptable:
                 parts_by_offset_size = {}
-                disk.ptable = self._on_volume.schema
+                disk.ptable = on_volume.schema
             else:
                 parts_by_offset_size = {
                     (part.offset, part.size): part for part in disk.partitions()
                 }
 
-                for _struct, offset, size in self._on_volume.offsets_and_sizes():
+                for _struct, offset, size in on_volume.offsets_and_sizes():
                     if (offset, size) in parts_by_offset_size:
                         preserved_parts.add(parts_by_offset_size[(offset, size)])
 
@@ -1160,19 +1162,19 @@ class StorageController(SubiquityController, StorageManipulator):
                         del parts_by_offset_size[(part.offset, part.size)]
 
             if not preserved_parts:
-                self.reformat(disk, self._on_volume.schema)
+                self.reformat(disk, on_volume.schema)
         else:
             raise RuntimeError(
                 "only reformat (and experimental use-gap) are supported for TPM/FDE"
             )
 
-        for structure, offset, size in self._on_volume.offsets_and_sizes():
+        for structure, offset, size in on_volume.offsets_and_sizes():
             if (offset, size) in parts_by_offset_size:
                 part = parts_by_offset_size[(offset, size)]
             else:
                 if (
                     structure.role == snapdtypes.Role.SYSTEM_DATA
-                    and structure == self._on_volume.structure[-1]
+                    and structure == on_volume.structure[-1]
                 ):
                     gap = gaps.at_offset(disk, offset)
                     size = gap.size
@@ -1205,126 +1207,19 @@ class StorageController(SubiquityController, StorageManipulator):
 
         disk._partitions.sort(key=lambda p: p.number)
 
-    def _on_volumes(self) -> Dict[str, snapdtypes.OnVolume]:
-        # Return a value suitable for use as the 'on-volumes' part of a
-        # SystemActionRequest.
-        #
-        # This must be run after curtin partitioning, which will result in a
-        # call to update_devices which will have set .path on all block
-        # devices.
-        [key] = self._info.system.volumes.keys()
-        return {key: self._on_volume}
-
-    @with_context(description="configuring TPM-backed full disk encryption")
-    async def setup_encryption(self, context):
-        label = self._info.label
-        kwargs = dict(
-            action=snapdtypes.SystemAction.INSTALL,
-            step=snapdtypes.SystemActionStep.SETUP_STORAGE_ENCRYPTION,
-            on_volumes=self._on_volumes(),
-        )
-        if self._volumes_auth is not None:
-            kwargs["volumes_auth"] = self._volumes_auth
-        # This is required to have the proper keyboard layout on first boot
-        # before typing the passphrase.
-        # Only supported since 2.76 but ignored on older versions.
-        kwargs["keyboard_config"] = snapdtypes.KeyboardConfig.from_subiquity_kb_model(
-            self.app.base_model.keyboard
-        )
-        result = await snapdapi.post_and_wait(
-            self.app.snapdapi,
-            self.app.snapdapi.v2.systems[label].POST,
-            snapdtypes.SystemActionRequest(**kwargs),
-            ann=snapdtypes.SystemActionResponseSetupEncryption,
-        )
-        for role, enc_path in result.encrypted_devices.items():
+    def apply_encrypted_devices(
+        self, encrypted_devices: dict[str | snapdtypes.Role, str]
+    ) -> None:
+        """Update the storage model using the encrypted devices reported by
+        snapd.
+        """
+        for role, enc_path in encrypted_devices.items():
             arb_device = ArbitraryDevice(m=self.model, path=enc_path)
             self.model._actions.append(arb_device)
             part = self._role_to_device[role]
             for fs in self.model._all(type="format"):
                 if fs.volume == part:
                     fs.volume = arb_device
-
-    async def fetch_core_boot_recovery_key(self):
-        """Fetch the recovery key from snapd and store it in the model."""
-        label = self._info.label
-
-        result = await self.app.snapdapi.v2.systems[label].POST(
-            snapdtypes.SystemActionRequest(
-                action=snapdtypes.SystemAction.INSTALL,
-                step=snapdtypes.SystemActionStep.GENERATE_RECOVERY_KEY,
-                on_volumes={},
-            ),
-            return_type=snapdtypes.SystemActionResponseGenerateRecoveryKey,
-        )
-
-        self.model.set_core_boot_recovery_key(result.recovery_key)
-
-    async def snapd_target_preseed(self, target: pathlib.Path):
-        async with AsyncExitStack() as es:
-            # Bind-mount required filesystems
-            # Some of these might already be mounted by curtin, but
-            # it should be fine to bind-mount twice.
-            mounter = Mounter(self.app)
-
-            to_bind_mount = [
-                "dev",
-                "proc",
-                "sys",
-                "sys/kernel/security",
-                "var/lib/snapd/seed",
-            ]
-
-            for fs in to_bind_mount:
-                # Needed at least for var/lib/snapd/seed in dry-run mode.
-                (target / fs).parent.mkdir(parents=True, exist_ok=True)
-
-                await es.enter_async_context(
-                    mounter.bind_mounted(pathlib.Path("/") / fs, target / fs)
-                )
-
-            label = self._info.label
-            await snapdapi.post_and_wait(
-                self.app.snapdapi,
-                self.app.snapdapi.v2.systems[label].POST,
-                snapdtypes.SystemActionRequest(
-                    action=snapdtypes.SystemAction.INSTALL,
-                    step=snapdtypes.SystemActionStep.PRESEED,
-                    target_root=str(target),
-                ),
-            )
-
-    @with_context(description="making system bootable")
-    async def finish_install(self, context, kernel_components):
-        log.debug(f"finish_install: {kernel_components=}")
-        label = self._info.label
-        kernels = self._info.system.model.snaps_of_type(snapdtypes.ModelSnapType.KERNEL)
-        if len(kernels) == 1:
-            optional_snaps = []
-            if (optionals := self._info.system.available_optional) is not None:
-                optional_snaps = optionals.snaps
-
-            optional_install = snapdtypes.OptionalInstall(
-                components={kernels[0].name: kernel_components},
-                snaps=optional_snaps,
-            )
-        else:
-            log.error(f"unexpected number of kernel snaps {len(kernels)}")
-            # multi-kernel model case unknown, let snapd try to install all
-            # optional things here.
-            optional_install = snapdtypes.OptionalInstall(all=True)
-        log.debug(f"finish_install: {optional_install=}")
-
-        await snapdapi.post_and_wait(
-            self.app.snapdapi,
-            self.app.snapdapi.v2.systems[label].POST,
-            snapdtypes.SystemActionRequest(
-                action=snapdtypes.SystemAction.INSTALL,
-                step=snapdtypes.SystemActionStep.FINISH,
-                on_volumes=self._on_volumes(),
-                optional_install=optional_install,
-            ),
-        )
 
     async def has_rst_GET(self) -> bool:
         search = "/sys/module/ahci/drivers/pci:ahci/*/remapped_nvme"

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -88,6 +88,7 @@ from subiquity.server.controllers.storage import (
 from subiquity.server.dryrun import DRConfig
 from subiquity.server.snapd import api as snapdapi
 from subiquity.server.snapd import types as snapdtypes
+from subiquity.server.snapd.core_boot_installer import CoreBootInstaller
 from subiquity.server.snapd.info import SnapdInfo
 from subiquity.server.snapd.system_getter import SystemGetter
 from subiquity.server.snapd.types import VolumesAuth, VolumesAuthMode
@@ -581,42 +582,6 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
             await self.ctrler._probe_once(restricted=True)
         self.assertIsNone(self.ctrler.queued_probe_data)
         load.assert_not_called()
-
-    async def test_setup_encryption__passes_keyboard_config(self):
-        self.ctrler._info = mock.Mock()
-        self.ctrler._info.label = "prefer-encrypted"
-        self.ctrler._info.system.volumes = {"vol-key": mock.Mock()}
-        self.ctrler._on_volume = mock.Mock()
-        self.ctrler._volumes_auth = None
-
-        kb = self.app.base_model.keyboard
-        kb.setting.layout = "fr"
-        kb.setting.variant = "azerty"
-        kb.setting.toggle = "alt_shift_toggle"
-
-        with mock.patch.object(
-            snapdapi,
-            "post_and_wait",
-            return_value=mock.Mock(encrypted_devices={}),
-        ) as m_post:
-            await self.ctrler.setup_encryption()
-
-        # post_and_wait is called as:
-        #   post_and_wait(client, meth, request, ann=...)
-        # so:
-        #   args[0] is the snapdapi client
-        #   args[1] is the systems[label].POST bound method
-        #   args[2] is the SystemActionRequest
-        req = m_post.call_args.args[2]
-        self.assertEqual(
-            snapdtypes.KeyboardConfig(
-                model="pc105",
-                layout="fr",
-                variant="azerty",
-                options=["grp:alt_shift_toggle"],
-            ),
-            req.keyboard_config,
-        )
 
     fw_lenovo = {
         "bios-vendor": "LENOVO",
@@ -1744,115 +1709,6 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
 
         self.assertEqual(leading_gap.offset, gap.offset)
         self.assertEqual(part.size + leading_gap.size + trailing_gap.size, gap.size)
-
-    async def test_fetch_core_boot_recovery_key(self):
-        self.app.snapd = AsyncSnapd(get_fake_connection())
-        self.app.snapdapi = snapdapi.make_api_client(self.app.snapd)
-        self.ctrler._info = mock.Mock(label="my-label")
-
-        with mock.patch.object(
-            self.ctrler.model, "set_core_boot_recovery_key"
-        ) as m_set_key:
-            await self.ctrler.fetch_core_boot_recovery_key()
-
-        m_set_key.assert_called_once_with("my-recovery-key")
-
-    @mock.patch("subiquity.server.mounter.Mounter.bind_mounted")
-    @mock.patch.object(Path, "mkdir", mock.Mock())
-    async def test_snapd_target_preseed(self, m_bind_mounted):
-        self.ctrler._info = mock.Mock(label="mock-label")
-
-        with mock.patch.object(snapdapi, "post_and_wait") as mock_post:
-            await self.ctrler.snapd_target_preseed(Path("/target"))
-
-        expected_mounted_calls = [
-            mock.call(Path("/dev"), Path("/target/dev")),
-            mock.call(Path("/proc"), Path("/target/proc")),
-            mock.call(Path("/sys"), Path("/target/sys")),
-            mock.call(
-                Path("/sys/kernel/security"), Path("/target/sys/kernel/security")
-            ),
-            mock.call(Path("/var/lib/snapd/seed"), Path("/target/var/lib/snapd/seed")),
-        ]
-
-        self.assertEqual(expected_mounted_calls, m_bind_mounted.call_args_list)
-
-        mock_post.assert_called_once()
-
-    async def test_finish_install(self):
-        self.app.snapdapi = snapdapi.make_api_client(AsyncSnapd(get_fake_connection()))
-        variation_info = VariationInfo(
-            name="mock",
-            label="mock-label",
-            system=snapdtypes.SystemDetails(
-                label="mock-label",
-                volumes={
-                    "mockVol": snapdtypes.Volume(
-                        schema="mock", structure=None, bootloader="grub"
-                    ),
-                },
-                model=snapdtypes.Model(
-                    architecture="mock-arch",
-                    snaps=[
-                        snapdtypes.ModelSnap(
-                            name="MockKernel",
-                            type=snapdtypes.ModelSnapType.KERNEL,
-                            presence=snapdtypes.PresenceValue.REQUIRED,
-                            components={
-                                "nvidia-510-uda-ko": snapdtypes.PresenceValue.OPTIONAL,
-                                "nvidia-510-uda-user": snapdtypes.PresenceValue.OPTIONAL,
-                                "foo": snapdtypes.PresenceValue.OPTIONAL,
-                                "bar": snapdtypes.PresenceValue.OPTIONAL,
-                            },
-                            default_channel="foo",
-                            id="bar",
-                        ),
-                        snapdtypes.ModelSnap(
-                            name="MockApp1",
-                            type=snapdtypes.ModelSnapType.APP,
-                            presence=snapdtypes.PresenceValue.REQUIRED,
-                            default_channel="foo",
-                            id="bar",
-                        ),
-                        snapdtypes.ModelSnap(
-                            name="MockApp2",
-                            type=snapdtypes.ModelSnapType.APP,
-                            presence=snapdtypes.PresenceValue.OPTIONAL,
-                            default_channel="foo",
-                            id="bar",
-                        ),
-                    ],
-                ),
-                available_optional=snapdtypes.AvailableOptional(
-                    snaps=["MockApp2"],
-                    components={
-                        "MockKernel": [
-                            "nvidia-510-uda-ko",
-                            "nvidia-510-uda-user",
-                            "foo",
-                            "bar",
-                        ]
-                    },
-                ),
-            ),
-        )
-        self.ctrler._info = variation_info
-        with mock.patch.object(snapdapi, "post_and_wait") as mock_post:
-            await self.ctrler.finish_install(
-                context=self.ctrler.context,
-                kernel_components=["nvidia-510-uda-ko", "nvidia-510-uda-user"],
-            )
-        mock_post.assert_called_once()
-
-        # Assert installing all optional snaps but only the requested components
-        expected_optional_install = snapdtypes.OptionalInstall(
-            all=False,
-            components={"MockKernel": ["nvidia-510-uda-ko", "nvidia-510-uda-user"]},
-            snaps=variation_info.system.available_optional.snaps,
-        )
-        actual = mock_post.call_args.args[2].optional_install
-
-        self.assertEqual(expected_optional_install, actual)
 
 
 class TestRunAutoinstallGuided(IsolatedAsyncioTestCase):
@@ -3329,9 +3185,9 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         )
         await self.ctrler.guided_core_boot(disk, choice)
         if va_expected is None:
-            self.assertIsNone(self.ctrler._volumes_auth)
+            self.assertIsNone(self.ctrler.core_boot_data.volumes_auth)
         else:
-            self.assertEqual(va_expected, self.ctrler._volumes_auth)
+            self.assertEqual(va_expected, self.ctrler.core_boot_data.volumes_auth)
         [part1, part2] = disk.partitions()
         self.assertEqual(part1.offset, 1 << 20)
         self.assertEqual(part1.size, 1 << 30)
@@ -3373,7 +3229,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
             capability=self.capability,
         )
         await self.ctrler.guided_core_boot(disk, choice)
-        self.assertIsNone(self.ctrler._volumes_auth)
+        self.assertIsNone(self.ctrler.core_boot_data.volumes_auth)
         [part] = disk.partitions()
         self.assertEqual(reused_part, part)
         self.assertEqual(reused_part.wipe, "superblock")
@@ -3401,7 +3257,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
             capability=self.capability,
         )
         await self.ctrler.guided_core_boot(disk, choice)
-        self.assertIsNone(self.ctrler._volumes_auth)
+        self.assertIsNone(self.ctrler.core_boot_data.volumes_auth)
         [part] = disk.partitions()
         self.assertEqual(existing_part, part)
         self.assertEqual(existing_part.wipe, None)
@@ -3435,7 +3291,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
             capability=self.capability,
         )
         await self.ctrler.guided_core_boot(disk, choice)
-        self.assertIsNone(self.ctrler._volumes_auth)
+        self.assertIsNone(self.ctrler.core_boot_data.volumes_auth)
         [bios_part, part] = disk.partitions()
         self.assertEqual(part.offset, 2 << 20)
         self.assertEqual(part.partition_name, "ptname")
@@ -3492,6 +3348,8 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         device_map = {p.id: random_string() for p in disk.partitions()}
         self.ctrler.update_devices(device_map)
 
+        installer = CoreBootInstaller(self.app, self.ctrler.core_boot_data)
+
         with mock.patch.object(
             snapdapi, "post_and_wait", new_callable=mock.AsyncMock
         ) as mocked:
@@ -3500,7 +3358,10 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
                     snapdtypes.Role.SYSTEM_DATA: "enc-system-data",
                 },
             )
-            await self.ctrler.setup_encryption(context=self.ctrler.context)
+            await installer.setup_encryption(
+                context=self.ctrler.context,
+                apply_encrypted_devices=self.ctrler.apply_encrypted_devices,
+            )
 
         # setup_encryption mutates the filesystem model objects to
         # reference the newly created encrypted objects so re-read the
@@ -3511,7 +3372,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         with mock.patch.object(
             snapdapi, "post_and_wait", new_callable=mock.AsyncMock
         ) as mocked:
-            await self.ctrler.finish_install(
+            await installer.finish_install(
                 context=self.ctrler.context, kernel_components=[]
             )
         mocked.assert_called_once()
@@ -3813,9 +3674,8 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
         label = self.ctrler._info.label
         self.app.snapd = AsyncSnapd(get_fake_connection())
 
-        with mock.patch(
-            "subiquity.server.controllers.storage.snapdapi.make_api_client",
-            return_value=self.app.snapdapi,
+        with mock.patch.object(
+            snapdapi, "make_api_client", return_value=self.app.snapdapi
         ):
             with mock.patch.object(
                 self.app.snapdapi.v2.systems[label],
@@ -3848,9 +3708,8 @@ class TestCalculateEntropy(IsolatedAsyncioTestCase):
         label = self.ctrler._info.label
         self.app.snapd = AsyncSnapd(get_fake_connection())
 
-        with mock.patch(
-            "subiquity.server.controllers.storage.snapdapi.make_api_client",
-            return_value=self.app.snapdapi,
+        with mock.patch.object(
+            snapdapi, "make_api_client", return_value=self.app.snapdapi
         ):
             with mock.patch.object(
                 self.app.snapdapi.v2.systems[label],

--- a/subiquity/server/snapd/core_boot_installer.py
+++ b/subiquity/server/snapd/core_boot_installer.py
@@ -115,7 +115,7 @@ class CoreBootInstaller:
 
         return result.recovery_key
 
-    async def snapd_target_preseed(self, target: pathlib.Path) -> None:
+    async def target_preseed(self, target: pathlib.Path) -> None:
         async with AsyncExitStack() as es:
             # Bind-mount required filesystems
             # Some of these might already be mounted by curtin, but

--- a/subiquity/server/snapd/core_boot_installer.py
+++ b/subiquity/server/snapd/core_boot_installer.py
@@ -60,12 +60,13 @@ class CoreBootInstaller:
         self.data: CoreBootInstallData = data
 
     def _on_volumes(self) -> dict[str, snapdtypes.OnVolume]:
-        # Return a value suitable for use as the 'on-volumes' part of a
-        # SystemActionRequest.
-        #
-        # This must be run after curtin partitioning, which will result in a
-        # call to update_devices which will have set .path on all block
-        # devices.
+        """Return a value suitable for use as the 'on-volumes' part of a
+        SystemActionRequest.
+
+        This must be run after curtin partitioning, which will result in a
+        call to update_devices which will have set .path on all block
+        devices.
+        """
         [key] = self.data.info.system.volumes.keys()
         return {key: self.data.on_volume}
 

--- a/subiquity/server/snapd/core_boot_installer.py
+++ b/subiquity/server/snapd/core_boot_installer.py
@@ -1,0 +1,183 @@
+# Copyright 2026 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Implementation of the snapd "core boot" / TPM-FDE system install steps.
+
+These steps (storage-encryption setup, recovery-key generation, finalizing
+the install and preseeding the snapd seed in the target) are install-phase
+operations that talk to snapd's /v2/systems/<label> API.
+"""
+
+import logging
+import pathlib
+from contextlib import AsyncExitStack
+from typing import TYPE_CHECKING, Callable
+
+import attrs
+
+from subiquity.server.mounter import Mounter
+from subiquity.server.snapd import api as snapdapi
+from subiquity.server.snapd import types as snapdtypes
+from subiquitycore.context import with_context
+
+if TYPE_CHECKING:
+    from subiquity.server.controllers.storage import VariationInfo
+
+log = logging.getLogger("subiquity.server.snapd.core_boot_installer")
+
+
+@attrs.define
+class CoreBootInstallData:
+    """Bridge data shared between the storage controller and the installer.
+
+    Produced by the storage controller once a core-boot classic (TPM/FDE)
+    guided choice has been applied, and passed to CoreBootInstaller for the
+    install-phase snapd steps."""
+
+    info: "VariationInfo"
+    on_volume: snapdtypes.OnVolume | None
+    volumes_auth: snapdtypes.VolumesAuth | None
+
+
+class CoreBootInstaller:
+    """Implement the snapd system install steps for a core-boot classic
+    install.
+    """
+
+    def __init__(self, app, data: CoreBootInstallData) -> None:
+        self.app = app
+        self.data: CoreBootInstallData = data
+
+    def _on_volumes(self) -> dict[str, snapdtypes.OnVolume]:
+        # Return a value suitable for use as the 'on-volumes' part of a
+        # SystemActionRequest.
+        #
+        # This must be run after curtin partitioning, which will result in a
+        # call to update_devices which will have set .path on all block
+        # devices.
+        [key] = self.data.info.system.volumes.keys()
+        return {key: self.data.on_volume}
+
+    @with_context(description="configuring TPM-backed full disk encryption")
+    async def setup_encryption(
+        self,
+        context,
+        apply_encrypted_devices: Callable[[dict[snapdtypes.Role, str]], None],
+    ) -> None:
+        label = self.data.info.label
+        kwargs = dict(
+            action=snapdtypes.SystemAction.INSTALL,
+            step=snapdtypes.SystemActionStep.SETUP_STORAGE_ENCRYPTION,
+            on_volumes=self._on_volumes(),
+        )
+        if self.data.volumes_auth is not None:
+            kwargs["volumes_auth"] = self.data.volumes_auth
+        # This is required to have the proper keyboard layout on first boot
+        # before typing the passphrase.
+        # Only supported since 2.76 but ignored on older versions.
+        kwargs["keyboard_config"] = snapdtypes.KeyboardConfig.from_subiquity_kb_model(
+            self.app.base_model.keyboard
+        )
+        result = await snapdapi.post_and_wait(
+            self.app.snapdapi,
+            self.app.snapdapi.v2.systems[label].POST,
+            snapdtypes.SystemActionRequest(**kwargs),
+            ann=snapdtypes.SystemActionResponseSetupEncryption,
+        )
+        apply_encrypted_devices(result.encrypted_devices)
+
+    async def fetch_core_boot_recovery_key(self) -> str:
+        """Fetch the recovery key from snapd and return it.
+
+        The caller is responsible for storing the key on the storage model.
+        """
+        label = self.data.info.label
+
+        result = await self.app.snapdapi.v2.systems[label].POST(
+            snapdtypes.SystemActionRequest(
+                action=snapdtypes.SystemAction.INSTALL,
+                step=snapdtypes.SystemActionStep.GENERATE_RECOVERY_KEY,
+                on_volumes={},
+            ),
+            return_type=snapdtypes.SystemActionResponseGenerateRecoveryKey,
+        )
+
+        return result.recovery_key
+
+    async def snapd_target_preseed(self, target: pathlib.Path) -> None:
+        async with AsyncExitStack() as es:
+            # Bind-mount required filesystems
+            # Some of these might already be mounted by curtin, but
+            # it should be fine to bind-mount twice.
+            mounter = Mounter(self.app)
+
+            to_bind_mount = [
+                "dev",
+                "proc",
+                "sys",
+                "sys/kernel/security",
+                "var/lib/snapd/seed",
+            ]
+
+            for fs in to_bind_mount:
+                # Needed at least for var/lib/snapd/seed in dry-run mode.
+                (target / fs).parent.mkdir(parents=True, exist_ok=True)
+
+                await es.enter_async_context(
+                    mounter.bind_mounted(pathlib.Path("/") / fs, target / fs)
+                )
+
+            await snapdapi.post_and_wait(
+                self.app.snapdapi,
+                self.app.snapdapi.v2.systems[self.data.info.label].POST,
+                snapdtypes.SystemActionRequest(
+                    action=snapdtypes.SystemAction.INSTALL,
+                    step=snapdtypes.SystemActionStep.PRESEED,
+                    target_root=str(target),
+                ),
+            )
+
+    @with_context(description="making system bootable")
+    async def finish_install(self, context, kernel_components: list[str]) -> None:
+        log.debug(f"finish_install: {kernel_components=}")
+        label = self.data.info.label
+        kernels = self.data.info.system.model.snaps_of_type(
+            snapdtypes.ModelSnapType.KERNEL
+        )
+        if len(kernels) == 1:
+            optional_snaps = []
+            if (optionals := self.data.info.system.available_optional) is not None:
+                optional_snaps = optionals.snaps
+
+            optional_install = snapdtypes.OptionalInstall(
+                components={kernels[0].name: kernel_components},
+                snaps=optional_snaps,
+            )
+        else:
+            log.error(f"unexpected number of kernel snaps {len(kernels)}")
+            # multi-kernel model case unknown, let snapd try to install all
+            # optional things here.
+            optional_install = snapdtypes.OptionalInstall(all=True)
+        log.debug(f"finish_install: {optional_install=}")
+
+        await snapdapi.post_and_wait(
+            self.app.snapdapi,
+            self.app.snapdapi.v2.systems[label].POST,
+            snapdtypes.SystemActionRequest(
+                action=snapdtypes.SystemAction.INSTALL,
+                step=snapdtypes.SystemActionStep.FINISH,
+                on_volumes=self._on_volumes(),
+                optional_install=optional_install,
+            ),
+        )

--- a/subiquity/server/snapd/test/test_core_boot_installer.py
+++ b/subiquity/server/snapd/test/test_core_boot_installer.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from unittest import IsolatedAsyncioTestCase, mock
+
+from subiquity.server.controllers.storage import VariationInfo
+from subiquity.server.snapd import api as snapdapi
+from subiquity.server.snapd import types as snapdtypes
+from subiquity.server.snapd.core_boot_installer import (
+    CoreBootInstallData,
+    CoreBootInstaller,
+)
+from subiquitycore.snapd import AsyncSnapd, get_fake_connection
+from subiquitycore.tests.mocks import make_app
+
+
+class TestCoreBootInstaller(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.app = make_app()
+
+    async def test_setup_encryption__passes_keyboard_config(self):
+        info = mock.Mock()
+        info.label = "prefer-encrypted"
+        info.system.volumes = {"vol-key": mock.Mock()}
+        data = CoreBootInstallData(
+            info=info,
+            on_volume=mock.Mock(),
+            volumes_auth=None,
+        )
+
+        kb = self.app.base_model.keyboard
+        kb.setting.layout = "fr"
+        kb.setting.variant = "azerty"
+        kb.setting.toggle = "alt_shift_toggle"
+
+        with mock.patch.object(
+            snapdapi,
+            "post_and_wait",
+            return_value=mock.Mock(encrypted_devices={}),
+        ) as m_post:
+            installer = CoreBootInstaller(self.app, data)
+            await installer.setup_encryption(
+                context=mock.MagicMock(),
+                apply_encrypted_devices=mock.Mock(),
+            )
+
+        # post_and_wait is called as:
+        #   post_and_wait(client, meth, request, ann=...)
+        # so:
+        #   args[0] is the snapdapi client
+        #   args[1] is the systems[label].POST bound method
+        #   args[2] is the SystemActionRequest
+        req = m_post.call_args.args[2]
+        self.assertEqual(
+            snapdtypes.KeyboardConfig(
+                model="pc105",
+                layout="fr",
+                variant="azerty",
+                options=["grp:alt_shift_toggle"],
+            ),
+            req.keyboard_config,
+        )
+
+    async def test_fetch_core_boot_recovery_key(self):
+        self.app.snapd = AsyncSnapd(get_fake_connection())
+        self.app.snapdapi = snapdapi.make_api_client(self.app.snapd)
+        info = mock.Mock(label="my-label")
+        data = CoreBootInstallData(
+            info=info,
+            on_volume=None,
+            volumes_auth=None,
+        )
+
+        m_set_key = mock.Mock()
+        installer = CoreBootInstaller(self.app, data)
+        key = await installer.fetch_core_boot_recovery_key()
+        m_set_key(key)
+
+        m_set_key.assert_called_once_with("my-recovery-key")
+
+    @mock.patch("subiquity.server.mounter.Mounter.bind_mounted")
+    @mock.patch.object(Path, "mkdir", mock.Mock())
+    async def test_snapd_target_preseed(self, m_bind_mounted):
+        info = mock.Mock(label="mock-label")
+        data = CoreBootInstallData(
+            info=info,
+            on_volume=None,
+            volumes_auth=None,
+        )
+
+        with mock.patch.object(snapdapi, "post_and_wait") as mock_post:
+            installer = CoreBootInstaller(self.app, data)
+            await installer.snapd_target_preseed(Path("/target"))
+
+        expected_mounted_calls = [
+            mock.call(Path("/dev"), Path("/target/dev")),
+            mock.call(Path("/proc"), Path("/target/proc")),
+            mock.call(Path("/sys"), Path("/target/sys")),
+            mock.call(
+                Path("/sys/kernel/security"), Path("/target/sys/kernel/security")
+            ),
+            mock.call(Path("/var/lib/snapd/seed"), Path("/target/var/lib/snapd/seed")),
+        ]
+
+        self.assertEqual(expected_mounted_calls, m_bind_mounted.call_args_list)
+
+        mock_post.assert_called_once()
+
+    async def test_finish_install(self):
+        self.app.snapdapi = snapdapi.make_api_client(AsyncSnapd(get_fake_connection()))
+        variation_info = VariationInfo(
+            name="mock",
+            label="mock-label",
+            system=snapdtypes.SystemDetails(
+                label="mock-label",
+                volumes={
+                    "mockVol": snapdtypes.Volume(
+                        schema="mock", structure=None, bootloader="grub"
+                    ),
+                },
+                model=snapdtypes.Model(
+                    architecture="mock-arch",
+                    snaps=[
+                        snapdtypes.ModelSnap(
+                            name="MockKernel",
+                            type=snapdtypes.ModelSnapType.KERNEL,
+                            presence=snapdtypes.PresenceValue.REQUIRED,
+                            components={
+                                "nvidia-510-uda-ko": snapdtypes.PresenceValue.OPTIONAL,
+                                "nvidia-510-uda-user": snapdtypes.PresenceValue.OPTIONAL,
+                                "foo": snapdtypes.PresenceValue.OPTIONAL,
+                                "bar": snapdtypes.PresenceValue.OPTIONAL,
+                            },
+                            default_channel="foo",
+                            id="bar",
+                        ),
+                        snapdtypes.ModelSnap(
+                            name="MockApp1",
+                            type=snapdtypes.ModelSnapType.APP,
+                            presence=snapdtypes.PresenceValue.REQUIRED,
+                            default_channel="foo",
+                            id="bar",
+                        ),
+                        snapdtypes.ModelSnap(
+                            name="MockApp2",
+                            type=snapdtypes.ModelSnapType.APP,
+                            presence=snapdtypes.PresenceValue.OPTIONAL,
+                            default_channel="foo",
+                            id="bar",
+                        ),
+                    ],
+                ),
+                available_optional=snapdtypes.AvailableOptional(
+                    snaps=["MockApp2"],
+                    components={
+                        "MockKernel": [
+                            "nvidia-510-uda-ko",
+                            "nvidia-510-uda-user",
+                            "foo",
+                            "bar",
+                        ]
+                    },
+                ),
+            ),
+        )
+        data = CoreBootInstallData(
+            info=variation_info,
+            on_volume=None,
+            volumes_auth=None,
+        )
+        with mock.patch.object(snapdapi, "post_and_wait") as mock_post:
+            installer = CoreBootInstaller(self.app, data)
+            await installer.finish_install(
+                context=mock.MagicMock(),
+                kernel_components=["nvidia-510-uda-ko", "nvidia-510-uda-user"],
+            )
+        mock_post.assert_called_once()
+
+        # Assert installing all optional snaps but only the requested components
+        expected_optional_install = snapdtypes.OptionalInstall(
+            all=False,
+            components={"MockKernel": ["nvidia-510-uda-ko", "nvidia-510-uda-user"]},
+            snaps=variation_info.system.available_optional.snaps,
+        )
+        actual = mock_post.call_args.args[2].optional_install
+
+        self.assertEqual(expected_optional_install, actual)

--- a/subiquity/server/snapd/test/test_core_boot_installer.py
+++ b/subiquity/server/snapd/test/test_core_boot_installer.py
@@ -92,7 +92,7 @@ class TestCoreBootInstaller(IsolatedAsyncioTestCase):
 
     @mock.patch("subiquity.server.mounter.Mounter.bind_mounted")
     @mock.patch.object(Path, "mkdir", mock.Mock())
-    async def test_snapd_target_preseed(self, m_bind_mounted):
+    async def test_target_preseed(self, m_bind_mounted):
         info = mock.Mock(label="mock-label")
         data = CoreBootInstallData(
             info=info,
@@ -102,7 +102,7 @@ class TestCoreBootInstaller(IsolatedAsyncioTestCase):
 
         with mock.patch.object(snapdapi, "post_and_wait") as mock_post:
             installer = CoreBootInstaller(self.app, data)
-            await installer.snapd_target_preseed(Path("/target"))
+            await installer.target_preseed(Path("/target"))
 
         expected_mounted_calls = [
             mock.call(Path("/dev"), Path("/target/dev")),


### PR DESCRIPTION
This PR introduces a new core_boot_installer.py file, containing the implementation of the different "steps" that Subiquity needs to run in a TPM/FDE installation.

For now, I've left the GET /v2/systems/<label> and GET /v2/systems operations in storage.py but we can move them in the future.

This makes storage.py smaller, which is always nice, and makes the overall structure more consistent.