### PR TITLE
subiquity: fix AttributeError when building the About message

### DIFF
--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -16,6 +16,7 @@
 import logging
 import os
 
+import attrs
 from urwid import Divider, Filler, PopUpLauncher, Text, connect_signal
 
 from subiquity.common.os import read_ubuntu_info
@@ -472,13 +473,14 @@ class HelpMenu(PopUpLauncher):
             template = _(ABOUT_INSTALLER_LTS)
         else:
             template = _(ABOUT_INSTALLER)
-        info.update(
+        fields = attrs.asdict(info)
+        fields.update(
             {
                 "snap_version": os.environ.get("SNAP_VERSION", "SNAP_VERSION"),
                 "snap_revision": os.environ.get("SNAP_REVISION", "SNAP_REVISION"),
             }
         )
-        return template.format(**info)
+        return template.format(**fields)
 
     def about(self, sender=None):
         if not self._about_message:

--- a/subiquity/ui/views/tests/test_help.py
+++ b/subiquity/ui/views/tests/test_help.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest import mock
+
+from subiquity.ui.views.help import HelpMenu
+
+
+class HelpMenuTests(unittest.TestCase):
+    def test__default_about_msg(self):
+        # Regression test for the AttributeError raised when
+        # _default_about_msg treated the UbuntuInfo returned by
+        # read_ubuntu_info() as a dict.
+        # LP: #2165329
+        app = mock.Mock()
+        # dry-run loads examples/os-release-stonking (Ubuntu 26.10).
+        app.opts.dry_run = True
+        menu = HelpMenu(app)
+        msg = menu._default_about_msg()
+        self.assertIn("26.10", msg)


### PR DESCRIPTION
In the following commit, we introduced read_ubuntu_info(), returning an UbuntuInfo object instead of an lsb_release dictionary:

  515ddf1a subiquity: replace use of lsb-release by read_ubuntu_info

Unfortunately, replacing the dict by an UbuntuInfo object broke the ability to display help because _default_about_msg() calls info.update() and template.format(**info) on the object returned by read_ubuntu_info(). The UbuntuInfo attrs class has no update() method and is not a mapping, causing an AttributeError when opening the About dialog.

Fixed by converting the UbuntuInfo instance to a plain dict with attrs.asdict() before merging in the snap version/revision fields and formatting the template.

LP:#2165329