### PR TITLE
github: configure dependabot to maintain github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
+
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
This should help us keep GitHub actions up-to-date.

The syntax:
```yaml
uses: <repo>@<sha> # vx.y.z 
```

is preserved, as in the following example:

```diff
    steps:
-       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

Example PR: https://github.com/ogayot/subiquity/pull/2/changes