### PR TITLE
storage: ignore variations that have missing snapd system

### DIFF
--- a/subiquity/server/controllers/storage.py
+++ b/subiquity/server/controllers/storage.py
@@ -660,7 +660,22 @@ class StorageController(SubiquityController, StorageManipulator):
                     # though it might be called again concurrently.
                     raise
 
+                if system is None:
+                    # The snapd system referenced by this variation's label
+                    # could not be found on the source, which means the ISO
+                    # is broken; skip it rather than mis-handling it as a
+                    # classic/dd variation.
+                    # See LP: #2167127
+                    log.warning(
+                        "ignoring variation [%s] because the snapd system"
+                        " with label [%s] is missing",
+                        name,
+                        label,
+                    )
+                    continue
+
             log.debug("got system %s for variation %s", system, name)
+
             if system is not None and len(system.volumes) > 0:
                 if not self.app.opts.enhanced_secureboot:
                     log.debug("Not offering enhanced_secureboot: commandline disabled")

--- a/subiquity/server/controllers/tests/test_storage.py
+++ b/subiquity/server/controllers/tests/test_storage.py
@@ -1617,6 +1617,40 @@ class TestSubiquityControllerStorage(IsolatedAsyncioTestCase):
         self.assertEqual(len(self.ctrler._variation_info), 1)
         self.assertEqual(self.ctrler._variation_info["default"].name, "default")
 
+    async def test_examine_systems_missing_snapd_system(self):
+        # When SystemGetter.get returns no system for a variation that has a
+        # snapd_system_label, the snapd system referenced by that label could
+        # not be found on the source. This means the ISO is broken; the
+        # variation must be skipped rather than mis-handled as a classic/dd
+        # variation.
+        # LP: #2167127
+        self.ctrler._system_getter.get = mock.AsyncMock(return_value=(None, False))
+
+        self.app.base_model.source.current.type = "fsimage"
+        self.app.base_model.source.current.variations = {
+            "core-boot": CatalogEntryVariation(
+                path="", size=1, snapd_system_label="prefer-encrypted"
+            ),
+            "classic": CatalogEntryVariation(path="", size=1),
+        }
+
+        with self.assertLogs(
+            "subiquity.server.controllers.storage", level="WARNING"
+        ) as logs:
+            await self.ctrler._examine_systems()
+
+        # The broken "core-boot" variation is skipped entirely.
+        self.assertNotIn("core-boot", self.ctrler._variation_info)
+        # The unlabelled "classic" variation is unaffected.
+        self.assertIn("classic", self.ctrler._variation_info)
+        self.assertEqual(self.ctrler._variation_info["classic"].name, "classic")
+        # The getter is only called for the labelled variation.
+        self.ctrler._system_getter.get.assert_awaited_once()
+        # A warning was emitted mentioning both the variation and its label.
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("core-boot", logs.output[0])
+        self.assertIn("prefer-encrypted", logs.output[0])
+
     def test_valid_schema(self):
         """Test that the expected autoinstall JSON schema is valid"""
 


### PR DESCRIPTION
If a source variation declares a snapd-system-label but no matching system seed is found, Subiquity automatically assumed the variation corresponds to a classic variation.

This is a problem in setups with multiple variations because Subiquity won't know which is the real classic variation, and will use the first variation declared instead.

While this should not happen for ISOs that are correctly built, the correct thing to do is to ignore such a variation instead of assuming it's a classic variation.

LP:#2167127