### PR TITLE
Fix issue when resizing LVM LVs

### DIFF
--- a/subiquity/common/storage/manipulator.py
+++ b/subiquity/common/storage/manipulator.py
@@ -374,9 +374,11 @@ class StorageManipulator:
             if "name" in spec:
                 lv.name = spec["name"]
             if "size" in spec:
-                lv.size = align_up(spec["size"], LVM_CHUNK_SIZE)
-                if gaps.largest_gap_size(vg) < 0:
+                new_size = align_up(spec["size"], LVM_CHUNK_SIZE)
+                size_change = new_size - lv.size
+                if size_change > gaps.largest_gap_size(vg):
                     raise Exception("lv size too large")
+                lv.size = new_size
             self.delete_filesystem(lv.fs())
             self.create_filesystem(lv, spec)
             return

--- a/subiquity/common/storage/manipulator.py
+++ b/subiquity/common/storage/manipulator.py
@@ -372,7 +372,7 @@ class StorageManipulator:
                 lv.name = spec["name"]
             if "size" in spec:
                 lv.size = align_up(spec["size"])
-                if gaps.largest_gap_size(vg) < lv.size:
+                if gaps.largest_gap_size(vg) < 0:
                     raise Exception("lv size too large")
             self.delete_filesystem(lv.fs())
             self.create_filesystem(lv, spec)

--- a/subiquity/common/storage/manipulator.py
+++ b/subiquity/common/storage/manipulator.py
@@ -28,6 +28,7 @@ from subiquity.common.storage.spec import (
 )
 from subiquity.common.types.storage import FirmwareType
 from subiquity.models.storage import (
+    LVM_CHUNK_SIZE,
     LVM_LogicalVolume,
     LVM_VolGroup,
     Partition,
@@ -197,7 +198,9 @@ class StorageManipulator:
         self.model.remove_zpool(zpool)
 
     def create_logical_volume(self, vg: LVM_VolGroup, spec: LogicalVolumeSpec):
-        lv = self.model.add_logical_volume(vg=vg, name=spec["name"], size=spec["size"])
+        lv = self.model.add_logical_volume(
+            vg=vg, name=spec["name"], size=align_up(spec["size"], LVM_CHUNK_SIZE)
+        )
         self.create_filesystem(lv, spec)
         return lv
 
@@ -371,7 +374,7 @@ class StorageManipulator:
             if "name" in spec:
                 lv.name = spec["name"]
             if "size" in spec:
-                lv.size = align_up(spec["size"])
+                lv.size = align_up(spec["size"], LVM_CHUNK_SIZE)
                 if gaps.largest_gap_size(vg) < 0:
                     raise Exception("lv size too large")
             self.delete_filesystem(lv.fs())

--- a/subiquity/common/storage/tests/test_manipulator.py
+++ b/subiquity/common/storage/tests/test_manipulator.py
@@ -108,7 +108,6 @@ class TestStorageManipulator(unittest.TestCase):
         fs = make_filesystem(
             manipulator.model, partition=p, fstype="ext2", preserve=True
         )
-        manipulator.model._actions.append(fs)
         manipulator.delete_filesystem(fs)
         spec = {"wipe": "random"}
         with mock.patch.object(p, "original_fstype") as original_fstype:

--- a/subiquity/common/storage/tests/test_manipulator.py
+++ b/subiquity/common/storage/tests/test_manipulator.py
@@ -26,8 +26,10 @@ from subiquity.models.storage import FirmwareType, MiB, Partition
 from subiquity.models.tests.test_storage import (
     make_disk,
     make_filesystem,
+    make_lv,
     make_model,
     make_partition,
+    make_vg,
 )
 from subiquitycore.tests.parameterized import parameterized
 
@@ -790,3 +792,40 @@ class TestCanResize(unittest.TestCase):
         part = make_partition(self.manipulator.model, disk, preserve=True)
         make_filesystem(self.manipulator.model, partition=part, fstype="asdf")
         self.assertTrue(self.manipulator.can_resize_partition(part, wipe="superblock"))
+
+
+class TestLogicalVolumeResize(unittest.TestCase):
+    # LP: #2166333
+    def setUp(self):
+        self.manipulator = make_manipulator()
+
+    def _make_vg_with_half_lv(self):
+        disk = make_disk(self.manipulator.model)
+        vg = make_vg(self.manipulator.model, [disk])
+        half = gaps.align_down(gaps.largest_gap_size(vg) // 2, gaps.LVM_CHUNK_SIZE)
+        lv = make_lv(self.manipulator.model, vg=vg, size=half)
+        make_filesystem(self.manipulator.model, partition=lv, fstype="ext4")
+        return vg, lv
+
+    def test_resize_lv_to_max_allowed(self):
+        vg, lv = self._make_vg_with_half_lv()
+        free = gaps.largest_gap_size(vg)
+        max_size = lv.size + free
+        self.manipulator.logical_volume_handler(
+            vg,
+            {"size": max_size, "fstype": "ext4"},
+            partition=lv,
+            gap=None,
+        )
+        self.assertEqual(lv.size, max_size)
+
+    def test_resize_lv_too_large(self):
+        vg, lv = self._make_vg_with_half_lv()
+        free = gaps.largest_gap_size(vg)
+        with self.assertRaisesRegex(Exception, "lv size too large"):
+            self.manipulator.logical_volume_handler(
+                vg,
+                {"size": lv.size + free + gaps.LVM_CHUNK_SIZE, "fstype": "ext4"},
+                partition=lv,
+                gap=None,
+            )

--- a/subiquity/models/tests/test_storage.py
+++ b/subiquity/models/tests/test_storage.py
@@ -222,7 +222,9 @@ def make_partition(
 
 
 def make_filesystem(model, partition, *, fstype="ext4", **kw):
-    return Filesystem(m=model, volume=partition, fstype=fstype, **kw)
+    fs = Filesystem(m=model, volume=partition, fstype=fstype, **kw)
+    model._actions.append(fs)
+    return fs
 
 
 def make_mount(model, fs: Filesystem, path):


### PR DESCRIPTION
In e8dac16ea51ad6f2770b27e3a23d35c1c90563a1, we replaced 
    
```python
if gaps.largest_gap_size(vg) < 0:
```
with
```python    
if gaps.largest_gap_size(vg) < lv.size:
```
after noticing that the if body was unreachable (i.e., `largest_gap_size` always returns positive values).

However, we wrongly assumed why the branch had become unreachable. What made the branch actually unreachable was commit 83cfdbdf, which replaced:

```python
if vg.free_for_partitions < 0:    # free_for_partitions can be negative
```
by
```python
if gaps.largest_gap_size(vg) < 0:   # gaps.largest_gap_size(vg) can't return negative values
```

The intent of `vg.free_for_partitions < 0` was to check **after performing the resize** that we're not occupying more space than there is on the VG. But that does not work anymore when we switch to `largest_gap_size`.

The proper way to test if the LV would become too large is to do the comparison **before** resizing.

Also, LVM LV inconsistently aligns sizes to 1 MiB or 4 MiB. Changed to 4 MiB (i.e., LVM_CHUNK_SIZE) for consistency. 

LP:#2166333