### PR TITLE
subiquity: bump dry-run version to stonking to add 26.10+ grub requirements

### DIFF
--- a/examples/answers/bridge.yaml
+++ b/examples/answers/bridge.yaml
@@ -1,4 +1,5 @@
 #source-catalog: examples/sources/bridge.yaml
+#dr-config: examples/dry-run-configs/bridge.yaml
 Source:
   source: ubuntu-server
   search_drivers: true

--- a/examples/dry-run-configs/bridge.yaml
+++ b/examples/dry-run-configs/bridge.yaml
@@ -1,0 +1,1 @@
+ubuntu_drivers_strategy: has-drivers-no-oem

--- a/examples/os-release-stonking
+++ b/examples/os-release-stonking
@@ -1,0 +1,13 @@
+PRETTY_NAME="Ubuntu 26.10"
+NAME="Ubuntu"
+VERSION_ID="26.10"
+VERSION="26.10 (Stonking Stingray)"
+VERSION_CODENAME=stonking
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=stonking
+LOGO=ubuntu-logo

--- a/subiquity/common/os.py
+++ b/subiquity/common/os.py
@@ -24,10 +24,10 @@ log = logging.getLogger("subiquity.common.os")
 
 
 OS_RELEASE = Path("/etc/os-release")
-OS_RELEASE_EXAMPLE = Path("examples/os-release-focal")
+OS_RELEASE_EXAMPLE = Path("examples/os-release-stonking")
 
 LEGACY_LSB_RELEASE = Path("/etc/lsb-release")
-LEGACY_LSB_RELEASE_EXAMPLE = Path("examples/lsb-release-focal")
+LEGACY_LSB_RELEASE_EXAMPLE = Path("examples/lsb-release-stonking")
 
 
 @attrs.define

--- a/subiquity/server/controllers/tests/test_kernel.py
+++ b/subiquity/server/controllers/tests/test_kernel.py
@@ -16,9 +16,12 @@
 import itertools
 import os
 import os.path
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import attr
 
+from subiquity.common.os import UbuntuInfo
 from subiquity.models.kernel import KernelModel
 from subiquity.models.source import BridgeKernelReason, SourceModel
 from subiquity.server.controllers.kernel import KernelController
@@ -79,6 +82,10 @@ for bridge_zfs, bridge_drivers, has_zfs, has_drivers in n_booleans(n=4):
         )
 
 
+@patch(
+    "subiquity.server.kernel.read_ubuntu_info",
+    Mock(return_value=UbuntuInfo.from_lsb_release(Path("examples/lsb-release-noble"))),
+)
 class TestMetapackageSelection(SubiTestCase):
     def setUp(self):
         self.app = make_app()
@@ -139,8 +146,8 @@ class TestMetapackageSelection(SubiTestCase):
             [None, {"package": "linux-aaaa", "flavor": "bbbb"}, "linux-aaaa"],
             [None, {"flavor": None}, "linux-generic"],
             [None, {"flavor": "generic"}, "linux-generic"],
-            [None, {"flavor": "hwe"}, "linux-generic-hwe-20.04"],
-            [None, {"flavor": "bbbb"}, "linux-bbbb-20.04"],
+            [None, {"flavor": "hwe"}, "linux-generic-hwe-24.04"],
+            [None, {"flavor": "bbbb"}, "linux-bbbb-24.04"],
         ]
     )
     async def test_ai(self, mpfile_data, ai_data, metapkg_name):

--- a/subiquity/server/dryrun.py
+++ b/subiquity/server/dryrun.py
@@ -91,6 +91,9 @@ class DRConfig:
         "examples/umockdev/dell-certified+nvidia.yaml"
     )
 
+    # Can be overridden by SUBIQUITY_DEBUG flags.
+    ubuntu_drivers_strategy: str = "has-drivers"
+
     @classmethod
     def load(cls, stream):
         data = yaml.safe_load(stream)

