### PR TITLE
Apply requirement for signed grub in 26.10+: /boot sits on simple setup

### DIFF
--- a/subiquity/common/storage/requirements.py
+++ b/subiquity/common/storage/requirements.py
@@ -167,7 +167,7 @@ class Requirements:
         severity=RequirementSeverity.BLOCKING,
         check=lambda m: not m.needs_bootloader_partition(),
     )
-    BOOT_FILESYSTEM = StorageRequirement(
+    BOOT_EXT4 = StorageRequirement(
         guidance_message_kind=GuidanceMessageKind.USE_EXT4_BOOT,
         severity=RequirementSeverity.BLOCKING,
         check=_is_boot_ext4,
@@ -189,6 +189,6 @@ class Requirements:
             Requirements.ROOT_MOUNTED,
             Requirements.REMOTE_BOOT_LOCAL,
             Requirements.BOOTLOADER_NEEDED,
-            Requirements.BOOT_FILESYSTEM,
+            Requirements.BOOT_EXT4,
             Requirements.BOOT_ON_SIMPLE_SETUP,
         ]

--- a/subiquity/common/storage/requirements.py
+++ b/subiquity/common/storage/requirements.py
@@ -47,6 +47,7 @@ class GuidanceMessageKind(enum.Enum):
     MOUNT_LOCAL_BOOT = _("Mount a local filesystem at /boot")
     SELECT_BOOT_DISK = _("Select a boot disk")
     USE_EXT4_BOOT = _("Use the ext4 filesystem for /boot")
+    BOOT_ON_SIMPLE_SETUP = _("Place /boot on a partition of a disk (or RAID 1 disk)")
 
 
 @attrs.define
@@ -97,7 +98,43 @@ def _is_boot_ext4(model) -> bool:
     return mount.fstype == "ext4"
 
 
-def _needs_ext4_boot(model) -> bool:
+def _is_boot_on_simple_setup(model) -> bool:
+    """Signed GRUB on 26.10+ can only boot from simple storage setups.
+
+    The /boot filesystem (or / if /boot is not mounted separately) must
+    sit on one of the following, and nothing else:
+    * a directly-formatted disk
+    * a partition on a disk
+    * a RAID 1 (optionally with partitions on top)
+
+    Any other volume type is rejected: LVM (volume groups and logical
+    volumes), LUKS/dm-crypt, ZFS (zpools and datasets), non-RAID-1 RAID
+    levels, and arbitrary devices.
+
+    Walks the full storage chain backing the /boot mount and checks that
+    every element is one of the accepted types (and that any RAID is
+    level 1).
+
+    See https://discourse.ubuntu.com/t/streamlining-secure-boot-for-26-10/79069
+    """
+    mount = model._mount_for_path("/boot", parent_ok=True)
+    if mount is None:
+        return False
+
+    # Deferred import: subiquity.models.storage imports this module at top
+    # level, so importing it here avoids a circular import at module load.
+    from subiquity.models.storage import Disk, Filesystem, Mount, Partition, Raid
+
+    accepted = (Disk, Filesystem, Mount, Partition, Raid)
+    for element in mount.iter_storage_chain():
+        if not isinstance(element, accepted):
+            return False
+        if isinstance(element, Raid) and element.raidlevel != "raid1":
+            return False
+    return True
+
+
+def _uses_signed_grub_26_10(model) -> bool:
     """UEFI systems with signed GRUB require ext4 for /boot on 26.10+."""
     if not model.is_root_mounted() or not model.uses_signed_grub():
         return False
@@ -134,7 +171,15 @@ class Requirements:
         guidance_message_kind=GuidanceMessageKind.USE_EXT4_BOOT,
         severity=RequirementSeverity.BLOCKING,
         check=_is_boot_ext4,
-        applies_to=_needs_ext4_boot,
+        applies_to=_uses_signed_grub_26_10,
+    )
+    # This requirement could be merged with BOOT_EXT4, but the resulting error
+    # message would become a bit vague.
+    BOOT_ON_SIMPLE_SETUP = StorageRequirement(
+        guidance_message_kind=GuidanceMessageKind.BOOT_ON_SIMPLE_SETUP,
+        severity=RequirementSeverity.BLOCKING,
+        check=_is_boot_on_simple_setup,
+        applies_to=_uses_signed_grub_26_10,
     )
 
     @staticmethod
@@ -145,4 +190,5 @@ class Requirements:
             Requirements.REMOTE_BOOT_LOCAL,
             Requirements.BOOTLOADER_NEEDED,
             Requirements.BOOT_FILESYSTEM,
+            Requirements.BOOT_ON_SIMPLE_SETUP,
         ]

