### PR TITLE
examples: make ubuntu-and-free-space resizable

### DIFF
--- a/examples/machines/ubuntu-and-free-space.json
+++ b/examples/machines/ubuntu-and-free-space.json
@@ -690,7 +690,8 @@
                 "USAGE": "filesystem",
                 "UUID": "19e681fc-9577-4cfc-96ea-ebfebaa3aba6",
                 "UUID_ENC": "19e681fc-9577-4cfc-96ea-ebfebaa3aba6",
-                "VERSION": "1.0"
+                "VERSION": "1.0",
+                "ESTIMATED_MIN_SIZE": 2147483648
             },
             "/dev/sr0": {
                 "BOOT_SYSTEM_ID": "EL\\x20TORITO\\x20SPECIFICATION",


### PR DESCRIPTION
Many `examples/machines` files were introduced before we added support for resizing filesystems. Therefore, they don't include ESTIMATED_MIN_SIZE properties on filesystems.

Adding ESTIMATED_MIN_SIZE on the last ext4 filesystem of the disk in `ubuntu-and-free-space.json`, so that we can exercise resize scenarios in dry-run.