--- a/subiquity/server/tests/test_apt.py
+++ b/subiquity/server/tests/test_apt.py
@@ -39,23 +39,23 @@ from subiquitycore.tests.parameterized import parameterized
 from subiquitycore.utils import astart_command
 
 APT_UPDATE_SUCCESS = """\
-Hit:1 http://mirror focal InRelease
-Get:2 http://mirror focal-updates InRelease [109 kB]
-Get:3 http://mirror focal-backports InRelease [99,9 kB]
-Get:4 http://mirror focal-security InRelease [109 kB]
-Get:5 http://mirror focal-updates/main amd64 DEP-11 Metadata [22,5 kB]
-Get:6 http://mirror focal-updates/universe amd64 DEP-11 Metadata [33,6 kB]
+Hit:1 http://mirror stonking InRelease
+Get:2 http://mirror stonking-updates InRelease [109 kB]
+Get:3 http://mirror stonking-backports InRelease [99,9 kB]
+Get:4 http://mirror stonking-security InRelease [109 kB]
+Get:5 http://mirror stonking-updates/main amd64 DEP-11 Metadata [22,5 kB]
+Get:6 http://mirror stonking-updates/universe amd64 DEP-11 Metadata [33,6 kB]
 """
 
 APT_UPDATE_FAILURE = """\
-Err:1 http://bad-mirror focal-updates InRelease
+Err:1 http://bad-mirror stonking-updates InRelease
   Could not resolve 'arcive.ubuntu.com'
-Hit:2 http://mirror focal InRelease
-Hit:3 http://security.ubuntu.com/ubuntu focal-security InRelease
-Hit:4 http://mirror focal-updates InRelease
-Hit:5 http://mirror focal-backports InRelease
+Hit:2 http://mirror stonking InRelease
+Hit:3 http://security.ubuntu.com/ubuntu stonking-security InRelease
+Hit:4 http://mirror stonking-updates InRelease
+Hit:5 http://mirror stonking-backports InRelease
 Reading package lists... Done
-E: Failed to fetch http://bad-mirror/dists/focal-updates/InRelease \
+E: Failed to fetch http://bad-mirror/dists/stonking-updates/InRelease \
 Could not resolve 'bad-mirror'
 E: Some index files failed to download. \
 They have been ignored, or old ones used instead.

--- a/subiquity/server/tests/test_kernel.py
+++ b/subiquity/server/tests/test_kernel.py
@@ -14,22 +14,29 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
 
+from subiquity.common.os import UbuntuInfo
 from subiquity.server.kernel import flavor_to_pkgname
 
 
+@patch(
+    "subiquity.server.kernel.read_ubuntu_info",
+    Mock(return_value=UbuntuInfo.from_lsb_release(Path("examples/lsb-release-noble"))),
+)
 class TestFlavorToPkgname(unittest.TestCase):
     def test_flavor_generic(self):
         self.assertEqual("linux-generic", flavor_to_pkgname("generic", dry_run=True))
 
     def test_flavor_oem(self):
-        self.assertEqual("linux-oem-20.04", flavor_to_pkgname("oem", dry_run=True))
+        self.assertEqual("linux-oem-24.04", flavor_to_pkgname("oem", dry_run=True))
 
     def test_flavor_hwe(self):
         self.assertEqual(
-            "linux-generic-hwe-20.04", flavor_to_pkgname("hwe", dry_run=True)
+            "linux-generic-hwe-24.04", flavor_to_pkgname("hwe", dry_run=True)
         )
 
         self.assertEqual(
-            "linux-generic-hwe-20.04", flavor_to_pkgname("generic-hwe", dry_run=True)
+            "linux-generic-hwe-24.04", flavor_to_pkgname("generic-hwe", dry_run=True)
         )

--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -339,6 +339,13 @@ class UbuntuDriversHasDriversInterface(UbuntuDriversInterface):
         return self.oem_metapackages
 
 
+class UbuntuDriversHasDriversNoOEMInterface(UbuntuDriversHasDriversInterface):
+    """A dry-run implementation of ubuntu-drivers that returns a hard-coded
+    list of drivers, but no OEM metapackage."""
+
+    oem_metapackages: list[str] = []
+
+
 class UbuntuDriversNoDriversInterface(UbuntuDriversHasDriversInterface):
     """A dry-run implementation of ubuntu-drivers that returns a hard-coded
     empty list of drivers."""
@@ -407,6 +414,7 @@ def get_ubuntu_drivers_interface(app) -> UbuntuDriversInterface:
         strat_to_interface = {
             "no-drivers": UbuntuDriversNoDriversInterface,
             "has-drivers": UbuntuDriversHasDriversInterface,
+            "has-drivers-no-oem": UbuntuDriversHasDriversNoOEMInterface,
             "run-drivers": UbuntuDriversRunDriversInterface,
         }
         # debug flags have precendence over dry-run config

--- a/subiquity/server/ubuntu_drivers.py
+++ b/subiquity/server/ubuntu_drivers.py
@@ -404,12 +404,17 @@ def get_ubuntu_drivers_interface(app) -> UbuntuDriversInterface:
     use_gpgpu = app.base_model.source.current.variant == "server"
     cls: Type[UbuntuDriversInterface] = UbuntuDriversClientInterface
     if app.opts.dry_run:
-        if "no-drivers" in app.debug_flags:
-            cls = UbuntuDriversNoDriversInterface
-        elif "run-drivers" in app.debug_flags:
-            cls = UbuntuDriversRunDriversInterface
+        strat_to_interface = {
+            "no-drivers": UbuntuDriversNoDriversInterface,
+            "has-drivers": UbuntuDriversHasDriversInterface,
+            "run-drivers": UbuntuDriversRunDriversInterface,
+        }
+        # debug flags have precendence over dry-run config
+        matching_flags = set(app.debug_flags) & set(strat_to_interface.keys())
+        if matching_flags:
+            cls = strat_to_interface[list(matching_flags)[0]]
         else:
-            cls = UbuntuDriversHasDriversInterface
+            cls = strat_to_interface[app.dr_cfg.ubuntu_drivers_strategy]
 
     if app.opts.kernel_cmdline.get("subiquity-fake-pci-devices"):
         log.debug("Using umockdev wrapper")

--- a/subiquity/tests/api/test_api.py
+++ b/subiquity/tests/api/test_api.py
@@ -2069,12 +2069,6 @@ class TestOEM(TestAPI):
                 self.assertEqual(expected, resp["metapackages"])
 
     @timeout()
-    async def test_listing_certified_ubuntu_server(self):
-        # Listing of OEM meta-packages is intentionally disabled on
-        # ubuntu-server pre-resolute (default dry-run lsb is Focal).
-        await self._test_listing_certified(source_id="ubuntu-server", expected=[])
-
-    @timeout()
     async def test_listing_certified_ubuntu_desktop(self):
         await self._test_listing_certified(
             source_id="ubuntu-desktop", expected=["oem-somerville-tentacool-meta"]


### PR DESCRIPTION
26.10+ boot requirements for signed grub are currently not exercised in dry-run mode because the default os-release / lsb-release files are from focal.

The main drawback of moving to stonking is that it's not a LTS - therefore the Ubuntu Pro screen will vanish. 

Marking as a draft until we figure out the options.

LP:#2165727