### PR TITLE
feat(keyboard): add localectl support for X11 keyboard layout persistence

### DIFF
--- a/subiquity/server/controllers/keyboard.py
+++ b/subiquity/server/controllers/keyboard.py
@@ -16,6 +16,7 @@
 import logging
 import os
 import pwd
+import subprocess
 from typing import Dict, Optional, Sequence, Tuple
 
 import attr
@@ -256,6 +257,38 @@ class KeyboardController(SubiquityController):
             f"[('xkb','{xkb_value}')]",
         ]
         await self._run_gui_command(gsettings, **kwargs)
+        await self._set_localectl_x11_keyboard(layout, variant)
+
+    async def _set_localectl_x11_keyboard(self, layout: str, variant: str) -> None:
+        """Persist the layout via logind's org.freedesktop.locale1
+        SetX11Keyboard (through localectl), so desktops that honour it (e.g.
+        KDE Plasma with FollowLocale1=true) pick it up without a
+        desktop-specific call.
+        """
+        new = latinizable(layout, variant)
+        if new is not None:
+            layout, variant = new
+        cmd = [
+            "localectl",
+            "--no-ask-password",
+            "--no-convert",
+            "--",
+            "set-x11-keymap",
+            layout,
+            "",  # model
+            variant,
+        ]
+        if self.opts.dry_run:
+            scale = os.environ.get("SUBIQUITY_REPLAY_TIMESCALE", "1")
+            cmd = ["sleep", str(1 / float(scale))]
+        try:
+            # Run directly rather than via _run_gui_command: that helper
+            # de-privileges to the target user via systemd-run, whereas this
+            # call relies on subiquity's own root privileges to set the
+            # keymap without a polkit prompt.
+            await arun_command(cmd, check=True)
+        except subprocess.CalledProcessError as exc:
+            log.warning("Could not localectl set-x11-keymap: %r", exc)
 
     @with_context(description="configuring keyboard")
     async def setup_target(self, context):

--- a/subiquity/server/controllers/tests/test_keyboard.py
+++ b/subiquity/server/controllers/tests/test_keyboard.py
@@ -15,7 +15,7 @@
 
 import os
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import jsonschema
 from jsonschema.validators import validator_for
@@ -64,11 +64,21 @@ class TestInputSource(unittest.IsolatedAsyncioTestCase):
 
     @parameterized.expand(
         [
-            ("us", "", "[('xkb','us')]"),
-            ("fr", "latin9", "[('xkb','fr+latin9')]"),
+            ("us", "", "[('xkb','us')]", "us", ""),
+            ("fr", "latin9", "[('xkb','fr+latin9')]", "fr", "latin9"),
+            # non-latin layouts get expanded to a dual layout with a latin
+            # fallback, same as for the "main" set_keyboard flow.
+            ("ru", "", "[('xkb','ru')]", "us,ru", ","),
         ]
     )
-    async def test_input_source(self, layout, variant, expected_xkb):
+    async def test_input_source(
+        self,
+        layout,
+        variant,
+        expected_xkb,
+        expected_locale_layout,
+        expected_locale_variant,
+    ):
         with (
             patch(
                 "subiquity.server.controllers.keyboard.arun_command"
@@ -87,7 +97,7 @@ class TestInputSource(unittest.IsolatedAsyncioTestCase):
                 "sources",
                 expected_xkb,
             ]
-            cmd = [
+            gsettings_cmd = [
                 "systemd-run",
                 "--wait",
                 "--uid=99",
@@ -97,4 +107,17 @@ class TestInputSource(unittest.IsolatedAsyncioTestCase):
                 "--",
                 *gsettings,
             ]
-            mock_arun_command.assert_called_once_with(cmd)
+            localectl_cmd = [
+                "localectl",
+                "--no-ask-password",
+                "--no-convert",
+                "--",
+                "set-x11-keymap",
+                expected_locale_layout,
+                "",
+                expected_locale_variant,
+            ]
+            self.assertEqual(
+                mock_arun_command.call_args_list,
+                [call(gsettings_cmd), call(localectl_cmd, check=True)],
+            )


### PR DESCRIPTION
As ubuntu-desktop-bootstrap was built to be used by all Ubuntu flavors, we need to make sure we're not using too many GNOME-specific idioms. Otherwise desktops, such as KDE Plasma, miss out on certain features like setting the keyboard layout. Currently, this is completely missed when one uses this installer on Ubuntu Studio.

This pull request makes the keyboard layout setting more DE-agnostic and, since subiquity runs as root, this can be applied directly with --no-ask-password unlike the (unprivileged) installer frontend, which would otherwise have to either fail or show a polkit prompt asking for credentials that do not yet exist.