### PR TITLE
Only preserve TPM/FDE partitions that have the same type/flag

### DIFF
--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -1171,8 +1171,18 @@ class StorageController(SubiquityController, StorageManipulator):
                 }
 
                 for _struct, offset, size in on_volume.offsets_and_sizes():
-                    if (offset, size) in parts_by_offset_size:
-                        preserved_parts.add(parts_by_offset_size[(offset, size)])
+                    if (offset, size) not in parts_by_offset_size:
+                        continue
+                    part = parts_by_offset_size[(offset, size)]
+                    if on_volume.schema == "gpt":
+                        # Curtin explicitly checks if partitions that we
+                        # preserve have the expected flag.
+                        type_uuid = _struct.gpt_part_type_uuid()
+                        if type_uuid and part.flag != ptable_part_type_to_flag(
+                            type_uuid
+                        ):
+                            continue
+                    preserved_parts.add(part)
 
                 for part in list(disk.partitions()):
                     if part not in preserved_parts:

--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -1155,6 +1155,11 @@ class StorageController(SubiquityController, StorageManipulator):
             if not self._info.is_core_boot_use_gap_compatible(gap):
                 raise IncompatibleLocationError
         elif isinstance(choice.target, GuidedStorageTargetReformat):
+            # NOTE: it is not obvious why we try to preserve existing
+            # partitions here rather than simply deleting and recreating
+            # them all, which would be simpler and is cheap for GPT.
+            # This behavior was introduced in commit 72c7e8df and carried
+            # over since.
             preserved_parts = set()
 
             if on_volume.schema != disk.ptable:

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -118,6 +118,9 @@ default_capabilities = [
     GuidedCapability.ZFS_LUKS_KEYSTORE,
 ]
 
+# GPT type UUID for a Linux filesystem data partition (curtin flag "linux").
+GPT_LINUX_TYPE = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+
 
 default_capabilities_disallowed_too_small = [
     GuidedDisallowedCapability(
@@ -3334,7 +3337,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.assertEqual(part1.fs().fstype, "ext4")
         self.assertEqual(part1.flag, "linux")
         self.assertEqual(part1.partition_name, "one")
-        self.assertEqual(part1.partition_type, "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
+        self.assertEqual(part1.partition_type, GPT_LINUX_TYPE)
         self.assertEqual(part2.flag, None)
         self.assertEqual(part2.partition_type, arbitrary_uuid)
 
@@ -3342,7 +3345,12 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         disk = make_disk(self.ctrler.model)
         # Add a partition that matches one in the volume structure
         reused_part = make_partition(
-            self.ctrler.model, disk, offset=1 << 20, size=1 << 30, preserve=True
+            self.ctrler.model,
+            disk,
+            offset=1 << 20,
+            size=1 << 30,
+            preserve=True,
+            flag="linux",
         )
         self.ctrler.model.add_filesystem(reused_part, "ext4")
         # And two that do not.
@@ -3355,7 +3363,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self._add_details_for_structures(
             [
                 snapdtypes.VolumeStructure(
-                    type="0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    type=GPT_LINUX_TYPE,
                     offset=1 << 20,
                     size=1 << 30,
                     filesystem="ext4",
@@ -3378,12 +3386,17 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
     async def test_guided_core_boot_reuse_no_format(self):
         disk = make_disk(self.ctrler.model)
         existing_part = make_partition(
-            self.ctrler.model, disk, offset=1 << 20, size=1 << 30, preserve=True
+            self.ctrler.model,
+            disk,
+            offset=1 << 20,
+            size=1 << 30,
+            preserve=True,
+            flag="linux",
         )
         self._add_details_for_structures(
             [
                 snapdtypes.VolumeStructure(
-                    type="0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    type=GPT_LINUX_TYPE,
                     offset=1 << 20,
                     size=1 << 30,
                     filesystem=None,
@@ -3402,6 +3415,49 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
         self.assertEqual(existing_part, part)
         self.assertEqual(existing_part.wipe, None)
 
+    async def test_guided_core_boot_reuse_wrong_type(self):
+        """LP: #2166668 - a partition at the right offset/size but with the
+        wrong type must not be preserved, or curtin fails flag verification."""
+        disk = make_disk(self.ctrler.model)
+        # Add a partition at the right offset and size, but with a
+        # partition type that does not match the volume structure. It
+        # must not be preserved, otherwise curtin would fail verifying
+        # the partition flag/type.
+        wrong_part = make_partition(
+            self.ctrler.model,
+            disk,
+            offset=1 << 20,
+            size=1 << 30,
+            preserve=True,
+            flag="bios_grub",
+        )
+        self._add_details_for_structures(
+            [
+                snapdtypes.VolumeStructure(
+                    type=GPT_LINUX_TYPE,
+                    offset=1 << 20,
+                    size=1 << 30,
+                    filesystem="ext4",
+                ),
+            ]
+        )
+        choice = GuidedChoiceV2(
+            target=GuidedStorageTargetReformat(
+                disk_id=disk.id,
+            ),
+            capability=self.capability,
+        )
+        await self.ctrler.guided_core_boot(disk, choice)
+        self.assertIsNone(self.ctrler.core_boot_data.volumes_auth)
+        [part] = disk.partitions()
+        self.assertNotEqual(wrong_part, part)
+        self.assertEqual(part.offset, 1 << 20)
+        self.assertEqual(part.size, 1 << 30)
+        self.assertEqual(part.flag, "linux")
+        self.assertEqual(part.partition_type, GPT_LINUX_TYPE)
+        self.assertFalse(part.preserve)
+        self.assertEqual(part.fs().fstype, "ext4")
+
     async def test_guided_core_boot_system_data(self):
         disk = make_disk(self.ctrler.model)
         self._add_details_for_structures(
@@ -3415,7 +3471,7 @@ class TestCoreBootInstallMethods(IsolatedAsyncioTestCase):
                     filesystem="",
                 ),
                 snapdtypes.VolumeStructure(
-                    type="0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    type=GPT_LINUX_TYPE,
                     offset=2 << 20,
                     name="ptname",
                     size=2 << 30,


### PR DESCRIPTION
For a reason I don't know, when we're doing a TPM/FDE installation, we try to preserve partitions that are at the same offset and size. However, before honoring `preserve: true` for partitions, curtin does additional checks, which include partition type / flag.

Therefore, if we try to reuse a partition but want to change the partition type, we run into a curtin error. Instead we should delete and recreate the partition so that the new one has the right type/flag.

LP:#2166668