--- a/subiquity/common/storage/tests/test_requirements.py
+++ b/subiquity/common/storage/tests/test_requirements.py
@@ -23,11 +23,16 @@ from subiquity.common.storage.requirements import (
     StorageRequirement,
 )
 from subiquity.models.tests.test_storage import (
+    make_dm_crypt,
     make_filesystem,
+    make_lv,
     make_model,
     make_model_and_disk,
+    make_model_and_partition,
+    make_model_and_vg,
     make_mount,
     make_partition,
+    make_raid,
 )
 from subiquitycore.tests.parameterized import parameterized
 
@@ -98,6 +103,7 @@ class TestRequirements(unittest.TestCase):
                 Requirements.REMOTE_BOOT_LOCAL,
                 Requirements.BOOTLOADER_NEEDED,
                 Requirements.BOOT_FILESYSTEM,
+                Requirements.BOOT_ON_SIMPLE_SETUP,
             ],
         )
 
@@ -240,3 +246,43 @@ class TestRequirements(unittest.TestCase):
             make_mount(model, boot_fs, "/boot")
 
         self.assertEqual(expected, Requirements.BOOT_FILESYSTEM.is_satisfied(model))
+
+    def test_BOOT_ON_SIMPLE_SETUP_check__disk(self):
+        model, disk = make_model_and_disk()
+        make_mount(model, make_filesystem(model, disk, fstype="ext4"), "/boot")
+        self.assertTrue(Requirements.BOOT_ON_SIMPLE_SETUP.is_satisfied(model))
+
+    def test_BOOT_ON_SIMPLE_SETUP_check__partition(self):
+        model, partition = make_model_and_partition()
+        make_mount(model, make_filesystem(model, partition, fstype="ext4"), "/boot")
+        self.assertTrue(Requirements.BOOT_ON_SIMPLE_SETUP.is_satisfied(model))
+
+    def test_BOOT_ON_SIMPLE_SETUP_check__raid1(self):
+        model = make_model()
+        raid1 = make_raid(model)
+        make_mount(model, make_filesystem(model, raid1, fstype="ext4"), "/boot")
+        self.assertTrue(Requirements.BOOT_ON_SIMPLE_SETUP.is_satisfied(model))
+
+    def test_BOOT_ON_SIMPLE_SETUP_check__raid1_partition(self):
+        model = make_model()
+        raid1p1 = make_partition(model, make_raid(model))
+        make_mount(model, make_filesystem(model, raid1p1, fstype="ext4"), "/boot")
+        self.assertTrue(Requirements.BOOT_ON_SIMPLE_SETUP.is_satisfied(model))
+
+    def test_BOOT_ON_SIMPLE_SETUP_check__raid0(self):
+        model = make_model()
+        raid0 = make_raid(model, raidlevel="raid0")
+        make_mount(model, make_filesystem(model, raid0, fstype="ext4"), "/boot")
+        self.assertFalse(Requirements.BOOT_ON_SIMPLE_SETUP.is_satisfied(model))
+
+    def test_BOOT_ON_SIMPLE_SETUP_check__lvm_lv(self):
+        model, vg = make_model_and_vg()
+        lv = make_lv(model, vg=vg)
+        make_mount(model, make_filesystem(model, lv, fstype="ext4"), "/boot")
+        self.assertFalse(Requirements.BOOT_ON_SIMPLE_SETUP.is_satisfied(model))
+
+    def test_BOOT_ON_SIMPLE_SETUP_check__encrypted_partition(self):
+        model, partition = make_model_and_partition()
+        dmcrypt = make_dm_crypt(model, partition)
+        make_mount(model, make_filesystem(model, dmcrypt, fstype="ext4"), "/boot")
+        self.assertFalse(Requirements.BOOT_ON_SIMPLE_SETUP.is_satisfied(model))

--- a/subiquity/common/storage/tests/test_requirements.py
+++ b/subiquity/common/storage/tests/test_requirements.py
@@ -102,7 +102,7 @@ class TestRequirements(unittest.TestCase):
                 Requirements.ROOT_MOUNTED,
                 Requirements.REMOTE_BOOT_LOCAL,
                 Requirements.BOOTLOADER_NEEDED,
-                Requirements.BOOT_FILESYSTEM,
+                Requirements.BOOT_EXT4,
                 Requirements.BOOT_ON_SIMPLE_SETUP,
             ],
         )
@@ -199,7 +199,7 @@ class TestRequirements(unittest.TestCase):
             (True, True, True),
         )
     )
-    def test_BOOT_FILESYSTEM_applies_to(
+    def test_BOOT_EXT4_applies_to(
         self,
         root_mounted: bool,
         uses_signed_grub: bool,
@@ -218,9 +218,7 @@ class TestRequirements(unittest.TestCase):
                 ),
             ),
         ):
-            self.assertEqual(
-                expected, Requirements.BOOT_FILESYSTEM.is_applicable(model)
-            )
+            self.assertEqual(expected, Requirements.BOOT_EXT4.is_applicable(model))
 
     @parameterized.expand(
         (
@@ -230,7 +228,7 @@ class TestRequirements(unittest.TestCase):
             (None, "xfs", False),
         )
     )
-    def test_BOOT_FILESYSTEM_check(
+    def test_BOOT_EXT4_check(
         self,
         boot_fstype: str | None,
         root_fstype: str,
@@ -245,7 +243,7 @@ class TestRequirements(unittest.TestCase):
             boot_fs = make_filesystem(model, p2, fstype=boot_fstype)
             make_mount(model, boot_fs, "/boot")
 
-        self.assertEqual(expected, Requirements.BOOT_FILESYSTEM.is_satisfied(model))
+        self.assertEqual(expected, Requirements.BOOT_EXT4.is_satisfied(model))
 
     def test_BOOT_ON_SIMPLE_SETUP_check__disk(self):
         model, disk = make_model_and_disk()

--- a/subiquity/models/storage.py
+++ b/subiquity/models/storage.py
@@ -623,6 +623,10 @@ class _Formattable(ABC):
         else:
             return cd
 
+    def iter_underlying(self) -> Iterator["_Formattable"]:
+        """Yield the volumes backing this one, depth-first, down to the Disk(s)."""
+        yield from ()
+
     @property
     def format(self):
         if not self._fs:
@@ -1054,6 +1058,10 @@ class Partition(_Formattable):
     def on_supported_ptable(self) -> bool:
         return self.device.ptable != "unsupported"
 
+    def iter_underlying(self) -> Iterator["_Formattable"]:
+        yield self.device
+        yield from self.device.iter_underlying()
+
 
 @fsobj("raid")
 class Raid(_Device):
@@ -1149,6 +1157,13 @@ class Raid(_Device):
 
         return False
 
+    def iter_underlying(self) -> Iterator["_Formattable"]:
+        # Walk every member (data + spare) of the array.  Members can be
+        # Disks, Partitions or nested Raids.
+        for dev in self.devices | self.spare_devices:
+            yield dev
+            yield from dev.iter_underlying()
+
 
 @fsobj("lvm_volgroup")
 class LVM_VolGroup(_Device):
@@ -1184,6 +1199,11 @@ class LVM_VolGroup(_Device):
                 return True
         return False
 
+    def iter_underlying(self) -> Iterator["_Formattable"]:
+        for dev in self.devices:
+            yield dev
+            yield from dev.iter_underlying()
+
 
 @fsobj("lvm_partition")
 class LVM_LogicalVolume(_Formattable):
@@ -1217,6 +1237,10 @@ class LVM_LogicalVolume(_Formattable):
 
     def on_remote_storage(self) -> bool:
         return self.volgroup.on_remote_storage()
+
+    def iter_underlying(self) -> Iterator["_Formattable"]:
+        yield self.volgroup
+        yield from self.volgroup.iter_underlying()
 
 
 LUKS_OVERHEAD = 16 * (2**20)
@@ -1321,6 +1345,10 @@ class DM_Crypt(_Formattable):
     def on_remote_storage(self) -> bool:
         return self.volume.on_remote_storage()
 
+    def iter_underlying(self) -> Iterator["_Formattable"]:
+        yield self.volume
+        yield from self.volume.iter_underlying()
+
 
 @fsobj("device")
 class ArbitraryDevice(_Device):
@@ -1397,6 +1425,22 @@ class Mount:
     def on_remote_storage(self) -> bool:
         return self.device.on_remote_storage()
 
+    def iter_storage_chain(self) -> Iterator[Any]:
+        """Yield the full stack backing this mount, depth-first, from the
+        Mount itself down through the Filesystem, the formatted volume and
+        every underlying volume all the way to the Disk(s).
+
+        Yields: self, the Filesystem (if any), the top-level volume, then
+        everything produced by that volume's ``iter_underlying``.
+        """
+        yield self
+        fs = self.device
+        if fs is None:
+            return
+        yield fs
+        yield fs.volume
+        yield from fs.volume.iter_underlying()
+
 
 def get_canmount(properties: Optional[dict], default: bool) -> bool:
     """Handle the possible values of the zfs canmount property, which should be
@@ -1471,6 +1515,17 @@ class ZPool:
     def on_remote_storage(self) -> bool:
         return any(vdev.on_remote_storage() for vdev in self.vdevs)
 
+    def iter_underlying(self) -> Iterator["_Formattable"]:
+        for vdev in self.vdevs:
+            yield vdev
+            yield from vdev.iter_underlying()
+
+    def iter_storage_chain(self) -> Iterator[Any]:
+        """Yield the full stack backing this zpool mountlike, depth-first,
+        from the ZPool itself down through every vdev to the Disk(s)."""
+        yield self
+        yield from self.iter_underlying()
+
 
 @fsobj("zfs")
 class ZFS:
@@ -1496,6 +1551,13 @@ class ZFS:
 
     def on_remote_storage(self) -> bool:
         return self.pool.on_remote_storage()
+
+    def iter_storage_chain(self) -> Iterator[Any]:
+        """Yield the full stack backing this zfs mountlike, depth-first,
+        from the ZFS dataset itself down through the pool to the Disk(s)."""
+        yield self
+        yield self.pool
+        yield from self.pool.iter_underlying()
 
 
 ConstructedDevice = Union[Raid, LVM_VolGroup, ZPool]

--- a/subiquity/models/tests/test_storage.py
+++ b/subiquity/models/tests/test_storage.py
@@ -2003,6 +2003,77 @@ class TestMountForPath(SubiTestCase):
         self.assertIsNone(mount)
 
 
+class TestIterStorageChain(SubiTestCase):
+    """Tests for Mountlike.iter_storage_chain() and the per-volume
+    iter_underlying() helpers that back it."""
+
+    def _types(self, chain):
+        return [type(x).__name__ for x in chain]
+
+    def test_disk_directly_formatted(self):
+        m, d = make_model_and_disk()
+        fs = make_filesystem(m, d)
+        mt = make_mount(m, fs, "/boot")
+        self.assertEqual(
+            self._types(mt.iter_storage_chain()),
+            ["Mount", "Filesystem", "Disk"],
+        )
+
+    def test_disk_partition(self):
+        m, d = make_model_and_disk()
+        p = make_partition(m, d)
+        fs = make_filesystem(m, p)
+        mt = make_mount(m, fs, "/boot")
+        self.assertEqual(
+            self._types(mt.iter_storage_chain()),
+            ["Mount", "Filesystem", "Partition", "Disk"],
+        )
+
+    def test_raid1(self):
+        m = make_model()
+        r = make_raid(m)
+        fs = make_filesystem(m, r)
+        mt = make_mount(m, fs, "/boot")
+        chain = list(mt.iter_storage_chain())
+        self.assertEqual(chain[0:3], [mt, fs, r])
+        # raid1 is built from two disks (see make_raid).
+        self.assertEqual(self._types(chain[3:]), ["Disk", "Disk"])
+        self.assertEqual(r.raidlevel, "raid1")
+
+    def test_lvm(self):
+        m = make_model()
+        vg = make_vg(m)
+        lv = make_lv(m, vg=vg)
+        fs = make_filesystem(m, lv)
+        mt = make_mount(m, fs, "/boot")
+        self.assertEqual(
+            self._types(mt.iter_storage_chain()),
+            ["Mount", "Filesystem", "LVM_LogicalVolume", "LVM_VolGroup", "Disk"],
+        )
+
+    def test_dm_crypt_on_partition(self):
+        m, d = make_model_and_disk()
+        p = make_partition(m, d)
+        dm = make_dm_crypt(m, p)
+        fs = make_filesystem(m, dm)
+        mt = make_mount(m, fs, "/boot")
+        self.assertEqual(
+            self._types(mt.iter_storage_chain()),
+            ["Mount", "Filesystem", "DM_Crypt", "Partition", "Disk"],
+        )
+
+    def test_zpool_mountlike(self):
+        m = make_model()
+        zp = make_zpool(model=m, mountpoint="/boot")
+        self.assertEqual(self._types(zp.iter_storage_chain()), ["ZPool", "Disk"])
+
+    def test_zfs_mountlike(self):
+        m = make_model()
+        zp = make_zpool(model=m, mountpoint="/")
+        z = make_zfs(m, pool=zp, volume="rpool/boot")
+        self.assertEqual(self._types(z.iter_storage_chain()), ["ZFS", "ZPool", "Disk"])
+
+
 class TestLivePackages(SubiTestCase):
     async def test_defaults(self):
         m = make_model()


### PR DESCRIPTION
Implement one of the new 26.10 boot requirements announced in the [Secure Boot streamlining spec][spec]: signed GRUB on 26.10+ can no longer boot from complex storage setups (LVM, LUKS-encrypted /boot, non-RAID-1 md arrays, ZFS).

Subiquity now blocks installs whose /boot sits on such a stack.

To make the check possible, this PR also adds a small generic helper to walk a mount's full storage chain down to its backing disk(s).

[spec]: https://discourse.ubuntu.com/t/streamlining-secure-boot-for-26-10/79069

LP:#2165727